### PR TITLE
feat: antd v5 page header

### DIFF
--- a/documentation/docs/api-reference/antd/components/basic-views/create.md
+++ b/documentation/docs/api-reference/antd/components/basic-views/create.md
@@ -4,9 +4,6 @@ title: Create
 swizzle: true
 ---
 
-import pageHeaderPropsUsage from '@site/static/img/guides-and-concepts/basic-views/create/pageHeaderPropsUsage.png'
-import actionButtonsUsage from '@site/static/img/guides-and-concepts/basic-views/create/actionButtonsUsage.png'
-
 `<Create>` provides us a layout to display the page. It does not contain any logic but adds extra functionalities like action buttons and giving titles to the page.
 
 We'll show what `<Create>` does using properties with examples.
@@ -727,67 +724,10 @@ render(
 );
 ```
 
-### ~~`actionButtons`~~
-
-:::caution Deprecated
-Use `headerButtons` or `footerButtons` instead.
-:::
-
-`<Create>` uses the Ant Design [`<Card>`](https://ant.design/components/card) component. The `action` property of the `<Card>` component shows `<SaveButton>` and `<DeleteButton>` based on your resource definition in the `resources` property you pass to `<Refine>`. If you want to use other things instead of these buttons, you can use the `actionButton` property like the code below.
-
-```tsx
-import { Create, Button } from "@pankod/refine-antd";
-
-export const CreatePage: React.FC = () => {
-    return (
-        <Create
-            actionButtons={
-                <>
-                    <Button type="primary">Custom Button 1</Button>
-                    <Button size="small">Custom Button 2</Button>
-                </>
-            }
-        >
-            ...
-        </Create>
-    );
-};
-```
-
-### ~~`pageHeaderProps`~~
-
-:::caution Deprecated
-Use `headerProps`, `wrapperProps` or `contentProps` instead.
-:::
-
-`<Create>` uses the Ant Design `<PageHeader>` components so you can customize with the props of `pageHeaderProps`.
-
-By default, the `breadcrumb` property of the `<PageHeader>` component shows [`<Breadcrumb>`][breadcrumb-component] component.
-
-[Refer to the `<PageHeader>` documentation for detailed usage. &#8594](https://ant.design/components/page-header/#API)
-
-```tsx
-import { Create, Breadcrumb } from "@pankod/refine-antd";
-
-export const CreatePage: React.FC = () => {
-    return (
-        <Create
-            pageHeaderProps={{
-                onBack: () => console.log("Hello, refine"),
-                subTitle: "Subtitle",
-                breadcrumb: <Breadcrumb breadcrumbProps={{ separator: "-" }} />,
-            }}
-        >
-            ...
-        </Create>
-    );
-};
-```
-
 ## API Reference
 
 ### Props
 
-<PropsTable module="@pankod/refine-antd/Create" goBack-default="`<ArrowLeft />`" />
+<PropsTable module="@pankod/refine-antd/Create" goBack-default="`<ArrowLeft />`" headerProps-type="[`PageHeaderProps`](https://procomponents.ant.design/en-US/components/page-header)" />
 
 [breadcrumb-component]: /api-reference/antd/components/breadcrumb.md

--- a/documentation/docs/api-reference/antd/components/basic-views/edit.md
+++ b/documentation/docs/api-reference/antd/components/basic-views/edit.md
@@ -4,9 +4,6 @@ title: Edit
 swizzle: true
 ---
 
-import pageHeaderPropsUsage from '@site/static/img/guides-and-concepts/basic-views/edit/pageHeaderPropsUsage.png'
-import actionButtonsUsage from '@site/static/img/guides-and-concepts/basic-views/edit/actionButtonsUsage.png'
-
 `<Edit>` provides us a layout for displaying the page. It does not contain any logic but adds extra functionalities like a refresh button.
 
 We will show what `<Edit>` does using properties with examples.
@@ -1031,92 +1028,13 @@ render(
 );
 ```
 
