### PR TITLE
fix: `chakra-ui` and `mantine` number field props

### DIFF
--- a/.changeset/pretty-buttons-stare.md
+++ b/.changeset/pretty-buttons-stare.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mantine": patch
+---
+
+Fixed `<NumberField />` type for missing `value` prop type, which was erroring out when using `<NumberField />`.

--- a/.changeset/stupid-radios-agree.md
+++ b/.changeset/stupid-radios-agree.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-chakra-ui": patch
+---
+
+Fixed `<NumberField />` type for missing `value` prop type, which was erroring out when using `<NumberField />`.

--- a/packages/chakra-ui/src/components/fields/number/index.tsx
+++ b/packages/chakra-ui/src/components/fields/number/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactChild } from "react";
 
 import { RefineFieldNumberProps } from "@pankod/refine-ui-types";
 import { Text, TextProps } from "@chakra-ui/react";
@@ -10,7 +10,7 @@ function toLocaleStringSupportsOptions() {
         typeof Intl.NumberFormat == "function"
     );
 }
-export type NumberFieldProps = RefineFieldNumberProps<TextProps>;
+export type NumberFieldProps = RefineFieldNumberProps<ReactChild, TextProps>;
 /**
  * This field is used to display a number formatted according to the browser locale, right aligned. and uses {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl `Intl`} to display date format
  * and Chakra UI {@link https://chakra-ui.com/docs/components/text  `<Text>`} component.

--- a/packages/mantine/src/components/fields/number/index.tsx
+++ b/packages/mantine/src/components/fields/number/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactChild } from "react";
 
 import { RefineFieldNumberProps } from "@pankod/refine-ui-types";
 import { Text, TextProps } from "@mantine/core";
@@ -10,7 +10,7 @@ function toLocaleStringSupportsOptions() {
         typeof Intl.NumberFormat == "function"
     );
 }
-export type NumberFieldProps = RefineFieldNumberProps<TextProps>;
+export type NumberFieldProps = RefineFieldNumberProps<ReactChild, TextProps>;
 /**
  * This field is used to display a number formatted according to the browser locale, right aligned. and uses {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl `Intl`} to display date format
  * and Mantine {@link https://mantine.dev/core/text/  `<Text>`} component.


### PR DESCRIPTION
Added missing generic type to `<NumberField />` type in `@pankod/refine-chakra-ui` and `@pankod/refine-mantine`

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
