### PR TITLE
fix(core): `useLogout` `onSuccess` behaviour

### DIFF
--- a/.changeset/old-planets-flash.md
+++ b/.changeset/old-planets-flash.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Fix `useLogout()`'s `onSuccess`behavious according to `AuthProvider` `resolved-rejected` values.

--- a/documentation/docs/api-reference/core/providers/auth-provider.md
+++ b/documentation/docs/api-reference/core/providers/auth-provider.md
@@ -477,7 +477,7 @@ const authProvider = {
     logout: () => {
         localStorage.removeItem("auth");
 // highlight-next-line
-        return Promise.resolve("custom-url");
+        return Promise.resolve("/custom-url");
     }
 }
 ```
@@ -542,7 +542,7 @@ You can override the default redirection by giving a path to the rejected promis
 ```tsx
 checkError: (error) => {
     if (error.status === 401) {
-        return Promise.reject("custom-url");
+        return Promise.reject("/custom-url");
     }
     ...
 }

--- a/packages/core/src/hooks/auth/useCheckError/index.spec.ts
+++ b/packages/core/src/hooks/auth/useCheckError/index.spec.ts
@@ -31,7 +31,7 @@ describe("useCheckError Hook", () => {
                     isProvided: true,
                     login: () => Promise.resolve(),
                     checkAuth: () => Promise.resolve(),
-                    checkError: () => Promise.reject("rejected"),
+                    checkError: () => Promise.reject(),
                     getPermissions: () => Promise.resolve(),
                     logout: logoutMock,
                     getUserIdentity: () => Promise.resolve(),

--- a/packages/core/src/hooks/auth/useCheckError/index.ts
+++ b/packages/core/src/hooks/auth/useCheckError/index.ts
@@ -20,7 +20,7 @@ export const useCheckError = (): UseMutationResult<
     const { checkError: checkErrorFromContext } =
         React.useContext<IAuthContext>(AuthContext);
 
-    const { mutate: logout } = useLogout<{ redirectPath?: string }>();
+    const { mutate: logout } = useLogout();
 
     const queryResponse = useMutation(
         ["useCheckError"],

--- a/packages/core/src/hooks/auth/useLogout/index.spec.ts
+++ b/packages/core/src/hooks/auth/useLogout/index.spec.ts
@@ -4,6 +4,7 @@ import ReactRouterDom from "react-router-dom";
 import { act, TestWrapper } from "@test";
 
 import { useLogout } from "./";
+import { useCheckError } from "../useCheckError";
 
 const mHistory = jest.fn();
 
@@ -174,6 +175,98 @@ describe("useLogout Hook", () => {
             } catch (error) {
                 expect(error).not.toBeDefined();
             }
+        });
+    });
+
+    it("logout and not redirect if check error rejected with false", async () => {
+        const logoutMock = jest.fn();
+
+        const { result } = renderHook(() => useCheckError(), {
+            wrapper: TestWrapper({
+                authProvider: {
+                    isProvided: true,
+                    login: () => Promise.resolve(),
+                    checkAuth: () => Promise.resolve(),
+                    checkError: () => Promise.reject(false),
+                    getPermissions: () => Promise.resolve(),
+                    logout: () => Promise.resolve(),
+                    getUserIdentity: () => Promise.resolve(),
+                },
+            }),
+        });
+
+        const { mutate: checkError } = result.current!;
+
+        await act(async () => {
+            await checkError({});
+        });
+
+        await waitFor(() => {
+            expect(!result.current.isLoading).toBeTruthy();
+        });
+
+        await act(async () => {
+            expect(mHistory).toBeCalledTimes(0);
+        });
+    });
+
+    it("logout and not redirect if logout resolved false", async () => {
+        const { result } = renderHook(() => useCheckError(), {
+            wrapper: TestWrapper({
+                authProvider: {
+                    isProvided: true,
+                    login: () => Promise.resolve(),
+                    checkAuth: () => Promise.resolve(),
+                    checkError: () => Promise.reject(),
+                    getPermissions: () => Promise.resolve(),
+                    logout: () => Promise.resolve(false),
+                    getUserIdentity: () => Promise.resolve(),
+                },
+            }),
+        });
+
+        const { mutate: checkError } = result.current!;
+
+        await act(async () => {
+            await checkError({});
+        });
+
+        await waitFor(() => {
+            expect(!result.current.isLoading).toBeTruthy();
+        });
+
+        await act(async () => {
+            expect(mHistory).toBeCalledTimes(0);
+        });
+    });
+
+    it("logout and not redirect to resolved custom path", async () => {
+        const { result } = renderHook(() => useLogout(), {
+            wrapper: TestWrapper({
+                authProvider: {
+                    isProvided: true,
+                    login: () => Promise.resolve(),
+                    checkAuth: () => Promise.resolve(),
+                    checkError: () => Promise.reject(),
+                    getPermissions: () => Promise.resolve(),
+                    logout: () => Promise.resolve("/custom-path"),
+                    getUserIdentity: () => Promise.resolve(),
+                },
+            }),
+        });
+
+        const { mutate: logout } = result.current!;
+
+        await act(async () => {
+            await logout();
+        });
+
+        await waitFor(() => {
+            return result.current?.status === "success";
+        });
+
+        await act(async () => {
+            expect(mHistory).toBeCalledWith("/custom-path");
         });
     });
 });