-### ~~`actionButtons`~~
-
-:::caution Deprecated
-Use `headerButtons` or `footerButtons` instead.
-:::
-
-`<Edit>` uses the Ant Design [`<Card>`](https://ant.design/components/card) component. The `action` property of the `<Card>` component shows `<SaveButton>` or `<DeleteButton>` based on your resource definition in the `resources` property you pass to `<Refine>`. If you want to use other things instead of these buttons, you can use the `actionButton` property like the code below.
-
-```tsx
-import { Edit, Button } from "@pankod/refine-antd";
-
-export const EditPage: React.FC = () => {
-    return (
-        <Edit
-            actionButtons={
-                <>
-                    <Button type="primary">Custom Button 1</Button>
-                    <Button size="small">Custom Button 2</Button>
-                </>
-            }
-        >
-            ...
-        </Edit>
-    );
-};
-```
-
-<br/>
-<div class="img-container">
-    <div class="window">
-        <div class="control red"></div>
-        <div class="control orange"></div>
-        <div class="control green"></div>
-    </div>
-    <img src={actionButtonsUsage} alt="actionButton Usage" />
-</div>
-<br/>
-
-### ~~`pageHeaderProps`~~
-
-:::caution Deprecated
-Use `headerProps`, `wrapperProps` or `contentProps` instead.
-:::
-
-`<Edit>` uses the Ant Design [`<PageHeader>`](https://ant.design/components/page-header/#API) components, which means that you can customize the properties of `pageHeaderProps`.
-
-By default, the `extra` property of the `<PageHeader>` component shows `<RefreshButton>` or `<ListButton>` based on your resource definition in the `resources` property you pass to `<Refine>` and the `breadcrumb` property shows [`<Breadcrumb>`][breadcrumb-component] component.
-
-```tsx
-import { Edit } from "@pankod/refine-antd";
-
-export const EditPage: React.FC = () => {
-    return (
-        <Edit
-            pageHeaderProps={{
-                onBack: () => console.log("Hello, refine"),
-                subTitle: "Subtitle",
-            }}
-        >
-            ...
-        </Edit>
-    );
-};
-```
-
-<br/>
-<div class="img-container">
-    <div class="window">
-        <div class="control red"></div>
-        <div class="control orange"></div>
-        <div class="control green"></div>
-    </div>
-    <img src={pageHeaderPropsUsage} alt="pageHeaderProps Usage"/>
-</div>
-<br/>
-
-:::caution
-`<Edit>` component needs the `id` information for work properly so if you use the `<Edit>` component in custom pages, you should pass the `recordItemId` property.
-:::
-
 ## API Reference
+
 ### Properties
 
 <PropsTable module="@pankod/refine-antd/Edit" 
 contentProps-type="[`CardProps`](https://ant.design/components/card/#API)"
-headerProps-type="[`PageHeaderProps`](https://ant.design/components/page-header/#API)"
+headerProps-type="[`PageHeaderProps`](https://procomponents.ant.design/en-US/components/page-header)" 
 headerButtons-default="[`ListButton`](https://refine.dev/docs/api-reference/antd/components/buttons/list-button/) and [`RefreshButton`](https://refine.dev/docs/api-reference/antd/components/buttons/refresh-button/)"
 headerButtonProps-type="[`SpaceProps`](https://ant.design/components/space/)"
 deleteButtonProps-type="[`DeleteButtonProps`](/docs/api-reference/antd/components/buttons/delete-button/)"

--- a/documentation/docs/api-reference/antd/components/basic-views/list.md
+++ b/documentation/docs/api-reference/antd/components/basic-views/list.md
@@ -5,8 +5,6 @@ sidebar_label: List
 swizzle: true
 ---
 
-import pageHeaderPropsUsage from '@site/static/img/guides-and-concepts/basic-views/list/pageHeaderProps.png'
-
 `<List>` provides us a layout to display the page. It does not contain any logic but adds extra functionalities like a create button or giving the page titles.
 
 We will show what `<List>` does using properties with examples.
@@ -502,57 +500,16 @@ render(
 );
 ```
 
-### ~~`pageHeaderProps`~~
-
-:::caution Deprecated
-Use `headerProps`, `wrapperProps` or `contentProps` instead.
-:::
-
-`<List>` uses ant-design `<PageHeader>` components so you can customize with the props of `pageHeaderProps`.
-
-By default, the `breadcrumb` property of the `<PageHeader>` component shows [`<Breadcrumb>`][breadcrumb-component] component.
-
-[Refer to the `<PageHeader>` documentation for detailed usage. &#8594](https://ant.design/components/page-header/#API)
-
-```tsx
-import { List } from "@pankod/refine-antd";
-
-export const ListPage: React.FC = () => {
-    return (
-        <List
-            pageHeaderProps={{
-                onBack: () => console.log("clicked"),
-                subTitle: "Subtitle",
-            }}
-        >
-            ...
-        </List>
-    );
-};
-```
-
-<br/>
-<div class="img-container">
-    <div class="window">
-        <div class="control red"></div>
-        <div class="control orange"></div>
-        <div class="control green"></div>
-    </div>
-       <img src={pageHeaderPropsUsage} alt="pageHeaderProps Usage"/>
-
-</div>
-<br/>
-
 ## API Reference
 
 ### Properties
 
 <PropsTable module="@pankod/refine-antd/List" 
-headerProps-type="[`PageHeaderProps`](https://ant.design/components/page-header/#API)"
+headerProps-type="[`PageHeaderProps`](https://procomponents.ant.design/en-US/components/page-header)" 
 headerButtonProps-type="[`SpaceProps`](https://ant.design/components/space/)"
 createButtonProps-type="[`ButtonProps`](https://ant.design/components/button/#API) & `{ resourceName: string }`"
 breadcrumb-default="[`<Breadcrumb>`](https://ant.design/components/breadcrumb/)"
 canCreate-default="If the resource is passed a create component, `true` else `false`"
- />
+/>
 
 [breadcrumb-component]: /api-reference/antd/components/breadcrumb.md

--- a/documentation/docs/api-reference/antd/components/basic-views/show.md
+++ b/documentation/docs/api-reference/antd/components/basic-views/show.md
@@ -4,8 +4,6 @@ title: Show
 swizzle: true
 ---
 
-import pageHeaderPropsUsage from '@site/static/img/guides-and-concepts/basic-views/show/pageHeaderPropsUsage.png'
-import actionButtonsUsage from '@site/static/img/guides-and-concepts/basic-views/show/actionButtonsUsage.png'
 import isLoading from '@site/static/img/guides-and-concepts/basic-views/show/isLoading.png'
 
 `<Show>` provides us a layout for displaying the page. It does not contain any logic but adds extra functionalities like a refresh button or giving title to the page.
@@ -820,91 +818,13 @@ render(
 );
 ```
 
-### ~~`actionButtons`~~
-
-:::caution Deprecated
-Use `headerButtons` or `footerButtons` instead.
-:::
-
-`<Show>` uses the Ant Design [`<Card>`](https://ant.design/components/card/) component so you can customize the `action` property with the properties of `actionButtons`. By default, the `action` property of the `<Card>` component shows nothing in the `<Show>` component.
-
-```tsx
-import { Show, Space, Button } from "@pankod/refine-antd";
-
-export const ShowPage: React.FC = () => {
-    return (
-        <Show
-            actionButtons={
-                <Space>
-                    <Button type="primary">Custom Button 1</Button>
-                    <Button type="default">Custom Button 2</Button>
-                </Space>
-            }
-        >
-            ...
-        </Show>
-    );
-};
-```
-
-<div class="img-container">
-    <div class="window">
-        <div class="control red"></div>
-        <div class="control orange"></div>
-        <div class="control green"></div>
-    </div>
-    <img src={actionButtonsUsage} alt="actionButton Usage" />
-</div>
-<br/>
-
-### ~~`pageHeaderProps`~~
-
-:::caution Deprecated
-Use `headerProps`, `wrapperProps` or `contentProps` instead.
-:::
-
-`<Show>` uses the Ant Design [`<PageHeader>`](https://ant.design/components/page-header/#API) components so you can customize it with the properties of `pageHeaderProps`.
-
-By default, the `extra` property of the `<PageHeader>` component shows `<RefreshButton>`, `<ListButton>`, `<EditButton>` and `<DeleteButton>` based on your resource definition in the `resources` property you pass to `<Refine>` and the `breadcrumb` property shows [`<Breadcrumb>`][breadcrumb-component] component.
-
-```tsx
-import { Show } from "@pankod/refine-antd";
-
-export const ShowPage: React.FC = () => {
-    return (
-        <Show
-            pageHeaderProps={{
-                onBack: () => console.log("Hello, refine"),
-                subTitle: "Subtitle",
-            }}
-        >
-            ...
-        </Show>
-    );
-};
-```
-
-<div class="img-container">
-    <div class="window">
-        <div class="control red"></div>
-        <div class="control orange"></div>
-        <div class="control green"></div>
-    </div>
-    <img src={pageHeaderPropsUsage} alt="pageHeaderProps Usage"/>
-</div>
-<br/>
-
-:::caution
-The `<Show>` component needs the `id` information for work properly, so if you use the `<Show>` component in custom pages, you should pass the `recordItemId` property.
-:::
-
 ## API Reference
 
 ### Properties
 
 <PropsTable module="@pankod/refine-antd/Show"
 contentProps-type="[`CardProps`](https://ant.design/components/card/#API)"
-headerProps-type="[`PageHeaderProps`](https://ant.design/components/page-header/#API)"
+headerProps-type="[`PageHeaderProps`](https://procomponents.ant.design/en-US/components/page-header)" 
 headerButtons-default="[`ListButton`](https://refine.dev/docs/api-reference/antd/components/buttons/list-button/), [`RefreshButton`](https://refine.dev/docs/api-reference/antd/components/buttons/refresh-button/), [`EditButton`](https://refine.dev/docs/api-reference/antd/components/buttons/edit-button/) and [`DeleteButton`](https://refine.dev/docs/api-reference/antd/components/buttons/delete-button/)"
 headerButtonProps-type="[`SpaceProps`](https://ant.design/components/space/)"
 deleteButtonProps-type="[`DeleteButtonProps`](/docs/api-reference/antd/components/buttons/delete-button/)"
@@ -914,26 +834,3 @@ breadcrumb-default="[`<Breadcrumb>`](https://ant.design/components/breadcrumb/)"
 goBack-default="`<ArrowLeft />`"
 goBack-type="`ReactNode`"
 />
-
-| Property                                                                                                     | Description                                                       | Type                                                                            | Default                                                                                                                        |
-| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| title                                                                                                        | Adds a title                                                      | `React.ReactNode`                                                               | `"Show"` prefix and singular of `resource.name`                                                                                |
-| resource                                                                                                     | Resource name for API data interactions                           | `string`                                                                        | Resource name that it reads from the URL.                                                                                      |
-| canDelete                                                                                                    | Adds a delete button                                              | `boolean`                                                                       | If the resource has `canDelete` prop it is `true` else `false`                                                                 |
-| canEdit                                                                                                      | Adds an edit button                                               | `boolean`                                                                       | If the resource has `canEdit` prop it is `true` else `false`                                                                   |
-| recordItemId                                                                                                 | The record id for `<RefreshButton>`                               | [`BaseKey`](/api-reference/core/interfaces.md#basekey)                          |                                                                                                                                |
-| dataProviderName                                                                                             | To specify a data provider other than `default` use this property | `string`                                                                        |                                                                                                                                |
-| goBack                                                                                                       | Custom back icon element                                          | `React.ReactNode`                                                               | `<ArrowLeft />`                                                                                                                |
-| isLoading                                                                                                    | Gets passed to the `loading` prop of the `<Card>`                 | `boolean`                                                                       | `false`                                                                                                                        |
-| breadcrumb                                                                                                   | Custom breadcrumb element                                         | `React.ReactNode`                                                               | `<Breadcrumb/>`                                                                                                                |
-| wrapperProps                                                                                                 | Wrapper element props                                             | `React.DetailedHTMLProps<HTMLDivElement>`                                       |                                                                                                                                |
-| headerProps                                                                                                  | Header element props                                              | `PageHeaderProps`                                                               |                                                                                                                                |
-| contentProps                                                                                                 | Content wrapper element props                                     | `CardProps`                                                                     |                                                                                                                                |
-| headerButtons                                                                                                | Header buttons element or render function                         | `({ defaultButtons: React.ReactNode }) => React.ReactNode` \| `React.ReactNode` |                                                                                                                                |
-| headerButtonProps                                                                                            | Header buttons wrapper element props                              | `SpaceProps`                                                                    |                                                                                                                                |
-| footerButtons                                                                                                | Footer buttons element or render function                         | `({ defaultButtons: React.ReactNode }) => React.ReactNode` \| `React.ReactNode` |                                                                                                                                |
-| footerButtonProps                                                                                            | Footer buttons wrapper element props                              | `SpaceProps`                                                                    |                                                                                                                                |
-| <div className="required-block"><div>actionButtons</div> <div className=" required">deprecated</div></div>   | Gets passed to the `extra` prop of the `<Card>`                   | `React.ReactNode`                                                               | `<SaveButton>` and depending on your resource configuration (`canDelete` prop)                                                 |
-| <div className="required-block"><div>pageHeaderProps</div> <div className=" required">deprecated</div></div> | Passes props for `<PageHeader>`                                   | [PageHeaderProps](https://ant.design/components/page-header/#API)               | { ghost: false, [title](#title), extra: `<ListButton>` and `<RefreshButton>`, breadcrumb: [Breadcrumb][breadcrumb-component] } |
-
-[breadcrumb-component]: /api-reference/antd/components/breadcrumb.md

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -15,12 +15,12 @@
     },
     "peerDependencies": {
         "@pankod/refine-core": "^3.23.2",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0",
         "antd": "^5.0.3",
         "dayjs": "^1.10.7",
         "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "@types/react-dom": "^17.0.0 || ^18.0.0"
+        "react-dom": "^17.0.0 || ^18.0.0"
     },
     "devDependencies": {
         "@pankod/refine-cli": "^1.7.0",
@@ -46,12 +46,13 @@
         "typescript": "^4.7.4"
     },
     "dependencies": {
-        "@pankod/refine-ui-types": "^0.14.0",
         "@ant-design/icons": "^4.5.0",
+        "@ant-design/pro-layout": "^7.3.4",
+        "@pankod/refine-ui-types": "^0.14.0",
+        "@tanstack/react-query": "^4.10.1",
         "antd": "^5.0.3",
         "dayjs": "^1.10.7",
         "react-markdown": "^6.0.1",
-        "@tanstack/react-query": "^4.10.1",
         "remark-gfm": "^1.0.0",
         "sunflower-antd": "1.0.0-beta.3",
         "tslib": "^2.3.1"

--- a/packages/antd/src/components/crud/create/index.tsx
+++ b/packages/antd/src/components/crud/create/index.tsx
@@ -20,10 +20,8 @@ import { Breadcrumb, CreateProps, SaveButton, PageHeader } from "@components";
  */
 export const Create: React.FC<CreateProps> = ({
     title,
-    actionButtons,
     saveButtonProps,
     children,
-    pageHeaderProps,
     resource: resourceFromProps,
     isLoading = false,
     breadcrumb: breadcrumbFromProps,
@@ -55,13 +53,11 @@ export const Create: React.FC<CreateProps> = ({
 
     const defaultFooterButtons = (
         <>
-            {actionButtons ?? (
-                <SaveButton
-                    {...(isLoading ? { disabled: true } : {})}
-                    {...saveButtonProps}
-                    htmlType="submit"
-                />
-            )}
+            <SaveButton
+                {...(isLoading ? { disabled: true } : {})}
+                {...saveButtonProps}
+                htmlType="submit"
+            />
         </>
     );
 
@@ -99,7 +95,6 @@ export const Create: React.FC<CreateProps> = ({
                             : null}
                     </Space>
                 }
-                {...(pageHeaderProps ?? {})}
                 {...(headerProps ?? {})}
             >
                 <Spin spinning={isLoading}>

--- a/packages/antd/src/components/crud/edit/index.tsx
+++ b/packages/antd/src/components/crud/edit/index.tsx
@@ -30,13 +30,11 @@ import {
  */
 export const Edit: React.FC<EditProps> = ({
     title,
-    actionButtons,
     saveButtonProps,
     mutationMode: mutationModeProp,
     recordItemId,
     children,
     deleteButtonProps,
-    pageHeaderProps,
     canDelete,
     resource: resourceFromProps,
     isLoading = false,
@@ -150,7 +148,6 @@ export const Edit: React.FC<EditProps> = ({
                         <Breadcrumb />
                     )
                 }
-                {...(pageHeaderProps ?? {})}
                 {...(headerProps ?? {})}
             >
                 <Spin spinning={isLoading}>
@@ -173,8 +170,6 @@ export const Edit: React.FC<EditProps> = ({
                                                   defaultFooterButtons,
                                           })
                                         : footerButtons
-                                    : actionButtons
-                                    ? actionButtons
                                     : defaultFooterButtons}
                             </Space>,
                         ]}

--- a/packages/antd/src/components/crud/list/index.tsx
+++ b/packages/antd/src/components/crud/list/index.tsx
@@ -22,7 +22,6 @@ export const List: React.FC<ListProps> = ({
     title,
     children,
     createButtonProps,
-    pageHeaderProps,
     resource: resourceFromProps,
     wrapperProps,
     contentProps,
@@ -91,7 +90,6 @@ export const List: React.FC<ListProps> = ({
                         <Breadcrumb />
                     )
                 }
-                {...(pageHeaderProps ?? {})}
                 {...(headerProps ?? {})}
             >
                 <div {...(contentProps ?? {})}>{children}</div>

--- a/packages/antd/src/components/crud/show/index.tsx
+++ b/packages/antd/src/components/crud/show/index.tsx
@@ -30,10 +30,8 @@ export const Show: React.FC<ShowProps> = ({
     title,
     canEdit,
     canDelete,
-    actionButtons,
     isLoading = false,
     children,
-    pageHeaderProps,
     resource: resourceFromProps,
     recordItemId,
     dataProviderName,
@@ -142,7 +140,6 @@ export const Show: React.FC<ShowProps> = ({
                         <Breadcrumb />
                     )
                 }
-                {...(pageHeaderProps ?? {})}
                 {...(headerProps ?? {})}
             >
                 <Spin spinning={isLoading}>
@@ -163,8 +160,6 @@ export const Show: React.FC<ShowProps> = ({
                                               : footerButtons}
                                       </Space>,
                                   ]
-                                : actionButtons
-                                ? [actionButtons]
                                 : undefined
                         }
                         {...(contentProps ?? {})}

--- a/packages/antd/src/components/crud/types.ts
+++ b/packages/antd/src/components/crud/types.ts
@@ -10,7 +10,7 @@ import {
     RefineCrudListProps,
     RefineCrudShowProps,
 } from "@pankod/refine-ui-types";
-import { PageHeaderProps } from "@components/pageHeader";
+import { PageHeaderProps } from "../pageHeader";
 
 export type CreateProps = RefineCrudCreateProps<
     SaveButtonProps,
@@ -21,22 +21,7 @@ export type CreateProps = RefineCrudCreateProps<
         HTMLDivElement
     >,
     PageHeaderProps,
-    CardProps,
-    {
-        /**
-         * Action buttons node at the top of the view
-         * @default `<SaveButton />`
-         *
-         * @deprecated use `headerButtons` or `footerButtons` instead.
-         */
-        actionButtons?: React.ReactNode;
-        /**
-         * Additional props to be passed to the `PageHeader` component
-         *
-         * @deprecated use `headerProps`, `wrapperProps` and `contentProps` instead.
-         */
-        pageHeaderProps?: PageHeaderProps;
-    }
+    CardProps
 >;
 
 export type EditProps = RefineCrudEditProps<
@@ -49,22 +34,7 @@ export type EditProps = RefineCrudEditProps<
         HTMLDivElement
     >,
     PageHeaderProps,
-    CardProps,
-    {
-        /**
-         * Action buttons node at the bottom of the view
-         * @default `<DeleteButton />` and `<SaveButton />`
-         *
-         * @deprecated use `headerButtons` or `footerButtons` instead.
-         */
-        actionButtons?: React.ReactNode;
-        /**
-         * Additional props to be passed to the `PageHeader` component
-         *
-         * @deprecated use `headerProps`, `wrapperProps` and `contentProps` instead.
-         */
-        pageHeaderProps?: PageHeaderProps;
-    }
+    CardProps
 >;
 
 export type ListProps = RefineCrudListProps<
@@ -78,13 +48,7 @@ export type ListProps = RefineCrudListProps<
     React.DetailedHTMLProps<
         React.HTMLAttributes<HTMLDivElement>,
         HTMLDivElement
-    >,
-    {
-        /**
-         * @deprecated use `headerProps`, `wrapperProps` and `contentProps` instead.
-         */
-        pageHeaderProps?: PageHeaderProps;
-    }
+    >
 >;
 
 export type ShowProps = RefineCrudShowProps<
@@ -95,15 +59,5 @@ export type ShowProps = RefineCrudShowProps<
         HTMLDivElement
     >,
     PageHeaderProps,
-    CardProps,
-    {
-        /**
-         * @deprecated use `headerButtons` or `footerButtons` instead.
-         */
-        actionButtons?: React.ReactNode;
-        /**
-         * @deprecated use `headerProps`, `wrapperProps` and `contentProps` instead.
-         */
-        pageHeaderProps?: PageHeaderProps;
-    }
+    CardProps
 >;

--- a/packages/antd/src/components/pageHeader/index.tsx
+++ b/packages/antd/src/components/pageHeader/index.tsx
@@ -1,27 +1,11 @@
 import React, { FC } from "react";
+import {
+    PageHeader as AntdPageHeader,
+    PageHeaderProps as AntdPageHeaderProps,
+} from "@ant-design/pro-layout";
 
-export type PageHeaderProps = {
-    ghost?: boolean;
-    backIcon?: React.ReactNode;
-    onBack?: (() => void) | undefined;
-    title?: React.ReactNode;
-    breadcrumb?: React.ReactNode;
-    extra?: React.ReactNode;
-    children?: JSX.Element;
-};
+export type PageHeaderProps = AntdPageHeaderProps;
 
-export const PageHeader: FC<PageHeaderProps> = ({
-    title,
-    breadcrumb,
-    extra,
-    children,
-}) => {
-    return (
-        <>
-            <h4>{title}</h4>
-            <div>{breadcrumb}</div>
-            <div>{extra}</div>
-            {children}
-        </>
-    );
+export const PageHeader: FC<AntdPageHeaderProps> = ({ children, ...props }) => {
+    return <AntdPageHeader {...props}>{children}</AntdPageHeader>;
 };


### PR DESCRIPTION
On `antd v5`, `PageHeader` moved to `@ant-design/pro-components`.
Because of that, `@ant-design/pro-components` added as a dependency.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
