### PR TITLE
fix: `@pankod/refine-simple-rest` files config

### DIFF
--- a/.changeset/angry-ladybugs-laugh.md
+++ b/.changeset/angry-ladybugs-laugh.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-simple-rest": patch
+---
+
+Add `refine.config.js` to included package files.

--- a/packages/simple-rest/package.json
+++ b/packages/simple-rest/package.json
@@ -8,7 +8,8 @@
   "private": false,
   "files": [
     "dist",
-    "src"
+    "src",
+    "./refine.config.js"
   ],
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Added missing `refine.config.js` file to `files` property in `package.json` of `@pankod/refine-simple-rest`