### PR TITLE
docs: add filter for conflicting namespaces

### DIFF
--- a/documentation/plugins/examples.js
+++ b/documentation/plugins/examples.js
@@ -105,7 +105,8 @@ function plugin() {
                             " " +
                             doc.title
                                 .replace("antd", "Ant Design")
-                                .replace("mui", "Material UI");
+                                .replace("mui", "Material UI")
+                                .replace("chakra-ui", "Chakra UI");
 
                         return {
                             // ...doc,
@@ -113,7 +114,8 @@ function plugin() {
                             baseTitle: doc.title,
                             title: doc.title
                                 .replace("antd", "Ant Design")
-                                .replace("mui", "Material UI"),
+                                .replace("mui", "Material UI")
+                                .replace("chakra-ui", "Chakra UI"),
                             displayTitle: _nullishCoalesce(
                                 _nullishCoalesce(
                                     doc.frontMatter["example-title"],
@@ -122,7 +124,8 @@ function plugin() {
                                 () =>
                                     doc.title
                                         .replace("antd", "Ant Design")
-                                        .replace("mui", "Material UI"),
+                                        .replace("mui", "Material UI")
+                                        .replace("chakra-ui", "Chakra UI"),
                             ),
                             description: doc.description,
                             permalink: doc.permalink,


### PR DESCRIPTION
Updated `docgen` plugin for conflicting exports causing `@pankod/refine-antd`'s `List` props to be removed.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
