### PR TITLE
fix(cli): check-updates shows packages when current version ahead of next

### DIFF
--- a/.changeset/strange-hats-argue.md
+++ b/.changeset/strange-hats-argue.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-cli": patch
+---
+
+Fixed `refine check-updates` showing packages when current version ahead of next

--- a/packages/cli/src/commands/check-updates/index.test.tsx
+++ b/packages/cli/src/commands/check-updates/index.test.tsx
@@ -1,0 +1,65 @@
+import {
+    NpmOutdatedResponse,
+    RefinePackageInstalledVersionData,
+} from "@definitions/package";
+import * as checkUpdates from "./index";
+const { getOutdatedRefinePackages } = checkUpdates;
+
+test("Get outdated refine packages", async () => {
+    const testCases: {
+        input: NpmOutdatedResponse;
+        output: RefinePackageInstalledVersionData[];
+    }[] = [
+        {
+            input: {
+                "@pankod/refine-core": {
+                    current: "1.0.0",
+                    wanted: "1.0.1",
+                    latest: "2.0.0",
+                },
+                "@pankod/refine-cli": {
+                    current: "1.1.1",
+                    wanted: "1.1.1",
+                    latest: "1.1.0",
+                },
+                "@pankod/canvas2video": {
+                    current: "1.1.1",
+                    wanted: "1.1.1",
+                    latest: "1.1.1",
+                },
+                "@owner/package-name": {
+                    current: "1.1.1",
+                    wanted: "1.1.1",
+                    latest: "1.1.0",
+                },
+                "@owner/package-name1": {
+                    current: "N/A",
+                    wanted: "undefined",
+                    latest: "NaN",
+                },
+                "@owner/refine-react": {
+                    current: "1.0.0",
+                    wanted: "1.0.1",
+                    latest: "2.0.0",
+                },
+            },
+            output: [
+                {
+                    name: "@pankod/refine-core",
+                    current: "1.0.0",
+                    wanted: "1.0.1",
+                    latest: "2.0.0",
+                },
+            ],
+        },
+    ];
+
+    for (const testCase of testCases) {
+        jest.spyOn(checkUpdates, "getOutdatedPackageList").mockResolvedValue(
+            testCase.input,
+        );
+
+        const result = await getOutdatedRefinePackages();
+        expect(result).toEqual(testCase.output);
+    }
+});

--- a/packages/cli/src/commands/update/interactive/index.test.tsx
+++ b/packages/cli/src/commands/update/interactive/index.test.tsx
@@ -28,6 +28,10 @@ test("Validate interactive prompt", () => {
 test("Categorize UI Group", () => {
     const testCases = [
         {
+            input: [],
+            output: null,
+        },
+        {
             input: [
                 {
                     name: "@pankod/refine-airtable",

--- a/packages/cli/src/commands/update/interactive/index.ts
+++ b/packages/cli/src/commands/update/interactive/index.ts
@@ -27,6 +27,11 @@ export const promptInteractiveRefineUpdate = async (
     packages: RefinePackageInstalledVersionData[],
 ) => {
     const uiGroup = createUIGroup(packages);
+    if (!uiGroup) {
+        console.log("All `refine` packages are up to date. 🎉");
+        return;
+    }
+
     const inquirerUI = createInquirerUI(uiGroup);
 
     const answers = await inquirer.prompt<{
@@ -64,7 +69,7 @@ export const validatePrompt = (input: string[]) => {
 
 export const createUIGroup = (
     packages: RefinePackageInstalledVersionData[],
-): UIGroup => {
+): UIGroup | null => {
     const packagesCategorized: UIGroup = {
         patch: [],
         minor: [],
@@ -105,7 +110,11 @@ export const createUIGroup = (
         }
     });
 
-    return packagesCategorized;
+    const allHasPackages = Object.values(packagesCategorized).every(
+        (group) => group.length > 0,
+    );
+
+    return allHasPackages ? packagesCategorized : null;
 };
 
 const createInquirerUI = (uiGroup: UIGroup) => {

--- a/packages/cli/src/definitions/package.ts
+++ b/packages/cli/src/definitions/package.ts
@@ -10,7 +10,7 @@ export type NpmOutdatedResponse = Record<
         current: string;
         wanted: string;
         latest: string;
-        dependet: string;
+        dependet?: string;
     }
 >;
 


### PR DESCRIPTION
When user has installed `next` version, it will be ahead of the `latest` version. But `npm outdated` command still returns as an outdated package. 
So we need to filter out the if `current` version is ahead of `latest` version.

![image](https://user-images.githubusercontent.com/23058882/203737341-ff11c794-e306-466a-8216-92d2fece8951.png)

-   [ ] Corresponding issues are created/updated or not needed
-   [ ] Docs are updated/provided or not needed
-   [ ] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
