### PR TITLE
feat: `accessControl` prop on refine buttons

### DIFF
--- a/.changeset/fluffy-planes-return.md
+++ b/.changeset/fluffy-planes-return.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-ui-types": minor
+---
+
+Add `accessControl` prop to buttons and deprecate `ignoreAccessControlProvider` prop.

--- a/.changeset/many-trains-bake.md
+++ b/.changeset/many-trains-bake.md
@@ -1,0 +1,14 @@
+---
+"@pankod/refine-antd": minor
+"@pankod/refine-mantine": minor
+"@pankod/refine-mui": minor
+---
+
+**Deprecation**
+
+`ignoreAccessControlProvider` prop on buttons is deprecated. Use `accessContro.enabled` instead.
+
+**Features**
+
+`accessControl.enabled` prop is added to buttons to enable/disable access control for buttons.
+`accessControl.hideIfUnauthorized` prop is added to buttons to hide the button if access is denied.

--- a/.changeset/short-balloons-smell.md
+++ b/.changeset/short-balloons-smell.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+`useCan` hook was returning the stale value if same call is made with skipped access control.

--- a/documentation/docs/api-reference/antd/components/buttons/clone.md
+++ b/documentation/docs/api-reference/antd/components/buttons/clone.md
@@ -178,15 +178,15 @@ render(
 );
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
 ```tsx
 import { CloneButton } from "@pankod/refine-antd";
 
 export const MyListComponent = () => {
-    return <CloneButton ignoreAccessControlProvider />;
+    return <CloneButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/antd/components/buttons/create.md
+++ b/documentation/docs/api-reference/antd/components/buttons/create.md
@@ -77,15 +77,15 @@ export const MyCreateComponent = () => {
 };
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
-```tsx 
+```tsx
 import { CreateButton } from "@pankod/refine-antd";
 
 export const MyListComponent = () => {
-    return <CreateButton ignoreAccessControlProvider />;
+    return <CreateButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/antd/components/buttons/delete.md
+++ b/documentation/docs/api-reference/antd/components/buttons/delete.md
@@ -193,16 +193,15 @@ export const MyDeleteComponent = () => {
 };
 ```
 
+### `accessControl`
 
