### PR TITLE
remove react-query export

### DIFF
--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -49,5 +49,3 @@ export { RcFile, UploadFile } from "antd/lib/upload/interface";
 
 // antd filterDropDownProps (using for <FilterDropDown> component)
 export { FilterDropdownProps } from "antd/lib/table/interface";
-
-export * from "react-query";


### PR DESCRIPTION
Test me! 'MASTER'
[Link to DELETE-REACT-QUERY-EXPORT](https://delete--refine.pankod.com)

Please provide enough information so that others can review your pull request:

"react-query" is no longer exported in refine. We think this is not the right way. We get an error when we want to use refine in next.js and test environment.

Explain the **details** for making this change. What existing problem does the pull request solve?

We removed the react-query export.

**Closing issues**

#1142 