### PR TITLE
fix: page components

### DIFF
--- a/.changeset/hungry-peas-pump.md
+++ b/.changeset/hungry-peas-pump.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-chakra-ui": patch
+---
+
+Fixed responsive style for error page.

--- a/.changeset/proud-mayflies-divide.md
+++ b/.changeset/proud-mayflies-divide.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mantine": patch
+---
+
+Added padding to ReadyPage component.

--- a/packages/chakra-ui/src/components/pages/error/index.tsx
+++ b/packages/chakra-ui/src/components/pages/error/index.tsx
@@ -73,7 +73,11 @@ export const ErrorComponent: React.FC<RefineErrorPageProps> = () => {
             alignItems="center"
             justifyContent="center"
             minH="100vh"
-            mt={{ base: "0", lg: "-150px" }}
+            sx={{
+                "@media (min-height: 755px)": {
+                    marginTop: "-150px",
+                },
+            }}
         >
             <Heading fontWeight={900} fontSize={[120, 160, 220]} color={color}>
                 404

--- a/packages/mantine/src/components/pages/ready/index.tsx
+++ b/packages/mantine/src/components/pages/ready/index.tsx
@@ -24,6 +24,8 @@ export const ReadyPage: React.FC<RefineReadyPageProps> = () => {
                 minHeight: "100vh",
                 backgroundColor: "#2A132E",
             }}
+            py="xl"
+            px="sm"
             src="https://refine.ams3.cdn.digitaloceanspaces.com/login-background/background.png"
         >
             <img src={logo} alt="Refine Logo" />
@@ -31,7 +33,7 @@ export const ReadyPage: React.FC<RefineReadyPageProps> = () => {
             <Title align="center" sx={{ color: "white", fontSize: "3rem" }}>
                 Welcome on board
             </Title>
-            <Text size="xl" sx={{ color: "white" }} mt="md">
+            <Text size="xl" sx={{ color: "white" }} mt="md" align="center">
                 Your configuration is completed.
             </Text>
             <Text size="lg" sx={{ color: "white" }} mt="md" align="center">


### PR DESCRIPTION
- Fixed responsive style for error page in `refine-chakra-ui` package.
- Added padding to ReadyPage component in `refine-mantine` package.

### Test plan (required)

All tests run successfully.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
