### PR TITLE
test(ui-tests): `CreateButton` disabled state check

### DIFF
--- a/.changeset/red-cobras-care.md
+++ b/.changeset/red-cobras-care.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-ui-tests": patch
+---
+
+Updated `CreateButton` tests to handle `disabled` check.

--- a/packages/ui-tests/src/tests/buttons/create.tsx
+++ b/packages/ui-tests/src/tests/buttons/create.tsx
@@ -73,7 +73,7 @@ export const buttonCreateTests = function (
 
             expect(container).toBeTruthy();
 
-            waitFor(() =>
+            await waitFor(() =>
                 expect(getByText("Create").closest("button")).toBeDisabled(),
             );
         });
@@ -113,10 +113,10 @@ export const buttonCreateTests = function (
 
             expect(container).toBeTruthy();
 
-            waitFor(() =>
+            await waitFor(() =>
                 expect(getByText("Create").closest("button")).toBeDisabled(),
             );
-            waitFor(() =>
+            await waitFor(() =>
                 expect(
                     getByText("Create")
                         .closest("button")


### PR DESCRIPTION
Updated `CreateButton` tests to handle `disabled`check.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [ ] Changesets are provided or not needed
