### PR TITLE
fix(chakra-ui): add href prop to breadcrumb link for nextjs compatibility

### DIFF
--- a/packages/chakra-ui/src/components/breadcrumb/index.tsx
+++ b/packages/chakra-ui/src/components/breadcrumb/index.tsx
@@ -42,7 +42,12 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
                     <ChakraBreadcrumbItem key={label}>
                         {!hideIcons && icon}
                         {href ? (
-                            <BreadcrumbLink ml={2} as={Link} to={href}>
+                            <BreadcrumbLink
+                                ml={2}
+                                as={Link}
+                                to={href}
+                                href={href}
+                            >
                                 {label}
                             </BreadcrumbLink>
                         ) : (


### PR DESCRIPTION
Added `href` property to breadcrumb links for the Nextjs compatibility. 