### PR TITLE
Fix tailwind preflight override of button module css (#2821)

### DIFF
--- a/examples/store/src/components/address/AddAddress/AddAddress.tsx
+++ b/examples/store/src/components/address/AddAddress/AddAddress.tsx
@@ -204,14 +204,16 @@ export const AddAddress: React.FC = () => {
                         </div>
                         <div className="mt-4">
                             <Button
-                                className="min-h-0 !border-gray-200 !bg-gray-200 !text-gray-900"
+                                variant="flat"
+                                className="min-h-0 !border-gray-200 !bg-gray-200 !text-gray-900 hover:!bg-gray-100 hover:!border-gray-100"
                                 onClick={handleClose}
                             >
                                 Cancel
                             </Button>
                             <Button
+                                variant="flat"
                                 type="submit"
-                                className="min-h-0"
+                                className="min-h-0 hover:!border-accent-6"
                                 disabled={formLoading}
                             >
                                 Save

--- a/examples/store/src/components/common/UserNav/UserNav.module.css
+++ b/examples/store/src/components/common/UserNav/UserNav.module.css
@@ -8,11 +8,11 @@
 
 .item {
   @apply ml-6 cursor-pointer relative transition ease-in-out
-  duration-100 flex items-center outline-none text-primary;
+  duration-100 flex items-center outline-none text-primary !important;
 }
 
 .item:hover {
-  @apply text-accent-6 transition scale-110 duration-100;
+  @apply text-accent-6 transition scale-110 duration-100 !important;
 }
 
 .item:first-child {
@@ -21,11 +21,11 @@
 
 .item:focus,
 .item:active {
-  @apply outline-none;
+  @apply outline-none !important;
 }
 
 .bagCount {
-  @apply border border-accent-1 bg-secondary text-secondary absolute rounded-full right-3 top-3 flex items-center justify-center font-bold text-xs;
+  @apply border border-accent-1 bg-secondary text-secondary absolute rounded-full right-3 top-3 flex items-center justify-center font-bold text-xs !important;
   padding-left: 2.5px;
   padding-right: 2.5px;
   min-width: 1.25rem;
@@ -37,16 +37,16 @@
 }
 
 .mobileMenu {
-  @apply flex lg:hidden ml-6 text-white;
+  @apply flex lg:hidden ml-6 text-white !important;
 }
 
 .avatarButton:focus,
 .mobileMenu:focus {
-  @apply outline-none;
+  @apply outline-none !important;
 }
 
 .dropdownDesktop {
-  @apply hidden -z-10;
+  @apply hidden -z-10 !important;
 }
 
 @media screen(lg) {

--- a/examples/store/src/components/ui/Button/Button.module.css
+++ b/examples/store/src/components/ui/Button/Button.module.css
@@ -3,50 +3,50 @@
   px-10 py-5 leading-6 transition ease-in-out duration-150
   shadow-sm text-center justify-center uppercase
   border border-transparent items-center text-sm font-semibold
-  tracking-wide;
+  tracking-wide !important;
   max-height: 64px;
 }
 
 .root:hover {
-  @apply border-accent-9 bg-accent-6;
+  @apply border-accent-9 bg-accent-6 !important;
 }
 
 .root:focus {
-  @apply shadow-outline-normal outline-none;
+  @apply shadow-outline-normal outline-none !important;
 }
 
 .root[data-active] {
-  @apply bg-accent-6;
+  @apply bg-accent-6 !important;
 }
 
 .loading {
-  @apply bg-accent-1 text-accent-3 border-accent-2 cursor-not-allowed;
+  @apply bg-accent-1 text-accent-3 border-accent-2 cursor-not-allowed !important;
 }
 
 .slim {
-  @apply py-2 transform-none normal-case;
+  @apply py-2 transform-none normal-case !important;
 }
 
 .ghost {
-  @apply border border-accent-2 bg-accent-0 text-accent-9 text-sm;
+  @apply border border-accent-2 bg-accent-0 text-accent-9 text-sm !important;
 }
 
 .ghost:hover {
-  @apply border-accent-9 bg-accent-9 text-accent-0;
+  @apply border-accent-9 bg-accent-9 text-accent-0 !important;
 }
 
 .naked {
-  @apply bg-transparent font-semibold border-none shadow-none outline-none py-0 px-0;
+  @apply bg-transparent font-semibold border-none shadow-none outline-none py-0 px-0 !important;
 }
 
 .naked:hover,
 .naked:focus {
-  @apply bg-transparent border-none;
+  @apply bg-transparent border-none !important;
 }
 
 .disabled,
 .disabled:hover {
-  @apply text-accent-4 border-accent-2 bg-accent-1 cursor-not-allowed;
+  @apply text-accent-4 border-accent-2 bg-accent-1 cursor-not-allowed !important;
   filter: grayscale(1);
   -webkit-transform: translateZ(0);
   -webkit-perspective: 1000;


### PR DESCRIPTION
Override Tailwind preflight in `Button.module.css`
We cannot disable preflight it is needed for other components
See https://github.com/tailwindlabs/tailwindcss/issues/6602 and https://github.com/tailwindlabs/tailwindcss/discussions/5969
This css file never worked properly so most of the buttons are styled using tailwind classes. All buttons might need to be checked and styled accordingly.
The buttons for the `add address` modal have been styled.

### Test plan (required)

`!important` has been added for every property in  `Button.module.css`  in order to override preflight

<!-- Make sure tests pass. -->

### Closing issues

Closes #2821 

### Self Check before Merge

Please check all items below before review.

-   [ ] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
