### PR TITLE
build: configure `lint-staged`

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint:fix
+npm run lint:staged

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bootstrap": "cd packages/codemod && npm ci && cd ../.. && lerna bootstrap --hoist --strict  --ignore @pankod/refine-codemod --ignore @pankod/refine-react-router --scope @pankod/refine*",
     "lint": "eslint -c ./.eslintrc packages examples",
     "lint:fix": "npm run lint -- --quiet --fix",
+    "lint:staged": "lint-staged",
     "build": "lerna run build --ignore @pankod/refine-react-router --scope @pankod/refine*",
     "start:docs": "concurrently \"cd documentation && npm run start\" \"npm run start -- --scope @pankod/refine-live-previews\" --names docs,live --prefix-colors blue,red",
     "nuke": "rm -rf node_modules; for d in for d in packages/*/node_modules; do echo $d; rm -rf $d; done; for d in for d in packages/*/dist; do echo $d; rm -rf $d; done; for d in packages/*/dist; do echo $d; rm -rf $d; done; for d in examples/*/node_modules; do echo $d; rm -rf $d; done;  for d in examples/*/package-lock.json; do echo $d; rm -rf $d; done;",
@@ -23,7 +24,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "npm run lint:fix"
+      "eslint -c ./.eslintrc --quiet --fix"
     ]
   },
   "name": "refinejs-repo",


### PR DESCRIPTION
Pre-commit hook was not working as expected and linting all files without cache which was increasing the verification duration to ~15-20 secs. Updated `lint-staged` configuration to lint only staged files to save us some development time. 

This change should not have any effects on CI and other checks.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
