### PR TITLE
feat: create multiple resource support for refine-cli

### DIFF
--- a/.changeset/polite-pillows-leave.md
+++ b/.changeset/polite-pillows-leave.md
@@ -1,0 +1,6 @@
+---
+"@pankod/refine-cli": patch
+---
+- Rename command name `generate:resource` to `create-resource`.
+- Removed the requirement for the `resource name` parameter. Ask for `resource name` and `actions` with `inquirer`.
+- Add multiple resource create support. (`refine create-resource post category user`)

--- a/packages/cli/src/commands/create-resource/index.ts
+++ b/packages/cli/src/commands/create-resource/index.ts
@@ -22,7 +22,7 @@ const load = (program: Command) => {
 
     return program
         .command("create-resource <name>")
-        .description("Generate a new resource")
+        .description("Create a new resource files")
         .option(
             "-a, --actions [actions]",
             "Only generate the specified actions. (ex: list,create,edit,show)",

--- a/packages/cli/src/commands/create-resource/index.ts
+++ b/packages/cli/src/commands/create-resource/index.ts
@@ -21,7 +21,7 @@ const load = (program: Command) => {
     const { path } = getResourcePath(projectType);
 
     return program
-        .command("generate:resource <name>")
+        .command("create-resource <name>")
         .description("Generate a new resource")
         .option(
             "-a, --actions [actions]",

--- a/packages/cli/src/commands/generate/resource/index.ts
+++ b/packages/cli/src/commands/generate/resource/index.ts
@@ -26,7 +26,7 @@ const load = (program: Command) => {
         .option(
             "-a, --actions [actions]",
             "Only generate the specified actions. (ex: list,create,edit,show)",
-            defaultActions,
+            "list,create,edit,show",
         )
         .option(
             "-p, --path [path]",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,17 +1,25 @@
 #!/usr/bin/env node
 import { Command } from "commander";
-import { readFileSync } from "fs-extra";
 
-import checkUpdates from "./commands/check-updates";
-import createResource from "./commands/create-resource";
-import update from "./commands/update";
-import { dev, build, start, run } from "./commands/runner";
+import checkUpdates from "@commands/check-updates";
+import createResource from "@commands/create-resource";
+import update from "@commands/update";
+import { dev, build, start, run } from "@commands/runner";
 import "@utils/env";
+import { getPackageJson } from "@utils/package";
 
 const bootstrap = () => {
-    const packageJson = JSON.parse(
-        readFileSync(`${__dirname}/../package.json`, "utf8"),
-    );
+    let packageJson;
+
+    // check package json if exists
+    try {
+        packageJson = getPackageJson();
+    } catch (e) {
+        console.error(
+            "The `package.json` file required to run could not be found.",
+        );
+        process.exit(1);
+    }
 
     const program = new Command();
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,7 +3,7 @@ import { Command } from "commander";
 import { readFileSync } from "fs-extra";
 
 import checkUpdates from "./commands/check-updates";
-import resourceGenerate from "./commands/generate/resource";
+import createResource from "./commands/create-resource";
 import update from "./commands/update";
 import { dev, build, start, run } from "./commands/runner";
 import "@utils/env";
@@ -25,7 +25,7 @@ const bootstrap = () => {
         .helpOption("-h, --help", "Output usage information.");
 
     // load commands
-    resourceGenerate(program);
+    createResource(program);
     checkUpdates(program);
     update(program);
     dev(program);


### PR DESCRIPTION
- Rename command name `generate:resource` to `create-resource`.
- Removed the requirement for the `resource name` parameter. Ask for `resource name` and `actions` with `inquirer`.
- Add multiple resource create support. (`refine create-resource post category user`)