--- a/packages/core/src/hooks/auth/useLogout/index.spec.ts
+++ b/packages/core/src/hooks/auth/useLogout/index.spec.ts
@@ -240,7 +240,7 @@ describe("useLogout Hook", () => {
         });
     });
 
-    it("logout and not redirect to resolved custom path", async () => {
+    it("logout and redirect to resolved custom path", async () => {
         const { result } = renderHook(() => useLogout(), {
             wrapper: TestWrapper({
                 authProvider: {

--- a/packages/core/src/hooks/auth/useLogout/index.ts
+++ b/packages/core/src/hooks/auth/useLogout/index.ts
@@ -5,16 +5,20 @@ import { AuthContext } from "@contexts/auth";
 import { IAuthContext, TLogoutData } from "../../../interfaces";
 import { useNavigation, useNotification } from "@hooks";
 
+type Variables = {
+    redirectPath?: string | false;
+};
+
 /**
  * `useLogout` calls the `logout` method from the {@link https://refine.dev/docs/api-references/providers/auth-provider `authProvider`} under the hood.
  *
  * @see {@link https://refine.dev/docs/core/hooks/auth/useLogout} for more details.
  *
  */
-export const useLogout = <TVariables = void>(): UseMutationResult<
+export const useLogout = <TVariables = {}>(): UseMutationResult<
     TLogoutData,
     Error,
-    TVariables,
+    (TVariables & Variables) | void,
     unknown
 > => {
     const { push } = useNavigation();
@@ -22,30 +26,36 @@ export const useLogout = <TVariables = void>(): UseMutationResult<
         React.useContext<IAuthContext>(AuthContext);
     const { open } = useNotification();
 
-    const queryResponse = useMutation<TLogoutData, Error, TVariables, unknown>(
-        ["useLogout"],
-        logoutFromContext,
-        {
-            onSuccess: (redirectPathFromAuth) => {
-                if (redirectPathFromAuth !== false) {
-                    if (redirectPathFromAuth) {
-                        push(redirectPathFromAuth);
-                    } else {
-                        push("/login");
-                    }
-                }
-            },
-            onError: (error: Error) => {
-                open?.({
-                    key: "useLogout-error",
-                    type: "error",
-                    message: error?.name || "Logout Error",
-                    description:
-                        error?.message || "Something went wrong during logout",
-                });
-            },
+    const queryResponse = useMutation<
+        TLogoutData,
+        Error,
+        (TVariables & Variables) | void,
+        unknown
+    >(["useLogout"], logoutFromContext, {
+        onSuccess: (data, variables) => {
+            const redirectPath = variables?.redirectPath ?? data;
+
+            if (redirectPath === false) {
+                return;
+            }
+
+            if (redirectPath) {
+                push(redirectPath);
+                return;
+            }
+
+            push("/login");
         },
-    );
+        onError: (error: Error) => {
+            open?.({
+                key: "useLogout-error",
+                type: "error",
+                message: error?.name || "Logout Error",
+                description:
+                    error?.message || "Something went wrong during logout",
+            });
+        },
+    });
 
     return queryResponse;
 };


### PR DESCRIPTION
- fixed: The "onSuccess" parameters were wrong.
- fixed: value overriding. [Redirection path given to checkError overrides the one on logout.](https://refine.dev/docs/api-reference/core/providers/auth-provider/#redirection-after-error)
  -  `onSuccess: (data, variables) => {}`
      data comes from: `logout:() => Pormise<any>`
      variables comes from: `checkError:() => Pormise<any>`
    

### Test plan (required)

<img width="300" alt="test results" src="https://user-images.githubusercontent.com/23058882/199516942-7e532082-02d6-4227-aec8-7e2c8b6cb6fa.png">


<!-- Make sure tests pass. -->

### Closing issues
closes #2927 


### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
