### PR TITLE
fix TS errors when 'useParams' set to 'any

### DIFF
--- a/.changeset/sixty-suns-agree.md
+++ b/.changeset/sixty-suns-agree.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-react-router-v6": patch
+---
+
+Fixed TypeScript type of `useParams` hook

--- a/packages/react-router-v6/src/index.ts
+++ b/packages/react-router-v6/src/index.ts
@@ -22,7 +22,7 @@ export type RefineRouteProps = RouteProps & {
 interface IReactRouterProvider extends IRouterProvider {
     useLocation: typeof useLocation;
     Link: typeof Link;
-    useParams: any;
+    useParams: <Params extends { [K in keyof Params]?: string } = {}>() => Params;
     RouterComponent: React.FC<BrowserRouterProps>;
     routes?: RefineRouteProps[];
 }


### PR DESCRIPTION
Please provide enough information so that others can review your pull request: quick fix for annoying ts error when using `useParams` through `routerProvider`

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->
