### PR TITLE
fix: empty filter value request issue for `useDataGrid`

### DIFF
--- a/.changeset/ninety-melons-appear.md
+++ b/.changeset/ninety-melons-appear.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Added `hasPagination` property to `useSelect` hook for disabling pagination.

--- a/.changeset/tricky-tigers-push.md
+++ b/.changeset/tricky-tigers-push.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": patch
+---
+
+Prevented server request when empty filter value is provided.

--- a/examples/table/mui/advancedTable/src/pages/table/index.tsx
+++ b/examples/table/mui/advancedTable/src/pages/table/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useEffect, useCallback } from "react";
 import {
     GetManyResponse,
     useDeleteMany,
@@ -30,10 +30,10 @@ import {
     TableCell,
     Checkbox,
     CheckboxProps,
-    Paper,
     TableBody,
     TableSortLabel,
     TablePagination,
+    List,
 } from "@pankod/refine-mui";
 import { useForm, Controller } from "@pankod/refine-react-hook-form";
 
@@ -332,16 +332,16 @@ export const PostList: React.FC = () => {
                     }),
                 }}
             >
-                {numSelected > 0 && (
-                    <Typography
-                        sx={{ flex: "1 1 100%" }}
-                        color="inherit"
-                        variant="subtitle1"
-                        component="div"
-                    >
-                        {numSelected} selected
-                    </Typography>
-                )}
+                <Typography
+                    sx={{ flex: "1 1 100%" }}
+                    color="inherit"
+                    variant="subtitle1"
+                    component="div"
+                >
+                    {numSelected > 0
+                        ? `${numSelected} selected`
+                        : "Not selected any row"}
+                </Typography>
                 {numSelected > 0 && <DeleteButton onClick={() => onDelete()} />}
             </Toolbar>
         );
