### PR TITLE
handle useCreateForm undefined id on redirection

### DIFF
--- a/packages/core/src/hooks/form/useCreateForm/useCreateForm.ts
+++ b/packages/core/src/hooks/form/useCreateForm/useCreateForm.ts
@@ -124,7 +124,7 @@ export const useCreateForm = <
 
                     form.resetFields();
 
-                    const id = data.data.id;
+                    const id = data?.data?.id;
 
                     handleSubmitWithRedirect({
                         redirect,


### PR DESCRIPTION
Test me! 'MASTER'
[Link to HANDLE-USECREATEFORM-UNDEFINED-ID](https://handle--refine.pankod.com)

Please provide enough information so that others can review your pull request:

now redirects to list page when `useCreate` hook does not return `id`

**Closing issues**

closes #1157 