### PR TITLE
feat: add argument support for create-refine-app

### DIFF
--- a/.changeset/breezy-suns-sort.md
+++ b/.changeset/breezy-suns-sort.md
@@ -1,0 +1,15 @@
+---
+"create-refine-app": minor
+---
+
+Added argument support
+
+before:
+```bash
+npm create refine-app -- -o refine-antd tutorial
+```
+
+after:
+```bash
+npm create refine-app -o refine-antd tutorial
+```

--- a/packages/create-refine-app/src/index.ts
+++ b/packages/create-refine-app/src/index.ts
@@ -17,14 +17,44 @@ const bootstrap = () => {
         )
         .usage("<command> [options]")
         .helpOption("-h, --help", "Output usage information.")
+        .option(
+            "-s, --source <source-path>",
+            "specify a custom source of plugins",
+        )
+        .option(
+            "-b, --branch <source-git-branch>",
+            "specify a custom branch in source of plugins",
+        )
+        .option(
+            "-o, --preset <preset-name>",
+            "specify a preset to use for the project",
+        )
+        .option(
+            "-l, --lucky",
+            "use this option to generate a project with random answers",
+        )
         .allowUnknownOption(true)
         .allowExcessArguments(true)
         .action((_, command: Command) => {
             const superplateExecutable = require.resolve(".bin/superplate");
+            console.log({ command: command });
             try {
                 execa.sync(
                     superplateExecutable,
-                    [...command.args, "--project=refine"],
+                    [
+                        ...command.args,
+                        "--project=refine",
+                        command.getOptionValue("source")
+                            ? "--source=" + command.getOptionValue("source")
+                            : "",
+                        command.getOptionValue("branch")
+                            ? "--branch=" + command.getOptionValue("branch")
+                            : "",
+                        command.getOptionValue("preset")
+                            ? "--preset=" + command.getOptionValue("preset")
+                            : "",
+                        command.getOptionValue("lucky") ? "--lucky" : "",
+                    ],
                     {
                         stdio: "inherit",
                     },


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Added argument support

before:
```bash
npm create refine-app -- -o refine-antd tutorial
```

after:
```bash
npm create refine-app -o refine-antd tutorial
```