### PR TITLE
chore: replace `react-live` with `@aliemir/react-live`

### DIFF
--- a/.changeset/old-swans-sell.md
+++ b/.changeset/old-swans-sell.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-inferencer": minor
+---
+
+Replaced `react-live` package with a maintained fork `@aliemir/react-live` with TypeScript support.

--- a/packages/inferencer/package.json
+++ b/packages/inferencer/package.json
@@ -132,7 +132,7 @@
         "remark-gfm": "^1.0.0",
         "tslib": "^2.3.1",
         "prettier": "^2.7.1",
-        "react-live": "github:aliemir/react-live"
+        "@aliemir/react-live": "^4.0.0"
     },
     "author": "Refine",
     "license": "MIT",

--- a/packages/inferencer/src/components/live/index.tsx
+++ b/packages/inferencer/src/components/live/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import * as RefineCore from "@pankod/refine-core";
 
-import { LivePreview, LiveProvider, ContextProps } from "react-live";
+import { LivePreview, LiveProvider, ContextProps } from "@aliemir/react-live";
 
 import { replaceImports, replaceExports } from "@/utilities";
 import { AdditionalScopeType, LiveComponentProps } from "@/types";

--- a/packages/live-previews/package.json
+++ b/packages/live-previews/package.json
@@ -25,7 +25,7 @@
     "next": "^13.0.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-live": "github:aliemir/react-live"
+    "@aliemir/react-live": "^4.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.24",

--- a/packages/live-previews/pages/preview.tsx
+++ b/packages/live-previews/pages/preview.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import type { NextPage } from "next";
-import { LivePreview, LiveProvider } from "react-live";
+import { LivePreview, LiveProvider } from "@aliemir/react-live";
 
 import Error from "@/pages/_error";
 import { Loading } from "@/src/components/loading";

--- a/packages/live-previews/src/components/live-error.tsx
+++ b/packages/live-previews/src/components/live-error.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { LiveContext } from "react-live";
+import { LiveContext } from "@aliemir/react-live";
 
 export const LiveError: React.FC = () => {
     const { error } = React.useContext(LiveContext);


### PR DESCRIPTION
Replaced `react-live` package with`@aliemir/react-live` to keep TypeScript support and resolve the issue with GitHub registry packages.

### Closing issues

Resolves #3161 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
