### PR TITLE
Table hooks doc fix - add queryOptions to table docs

### DIFF
--- a/documentation/docs/api-references/hooks/table/useEditableTable.md
+++ b/documentation/docs/api-references/hooks/table/useEditableTable.md
@@ -310,6 +310,8 @@ export const PostList: React.FC = () => {
 
 ## API
 
+### Properties
+
 | Key              | Description                                                                                                                                        | Type                                                        |
 | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
 | permanentFilter  | Default and unchangeable filter.                                                                                                                   | [`CrudFilters`][CrudFilters]                                |

--- a/documentation/docs/api-references/hooks/table/useTable.md
+++ b/documentation/docs/api-references/hooks/table/useTable.md
@@ -341,6 +341,8 @@ Filters we give to `initialFilter` are default filters. In order to prevent filt
 
 ## API
 
+### Properties
+
 | Key              | Description                                                                                                                                       | Type                                                        |
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
 | permanentFilter  | Default and unchangeable filter                                                                                                                   | [`CrudFilters`][CrudFilters]                                |


### PR DESCRIPTION
closes #1001 

Test documentation! 'MASTER'
[Link to TABLE-HOOKS-DOC-FIX](https://table-h-doc-refine.pankod.com)