### PR TITLE
fix(useShow): Pass queryOptions correctly through useShow hook

### DIFF
--- a/.changeset/short-mice-fry.md
+++ b/.changeset/short-mice-fry.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Fixed `queryOptions` parameter of `useShow` hook

--- a/packages/core/src/hooks/show/useShow.ts
+++ b/packages/core/src/hooks/show/useShow.ts
@@ -95,6 +95,7 @@ export const useShow = <
         id: showId ?? "",
         queryOptions: {
             enabled: showId !== undefined,
+            ...queryOptions,
         },
         successNotification,
         errorNotification,
@@ -102,7 +103,6 @@ export const useShow = <
         liveMode,
         onLiveEvent,
         dataProviderName,
-        ...queryOptions,
     });
 
     return {


### PR DESCRIPTION
A recent PR #3030 added a feature to accept queryOptions as a parameter to the `useShow` hook. It however was not passed in correctly through the `useShow` hook to the `useOne` hook (spread in the useOne props bag instead of the queryOptions bag, see further details in #3072.

Change fixes the bug.

### Test plan (required)

Tests pass.
Verified locally that the queryOptions are passed through to `useOne` from `useShow`.

### Closing issues

closes #3072

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
