### PR TITLE
feat: export material-ui localization files

### DIFF
--- a/.changeset/tasty-llamas-joke.md
+++ b/.changeset/tasty-llamas-joke.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": minor
+---
+
+exported material-ui localization files

--- a/packages/mui/src/index.tsx
+++ b/packages/mui/src/index.tsx
@@ -2,8 +2,10 @@ export * from "@mui/x-data-grid";
 export * from "@mui/system";
 
 import * as colors from "@mui/material/colors";
+import * as locale from "@mui/material/locale";
 
 export { colors };
+export { locale };
 export {
     alpha,
     createStyles,


### PR DESCRIPTION
closes #3055

> Currently, I have to install @mui/material manually to be able to use its translation files. It's not ideal. Especially because you have i18n provider, I assume this library is globally adopted so exporting locale files is essential.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [ ] Examples are updated/provided or not needed
-   [ ] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [ ] Changesets are provided or not needed
