### PR TITLE
fix(docs): footer cannot snap to bottom

### DIFF
--- a/documentation/src/components/github-floating-cta/index.tsx
+++ b/documentation/src/components/github-floating-cta/index.tsx
@@ -23,7 +23,7 @@ const GithubFloatingCta: FC = () => {
     if (isClosed) return null;
 
     return (
-        <div className="font-montserrat shadow-githubFloatingCta sticky bottom-0 mx-auto flex h-[48px] w-full items-center bg-[#2A2A42] px-3 text-xs font-bold text-white sm:bottom-[32px] sm:w-[350px] sm:rounded-3xl z-[999]">
+        <div className="font-montserrat shadow-githubFloatingCta fixed bottom-0 mx-auto flex h-[48px] w-full items-center bg-[#2A2A42] px-3 text-xs font-bold text-white left-0 right-0 sm:bottom-[32px] sm:w-[350px] sm:rounded-3xl z-[999]">
             <div className="ml-4">Star us on GitHub</div>
             {/* eslint-disable-next-line react/jsx-no-target-blank */}
             <a


### PR DESCRIPTION
> This issue occurs in only `firefox` and `safari`

Since "Github Floating Cta" was `position:sticky`. When the page was at the bottom it would leave a space after the footer.

Changing `position:sticky` to `position:fixed` solved the problem.



before
<img width="300" alt="refine website screenshot before ui improvements" src="https://user-images.githubusercontent.com/23058882/199678152-a2a934c6-3d44-42cb-8798-5c8a008a2823.png">


after 
<img width="300" alt="refine website screenshot after ui improvements" src="https://user-images.githubusercontent.com/23058882/199678217-3c64a30c-2769-4dbb-9393-9771287edcd9.png">



-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
