### PR TITLE
handle getMany invalidate cache queries on useCreate & useCreateMany

### DIFF
--- a/packages/core/src/hooks/data/useCreate.ts
+++ b/packages/core/src/hooks/data/useCreate.ts
@@ -11,7 +11,7 @@ import {
     SuccessErrorNotification,
     MetaDataQuery,
 } from "../../interfaces";
-import { useListResourceQueries, useTranslate, useCheckError } from "@hooks";
+import { useTranslate, useCheckError, useCacheQueries } from "@hooks";
 import { handleNotification } from "@definitions";
 
 type useCreateParams<TVariables> = {
@@ -50,7 +50,7 @@ export const useCreate = <
 >(): UseCreateReturnType<TData, TError, TVariables> => {
     const { mutate: checkError } = useCheckError();
     const { create } = useContext<IDataContext>(DataContext);
-    const getListQueries = useListResourceQueries();
+    const getAllQueries = useCacheQueries();
     const translate = useTranslate();
     const queryClient = useQueryClient();
 
@@ -88,7 +88,7 @@ export const useCreate = <
                     type: "success",
                 });
 
-                getListQueries(resource).forEach((query) => {
+                getAllQueries(resource).forEach((query) => {
                     queryClient.invalidateQueries(query.queryKey);
                 });
             },

--- a/packages/core/src/hooks/data/useCreateMany.ts
+++ b/packages/core/src/hooks/data/useCreateMany.ts
@@ -10,7 +10,7 @@ import {
     SuccessErrorNotification,
     MetaDataQuery,
 } from "../../interfaces";
-import { useListResourceQueries, useTranslate } from "@hooks";
+import { useCacheQueries, useTranslate } from "@hooks";
 import { handleNotification } from "@definitions";
 import pluralize from "pluralize";
 
@@ -49,7 +49,7 @@ export const useCreateMany = <
     TVariables = {},
 >(): UseCreateManyReturnType<TData, TError, TVariables> => {
     const { createMany } = useContext<IDataContext>(DataContext);
-    const getListQueries = useListResourceQueries();
+    const getAllQueries = useCacheQueries();
     const translate = useTranslate();
     const queryClient = useQueryClient();
 
@@ -83,7 +83,7 @@ export const useCreateMany = <
                     type: "success",
                 });
 
-                getListQueries(resource).forEach((query) => {
+                getAllQueries(resource).forEach((query) => {
                     queryClient.invalidateQueries(query.queryKey);
                 });
             },

--- a/packages/core/src/hooks/useListResourceQueries.ts
+++ b/packages/core/src/hooks/useListResourceQueries.ts
@@ -33,13 +33,31 @@ export const useGetOneQueries = () => {
     );
 };
 
+export const useGetManyQueries = () => {
+    const queryClient = useQueryClient();
+    const data = queryClient.getQueryCache();
+
+    const getManyResourceQueries = useCallback(
+        (resource: string) => {
+            return data.getAll().filter((query) => {
+                return query.queryKey.includes(`resource/getMany/${resource}`);
+            });
+        },
+        [data],
+    );
+
+    return getManyResourceQueries;
+};
+
 export const useCacheQueries = () => {
     const listResourceQueries = useListResourceQueries();
     const getOneQuery = useGetOneQueries();
+    const getManyResourceQuery = useGetManyQueries();
 
     return useCallback((resource: string, id?: string | string[]) => {
         const queries = getOneQuery(resource);
         const listQuery = listResourceQueries(resource);
+        const getManyQuery = getManyResourceQuery(resource);
 
         if (id) {
             let getOneQueriesWithId;
@@ -53,8 +71,9 @@ export const useCacheQueries = () => {
                 });
             }
 
-            return [...listQuery, ...getOneQueriesWithId];
+            return [...listQuery, ...getManyQuery, ...getOneQueriesWithId];
         }
-        return [...listQuery, ...queries];
+
+        return [...listQuery, ...getManyQuery, ...queries];
     }, []);
 };


### PR DESCRIPTION
Test me! 'MASTER'
[Link to ADD-INVALIDATE-GETMANY-QUERIES](https://add-inv-refine.pankod.com)

Please provide enough information so that others can review your pull request:

they now invalidate the `useCreate` and `useCreateMany` `getMany (useSelect, useCheckboxGroup, etc..)` caches as well.

Explain the **details** for making this change. What existing problem does the pull request solve?

**Closing issues**

closes #1156 