### PR TITLE
fix: disabled button anchors

### DIFF
--- a/.changeset/four-bottles-kick.md
+++ b/.changeset/four-bottles-kick.md
@@ -1,0 +1,7 @@
+---
+"@pankod/refine-antd": patch
+"@pankod/refine-mantine": patch
+"@pankod/refine-mui": patch
+---
+
+Fixed #2828 - Buttons were not respecting access control when navigating to a new page. Now, if button is disabled, it will not also block the navigation not just the onClick event.

--- a/packages/antd/src/components/buttons/clone/index.tsx
+++ b/packages/antd/src/components/buttons/clone/index.tsx
@@ -78,6 +78,10 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
             to={cloneUrl}
             replace={false}
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+                if (data?.can === false) {
+                    e.preventDefault();
+                    return;
+                }
                 if (onClick) {
                     e.preventDefault();
                     onClick(e);

--- a/packages/antd/src/components/buttons/create/index.tsx
+++ b/packages/antd/src/components/buttons/create/index.tsx
@@ -78,6 +78,10 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
             to={createUrl}
             replace={false}
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+                if (data?.can === false) {
+                    e.preventDefault();
+                    return;
+                }
                 if (onClick) {
                     e.preventDefault();
                     onClick(e);

--- a/packages/antd/src/components/buttons/edit/index.tsx
+++ b/packages/antd/src/components/buttons/edit/index.tsx
@@ -77,6 +77,10 @@ export const EditButton: React.FC<EditButtonProps> = ({
             to={editUrl}
             replace={false}
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+                if (data?.can === false) {
+                    e.preventDefault();
+                    return;
+                }
                 if (onClick) {
                     e.preventDefault();
                     onClick(e);

--- a/packages/antd/src/components/buttons/list/index.tsx
+++ b/packages/antd/src/components/buttons/list/index.tsx
@@ -77,6 +77,10 @@ export const ListButton: React.FC<ListButtonProps> = ({
             to={listUrl}
             replace={false}
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+                if (data?.can === false) {
+                    e.preventDefault();
+                    return;
+                }
                 if (onClick) {
                     e.preventDefault();
                     onClick(e);

--- a/packages/antd/src/components/buttons/show/index.tsx
+++ b/packages/antd/src/components/buttons/show/index.tsx
@@ -77,6 +77,10 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
             to={showUrl}
             replace={false}
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+                if (data?.can === false) {
+                    e.preventDefault();
+                    return;
+                }
                 if (onClick) {
                     e.preventDefault();
                     onClick(e);

--- a/packages/mantine/src/components/buttons/clone/index.tsx
+++ b/packages/mantine/src/components/buttons/clone/index.tsx
@@ -79,6 +79,10 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
             to={cloneUrl}
             replace={false}
             onClick={(e: React.PointerEvent<HTMLButtonElement>) => {
+                if (data?.can === false) {
+                    e.preventDefault();
+                    return;
+                }
                 if (onClick) {
                     e.preventDefault();
                     onClick(e);

--- a/packages/mantine/src/components/buttons/create/index.tsx
+++ b/packages/mantine/src/components/buttons/create/index.tsx
@@ -71,6 +71,10 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
             to={createUrl}
             replace={false}
             onClick={(e: React.PointerEvent<HTMLButtonElement>) => {
+                if (data?.can === false) {
+                    e.preventDefault();
+                    return;
+                }
                 if (onClick) {
                     e.preventDefault();
                     onClick(e);

--- a/packages/mantine/src/components/buttons/edit/index.tsx
+++ b/packages/mantine/src/components/buttons/edit/index.tsx
@@ -78,6 +78,10 @@ export const EditButton: React.FC<EditButtonProps> = ({
             to={editUrl}
             replace={false}
             onClick={(e: React.PointerEvent<HTMLButtonElement>) => {
+                if (data?.can === false) {
+                    e.preventDefault();
+                    return;
+                }
                 if (onClick) {
                     e.preventDefault();
                     onClick(e);

--- a/packages/mantine/src/components/buttons/list/index.tsx
+++ b/packages/mantine/src/components/buttons/list/index.tsx
@@ -79,6 +79,10 @@ export const ListButton: React.FC<ListButtonProps> = ({
             to={listUrl}
             replace={false}
             onClick={(e: React.PointerEvent<HTMLButtonElement>) => {
+                if (data?.can === false) {
+                    e.preventDefault();
+                    return;
+                }
                 if (onClick) {
                     e.preventDefault();
                     onClick(e);

--- a/packages/mantine/src/components/buttons/show/index.tsx
+++ b/packages/mantine/src/components/buttons/show/index.tsx
@@ -78,6 +78,10 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
             to={showUrl}
             replace={false}
             onClick={(e: React.PointerEvent<HTMLButtonElement>) => {
+                if (data?.can === false) {
+                    e.preventDefault();
+                    return;
+                }
                 if (onClick) {
                     e.preventDefault();
                     onClick(e);

--- a/packages/mui/src/components/buttons/clone/index.tsx
+++ b/packages/mui/src/components/buttons/clone/index.tsx
@@ -76,6 +76,10 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
             to={cloneUrl}
             replace={false}
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+                if (data?.can === false) {
+                    e.preventDefault();
+                    return;
+                }
                 if (onClick) {
                     e.preventDefault();
                     onClick(e);

--- a/packages/mui/src/components/buttons/create/index.tsx
+++ b/packages/mui/src/components/buttons/create/index.tsx
@@ -75,6 +75,10 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
             to={createUrl}
             replace={false}
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+                if (data?.can === false) {
+                    e.preventDefault();
+                    return;
+                }
                 if (onClick) {
                     e.preventDefault();
                     onClick(e);

--- a/packages/mui/src/components/buttons/edit/index.tsx
+++ b/packages/mui/src/components/buttons/edit/index.tsx
@@ -75,6 +75,10 @@ export const EditButton: React.FC<EditButtonProps> = ({
             to={editUrl}
             replace={false}
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+                if (data?.can === false) {
+                    e.preventDefault();
+                    return;
+                }
                 if (onClick) {
                     e.preventDefault();
                     onClick(e);

--- a/packages/mui/src/components/buttons/list/index.tsx
+++ b/packages/mui/src/components/buttons/list/index.tsx
@@ -76,6 +76,10 @@ export const ListButton: React.FC<ListButtonProps> = ({
             to={listUrl}
             replace={false}
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+                if (data?.can === false) {
+                    e.preventDefault();
+                    return;
+                }
                 if (onClick) {
                     e.preventDefault();
                     onClick(e);

--- a/packages/mui/src/components/buttons/show/index.tsx
+++ b/packages/mui/src/components/buttons/show/index.tsx
@@ -75,6 +75,10 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
             to={showUrl}
             replace={false}
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+                if (data?.can === false) {
+                    e.preventDefault();
+                    return;
+                }
                 if (onClick) {
                     e.preventDefault();
                     onClick(e);


### PR DESCRIPTION
Buttons with links/navigation was ignoring access provider and the disabled status.

### Closing issues

Resolves #2828

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