@@ -351,185 +351,168 @@ export const PostList: React.FC = () => {
     const categoryColumn = getColumn("category.id");
 
     return (
-        <>
-            <Box sx={{ width: "100%" }}>
-                <form onSubmit={handleSubmit(onFinish)}>
-                    <Paper sx={{ width: "100%", mb: 2 }}>
-                        <Box p={1}>
-                            <Stack direction="row" spacing={2}>
-                                <TextField
-                                    label="Search by title"
-                                    id="title"
-                                    type="search"
-                                    value={
-                                        (titleColumn.getFilterValue() as string) ??
-                                        ""
-                                    }
-                                    onChange={(event) =>
-                                        titleColumn.setFilterValue(
-                                            event.target.value,
-                                        )
-                                    }
-                                />
+        <List
+            title="React Table Usage"
+            breadcrumb={false}
+            headerButtons={
+                <Stack direction="row" spacing={2}>
+                    <TextField
+                        label="Search by title"
+                        id="title"
+                        type="search"
+                        value={(titleColumn.getFilterValue() as string) ?? ""}
+                        onChange={(event) =>
+                            titleColumn.setFilterValue(event.target.value)
+                        }
+                    />
 
-                                <TextField
-                                    select
-                                    id="category"
-                                    label="Category Select"
-                                    defaultValue={"0"}
-                                    onChange={(event) => {
-                                        categoryColumn.setFilterValue(
-                                            event.target.value === "0"
-                                                ? undefined
-                                                : event.target.value.toString(),
-                                        );
-                                    }}
-                                    sx={{ minWidth: 200 }}
-                                >
-                                    <MenuItem key="All Categories" value={"0"}>
-                                        All Categories
-                                    </MenuItem>
-                                    {options?.map((category) => (
-                                        <MenuItem
-                                            key={category.value}
-                                            value={category.value}
+                    <TextField
+                        select
+                        id="category"
+                        label="Category Select"
+                        defaultValue={"0"}
+                        onChange={(event) => {
+                            categoryColumn.setFilterValue(
+                                event.target.value === "0"
+                                    ? undefined
+                                    : event.target.value.toString(),
+                            );
+                        }}
+                        sx={{ minWidth: 200 }}
+                    >
+                        <MenuItem key="All Categories" value={"0"}>
+                            All Categories
+                        </MenuItem>
+                        {options?.map((category) => (
+                            <MenuItem
+                                key={category.value}
+                                value={category.value}
+                            >
+                                {category.label}
+                            </MenuItem>
+                        ))}
+                    </TextField>
+                </Stack>
+            }
+        >
+            <form onSubmit={handleSubmit(onFinish)}>
+                <EnhancedTableToolbar
+                    numSelected={Object.keys(rowSelection ?? {}).length}
+                    onDelete={() => {
+                        deleteSelectedItems(
+                            getSelectedRowModel().flatRows.map(
+                                (row) => row.original.id,
+                            ),
+                        );
+                    }}
+                />
+                <TableContainer>
+                    <Table size="small">
+                        <TableHead>
+                            {getHeaderGroups().map((headerGroup) => (
+                                <TableRow key={headerGroup.id}>
+                                    {headerGroup.headers.map((header) => (
+                                        <TableCell
+                                            key={header.id}
+                                            onClick={header.column.getToggleSortingHandler()}
                                         >
-                                            {category.label}
-                                        </MenuItem>
-                                    ))}
-                                </TextField>
-                            </Stack>
-                        </Box>
-                        <EnhancedTableToolbar
-                            numSelected={Object.keys(rowSelection ?? {}).length}
-                            onDelete={() => {
-                                deleteSelectedItems(
-                                    getSelectedRowModel().flatRows.map(
-                                        (row) => row.original.id,
-                                    ),
-                                );
-                            }}
-                        />
-                        <TableContainer>
-                            <Table size="small">
-                                <TableHead>
-                                    {getHeaderGroups().map((headerGroup) => (
-                                        <TableRow key={headerGroup.id}>
-                                            {headerGroup.headers.map(
-                                                (header) => (
-                                                    <TableCell
-                                                        key={header.id}
-                                                        onClick={header.column.getToggleSortingHandler()}
-                                                    >
-                                                        {flexRender(
-                                                            header.column
-                                                                .columnDef
-                                                                .header,
-                                                            header.getContext(),
-                                                        )}
-                                                        {header.column.id !==
-                                                        "selection" ? (
-                                                            <TableSortLabel
-                                                                active={
-                                                                    header.column.getIsSorted() !==
-                                                                    false
-                                                                }
-                                                                direction={
-                                                                    header.column.getIsSorted() ===
-                                                                    false
-                                                                        ? undefined
-                                                                        : (header.column.getIsSorted() as
-                                                                              | "asc"
-                                                                              | "desc")
-                                                                }
-                                                            />
-                                                        ) : null}
-                                                    </TableCell>
-                                                ),
+                                            {flexRender(
+                                                header.column.columnDef.header,
+                                                header.getContext(),
                                             )}
-                                        </TableRow>
+                                            {header.column.id !==
+                                            "selection" ? (
+                                                <TableSortLabel
+                                                    active={
+                                                        header.column.getIsSorted() !==
+                                                        false
+                                                    }
+                                                    direction={
+                                                        header.column.getIsSorted() ===
+                                                        false
+                                                            ? undefined
+                                                            : (header.column.getIsSorted() as
+                                                                  | "asc"
+                                                                  | "desc")
+                                                    }
+                                                />
+                                            ) : null}
+                                        </TableCell>
                                     ))}
-                                </TableHead>
-                                <TableBody>
-                                    {getRowModel().rows.map((row) => {
-                                        if (id === row.original.id) {
-                                            return renderEditRow(row);
-                                        } else
-                                            return (
-                                                <React.Fragment key={row.id}>
-                                                    <TableRow>
-                                                        {row
-                                                            .getAllCells()
-                                                            .map((cell) => {
-                                                                return (
-                                                                    <TableCell
-                                                                        key={
-                                                                            cell.id
-                                                                        }
-                                                                    >
-                                                                        {flexRender(
-                                                                            cell
-                                                                                .column
-                                                                                .columnDef
-                                                                                .cell,
-                                                                            cell.getContext(),
-                                                                        )}
-                                                                    </TableCell>
-                                                                );
-                                                            })}
-                                                    </TableRow>
-
-                                                    {row.getIsExpanded() ? (
-                                                        <TableRow>
+                                </TableRow>
+                            ))}
+                        </TableHead>
+                        <TableBody>
+                            {getRowModel().rows.map((row) => {
+                                if (id === row.original.id) {
+                                    return renderEditRow(row);
+                                } else
+                                    return (
+                                        <React.Fragment key={row.id}>
+                                            <TableRow>
+                                                {row
+                                                    .getAllCells()
+                                                    .map((cell) => {
+                                                        return (
                                                             <TableCell
-                                                                colSpan={
-                                                                    row.getVisibleCells()
-                                                                        .length
-                                                                }
+                                                                key={cell.id}
                                                             >
-                                                                {renderRowSubComponent(
-                                                                    {
-                                                                        row,
-                                                                    },
+                                                                {flexRender(
+                                                                    cell.column
+                                                                        .columnDef
+                                                                        .cell,
+                                                                    cell.getContext(),
                                                                 )}
                                                             </TableCell>
-                                                        </TableRow>
-                                                    ) : null}
-                                                </React.Fragment>
-                                            );
-                                    })}
-                                </TableBody>
-                            </Table>
-                        </TableContainer>
-                        <TablePagination
-                            component="div"
-                            rowsPerPageOptions={[
-                                5,
-                                10,
-                                25,
-                                {
-                                    label: "All",
-                                    value: tableData?.total ?? 100,
-                                },
-                            ]}
-                            showFirstButton
-                            showLastButton
-                            count={pageCount || 0}
-                            rowsPerPage={pagination?.pageSize || 10}
-                            page={pagination?.pageIndex || 0}
-                            onPageChange={(_, newPage: number) =>
-                                setPageIndex(newPage)
-                            }
-                            onRowsPerPageChange={(
-                                event: React.ChangeEvent<HTMLInputElement>,
-                            ) => {
-                                setPageSize(parseInt(event.target.value, 10));
-                                setPageIndex(0);
-                            }}
-                        />
-                    </Paper>
-                </form>
-            </Box>
-        </>
+                                                        );
+                                                    })}
+                                            </TableRow>
+
+                                            {row.getIsExpanded() ? (
+                                                <TableRow>
+                                                    <TableCell
+                                                        colSpan={
+                                                            row.getVisibleCells()
+                                                                .length
+                                                        }
+                                                    >
+                                                        {renderRowSubComponent({
+                                                            row,
+                                                        })}
+                                                    </TableCell>
+                                                </TableRow>
+                                            ) : null}
+                                        </React.Fragment>
+                                    );
+                            })}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+                <TablePagination
+                    component="div"
+                    rowsPerPageOptions={[
+                        5,
+                        10,
+                        25,
+                        {
+                            label: "All",
+                            value: tableData?.total ?? 100,
+                        },
+                    ]}
+                    showFirstButton
+                    showLastButton
+                    count={pageCount || 0}
+                    rowsPerPage={pagination?.pageSize || 10}
+                    page={pagination?.pageIndex || 0}
+                    onPageChange={(_, newPage: number) => setPageIndex(newPage)}
+                    onRowsPerPageChange={(
+                        event: React.ChangeEvent<HTMLInputElement>,
+                    ) => {
+                        setPageSize(parseInt(event.target.value, 10));
+                        setPageIndex(0);
+                    }}
+                />
+            </form>
+        </List>
     );
 };

--- a/examples/table/mui/dataGridPro/src/pages/posts/list.tsx
+++ b/examples/table/mui/dataGridPro/src/pages/posts/list.tsx
@@ -1,6 +1,10 @@
 import React from "react";
-import { useMany } from "@pankod/refine-core";
-import { useDataGrid, List } from "@pankod/refine-mui";
+import { Option, useSelect } from "@pankod/refine-core";
+import {
+    useDataGrid,
+    List,
+    GridValueFormatterParams,
+} from "@pankod/refine-mui";
 import { DataGridPro, GridColumns } from "@mui/x-data-grid-pro";
 
 import { ICategory, IPost } from "interfaces";
@@ -34,13 +38,12 @@ export const PostsList: React.FC = () => {
         syncWithLocation: true,
     });
 
-    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
-    const { data: categoriesData, isLoading } = useMany<ICategory>({
+    const {
+        options,
+        queryResult: { isLoading },
+    } = useSelect<ICategory>({
         resource: "categories",
-        ids: categoryIds,
-        queryOptions: {
-            enabled: categoryIds.length > 0,
-        },
+        hasPagination: false,
     });
 
     const columns = React.useMemo<GridColumns<IPost>>(
@@ -54,25 +57,38 @@ export const PostsList: React.FC = () => {
             {
                 field: "category.id",
                 headerName: "Category",
-                type: "number",
+                type: "singleSelect",
                 headerAlign: "left",
                 align: "left",
                 minWidth: 250,
                 flex: 0.5,
+                valueOptions: options,
+                valueFormatter: (params: GridValueFormatterParams<Option>) => {
+                    return params.value;
+                },
                 renderCell: function render({ row }) {
                     if (isLoading) {
                         return "Loading...";
                     }
 
-                    const category = categoriesData?.data.find(
-                        (item) => item.id === row.category.id,
+                    const category = options.find(
+                        (item) =>
+                            item.value.toString() ===
+                            row.category.id.toString(),
                     );
-                    return category?.title;
+                    return category?.label;
                 },
             },
-            { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
+            {
+                field: "status",
+                headerName: "Status",
+                minWidth: 120,
+                flex: 0.3,
+                type: "singleSelect",
+                valueOptions: ["draft", "published", "rejected"],
+            },
         ],
-        [categoriesData, isLoading],
+        [options, isLoading],
     );
 
     return (

--- a/examples/table/mui/tableFilter/src/pages/posts/list.tsx
+++ b/examples/table/mui/tableFilter/src/pages/posts/list.tsx
@@ -42,7 +42,7 @@ export const PostsList: React.FC = () => {
                 {
                     field: "q",
                     operator: "eq",
-                    value: q !== "" ? q : undefined,
+                    value: q,
                 },
                 {
                     field: "category.id",
@@ -251,6 +251,7 @@ export const PostsList: React.FC = () => {
                     <DataGrid
                         {...dataGridProps}
                         columns={columns}
+                        disableColumnFilter={true}
                         filterModel={undefined}
                         autoHeight
                         rowsPerPageOptions={[10, 20, 50, 100]}

--- a/examples/table/mui/useDataGrid/src/pages/posts/list.tsx
+++ b/examples/table/mui/useDataGrid/src/pages/posts/list.tsx
@@ -1,6 +1,12 @@
 import React from "react";
-import { useMany } from "@pankod/refine-core";
-import { useDataGrid, DataGrid, GridColumns, List } from "@pankod/refine-mui";
+import { Option, useSelect } from "@pankod/refine-core";
+import {
+    useDataGrid,
+    DataGrid,
+    GridColumns,
+    List,
+    GridValueFormatterParams,
+} from "@pankod/refine-mui";
 
 import { ICategory, IPost } from "interfaces";
 
@@ -24,13 +30,12 @@ export const PostsList: React.FC = () => {
         syncWithLocation: true,
     });
 
-    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
-    const { data: categoriesData, isLoading } = useMany<ICategory>({
+    const {
+        options,
+        queryResult: { isLoading },
+    } = useSelect<ICategory>({
         resource: "categories",
-        ids: categoryIds,
-        queryOptions: {
-            enabled: categoryIds.length > 0,
-        },
+        hasPagination: false,
     });
 
     const columns = React.useMemo<GridColumns<IPost>>(
@@ -45,25 +50,38 @@ export const PostsList: React.FC = () => {
             {
                 field: "category.id",
                 headerName: "Category",
-                type: "number",
+                type: "singleSelect",
                 headerAlign: "left",
                 align: "left",
                 minWidth: 250,
                 flex: 0.5,
+                valueOptions: options,
+                valueFormatter: (params: GridValueFormatterParams<Option>) => {
+                    return params.value;
+                },
                 renderCell: function render({ row }) {
                     if (isLoading) {
                         return "Loading...";
                     }
 
-                    const category = categoriesData?.data.find(
-                        (item) => item.id === row.category.id,
+                    const category = options.find(
+                        (item) =>
+                            item.value.toString() ===
+                            row.category.id.toString(),
                     );
-                    return category?.title;
+                    return category?.label;
                 },
             },
-            { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
+            {
+                field: "status",
+                headerName: "Status",
+                minWidth: 120,
+                flex: 0.3,
+                type: "singleSelect",
+                valueOptions: ["draft", "published", "rejected"],
+            },
         ],
-        [categoriesData, isLoading],
+        [options, isLoading],
     );
 
     return (

--- a/examples/table/mui/useDeleteMany/src/pages/posts/list.tsx
+++ b/examples/table/mui/useDeleteMany/src/pages/posts/list.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { useMany, useDeleteMany } from "@pankod/refine-core";
+import { Option, useSelect, useDeleteMany } from "@pankod/refine-core";
 import {
     useDataGrid,
     DataGrid,
     GridColumns,
     List,
     Button,
+    GridValueFormatterParams,
 } from "@pankod/refine-mui";
 
 import { ICategory, IPost } from "interfaces";
@@ -36,13 +37,12 @@ export const PostsList: React.FC = () => {
         initialPageSize: 10,
     });
 
-    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
-    const { data: categoriesData, isLoading } = useMany<ICategory>({
+    const {
+        options,
+        queryResult: { isLoading },
+    } = useSelect<ICategory>({
         resource: "categories",
-        ids: categoryIds,
-        queryOptions: {
-            enabled: categoryIds.length > 0,
-        },
+        hasPagination: false,
     });
 
     const columns = React.useMemo<GridColumns<IPost>>(
@@ -57,42 +57,54 @@ export const PostsList: React.FC = () => {
             {
                 field: "category.id",
                 headerName: "Category",
-                type: "number",
+                type: "singleSelect",
                 headerAlign: "left",
                 align: "left",
                 minWidth: 250,
                 flex: 0.5,
+                valueOptions: options,
+                valueFormatter: (params: GridValueFormatterParams<Option>) => {
+                    return params.value;
+                },
                 renderCell: function render({ row }) {
                     if (isLoading) {
                         return "Loading...";
                     }
 
-                    const category = categoriesData?.data.find(
-                        (item) => item.id === row.category.id,
+                    const category = options.find(
+                        (item) =>
+                            item.value.toString() ===
+                            row.category.id.toString(),
                     );
-                    return category?.title;
+                    return category?.label;
                 },
             },
-            { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
+            {
+                field: "status",
+                headerName: "Status",
+                minWidth: 120,
+                flex: 0.3,
+                type: "singleSelect",
+                valueOptions: ["draft", "published", "rejected"],
+            },
         ],
-        [categoriesData, isLoading],
+        [options, isLoading],
     );
 
     return (
         <List
             cardProps={{ sx: { paddingX: { xs: 2, md: 0 } } }}
-            cardHeaderProps={{
-                subheader: (
-                    <Button
-                        onClick={deleteSelectedItems}
-                        disabled={!hasSelected}
-                        size="small"
-                        variant="contained"
-                    >
-                        Delete Selected
-                    </Button>
-                ),
-            }}
+            headerButtons={
+                <Button
+                    onClick={deleteSelectedItems}
+                    disabled={!hasSelected}
+                    size="small"
+                    variant="contained"
+                    color="error"
+                >
+                    Delete Selected
+                </Button>
+            }
         >
             <DataGrid
                 {...dataGridProps}

--- a/packages/core/src/hooks/useSelect/index.ts
+++ b/packages/core/src/hooks/useSelect/index.ts
@@ -63,6 +63,12 @@ export type UseSelectProps<TData, TError> = {
      */
     pagination?: Pagination;
     /**
+     * Disabling pagination option from [`useList()`](/docs/api-reference/core/hooks/data/useList/)
+     * @type boolean
+     * @default `undefined`
+     */
+    hasPagination?: boolean;
+    /**
      * react-query [useQuery](https://react-query.tanstack.com/reference/useQuery) options
      */
     defaultValueQueryOptions?: UseQueryOptions<GetManyResponse<TData>, TError>;
@@ -120,6 +126,7 @@ export const useSelect = <
         queryOptions,
         fetchSize,
         pagination,
+        hasPagination,
         liveMode,
         defaultValue = [],
         onLiveEvent,
@@ -189,6 +196,7 @@ export const useSelect = <
                 current: pagination?.current,
                 pageSize: pagination?.pageSize ?? fetchSize,
             },
+            hasPagination,
         },
         queryOptions: {
             ...queryOptions,

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -204,6 +204,8 @@ export function useDataGrid<
         dataProviderName,
     });
 
+    const [muiCrudFilters, setMuiCrudFilters] = useState<CrudFilters>(filters);
+
     useEffect(() => {
         warnOnce(
             !!columns,
@@ -235,7 +237,8 @@ export function useDataGrid<
 
     const handleFilterModelChange = (filterModel: GridFilterModel) => {
         const crudFilters = transformFilterModelToCrudFilters(filterModel);
-        setFilters(crudFilters);
+        setMuiCrudFilters(crudFilters);
+        setFilters(crudFilters.filter((f) => f.value !== ""));
         if (hasPagination) {
             setCurrent(1);
         }
@@ -244,7 +247,8 @@ export function useDataGrid<
     const search = async (value: TSearchVariables) => {
         if (onSearchProp) {
             const searchFilters = await onSearchProp(value);
-            setFilters(searchFilters);
+            setMuiCrudFilters(searchFilters);
+            setFilters(searchFilters.filter((f) => f.value !== ""));
             if (hasPagination) {
                 setCurrent(1);
             }
@@ -313,7 +317,7 @@ export function useDataGrid<
             onSortModelChange: handleSortModelChange,
             filterMode: "server",
             filterModel: transformCrudFiltersToFilterModel(
-                differenceWith(filters, permanentFilter ?? [], isEqual),
+                differenceWith(muiCrudFilters, permanentFilter ?? [], isEqual),
                 columnsTypes,
             ),
             onFilterModelChange: handleFilterModelChange,


### PR DESCRIPTION
- Prevented server request when empty filter value is provided.
- Added `singleSelect` type column to category and status columns in Material UI examples for filter accordingly to relational data.

### Test plan (required)

All tests run successfully.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
