### PR TITLE
feat: add locales prop to `<DateField/>`

### DIFF
--- a/.changeset/weak-mice-change.md
+++ b/.changeset/weak-mice-change.md
@@ -1,0 +1,9 @@
+---
+"@pankod/refine-antd": minor
+"@pankod/refine-mantine": minor
+"@pankod/refine-mui": minor
+"@pankod/refine-ui-tests": minor
+"@pankod/refine-ui-types": minor
+---
+
+added locales prop to date fields

--- a/documentation/docs/api-reference/antd/components/fields/date.md
+++ b/documentation/docs/api-reference/antd/components/fields/date.md
@@ -64,5 +64,3 @@ interface IPost {
 :::tip External Props
 It also accepts all props of Ant Design [Text](https://ant.design/components/typography/#Typography.Text).
 :::
-
-[Refer to Text props &#8594](https://ant.design/components/typography/#Typography.Text)

--- a/packages/antd/src/components/fields/date/index.tsx
+++ b/packages/antd/src/components/fields/date/index.tsx
@@ -8,6 +8,8 @@ import LocalizedFormat from "dayjs/plugin/localizedFormat";
 
 dayjs.extend(LocalizedFormat);
 
+const defaultLocale = dayjs.locale();
+
 export type DateFieldProps = RefineFieldDateProps<ConfigType, TextProps>;
 
 /**
@@ -17,10 +19,17 @@ export type DateFieldProps = RefineFieldDateProps<ConfigType, TextProps>;
  */
 export const DateField: React.FC<DateFieldProps> = ({
     value,
+    locales,
     format: dateFormat = "L",
     ...rest
 }) => {
     const { Text } = Typography;
 
-    return <Text {...rest}>{dayjs(value).format(dateFormat)}</Text>;
+    return (
+        <Text {...rest}>
+            {dayjs(value)
+                .locale(locales || defaultLocale)
+                .format(dateFormat)}
+        </Text>
+    );
 };

--- a/packages/mantine/src/components/fields/date/index.tsx
+++ b/packages/mantine/src/components/fields/date/index.tsx
@@ -8,6 +8,8 @@ import { Text, TextProps } from "@mantine/core";
 
 dayjs.extend(LocalizedFormat);
 
+const defaultLocale = dayjs.locale();
+
 export type DateFieldProps = RefineFieldDateProps<ConfigType, TextProps>;
 
 /**
@@ -18,8 +20,15 @@ export type DateFieldProps = RefineFieldDateProps<ConfigType, TextProps>;
  */
 export const DateField: React.FC<DateFieldProps> = ({
     value,
+    locales,
     format: dateFormat = "L",
     ...rest
 }) => {
-    return <Text {...rest}>{dayjs(value).format(dateFormat)}</Text>;
+    return (
+        <Text {...rest}>
+            {dayjs(value)
+                .locale(locales || defaultLocale)
+                .format(dateFormat)}
+        </Text>
+    );
 };

--- a/packages/mui/src/components/fields/date/index.tsx
+++ b/packages/mui/src/components/fields/date/index.tsx
@@ -3,10 +3,11 @@ import React from "react";
 import { RefineFieldDateProps } from "@pankod/refine-ui-types";
 import dayjs, { ConfigType } from "dayjs";
 import LocalizedFormat from "dayjs/plugin/localizedFormat";
-
 import { Typography, TypographyProps } from "@mui/material";
 
 dayjs.extend(LocalizedFormat);
+
+const defaultLocale = dayjs.locale();
 
 export type DateFieldProps = RefineFieldDateProps<ConfigType, TypographyProps>;
 
@@ -18,12 +19,15 @@ export type DateFieldProps = RefineFieldDateProps<ConfigType, TypographyProps>;
  */
 export const DateField: React.FC<DateFieldProps> = ({
     value,
+    locales,
     format: dateFormat = "L",
     ...rest
 }) => {
     return (
         <Typography variant="body2" {...rest}>
-            {dayjs(value).format(dateFormat)}
+            {dayjs(value)
+                .locale(locales || defaultLocale)
+                .format(dateFormat)}
         </Typography>
     );
 };

--- a/packages/ui-tests/src/tests/fields/date.tsx
+++ b/packages/ui-tests/src/tests/fields/date.tsx
@@ -5,6 +5,8 @@ import { RefineFieldDateProps } from "@pankod/refine-ui-types";
 
 import { render } from "@test";
 
+import "dayjs/locale/tr";
+
 export const fieldDateTests = function (
     DateField: React.ComponentType<RefineFieldDateProps<ConfigType, any, any>>,
 ): void {
@@ -29,9 +31,17 @@ export const fieldDateTests = function (
         });
 
         it("renders date with given  LocalizedFormat", () => {
-            const { getByText } = render(
-                <DateField value={new Date("2021-05-20")} format="l" />,
+            const { getByText, rerender } = render(
+                <DateField
+                    value={new Date("2021-05-20")}
+                    format="l"
+                    locales="tr"
+                />,
             );
+
+            getByText("20.5.2021");
+
+            rerender(<DateField value={new Date("2021-05-20")} format="l" />);
 
             getByText("5/20/2021");
         });

--- a/packages/ui-types/src/types/field.tsx
+++ b/packages/ui-types/src/types/field.tsx
@@ -50,6 +50,9 @@ export type RefineFieldDateProps<
     TExtraProps & {
         /**
          * The locales of the date.
+         * By default, Day.js comes with English locale only. If you need other locales, you can load them on demand.
+         * [Refer to loading locales](https://day.js.org/docs/en/i18n/loading-into-browser)
+         * @default English
          */
         locales?: string;
         /**


### PR DESCRIPTION
The `locales` prop was not given to dayjs. It is now given


To use dayjs localization, user need to import supported locales on demand. Is this explanation enough for the this feature or should i create full example ?
![image](https://user-images.githubusercontent.com/23058882/196704731-e347864f-60f7-4885-b157-67ff14361de8.png)



### Test plan (required)

<img width="300"  alt="image" src="https://user-images.githubusercontent.com/23058882/196703121-cd8b1546-5e41-418e-9e30-41289d404916.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/23058882/196703515-b09e9a8e-cad0-458f-bc27-94c5527f6eff.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/23058882/196703680-128a1bcd-31ce-405c-a5e2-8e7fa96347a9.png">


### Self Check before Merge

-   [ ] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
