### PR TITLE
fix(core): notification provider with hooks

### DIFF
--- a/.changeset/seven-terms-design.md
+++ b/.changeset/seven-terms-design.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Update `notificationProvider` prop handling by converting to a custom hook to prevent hook usage errors.

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -42,6 +42,7 @@ import {
     AuditLogProvider,
     DashboardPageProps,
     IRefineOptions,
+    INotificationContext,
 } from "../../../interfaces";
 
 interface QueryClientConfig {
@@ -300,11 +301,13 @@ export const Refine: React.FC<RefineProps> = ({
         });
     }, [reactQueryWithDefaults.clientConfig]);
 
-    const notificationProviderContextValues = React.useMemo(() => {
+    const useNotificationProviderValues = React.useMemo(() => {
         return typeof notificationProvider === "function"
-            ? notificationProvider()
-            : notificationProvider ?? {};
+            ? notificationProvider
+            : () => notificationProvider ?? ({} as INotificationContext);
     }, [notificationProvider]);
+
+    const notificationProviderContextValues = useNotificationProviderValues();
 
     const resources: IResourceItem[] = useDeepMemo(() => {
         const _resources: IResourceItem[] = [];


### PR DESCRIPTION
Updated `notificationProvider` prop usage in `<Refine />` component to handle hook calls inside function values. This was causing warnings on console in `@pankod/refine-mui` and `@pankod/refine-chakra-ui`.

### Closing issues

Resolves #3089 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