-### `ignoreAccessControlProvider`
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
-
-```tsx 
+```tsx
 import { DeleteButton } from "@pankod/refine-antd";
 
 export const MyListComponent = () => {
-    return <DeleteButton ignoreAccessControlProvider />;
+    return <DeleteButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/antd/components/buttons/edit.md
+++ b/documentation/docs/api-reference/antd/components/buttons/edit.md
@@ -103,15 +103,15 @@ export const MyEditComponent = () => {
 };
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
-```tsx 
+```tsx
 import { EditButton } from "@pankod/refine-antd";
 
 export const MyListComponent = () => {
-    return <EditButton ignoreAccessControlProvider />;
+    return <EditButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/antd/components/buttons/list.md
+++ b/documentation/docs/api-reference/antd/components/buttons/list.md
@@ -87,15 +87,15 @@ export const MyListComponent = () => {
 };
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
 ```tsx
 import { ListButton } from "@pankod/refine-antd";
 
 export const MyListComponent = () => {
-    return <ListButton ignoreAccessControlProvider />;
+    return <ListButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/antd/components/buttons/show.md
+++ b/documentation/docs/api-reference/antd/components/buttons/show.md
@@ -102,15 +102,15 @@ export const MyShowComponent = () => {
 };
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
-```tsx 
+```tsx
 import { ShowButton } from "@pankod/refine-antd";
 
-export const MyShowComponent = () => {
-    return <ShowButton ignoreAccessControlProvider />;
+export const MyListComponent = () => {
+    return <ShowButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/mantine/components/buttons/clone.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/clone.md
@@ -313,15 +313,15 @@ render(
 );
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
 ```tsx
 import { CloneButton } from "@pankod/refine-mantine";
 
 export const MyListComponent = () => {
-    return <CloneButton ignoreAccessControlProvider />;
+    return <CloneButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/mantine/components/buttons/create.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/create.md
@@ -249,15 +249,15 @@ render(
 );
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
 ```tsx
 import { CreateButton } from "@pankod/refine-mantine";
 
 export const MyListComponent = () => {
-    return <CreateButton ignoreAccessControlProvider />;
+    return <CreateButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/mantine/components/buttons/delete.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/delete.md
@@ -453,15 +453,15 @@ render(
 );
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
 ```tsx
 import { DeleteButton } from "@pankod/refine-mantine";
 
 export const MyListComponent = () => {
-    return <DeleteButton ignoreAccessControlProvider />;
+    return <DeleteButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/mantine/components/buttons/edit.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/edit.md
@@ -299,15 +299,15 @@ render(
 );
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
 ```tsx
 import { EditButton } from "@pankod/refine-mantine";
 
 export const MyListComponent = () => {
-    return <EditButton ignoreAccessControlProvider />;
+    return <EditButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/mantine/components/buttons/list.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/list.md
@@ -210,15 +210,15 @@ render(
 );
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
 ```tsx
 import { ListButton } from "@pankod/refine-mantine";
 
 export const MyListComponent = () => {
-    return <ListButton ignoreAccessControlProvider />;
+    return <ListButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/mantine/components/buttons/show.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/show.md
@@ -304,15 +304,15 @@ render(
 );
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
 ```tsx
 import { ShowButton } from "@pankod/refine-mantine";
 
-export const MyShowComponent = () => {
-    return <ShowButton ignoreAccessControlProvider />;
+export const MyListComponent = () => {
+    return <ShowButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/mui/components/buttons/clone.md
+++ b/documentation/docs/api-reference/mui/components/buttons/clone.md
@@ -123,15 +123,15 @@ export const MyCloneComponent = () => {
 };
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
 ```tsx
 import { CloneButton } from "@pankod/refine-mui";
 
 export const MyCloneComponent = () => {
-    return <CloneButton ignoreAccessControlProvider />;
+    return <CloneButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/mui/components/buttons/create.md
+++ b/documentation/docs/api-reference/mui/components/buttons/create.md
@@ -98,15 +98,15 @@ export const MyCreateComponent = () => {
 };
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
 ```tsx
 import { CreateButton } from "@pankod/refine-mui";
 
 export const MyListComponent = () => {
-    return <CreateButton ignoreAccessControlProvider />;
+    return <CreateButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/mui/components/buttons/delete.md
+++ b/documentation/docs/api-reference/mui/components/buttons/delete.md
@@ -252,15 +252,15 @@ export const MyDeleteComponent = () => {
 };
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
 ```tsx
 import { DeleteButton } from "@pankod/refine-mui";
 
 export const MyListComponent = () => {
-    return <DeleteButton ignoreAccessControlProvider />;
+    return <DeleteButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/mui/components/buttons/edit.md
+++ b/documentation/docs/api-reference/mui/components/buttons/edit.md
@@ -102,15 +102,15 @@ export const MyEditComponent = () => {
 };
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
 ```tsx
 import { EditButton } from "@pankod/refine-mui";
 
 export const MyListComponent = () => {
-    return <EditButton ignoreAccessControlProvider />;
+    return <EditButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/mui/components/buttons/list.md
+++ b/documentation/docs/api-reference/mui/components/buttons/list.md
@@ -90,15 +90,15 @@ export const MyListComponent = () => {
 };
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
 ```tsx
 import { ListButton } from "@pankod/refine-mui";
 
 export const MyListComponent = () => {
-    return <ListButton ignoreAccessControlProvider />;
+    return <ListButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/mui/components/buttons/show.md
+++ b/documentation/docs/api-reference/mui/components/buttons/show.md
@@ -120,16 +120,17 @@ export const MyShowComponent = () => {
 };
 ```
 
-### `ignoreAccessControlProvider`
+### `accessControl`
 
-It is used to skip access control for the button so that it doesn't check for access control. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
+This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/api-reference/core/providers/accessControl-provider.md) is provided to [`<Refine/>`](/api-reference/core/components/refine-config.md)
 
 ```tsx
 import { ShowButton } from "@pankod/refine-mui";
 
-export const MyShowComponent = () => {
-    return <ShowButton ignoreAccessControlProvider />;
+export const MyListComponent = () => {
+    return <ShowButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
 };
+```
 ```
 
 ## API Reference

--- a/packages/antd/src/components/buttons/clone/index.tsx
+++ b/packages/antd/src/components/buttons/clone/index.tsx
@@ -36,11 +36,15 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
     resourceNameOrRouteName: propResourceNameOrRouteName,
     recordItemId,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     children,
     onClick,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const { cloneUrl: generateCloneUrl } = useNavigation();
     const { Link } = useRouterContext();
 
@@ -57,7 +61,7 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
         action: "create",
         params: { id, resource },
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
     });
 
@@ -72,6 +76,10 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
     };
 
     const cloneUrl = generateCloneUrl(propResourceName ?? resource.route!, id!);
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Link

--- a/packages/antd/src/components/buttons/create/index.tsx
+++ b/packages/antd/src/components/buttons/create/index.tsx
@@ -34,11 +34,15 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
     resourceName: propResourceName,
     resourceNameOrRouteName: propResourceNameOrRouteName,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     children,
     onClick,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const translate = useTranslate();
 
     const { Link } = useRouterContext();
@@ -54,7 +58,7 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
         resource: resourceName,
         action: "create",
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
         params: {
             resource,
@@ -72,6 +76,10 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
     };
 
     const createUrl = generateCreateUrl(propResourceName ?? resource.route!);
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Link

--- a/packages/antd/src/components/buttons/delete/index.tsx
+++ b/packages/antd/src/components/buttons/delete/index.tsx
@@ -39,6 +39,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     successNotification,
     errorNotification,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     metaData,
     dataProviderName,
@@ -48,6 +49,9 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     invalidates,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const translate = useTranslate();
 
     const { resourceName, id, resource } = useResource({
@@ -67,9 +71,13 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
         action: "delete",
         params: { id, resource },
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
     });
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Popconfirm

--- a/packages/antd/src/components/buttons/edit/index.tsx
+++ b/packages/antd/src/components/buttons/edit/index.tsx
@@ -35,11 +35,15 @@ export const EditButton: React.FC<EditButtonProps> = ({
     resourceNameOrRouteName: propResourceNameOrRouteName,
     recordItemId,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     children,
     onClick,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const translate = useTranslate();
 
     const { editUrl: generateEditUrl } = useNavigation();
@@ -56,7 +60,7 @@ export const EditButton: React.FC<EditButtonProps> = ({
         action: "edit",
         params: { id, resource },
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
     });
 
@@ -71,6 +75,10 @@ export const EditButton: React.FC<EditButtonProps> = ({
     };
 
     const editUrl = generateEditUrl(propResourceName ?? resource.route!, id!);
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Link

--- a/packages/antd/src/components/buttons/list/index.tsx
+++ b/packages/antd/src/components/buttons/list/index.tsx
@@ -35,11 +35,15 @@ export const ListButton: React.FC<ListButtonProps> = ({
     resourceName: propResourceName,
     resourceNameOrRouteName: propResourceNameOrRouteName,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     children,
     onClick,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const { listUrl: generateListUrl } = useNavigation();
     const { Link } = useRouterContext();
     const translate = useTranslate();
@@ -53,7 +57,7 @@ export const ListButton: React.FC<ListButtonProps> = ({
         resource: resourceName,
         action: "list",
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
         params: {
             resource,
@@ -71,6 +75,10 @@ export const ListButton: React.FC<ListButtonProps> = ({
     };
 
     const listUrl = generateListUrl(propResourceName ?? resource.route!);
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Link

--- a/packages/antd/src/components/buttons/show/index.tsx
+++ b/packages/antd/src/components/buttons/show/index.tsx
@@ -35,11 +35,15 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
     resourceNameOrRouteName: propResourceNameOrRouteName,
     recordItemId,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     children,
     onClick,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const { showUrl: generateShowUrl } = useNavigation();
     const { Link } = useRouterContext();
 
@@ -56,7 +60,7 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
         action: "show",
         params: { id, resource },
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
     });
 
@@ -71,6 +75,10 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
     };
 
     const showUrl = generateShowUrl(propResourceName ?? resource.route!, id!);
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Link

--- a/packages/core/src/hooks/accessControl/useCan/index.ts
+++ b/packages/core/src/hooks/accessControl/useCan/index.ts
@@ -56,6 +56,7 @@ export const useCan = ({
                 action,
                 resource,
                 params: { ...paramsRest, resource: restResource },
+                enabled: queryOptions?.enabled,
             },
         ],
         // Enabled check for `can` is enough to be sure that it's defined in the query function but TS is not smart enough to know that.

--- a/packages/mantine/src/components/buttons/clone/index.tsx
+++ b/packages/mantine/src/components/buttons/clone/index.tsx
@@ -34,12 +34,16 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
     resourceNameOrRouteName,
     recordItemId,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     svgIconProps,
     children,
     onClick,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const { resourceName, resource, id } = useResource({
         resourceNameOrRouteName,
         recordItemId,
@@ -55,7 +59,7 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
         action: "create",
         params: { id, resource },
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
     });
 
@@ -72,6 +76,10 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
     const cloneUrl = generateCloneUrl(resource.route!, id!);
 
     const { variant, styles, ...commonProps } = rest;
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Anchor

--- a/packages/mantine/src/components/buttons/create/index.tsx
+++ b/packages/mantine/src/components/buttons/create/index.tsx
@@ -25,12 +25,16 @@ export type CreateButtonProps = RefineCreateButtonProps<
 export const CreateButton: React.FC<CreateButtonProps> = ({
     resourceNameOrRouteName,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     svgIconProps,
     children,
     onClick,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const { resource, resourceName } = useResource({
         resourceNameOrRouteName,
     });
@@ -44,7 +48,7 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
         resource: resourceName,
         action: "create",
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
         params: {
             resource,
@@ -64,6 +68,10 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
     const createUrl = generateCreateUrl(resource.route!);
 
     const { variant, styles, ...commonProps } = rest;
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Anchor

--- a/packages/mantine/src/components/buttons/delete/index.tsx
+++ b/packages/mantine/src/components/buttons/delete/index.tsx
@@ -44,6 +44,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     successNotification,
     errorNotification,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     metaData,
     dataProviderName,
@@ -53,6 +54,9 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     svgIconProps,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const { resourceName, id, resource } = useResource({
         resourceNameOrRouteName,
         recordItemId,
@@ -71,7 +75,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
         action: "delete",
         params: { id, resource },
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
     });
 
@@ -98,6 +102,10 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     };
 
     const { variant, styles, ...commonProps } = rest;
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Popover opened={opened} onChange={setOpened} withArrow withinPortal>

--- a/packages/mantine/src/components/buttons/edit/index.tsx
+++ b/packages/mantine/src/components/buttons/edit/index.tsx
@@ -33,12 +33,16 @@ export const EditButton: React.FC<EditButtonProps> = ({
     resourceNameOrRouteName,
     recordItemId,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     svgIconProps,
     children,
     onClick,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const { resourceName, resource, id } = useResource({
         resourceNameOrRouteName,
         recordItemId,
@@ -54,7 +58,7 @@ export const EditButton: React.FC<EditButtonProps> = ({
         action: "edit",
         params: { id, resource },
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
     });
 
@@ -71,6 +75,10 @@ export const EditButton: React.FC<EditButtonProps> = ({
     const editUrl = generateEditUrl(resource.route!, id!);
 
     const { variant, styles, ...commonProps } = rest;
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Anchor

--- a/packages/mantine/src/components/buttons/list/index.tsx
+++ b/packages/mantine/src/components/buttons/list/index.tsx
@@ -33,12 +33,16 @@ export type ListButtonProps = RefineListButtonProps<
 export const ListButton: React.FC<ListButtonProps> = ({
     resourceNameOrRouteName,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     svgIconProps,
     children,
     onClick,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const { resource, resourceName } = useResource({
         resourceNameOrRouteName,
     });
@@ -52,7 +56,7 @@ export const ListButton: React.FC<ListButtonProps> = ({
         resource: resourceName,
         action: "list",
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
         params: {
             resource,
@@ -72,6 +76,10 @@ export const ListButton: React.FC<ListButtonProps> = ({
     const listUrl = generateListUrl(resource.route!);
 
     const { variant, styles, ...commonProps } = rest;
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Anchor

--- a/packages/mantine/src/components/buttons/show/index.tsx
+++ b/packages/mantine/src/components/buttons/show/index.tsx
@@ -33,12 +33,16 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
     resourceNameOrRouteName,
     recordItemId,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     svgIconProps,
     children,
     onClick,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const { resourceName, id, resource } = useResource({
         resourceNameOrRouteName,
         recordItemId,
@@ -54,7 +58,7 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
         action: "show",
         params: { id, resource },
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
     });
 
@@ -71,6 +75,10 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
     const showUrl = generateShowUrl(resource.route!, id!);
 
     const { variant, styles, ...commonProps } = rest;
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Anchor

--- a/packages/mui/src/components/buttons/clone/index.tsx
+++ b/packages/mui/src/components/buttons/clone/index.tsx
@@ -32,12 +32,16 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
     resourceNameOrRouteName,
     recordItemId,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     svgIconProps,
     children,
     onClick,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const { resourceName, resource, id } = useResource({
         resourceNameOrRouteName,
         recordItemId,
@@ -53,7 +57,7 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
         action: "create",
         params: { id, resource },
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
     });
 
@@ -70,6 +74,10 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
     const cloneUrl = generateCloneUrl(resource.route!, id!);
 
     const { sx, ...restProps } = rest;
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Link

--- a/packages/mui/src/components/buttons/create/index.tsx
+++ b/packages/mui/src/components/buttons/create/index.tsx
@@ -30,12 +30,16 @@ export type CreateButtonProps = RefineCreateButtonProps<
 export const CreateButton: React.FC<CreateButtonProps> = ({
     resourceNameOrRouteName,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     svgIconProps,
     children,
     onClick,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const { resource, resourceName } = useResource({
         resourceNameOrRouteName,
     });
@@ -49,7 +53,7 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
         resource: resourceName,
         action: "create",
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
         params: {
             resource,
@@ -69,6 +73,10 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
     const createUrl = generateCreateUrl(resource.route!);
 
     const { sx, ...restProps } = rest;
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Link

--- a/packages/mui/src/components/buttons/delete/index.tsx
+++ b/packages/mui/src/components/buttons/delete/index.tsx
@@ -46,6 +46,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     successNotification,
     errorNotification,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     metaData,
     dataProviderName,
@@ -56,6 +57,9 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     invalidates,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const { resourceName, id, resource } = useResource({
         resourceNameOrRouteName,
         recordItemId,
@@ -74,7 +78,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
         action: "delete",
         params: { id, resource },
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
     });
 
@@ -110,6 +114,10 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     };
 
     const { sx, ...restProps } = rest;
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <div>

--- a/packages/mui/src/components/buttons/edit/index.tsx
+++ b/packages/mui/src/components/buttons/edit/index.tsx
@@ -31,12 +31,16 @@ export const EditButton: React.FC<EditButtonProps> = ({
     resourceNameOrRouteName,
     recordItemId,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     svgIconProps,
     children,
     onClick,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const { resourceName, resource, id } = useResource({
         resourceNameOrRouteName,
         recordItemId,
@@ -52,7 +56,7 @@ export const EditButton: React.FC<EditButtonProps> = ({
         action: "edit",
         params: { id, resource },
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
     });
 
@@ -69,6 +73,10 @@ export const EditButton: React.FC<EditButtonProps> = ({
     const editUrl = generateEditUrl(resource.route!, id!);
 
     const { sx, ...restProps } = rest;
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Link

--- a/packages/mui/src/components/buttons/list/index.tsx
+++ b/packages/mui/src/components/buttons/list/index.tsx
@@ -31,12 +31,16 @@ export type ListButtonProps = RefineListButtonProps<
 export const ListButton: React.FC<ListButtonProps> = ({
     resourceNameOrRouteName,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     svgIconProps,
     children,
     onClick,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const { resource, resourceName } = useResource({
         resourceNameOrRouteName,
     });
@@ -50,7 +54,7 @@ export const ListButton: React.FC<ListButtonProps> = ({
         resource: resourceName,
         action: "list",
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
         params: {
             resource,
@@ -70,6 +74,10 @@ export const ListButton: React.FC<ListButtonProps> = ({
     const listUrl = generateListUrl(resource.route!);
 
     const { sx, ...restProps } = rest;
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Link

--- a/packages/mui/src/components/buttons/show/index.tsx
+++ b/packages/mui/src/components/buttons/show/index.tsx
@@ -31,12 +31,16 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
     resourceNameOrRouteName,
     recordItemId,
     hideText = false,
+    accessControl,
     ignoreAccessControlProvider = false,
     svgIconProps,
     children,
     onClick,
     ...rest
 }) => {
+    const accessControlEnabled =
+        accessControl?.enabled ?? !ignoreAccessControlProvider;
+    const hideIfUnauthorized = accessControl?.hideIfUnauthorized ?? false;
     const { resourceName, id, resource } = useResource({
         resourceNameOrRouteName,
         recordItemId,
@@ -52,7 +56,7 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
         action: "show",
         params: { id, resource },
         queryOptions: {
-            enabled: !ignoreAccessControlProvider,
+            enabled: accessControlEnabled,
         },
     });
 
@@ -69,6 +73,10 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
     const showUrl = generateShowUrl(resource.route!, id!);
 
     const { sx, ...restProps } = rest;
+
+    if (accessControlEnabled && hideIfUnauthorized && !data?.can) {
+        return null;
+    }
 
     return (
         <Link

--- a/packages/ui-types/src/types/button.tsx
+++ b/packages/ui-types/src/types/button.tsx
@@ -23,8 +23,17 @@ export type RefineButtonResourceProps = {
     resourceNameOrRouteName?: string;
     /**
      * Whether to skip access control for the resource and the delete action or not
+     * @deprecated `ignoreAccessControlProvider` deprecated. Use `accessControl.enabled` instead.
      */
     ignoreAccessControlProvider?: boolean;
+    /**
+     * Access Control configuration for the button
+     * @default `{ enabled: true }`
+     */
+    accessControl?: {
+        enabled?: boolean;
+        hideIfUnauthorized?: boolean;
+    };
 };
 
 export type RefineButtonLinkingProps = {


### PR DESCRIPTION
Replaced `ignoreAccessControlProvider` prop with `accessControl.enabled` and added `accessControl.hideIfUnauthorized` prop to hide the button if access control is denied.

### Closing issues

Resolves #2831 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
