### PR TITLE
fix(sider): set menu theme to dark matching antd sider default theme

### DIFF
--- a/packages/antd/src/assets/styles/custom-theme.less
+++ b/packages/antd/src/assets/styles/custom-theme.less
@@ -21,6 +21,9 @@
 @menu-highlight-color: #fff;
 @menu-item-active-bg: transparent;
 @menu-item-active-border-width: 0px;
+@menu-dark-color: #fff;
+@menu-dark-bg: @layout-sider-background;
+@menu-dark-item-active-bg: @layout-sider-background;
 @layout-trigger-background: rgba(0, 0, 0, 0.5);
 
 //form

--- a/packages/antd/src/assets/styles/styles.min.css
+++ b/packages/antd/src/assets/styles/styles.min.css
@@ -7425,7 +7425,7 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 }
 .ant-dropdown-menu-dark,
 .ant-dropdown-menu-dark .ant-dropdown-menu {
-  background: #001529;
+  background: #2a132e;
 }
 .ant-dropdown-menu-dark .ant-dropdown-menu-item,
 .ant-dropdown-menu-dark .ant-dropdown-menu-submenu-title,
@@ -16653,8 +16653,8 @@ textarea.ant-mentions {
 .ant-menu.ant-menu-dark,
 .ant-menu-dark .ant-menu-sub,
 .ant-menu.ant-menu-dark .ant-menu-sub {
-  color: rgba(255, 255, 255, 0.65);
-  background: #001529;
+  color: #fff;
+  background: #2a132e;
 }
 .ant-menu.ant-menu-dark .ant-menu-submenu-title .ant-menu-submenu-arrow,
 .ant-menu-dark .ant-menu-sub .ant-menu-submenu-title .ant-menu-submenu-arrow,
@@ -16684,11 +16684,11 @@ textarea.ant-mentions {
   top: 0;
   margin-top: 0;
   padding: 0 20px;
-  border-color: #001529;
+  border-color: #2a132e;
   border-bottom: 0;
 }
 .ant-menu-dark.ant-menu-horizontal > .ant-menu-item:hover {
-  background-color: #67be23;
+  background-color: #2a132e;
 }
 .ant-menu-dark.ant-menu-horizontal > .ant-menu-item > a::before {
   bottom: 0;
@@ -16697,7 +16697,7 @@ textarea.ant-mentions {
 .ant-menu-dark .ant-menu-item-group-title,
 .ant-menu-dark .ant-menu-item > a,
 .ant-menu-dark .ant-menu-item > span > a {
-  color: rgba(255, 255, 255, 0.65);
+  color: #fff;
 }
 .ant-menu-dark.ant-menu-inline,
 .ant-menu-dark.ant-menu-vertical,
@@ -16772,7 +16772,7 @@ textarea.ant-mentions {
   background-color: transparent;
 }
 .ant-menu-dark.ant-menu-dark:not(.ant-menu-horizontal) .ant-menu-item-selected {
-  background-color: #67be23;
+  background-color: #2a132e;
 }
 .ant-menu-dark .ant-menu-item-selected {
   color: #fff;
@@ -16797,7 +16797,7 @@ textarea.ant-mentions {
 }
 .ant-menu.ant-menu-dark .ant-menu-item-selected,
 .ant-menu-submenu-popup.ant-menu-dark .ant-menu-item-selected {
-  background-color: #67be23;
+  background-color: #2a132e;
 }
 .ant-menu-dark .ant-menu-item-disabled,
 .ant-menu-dark .ant-menu-submenu-disabled,
@@ -18196,6 +18196,9 @@ textarea.ant-pagination-options-quick-jumper input {
   cursor: auto;
   user-select: text;
 }
+.ant-popover-content {
+  position: relative;
+}
 .ant-popover::after {
   position: absolute;
   background: rgba(255, 255, 255, 0.01);
@@ -18277,8 +18280,8 @@ textarea.ant-pagination-options-quick-jumper input {
 .ant-popover-arrow {
   position: absolute;
   display: block;
-  width: 16px;
-  height: 16px;
+  width: 22px;
+  height: 22px;
   overflow: hidden;
   background: transparent;
   pointer-events: none;
@@ -18314,17 +18317,18 @@ textarea.ant-pagination-options-quick-jumper input {
 .ant-popover-placement-top .ant-popover-arrow,
 .ant-popover-placement-topLeft .ant-popover-arrow,
 .ant-popover-placement-topRight .ant-popover-arrow {
-  bottom: -0.6862915px;
+  bottom: 0;
+  transform: translateY(100%);
 }
 .ant-popover-placement-top .ant-popover-arrow-content,
 .ant-popover-placement-topLeft .ant-popover-arrow-content,
 .ant-popover-placement-topRight .ant-popover-arrow-content {
   box-shadow: 3px 3px 7px rgba(0, 0, 0, 0.07);
-  transform: translateY(-8px) rotate(45deg);
+  transform: translateY(-11px) rotate(45deg);
 }
 .ant-popover-placement-top .ant-popover-arrow {
   left: 50%;
-  transform: translateX(-50%);
+  transform: translateY(100%) translateX(-50%);
 }
 .ant-popover-placement-topLeft .ant-popover-arrow {
   left: 16px;
@@ -18335,17 +18339,18 @@ textarea.ant-pagination-options-quick-jumper input {
 .ant-popover-placement-right .ant-popover-arrow,
 .ant-popover-placement-rightTop .ant-popover-arrow,
 .ant-popover-placement-rightBottom .ant-popover-arrow {
-  left: -0.6862915px;
+  left: 0;
+  transform: translateX(-100%);
 }
 .ant-popover-placement-right .ant-popover-arrow-content,
 .ant-popover-placement-rightTop .ant-popover-arrow-content,
 .ant-popover-placement-rightBottom .ant-popover-arrow-content {
   box-shadow: 3px 3px 7px rgba(0, 0, 0, 0.07);
-  transform: translateX(8px) rotate(135deg);
+  transform: translateX(11px) rotate(135deg);
 }
 .ant-popover-placement-right .ant-popover-arrow {
   top: 50%;
-  transform: translateY(-50%);
+  transform: translateX(-100%) translateY(-50%);
 }
 .ant-popover-placement-rightTop .ant-popover-arrow {
   top: 12px;
@@ -18356,17 +18361,18 @@ textarea.ant-pagination-options-quick-jumper input {
 .ant-popover-placement-bottom .ant-popover-arrow,
 .ant-popover-placement-bottomLeft .ant-popover-arrow,
 .ant-popover-placement-bottomRight .ant-popover-arrow {
-  top: -0.6862915px;
+  top: 0;
+  transform: translateY(-100%);
 }
 .ant-popover-placement-bottom .ant-popover-arrow-content,
 .ant-popover-placement-bottomLeft .ant-popover-arrow-content,
 .ant-popover-placement-bottomRight .ant-popover-arrow-content {
   box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.06);
-  transform: translateY(8px) rotate(-135deg);
+  transform: translateY(11px) rotate(-135deg);
 }
 .ant-popover-placement-bottom .ant-popover-arrow {
   left: 50%;
-  transform: translateX(-50%);
+  transform: translateY(-100%) translateX(-50%);
 }
 .ant-popover-placement-bottomLeft .ant-popover-arrow {
   left: 16px;
@@ -18377,17 +18383,18 @@ textarea.ant-pagination-options-quick-jumper input {
 .ant-popover-placement-left .ant-popover-arrow,
 .ant-popover-placement-leftTop .ant-popover-arrow,
 .ant-popover-placement-leftBottom .ant-popover-arrow {
-  right: -0.6862915px;
+  right: 0;
+  transform: translateX(100%);
 }
 .ant-popover-placement-left .ant-popover-arrow-content,
 .ant-popover-placement-leftTop .ant-popover-arrow-content,
 .ant-popover-placement-leftBottom .ant-popover-arrow-content {
   box-shadow: 3px 3px 7px rgba(0, 0, 0, 0.07);
-  transform: translateX(-8px) rotate(-45deg);
+  transform: translateX(-11px) rotate(-45deg);
 }
 .ant-popover-placement-left .ant-popover-arrow {
   top: 50%;
-  transform: translateY(-50%);
+  transform: translateX(100%) translateY(-50%);
 }
 .ant-popover-placement-leftTop .ant-popover-arrow {
   top: 12px;

--- a/packages/antd/src/components/layout/sider/index.tsx
+++ b/packages/antd/src/components/layout/sider/index.tsx
@@ -87,6 +87,7 @@ export const Sider: React.FC = () => {
         >
             <RenderToTitle collapsed={collapsed} />
             <Menu
+                theme="dark"
                 selectedKeys={[selectedKey]}
                 defaultOpenKeys={defaultOpenKeys}
                 mode="inline"


### PR DESCRIPTION
This PR is related to issue #1862. Applying this change makes the default menu provided by Refine that is inside a Sider element to match the default AntD theme set to the Sider, dark.

With this change is possible to switch to a default AntD stylesheet without breaking the menu. 

The changes in the refine stylesheet ensure that the current look and feel is maintained after changing the menu theme.