### PR TITLE
fixed missing index.ts

### DIFF
--- a/documentation/docs/advanced-tutorials/data-provider/supabase.md
+++ b/documentation/docs/advanced-tutorials/data-provider/supabase.md
@@ -846,6 +846,15 @@ export const normalizeFile = (event: EventArgs) => {
 </p>
 </details>
 
+Finally expose those modules at `src/pages/posts` by adding
+
+```tsx title="src/pages/posts/index.ts"
+export * from "./create";
+export * from "./edit";
+export * from "./list";
+``` 
+    
+    
 ### Adding Resources
 One last thing we need to do is to add newly created CRUD pages to the `resources` property of `<Refine>` component. 
 


### PR DESCRIPTION
Some typo in a tutorial. An `index.ts` is required to expose the components in the subdirectory 