### PR TITLE
fix(mantine): add show pages to examples

### DIFF
--- a/examples/authentication/mantine/src/App.tsx
+++ b/examples/authentication/mantine/src/App.tsx
@@ -14,7 +14,7 @@ import dataProvider from "@pankod/refine-simple-rest";
 import routerProvider from "@pankod/refine-react-router-v6";
 import { IconBrandGoogle, IconBrandGithub } from "@tabler/icons";
 
-import { PostCreate, PostEdit, PostList } from "./pages";
+import { PostCreate, PostEdit, PostList, PostShow } from "./pages";
 
 const App: React.FC = () => {
     const authProvider: AuthProvider = {
@@ -143,6 +143,7 @@ const App: React.FC = () => {
                         {
                             name: "posts",
                             list: PostList,
+                            show: PostShow,
                             edit: PostEdit,
                             create: PostCreate,
                         },

--- a/examples/authentication/mantine/src/pages/posts/index.ts
+++ b/examples/authentication/mantine/src/pages/posts/index.ts
@@ -1,3 +1,4 @@
 export * from "./list";
 export * from "./create";
 export * from "./edit";
+export * from "./show";

--- a/examples/authentication/mantine/src/pages/posts/list.tsx
+++ b/examples/authentication/mantine/src/pages/posts/list.tsx
@@ -9,6 +9,7 @@ import {
     Select,
     Table,
     Pagination,
+    ShowButton,
     EditButton,
     DeleteButton,
     DateField,
@@ -89,6 +90,10 @@ export const PostList: React.FC = () => {
                 cell: function render({ getValue }) {
                     return (
                         <Group spacing="xs" noWrap>
+                            <ShowButton
+                                hideText
+                                recordItemId={getValue() as number}
+                            />
                             <EditButton
                                 hideText
                                 recordItemId={getValue() as number}

--- a/examples/authentication/mantine/src/pages/posts/show.tsx
+++ b/examples/authentication/mantine/src/pages/posts/show.tsx
@@ -1,0 +1,45 @@
+import { useShow, useOne } from "@pankod/refine-core";
+import { Show, Title, Text, MarkdownField } from "@pankod/refine-mantine";
+
+import { ICategory, IPost } from "../../interfaces";
+
+export const PostShow: React.FC = () => {
+    const { queryResult } = useShow<IPost>();
+    const { data, isLoading } = queryResult;
+    const record = data?.data;
+
+    const { data: categoryData } = useOne<ICategory>({
+        resource: "categories",
+        id: record?.category.id || "",
+        queryOptions: {
+            enabled: !!record?.category.id,
+        },
+    });
+
+    return (
+        <Show isLoading={isLoading}>
+            <Title order={5}>Id</Title>
+            <Text mt="xs">{record?.id}</Text>
+
+            <Title mt="xs" order={5}>
+                Title
+            </Title>
+            <Text mt="xs">{record?.title}</Text>
+
+            <Title mt="xs" order={5}>
+                Status
+            </Title>
+            <Text mt="xs">{record?.status}</Text>
+
+            <Title mt="xs" order={5}>
+                Category
+            </Title>
+            <Text mt="xs">{categoryData?.data?.title}</Text>
+
+            <Title mt="xs" order={5}>
+                Content
+            </Title>
+            <MarkdownField value={record?.content} />
+        </Show>
+    );
+};

--- a/examples/base/mantine/src/App.tsx
+++ b/examples/base/mantine/src/App.tsx
@@ -12,7 +12,7 @@ import {
 import dataProvider from "@pankod/refine-simple-rest";
 import routerProvider from "@pankod/refine-react-router-v6";
 
-import { PostCreate, PostEdit, PostList } from "./pages";
+import { PostCreate, PostEdit, PostList, PostShow } from "./pages";
 
 const App: React.FC = () => {
     return (
@@ -32,6 +32,7 @@ const App: React.FC = () => {
                         {
                             name: "posts",
                             list: PostList,
+                            show: PostShow,
                             edit: PostEdit,
                             create: PostCreate,
                         },

--- a/examples/base/mantine/src/pages/posts/index.ts
+++ b/examples/base/mantine/src/pages/posts/index.ts
@@ -1,3 +1,4 @@
 export * from "./list";
 export * from "./create";
 export * from "./edit";
+export * from "./show";

--- a/examples/base/mantine/src/pages/posts/list.tsx
+++ b/examples/base/mantine/src/pages/posts/list.tsx
@@ -9,6 +9,7 @@ import {
     Select,
     Table,
     Pagination,
+    ShowButton,
     EditButton,
     DeleteButton,
     DateField,
@@ -89,6 +90,10 @@ export const PostList: React.FC = () => {
                 cell: function render({ getValue }) {
                     return (
                         <Group spacing="xs" noWrap>
+                            <ShowButton
+                                hideText
+                                recordItemId={getValue() as number}
+                            />
                             <EditButton
                                 hideText
                                 recordItemId={getValue() as number}

--- a/examples/base/mantine/src/pages/posts/show.tsx
+++ b/examples/base/mantine/src/pages/posts/show.tsx
@@ -1,0 +1,45 @@
+import { useShow, useOne } from "@pankod/refine-core";
+import { Show, Title, Text, MarkdownField } from "@pankod/refine-mantine";
+
+import { ICategory, IPost } from "../../interfaces";
+
+export const PostShow: React.FC = () => {
+    const { queryResult } = useShow<IPost>();
+    const { data, isLoading } = queryResult;
+    const record = data?.data;
+
+    const { data: categoryData } = useOne<ICategory>({
+        resource: "categories",
+        id: record?.category.id || "",
+        queryOptions: {
+            enabled: !!record?.category.id,
+        },
+    });
+
+    return (
+        <Show isLoading={isLoading}>
+            <Title order={5}>Id</Title>
+            <Text mt="xs">{record?.id}</Text>
+
+            <Title mt="xs" order={5}>
+                Title
+            </Title>
+            <Text mt="xs">{record?.title}</Text>
+
+            <Title mt="xs" order={5}>
+                Status
+            </Title>
+            <Text mt="xs">{record?.status}</Text>
+
+            <Title mt="xs" order={5}>
+                Category
+            </Title>
+            <Text mt="xs">{categoryData?.data?.title}</Text>
+
+            <Title mt="xs" order={5}>
+                Content
+            </Title>
+            <MarkdownField value={record?.content} />
+        </Show>
+    );
+};

--- a/examples/customization/customTheme/mantine/src/App.tsx
+++ b/examples/customization/customTheme/mantine/src/App.tsx
@@ -16,7 +16,7 @@ import {
 import dataProvider from "@pankod/refine-simple-rest";
 import routerProvider from "@pankod/refine-react-router-v6";
 
-import { PostCreate, PostEdit, PostList } from "./pages";
+import { PostCreate, PostEdit, PostList, PostShow } from "./pages";
 import { Header } from "./components";
 
 const App: React.FC = () => {
@@ -56,6 +56,7 @@ const App: React.FC = () => {
                         resources={[
                             {
                                 name: "posts",
+                                show: PostShow,
                                 list: PostList,
                                 edit: PostEdit,
                                 create: PostCreate,

--- a/examples/customization/customTheme/mantine/src/pages/posts/index.ts
+++ b/examples/customization/customTheme/mantine/src/pages/posts/index.ts
@@ -1,3 +1,4 @@
 export * from "./list";
 export * from "./create";
 export * from "./edit";
+export * from "./show";

--- a/examples/customization/customTheme/mantine/src/pages/posts/list.tsx
+++ b/examples/customization/customTheme/mantine/src/pages/posts/list.tsx
@@ -9,6 +9,7 @@ import {
     Select,
     Table,
     Pagination,
+    ShowButton,
     EditButton,
     DeleteButton,
     DateField,
@@ -89,6 +90,10 @@ export const PostList: React.FC = () => {
                 cell: function render({ getValue }) {
                     return (
                         <Group spacing="xs" noWrap>
+                            <ShowButton
+                                hideText
+                                recordItemId={getValue() as number}
+                            />
                             <EditButton
                                 hideText
                                 recordItemId={getValue() as number}

--- a/examples/customization/customTheme/mantine/src/pages/posts/show.tsx
+++ b/examples/customization/customTheme/mantine/src/pages/posts/show.tsx
@@ -1,0 +1,45 @@
+import { useShow, useOne } from "@pankod/refine-core";
+import { Show, Title, Text, MarkdownField } from "@pankod/refine-mantine";
+
+import { ICategory, IPost } from "../../interfaces";
+
+export const PostShow: React.FC = () => {
+    const { queryResult } = useShow<IPost>();
+    const { data, isLoading } = queryResult;
+    const record = data?.data;
+
+    const { data: categoryData } = useOne<ICategory>({
+        resource: "categories",
+        id: record?.category.id || "",
+        queryOptions: {
+            enabled: !!record?.category.id,
+        },
+    });
+
+    return (
+        <Show isLoading={isLoading}>
+            <Title order={5}>Id</Title>
+            <Text mt="xs">{record?.id}</Text>
+
+            <Title mt="xs" order={5}>
+                Title
+            </Title>
+            <Text mt="xs">{record?.title}</Text>
+
+            <Title mt="xs" order={5}>
+                Status
+            </Title>
+            <Text mt="xs">{record?.status}</Text>
+
+            <Title mt="xs" order={5}>
+                Category
+            </Title>
+            <Text mt="xs">{categoryData?.data?.title}</Text>
+
+            <Title mt="xs" order={5}>
+                Content
+            </Title>
+            <MarkdownField value={record?.content} />
+        </Show>
+    );
+};

--- a/examples/upload/mantine/base64/src/App.tsx
+++ b/examples/upload/mantine/base64/src/App.tsx
@@ -12,7 +12,7 @@ import {
 import dataProvider from "@pankod/refine-simple-rest";
 import routerProvider from "@pankod/refine-react-router-v6";
 
-import { PostCreate, PostEdit, PostList } from "./pages";
+import { PostCreate, PostEdit, PostList, PostShow } from "./pages";
 
 const App: React.FC = () => {
     return (
@@ -32,6 +32,7 @@ const App: React.FC = () => {
                         {
                             name: "posts",
                             list: PostList,
+                            show: PostShow,
                             edit: PostEdit,
                             create: PostCreate,
                         },

--- a/examples/upload/mantine/base64/src/pages/posts/index.ts
+++ b/examples/upload/mantine/base64/src/pages/posts/index.ts
@@ -1,3 +1,4 @@
 export * from "./list";
 export * from "./create";
 export * from "./edit";
+export * from "./show";

--- a/examples/upload/mantine/base64/src/pages/posts/list.tsx
+++ b/examples/upload/mantine/base64/src/pages/posts/list.tsx
@@ -9,6 +9,7 @@ import {
     Select,
     Table,
     Pagination,
+    ShowButton,
     EditButton,
     DeleteButton,
     DateField,
@@ -89,6 +90,10 @@ export const PostList: React.FC = () => {
                 cell: function render({ getValue }) {
                     return (
                         <Group spacing="xs" noWrap>
+                            <ShowButton
+                                hideText
+                                recordItemId={getValue() as number}
+                            />
                             <EditButton
                                 hideText
                                 recordItemId={getValue() as number}

--- a/examples/upload/mantine/base64/src/pages/posts/show.tsx
+++ b/examples/upload/mantine/base64/src/pages/posts/show.tsx
@@ -1,0 +1,45 @@
+import { useShow, useOne } from "@pankod/refine-core";
+import { Show, Title, Text, MarkdownField } from "@pankod/refine-mantine";
+
+import { ICategory, IPost } from "../../interfaces";
+
+export const PostShow: React.FC = () => {
+    const { queryResult } = useShow<IPost>();
+    const { data, isLoading } = queryResult;
+    const record = data?.data;
+
+    const { data: categoryData } = useOne<ICategory>({
+        resource: "categories",
+        id: record?.category.id || "",
+        queryOptions: {
+            enabled: !!record?.category.id,
+        },
+    });
+
+    return (
+        <Show isLoading={isLoading}>
+            <Title order={5}>Id</Title>
+            <Text mt="xs">{record?.id}</Text>
+
+            <Title mt="xs" order={5}>
+                Title
+            </Title>
+            <Text mt="xs">{record?.title}</Text>
+
+            <Title mt="xs" order={5}>
+                Status
+            </Title>
+            <Text mt="xs">{record?.status}</Text>
+
+            <Title mt="xs" order={5}>
+                Category
+            </Title>
+            <Text mt="xs">{categoryData?.data?.title}</Text>
+
+            <Title mt="xs" order={5}>
+                Content
+            </Title>
+            <MarkdownField value={record?.content} />
+        </Show>
+    );
+};

--- a/examples/upload/mantine/multipart/src/App.tsx
+++ b/examples/upload/mantine/multipart/src/App.tsx
@@ -12,7 +12,7 @@ import {
 import dataProvider from "@pankod/refine-simple-rest";
 import routerProvider from "@pankod/refine-react-router-v6";
 
-import { PostCreate, PostEdit, PostList } from "./pages";
+import { PostCreate, PostEdit, PostList, PostShow } from "./pages";
 
 const App: React.FC = () => {
     return (
@@ -32,6 +32,7 @@ const App: React.FC = () => {
                         {
                             name: "posts",
                             list: PostList,
+                            show: PostShow,
                             edit: PostEdit,
                             create: PostCreate,
                         },

--- a/examples/upload/mantine/multipart/src/pages/posts/index.ts
+++ b/examples/upload/mantine/multipart/src/pages/posts/index.ts
@@ -1,3 +1,4 @@
 export * from "./list";
 export * from "./create";
 export * from "./edit";
+export * from "./show";

--- a/examples/upload/mantine/multipart/src/pages/posts/list.tsx
+++ b/examples/upload/mantine/multipart/src/pages/posts/list.tsx
@@ -9,6 +9,7 @@ import {
     Select,
     Table,
     Pagination,
+    ShowButton,
     EditButton,
     DeleteButton,
     DateField,
@@ -89,6 +90,10 @@ export const PostList: React.FC = () => {
                 cell: function render({ getValue }) {
                     return (
                         <Group spacing="xs" noWrap>
+                            <ShowButton
+                                hideText
+                                recordItemId={getValue() as number}
+                            />
                             <EditButton
                                 hideText
                                 recordItemId={getValue() as number}

--- a/examples/upload/mantine/multipart/src/pages/posts/show.tsx
+++ b/examples/upload/mantine/multipart/src/pages/posts/show.tsx
@@ -1,0 +1,45 @@
+import { useShow, useOne } from "@pankod/refine-core";
+import { Show, Title, Text, MarkdownField } from "@pankod/refine-mantine";
+
+import { ICategory, IPost } from "../../interfaces";
+
+export const PostShow: React.FC = () => {
+    const { queryResult } = useShow<IPost>();
+    const { data, isLoading } = queryResult;
+    const record = data?.data;
+
+    const { data: categoryData } = useOne<ICategory>({
+        resource: "categories",
+        id: record?.category.id || "",
+        queryOptions: {
+            enabled: !!record?.category.id,
+        },
+    });
+
+    return (
+        <Show isLoading={isLoading}>
+            <Title order={5}>Id</Title>
+            <Text mt="xs">{record?.id}</Text>
+
+            <Title mt="xs" order={5}>
+                Title
+            </Title>
+            <Text mt="xs">{record?.title}</Text>
+
+            <Title mt="xs" order={5}>
+                Status
+            </Title>
+            <Text mt="xs">{record?.status}</Text>
+
+            <Title mt="xs" order={5}>
+                Category
+            </Title>
+            <Text mt="xs">{categoryData?.data?.title}</Text>
+
+            <Title mt="xs" order={5}>
+                Content
+            </Title>
+            <MarkdownField value={record?.content} />
+        </Show>
+    );
+};


### PR DESCRIPTION
Added the show page to mantine examples.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
