### PR TITLE
feat: add `<PropsTable/>` to packages

### DIFF
--- a/documentation/docs/packages/documentation/command-palette.md
+++ b/documentation/docs/packages/documentation/command-palette.md
@@ -123,7 +123,7 @@ useRegisterActions(customAction);
 ```
 
 :::tip
-`refine-kbar` export the `kbar`. You can use all `kbar` features.
+`refine-kbar` exports the [`kbar`](https://github.com/timc1/kbar). You can use all [`kbar`](https://github.com/timc1/kbar) features.
 :::
 
 ## Live StackBlitz Example

--- a/documentation/docs/packages/documentation/react-hook-form/useForm.md
+++ b/documentation/docs/packages/documentation/react-hook-form/useForm.md
@@ -418,9 +418,15 @@ export const PostCreate: React.FC = () => {
 
 ### Properties
 
-Supports all the properties supported by the `useForm` hook are available in the [React Hook Form][react-hook-form] documentation. Also, we added the following property:
+<PropsTable module="@pankod/refine-react-hook-form/useForm" />
 
-`refineCoreProps`: You can define all properties provided by [`useForm`][use-form-core] here. You can see all of them in [here](/api-reference/core/hooks/useForm.md#properties).
+> `*`: These properties have default values in `RefineContext` and can also be set on the **<[Refine](/api-reference/core/components/refine-config.md)>** component.
+
+:::tip External Props
+It also accepts all props of [useForm](https://react-hook-form.com/api/useform) hook available in the  [React Hook Form](https://react-hook-form.com/).
+:::
+
+<br/>
 
 > For example, we can define the `refineCoreProps` property in the `useForm` hook as:
 

--- a/documentation/docs/packages/documentation/react-hook-form/useModalForm.md
+++ b/documentation/docs/packages/documentation/react-hook-form/useModalForm.md
@@ -388,21 +388,13 @@ export const EditPost: React.FC<UseModalFormReturnType> = ({
 
 ### Properties
 
-| Property                   | Description                                                         | Type                                                |
-| -------------------------- | ------------------------------------------------------------------- | --------------------------------------------------- |
-| modalProps                 | Configuration object for the modal                                  | [`ModalPropsType`](#modalpropstype)                 |
-| refineCoreProps            | Configuration object for the core of the [`useForm`][use-form-core] | [`UseFormProps`](/api-reference/core/hooks/useForm.md#properties) |
-| React Hook Form Properties | See [React Hook Form][react-hook-form-use-form] documentation       |
+<PropsTable module="@pankod/refine-react-hook-form/useModalForm" />
 
-<br />
+> `*`: These properties have default values in `RefineContext` and can also be set on the **<[Refine](/api-reference/core/components/refine-config.md)>** component.
 
-> -   #### ModalPropsType
->
-> | Property        | Description                                                   | Type      | Default |
-> | --------------- | ------------------------------------------------------------- | --------- | ------- |
-> | defaultVisible  | Initial visibility state of the modal                         | `boolean` | `false` |
-> | autoSubmitClose | Whether the form should be submitted when the modal is closed | `boolean` | `true`  |
-> | autoResetForm   | Whether the form should be reset when the form is submitted   | `boolean` | `true`  |
+:::tip External Props
+It also accepts all props of [useForm](https://react-hook-form.com/api/useform) hook available in the  [React Hook Form](https://react-hook-form.com/).
+:::
 
 ### Return values
 

--- a/documentation/docs/packages/documentation/react-hook-form/useStepsForm.md
+++ b/documentation/docs/packages/documentation/react-hook-form/useStepsForm.md
@@ -427,20 +427,13 @@ export const PostEdit: React.FC = () => {
 
 ### Properties
 
-| Property                   | Description                                                         | Type                                                |
-| -------------------------- | ------------------------------------------------------------------- | --------------------------------------------------- |
-| stepsProps                 | Configuration object for the steps                                  | [`StepsPropsType`](#stepspropstype)                 |
-| refineCoreProps            | Configuration object for the core of the [`useForm`][use-form-core] | [`UseFormProps`](/api-reference/core/hooks/useForm.md#properties) |
-| React Hook Form Properties | See [React Hook Form][react-hook-form-use-form] documentation       |
+<PropsTable module="@pankod/refine-react-hook-form/useStepsForm" />
 
-<br />
+> `*`: These properties have default values in `RefineContext` and can also be set on the **<[Refine](/api-reference/core/components/refine-config.md)>** component.
 
-> -   #### StepsPropsType
->
-> | Property       | Description                                             | Type      | Default |
-> | -------------- | ------------------------------------------------------- | --------- | ------- |
-> | defaultStep    | Allows you to set the initial step                      | `number`  | `0`     |
-> | isBackValidate | Whether to validation the current step when going back. | `boolean` | `false` |
+:::tip External Props
+It also accepts all props of [useForm](https://react-hook-form.com/api/useform) hook available in the  [React Hook Form](https://react-hook-form.com/).
+:::
 
 ### Return values
 

--- a/documentation/docs/packages/documentation/react-table.md
+++ b/documentation/docs/packages/documentation/react-table.md
@@ -626,10 +626,11 @@ export const PostList: React.FC = () => {
 
 ### Properties
 
-| Property                  | Description                                                                                   | Type                                                  |
-| ------------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| refineCoreProps           | Configuration object for the core of the [`useTable`][use-table-core]                         | [`UseTableProps`](/api-reference/core/hooks/useTable.md#properties) |
-| Tanstack Table Properties | See [TanStack Table](https://tanstack.com/table/v8/docs/api/core/table#options) documentation |
+<PropsTable module="@pankod/refine-react-table/useTable" />
+
+:::tip External Props
+It also accepts all props of [TanStack Table](https://tanstack.com/table/v8/docs/api/core/table#options).
+:::
 
 ### Type Parameters
 

--- a/documentation/src/components/tooltip/index.tsx
+++ b/documentation/src/components/tooltip/index.tsx
@@ -1,4 +1,5 @@
 import React, { FC, PropsWithChildren, ReactNode } from "react";
+import styles from "./styles.module.css";
 
 type Props = {
     label?: ReactNode;
@@ -8,13 +9,11 @@ const Tooltip: FC<PropsWithChildren<Props>> = ({ label, children }) => {
     if (!label) return <>{children}</>;
 
     return (
-        <div className="relative flex flex-col items-center group">
+        <div className={`${styles.tooltip} group`}>
             {children}
-            <div className="absolute bottom-0 left-0 flex flex-col items-center invisible mb-6 transition-all ease-out delay-75 group-hover:visible">
-                <span className="relative z-50 p-2 text-white bg-black rounded-sm shadow-2xl w-60">
-                    {label}
-                </span>
-                <div className="w-3 h-3 -mt-2 rotate-45 bg-black" />
+            <div className={`${styles.tooltipContainer} group-hover:visible`}>
+                <span className={styles.tooltipContent}>{label}</span>
+                <div className={styles.tooltipArrow} />
             </div>
         </div>
     );

--- a/documentation/src/components/tooltip/styles.module.css
+++ b/documentation/src/components/tooltip/styles.module.css
@@ -1,0 +1,21 @@
+.tooltip {
+    z-index: var(--ifm-z-index-overlay);
+    @apply relative flex flex-col items-center;
+}
+
+.tooltipContainer {
+    background: var(--ifm-background-color);
+    border: 1px solid var(--ifm-toc-border-color);
+    @apply absolute bottom-0 left-0 flex flex-col items-center invisible mb-6 transition-all ease-out delay-75 border rounded-sm shadow-lg;
+}
+
+.tooltipContent {
+    @apply relative p-2 w-60;
+}
+
+.tooltipArrow {
+    background: var(--ifm-background-color);
+    border-right: 1px solid var(--ifm-toc-border-color);
+    border-bottom: 1px solid var(--ifm-toc-border-color);
+    @apply absolute bottom-0 w-3 h-3 rotate-45 translate-y-2/4;
+}

--- a/packages/antd/src/components/buttons/clone/index.tsx
+++ b/packages/antd/src/components/buttons/clone/index.tsx
@@ -18,7 +18,7 @@ export type CloneButtonProps = RefineCloneButtonProps<
     {
         /**
          * Resource name for API data interactions
-         * @deprecated resourceName deprecated. Use resourceNameOrRouteName instead [Github Issue #1618](https://github.com/refinedev/refine/issues/1618)
+         * @deprecated `resourceName` deprecated. Use `resourceNameOrRouteName` instead [Github Issue #1618](https://github.com/refinedev/refine/issues/1618)
          */
         resourceName?: string;
     }

--- a/packages/react-hook-form/src/useForm/index.ts
+++ b/packages/react-hook-form/src/useForm/index.ts
@@ -36,7 +36,15 @@ export type UseFormProps<
     TVariables extends FieldValues = FieldValues,
     TContext extends object = {},
 > = {
+    /**
+     * Configuration object for the core of the [useForm](/docs/api-reference/core/hooks/useForm/)
+     * @type [`UseFormCoreProps<TData, TError, TVariables>`](/docs/api-reference/core/hooks/useForm/#properties)
+     */
     refineCoreProps?: UseFormCoreProps<TData, TError, TVariables>;
+    /**
+     * When you have unsaved changes and try to leave the current page, **refine** shows a confirmation modal box.
+     * @default `false*`
+     */
     warnWhenUnsavedChanges?: boolean;
 } & UseHookFormProps<TVariables, TContext>;
 

--- a/packages/react-hook-form/src/useModalForm/index.ts
+++ b/packages/react-hook-form/src/useModalForm/index.ts
@@ -34,6 +34,20 @@ export type UseModalFormProps<
     TVariables extends FieldValues = FieldValues,
     TContext extends object = {},
 > = UseFormProps<TData, TError, TVariables, TContext> & {
+    /**
+     * @description Configuration object for the modal.
+     * `defaultVisible`: Initial visibility state of the modal.
+     * 
+     * `autoSubmitClose`: Whether the form should be submitted when the modal is closed.
+     * 
+     * `autoResetForm`: Whether the form should be reset when the form is submitted.
+     * @type `{
+      defaultVisible?: boolean;
+      autoSubmitClose?: boolean;
+      autoResetForm?: boolean;
+      }`
+     * @default `defaultVisible = false` `autoSubmitClose = true` `autoResetForm = true`
+     */
     modalProps?: {
         defaultVisible?: boolean;
         autoSubmitClose?: boolean;

--- a/packages/react-hook-form/src/useStepsForm/index.ts
+++ b/packages/react-hook-form/src/useStepsForm/index.ts
@@ -22,6 +22,17 @@ export type UseStepsFormProps<
     TVariables extends FieldValues = FieldValues,
     TContext extends object = {},
 > = UseFormProps<TData, TError, TVariables, TContext> & {
+    /**
+     * @description Configuration object for the steps.
+     * `defaultStep`: Allows you to set the initial step.
+     * 
+     * `isBackValidate`: Whether to validation the current step when going back.
+     * @type `{
+      defaultStep?: number;
+      isBackValidate?: boolean;
+      }`
+     * @default `defaultStep = 0` `isBackValidate = false`
+     */
     stepsProps?: {
         defaultStep?: number;
         isBackValidate?: boolean;

--- a/packages/react-table/src/useTable/index.ts
+++ b/packages/react-table/src/useTable/index.ts
@@ -31,6 +31,10 @@ export type UseTableProps<
     TData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
 > = {
+    /**
+     * Configuration object for the core of the [useTable](/docs/api-reference/core/hooks/useTable/)
+     * @type [`useTablePropsCore<TData, TError>`](/docs/api-reference/core/hooks/useTable/#properties)
+     */
     refineCoreProps?: useTablePropsCore<TData, TError>;
 } & Pick<TableOptions<TData>, "columns"> &
     Partial<Omit<TableOptions<TData>, "columns">>;


### PR DESCRIPTION
### <PropsTable/> added to following docs.
1. [React Table](https://refine.dev/docs/packages/documentation/react-table/)
2. [useForm](https://refine.dev/docs/packages/documentation/react-hook-form/useForm/)
3. [useModalForm](https://refine.dev/docs/packages/documentation/react-hook-form/useModalForm/)
4. [useStepsForm](https://refine.dev/docs/packages/documentation/react-hook-form/useStepsForm/)

### Tooltip light theme fixed. 

Before
![image](https://user-images.githubusercontent.com/23058882/196937395-a3893046-9446-4eed-aa87-c60805698d85.png)

After
![image](https://user-images.githubusercontent.com/23058882/196937248-917b061c-910e-4088-9448-0ccd031126f3.png)


Please check all items below before review.

-   [ ] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
