### PR TITLE
fix(mantine): `userFormInput` generic type

### DIFF
--- a/.changeset/seven-mirrors-brush.md
+++ b/.changeset/seven-mirrors-brush.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mantine": patch
+---
+
+fixed: Mantine UserFormInput requires 2 type argument(s).

--- a/packages/mantine/src/components/pages/auth/index.tsx
+++ b/packages/mantine/src/components/pages/auth/index.tsx
@@ -10,7 +10,7 @@ import {
     UpdatePasswordPage,
 } from "./components";
 
-export type FormPropsType = UseFormInput<{}> & {
+export type FormPropsType = UseFormInput<{}, any> & {
     onSubmit: (values: any) => void;
 };
 


### PR DESCRIPTION
fixed: Mantine UserFormInput requires 2 type argument(s).

-   [ ] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
