### PR TITLE
fix: date fields of `antd/edit` in `inferencer` 

### DIFF
--- a/.changeset/fast-turtles-roll.md
+++ b/.changeset/fast-turtles-roll.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-inferencer": patch
+---
+
+Added `undefined` check for date field values in `@pankod/refine-inferencer/antd`'s `EditInferencer` component to prevent setting it to current date when it's not provided.

--- a/packages/inferencer/src/inferencers/antd/__tests__/__snapshots__/edit.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/antd/__tests__/__snapshots__/edit.test.tsx.snap
@@ -554,8 +554,8 @@ exports[`AntdEditInferencer should match the snapshot 1`] = `
                                   placeholder="Select date"
                                   readonly=""
                                   size="12"
-                                  title="2022-11-24"
-                                  value="2022-11-24"
+                                  title=""
+                                  value=""
                                 />
                                 <span
                                   class="ant-picker-suffix"
@@ -576,30 +576,6 @@ exports[`AntdEditInferencer should match the snapshot 1`] = `
                                     >
                                       <path
                                         d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </span>
-                                <span
-                                  class="ant-picker-clear"
-                                  role="button"
-                                >
-                                  <span
-                                    aria-label="close-circle"
-                                    class="anticon anticon-close-circle"
-                                    role="img"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      data-icon="close-circle"
-                                      fill="currentColor"
-                                      focusable="false"
-                                      height="1em"
-                                      viewBox="64 64 896 896"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
                                       />
                                     </svg>
                                   </span>
@@ -645,8 +621,8 @@ exports[`AntdEditInferencer should match the snapshot 1`] = `
                                   placeholder="Select date"
                                   readonly=""
                                   size="12"
-                                  title="2022-11-24"
-                                  value="2022-11-24"
+                                  title=""
+                                  value=""
                                 />
                                 <span
                                   class="ant-picker-suffix"
@@ -667,30 +643,6 @@ exports[`AntdEditInferencer should match the snapshot 1`] = `
                                     >
                                       <path
                                         d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </span>
-                                <span
-                                  class="ant-picker-clear"
-                                  role="button"
-                                >
-                                  <span
-                                    aria-label="close-circle"
-                                    class="anticon anticon-close-circle"
-                                    role="img"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      data-icon="close-circle"
-                                      fill="currentColor"
-                                      focusable="false"
-                                      height="1em"
-                                      viewBox="64 64 896 896"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
                                       />
                                     </svg>
                                   </span>

--- a/packages/inferencer/src/inferencers/antd/edit.tsx
+++ b/packages/inferencer/src/inferencers/antd/edit.tsx
@@ -338,7 +338,7 @@ export const EditInferencer: InferencerResultComponent = createInferencer({
                         .join(", ")
                         .replace(/"index"/, "index");
 
-                    return `
+                    return jsx`
                         <>
                             {(${accessor(
                                 recordName,
@@ -350,7 +350,7 @@ export const EditInferencer: InferencerResultComponent = createInferencer({
                                         field.key,
                                     )} \${index+1}\`}
                                     name={[${val}]}
-                                    getValueProps={(value) => ({ value: dayjs(value) })}
+                                    getValueProps={(value) => ({ value: value ? dayjs(value) : undefined })}
                                 >
                                     <DatePicker />
                                 </Form.Item>
@@ -369,7 +369,7 @@ export const EditInferencer: InferencerResultComponent = createInferencer({
                                 required: true,
                             },
                         ]}
-                        getValueProps={(value) => ({ value: dayjs(value) })}
+                        getValueProps={(value) => ({ value: value ? dayjs(value) : undefined })}
                     >
                         <DatePicker />
                     </Form.Item>


### PR DESCRIPTION
Added `undefined` check for date field values in `@pankod/refine-inferencer/antd`'s `EditInferencer` component to prevent setting it to current date when it's not provided.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
