### PR TITLE
chore(examples): add `ts-expect-error` to broken `mui` props

### DIFF
--- a/examples/fineFoods/admin/mui/src/components/dashboard/recentOrders/index.tsx
+++ b/examples/fineFoods/admin/mui/src/components/dashboard/recentOrders/index.tsx
@@ -156,6 +156,7 @@ export const RecentOrders: React.FC = () => {
                 type: "actions",
                 width: 80,
                 getActions: ({ id }) => [
+                    // @ts-expect-error `@mui/x-data-grid@5.17.12` broke the props of `GridActionsCellItem` and requires `onResize` and `onResizeCapture` props which should be optional.
                     <GridActionsCellItem
                         key={1}
                         icon={<CheckOutlined color="success" />}
@@ -175,6 +176,7 @@ export const RecentOrders: React.FC = () => {
                             });
                         }}
                     />,
+                    // @ts-expect-error `@mui/x-data-grid@5.17.12` broke the props of `GridActionsCellItem` and requires `onResize` and `onResizeCapture` props which should be optional.
                     <GridActionsCellItem
                         key={2}
                         icon={<CloseOutlined color="error" />}

--- a/examples/fineFoods/admin/mui/src/pages/categories/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/categories/list.tsx
@@ -402,6 +402,7 @@ const CategoryProductsTable: React.FC<{ record: ICategory }> = ({ record }) => {
                 type: "actions",
                 getActions: function render({ row }) {
                     return [
+                        // @ts-expect-error `@mui/x-data-grid@5.17.12` broke the props of `GridActionsCellItem` and requires `onResize` and `onResizeCapture` props which should be optional.
                         <GridActionsCellItem
                             key={1}
                             label={t("buttons.edit")}

--- a/examples/fineFoods/admin/mui/src/pages/couriers/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/couriers/list.tsx
@@ -95,6 +95,7 @@ export const CourierList: React.FC<IResourceComponentsProps> = () => {
                 type: "actions",
                 getActions: function render({ row }) {
                     return [
+                        // @ts-expect-error `@mui/x-data-grid@5.17.12` broke the props of `GridActionsCellItem` and requires `onResize` and `onResizeCapture` props which should be optional.
                         <GridActionsCellItem
                             key={1}
                             label={t("buttons.edit")}
@@ -102,6 +103,7 @@ export const CourierList: React.FC<IResourceComponentsProps> = () => {
                             onClick={() => edit("couriers", row.id)}
                             showInMenu
                         />,
+                        // @ts-expect-error `@mui/x-data-grid@5.17.12` broke the props of `GridActionsCellItem` and requires `onResize` and `onResizeCapture` props which should be optional.
                         <GridActionsCellItem
                             key={2}
                             label={t("buttons.delete")}

--- a/examples/fineFoods/admin/mui/src/pages/orders/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/orders/list.tsx
@@ -191,6 +191,7 @@ export const OrderList: React.FC<IResourceComponentsProps> = () => {
                 minWidth: 100,
                 sortable: false,
                 getActions: ({ id }) => [
+                    // @ts-expect-error `@mui/x-data-grid@5.17.12` broke the props of `GridActionsCellItem` and requires `onResize` and `onResizeCapture` props which should be optional.
                     <GridActionsCellItem
                         key={1}
                         icon={<CheckOutlinedIcon color="success" />}
@@ -210,6 +211,7 @@ export const OrderList: React.FC<IResourceComponentsProps> = () => {
                             });
                         }}
                     />,
+                    // @ts-expect-error `@mui/x-data-grid@5.17.12` broke the props of `GridActionsCellItem` and requires `onResize` and `onResizeCapture` props which should be optional.
                     <GridActionsCellItem
                         key={2}
                         icon={<CloseOutlinedIcon color="error" />}

--- a/examples/fineFoods/admin/mui/src/pages/reviews/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/reviews/list.tsx
@@ -158,6 +158,7 @@ export const ReviewsList: React.FC<IResourceComponentsProps> = () => {
                 headerName: t("table.actions"),
                 type: "actions",
                 getActions: ({ row }) => [
+                    // @ts-expect-error `@mui/x-data-grid@5.17.12` broke the props of `GridActionsCellItem` and requires `onResize` and `onResizeCapture` props which should be optional.
                     <GridActionsCellItem
                         key={1}
                         label={t("buttons.accept")}
@@ -165,6 +166,7 @@ export const ReviewsList: React.FC<IResourceComponentsProps> = () => {
                         onClick={() => handleUpdate(row.id, "approved")}
                         showInMenu
                     />,
+                    // @ts-expect-error `@mui/x-data-grid@5.17.12` broke the props of `GridActionsCellItem` and requires `onResize` and `onResizeCapture` props which should be optional.
                     <GridActionsCellItem
                         key={2}
                         label={t("buttons.reject")}

--- a/examples/fineFoods/admin/mui/src/pages/stores/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/stores/list.tsx
@@ -117,6 +117,7 @@ export const StoreList: React.FC<IResourceComponentsProps> = () => {
                 headerName: t("table.actions"),
                 type: "actions",
                 getActions: ({ row }) => [
+                    // @ts-expect-error `@mui/x-data-grid@5.17.12` broke the props of `GridActionsCellItem` and requires `onResize` and `onResizeCapture` props which should be optional.
                     <GridActionsCellItem
                         key={1}
                         label={t("buttons.edit")}
@@ -124,6 +125,7 @@ export const StoreList: React.FC<IResourceComponentsProps> = () => {
                         showInMenu
                         onClick={() => edit("stores", row.id)}
                     />,
+                    // @ts-expect-error `@mui/x-data-grid@5.17.12` broke the props of `GridActionsCellItem` and requires `onResize` and `onResizeCapture` props which should be optional.
                     <GridActionsCellItem
                         onClick={() => {
                             show();


### PR DESCRIPTION
`GridActionsCellItem` requires `onResize` and `onResizeCapture` props which should be optional. Looks like a type conflict between `@mui/x-data-grid` and `React`; I believe this will be fixed in future releases.