### PR TITLE
feat(inferencer): Ability to transform/ignore fields in inferencer components

### DIFF
--- a/.changeset/tasty-cameras-smell.md
+++ b/.changeset/tasty-cameras-smell.md
@@ -1,0 +1,7 @@
+---
+"@pankod/refine-inferencer": minor
+---
+
+- Added `fieldTransformer` prop to inferencer components to let users transform or hide the field to be rendered.
+- Hide networks errors caused by the relation detection process.
+- Added the ability to detect relations from basic types like `"text"` and `"number"`.

--- a/examples/multi-tenancy/appwrite/src/authProvider.ts
+++ b/examples/multi-tenancy/appwrite/src/authProvider.ts
@@ -1,24 +1,29 @@
+import { AppwriteException } from "@pankod/refine-appwrite";
 import { AuthProvider } from "@pankod/refine-core";
 
-import { appwriteClient } from "utility";
+import { account } from "utility";
 
 export const authProvider: AuthProvider = {
     login: async ({ email, password }) => {
         try {
-            await appwriteClient.account.createSession(email, password);
+            await account.createEmailSession(email, password);
             return Promise.resolve();
         } catch (e) {
-            return Promise.reject();
+            const { type, message, code } = e as AppwriteException;
+            return Promise.reject({
+                message,
+                name: `${code} - ${type}`,
+            });
         }
     },
     logout: async () => {
-        await appwriteClient.account.deleteSession("current");
+        await account.deleteSession("current");
 
         return "/";
     },
     checkError: () => Promise.resolve(),
     checkAuth: async () => {
-        const session = await appwriteClient.account.getSession("current");
+        const session = await account.getSession("current");
 
         if (session) {
             return Promise.resolve();
@@ -28,7 +33,7 @@ export const authProvider: AuthProvider = {
     },
     getPermissions: () => Promise.resolve(),
     getUserIdentity: async () => {
-        const user = await appwriteClient.account.get();
+        const user = await account.get();
 
         if (user) {
             return user;

--- a/examples/multi-tenancy/appwrite/src/components/product/create.tsx
+++ b/examples/multi-tenancy/appwrite/src/components/product/create.tsx
@@ -11,7 +11,7 @@ import {
     RcFile,
 } from "@pankod/refine-antd";
 
-import { appwriteClient, normalizeFile } from "utility";
+import { appwriteClient, normalizeFile, storage } from "utility";
 import { StoreContext } from "context/store";
 import { useContext } from "react";
 
@@ -90,19 +90,17 @@ export const CreateProduct: React.FC<CreateProductProps> = ({
                                         const rcFile = file as RcFile;
 
                                         const { $id } =
-                                            await appwriteClient.storage.createFile(
+                                            await storage.createFile(
                                                 "default",
                                                 rcFile.name,
                                                 rcFile,
                                                 ["role:all"],
-                                                ["role:all"],
                                             );
 
-                                        const url =
-                                            appwriteClient.storage.getFileView(
-                                                "default",
-                                                $id,
-                                            );
+                                        const url = storage.getFileView(
+                                            "default",
+                                            $id,
+                                        );
 
                                         onSuccess?.(
                                             { url },

--- a/examples/multi-tenancy/appwrite/src/components/product/edit.tsx
+++ b/examples/multi-tenancy/appwrite/src/components/product/edit.tsx
@@ -8,7 +8,7 @@ import {
     RcFile,
 } from "@pankod/refine-antd";
 
-import { appwriteClient, normalizeFile } from "utility";
+import { normalizeFile, storage } from "utility";
 
 type EditProductProps = {
     modalProps: ModalProps;
@@ -70,20 +70,17 @@ export const EditProduct: React.FC<EditProductProps> = ({
                                 try {
                                     const rcFile = file as RcFile;
 
-                                    const { $id } =
-                                        await appwriteClient.storage.createFile(
-                                            "default",
-                                            rcFile.name,
-                                            rcFile,
-                                            ["role:all"],
-                                            ["role:all"],
-                                        );
+                                    const { $id } = await storage.createFile(
+                                        "default",
+                                        rcFile.name,
+                                        rcFile,
+                                        ["role:all"],
+                                    );
 
-                                    const url =
-                                        appwriteClient.storage.getFileView(
-                                            "default",
-                                            $id,
-                                        );
+                                    const url = storage.getFileView(
+                                        "default",
+                                        $id,
+                                    );
 
                                     onSuccess?.({ url }, new XMLHttpRequest());
                                 } catch (error) {

--- a/examples/multi-tenancy/appwrite/src/components/sider/index.tsx
+++ b/examples/multi-tenancy/appwrite/src/components/sider/index.tsx
@@ -4,8 +4,11 @@ import {
     ITreeMenu,
     CanAccess,
     useRouterContext,
+    useLogout,
+    useIsExistAuthentication,
+    useMenu,
 } from "@pankod/refine-core";
-import { AntdLayout, Menu, useMenu, Grid, Icons } from "@pankod/refine-antd";
+import { AntdLayout, Menu, Grid, Icons } from "@pankod/refine-antd";
 import { antLayoutSider, antLayoutSiderMobile } from "./styles";
 
 import { StoreSelect } from "components/select";
@@ -17,6 +20,8 @@ export const CustomSider: React.FC = () => {
     const { SubMenu } = Menu;
     const { menuItems, selectedKey } = useMenu();
     const breakpoint = Grid.useBreakpoint();
+    const { mutate: mutateLogout } = useLogout();
+    const isExistAuthentication = useIsExistAuthentication();
 
     const isMobile =
         typeof breakpoint.lg === "undefined" ? false : !breakpoint.lg;
@@ -66,6 +71,16 @@ export const CustomSider: React.FC = () => {
         });
     };
 
+    const logout = isExistAuthentication && (
+        <Menu.Item
+            key="logout"
+            onClick={() => mutateLogout()}
+            icon={<Icons.LogoutOutlined />}
+        >
+            Logout
+        </Menu.Item>
+    );
+
     return (
         <AntdLayout.Sider
             collapsible
@@ -89,6 +104,7 @@ export const CustomSider: React.FC = () => {
                     <StoreSelect />
                 </Menu.Item>
                 {renderTreeView(menuItems, selectedKey)}
+                {logout}
             </Menu>
         </AntdLayout.Sider>
     );

--- a/examples/multi-tenancy/appwrite/src/utility/appwriteClient.ts
+++ b/examples/multi-tenancy/appwrite/src/utility/appwriteClient.ts
@@ -1,4 +1,4 @@
-import { Appwrite } from "@pankod/refine-appwrite";
+import { Account, Appwrite, Storage } from "@pankod/refine-appwrite";
 
 const APPWRITE_URL = "https://refine.appwrite.org/v1";
 const APPWRITE_PROJECT = "61caf74beffc8";
@@ -7,4 +7,7 @@ const appwriteClient = new Appwrite();
 
 appwriteClient.setEndpoint(APPWRITE_URL).setProject(APPWRITE_PROJECT);
 
-export { appwriteClient };
+const account = new Account(appwriteClient);
+const storage = new Storage(appwriteClient);
+
+export { appwriteClient, account, storage };

--- a/packages/inferencer/src/field-transformers/basic-to-relation.ts
+++ b/packages/inferencer/src/field-transformers/basic-to-relation.ts
@@ -1,0 +1,65 @@
+import { FieldTransformer, InferField } from "@/types";
+
+export const basicToRelation: FieldTransformer = (
+    fields,
+    resources,
+    resource,
+    record,
+) => {
+    const mapped: Array<InferField> = fields.map((field) => {
+        if (
+            !field.relation &&
+            (field.type === "text" ||
+                field.type === "richtext" ||
+                field.type === "number") &&
+            !field.canRelation
+        ) {
+            // check if value is a valid id (regex)
+            // if multiple, check value by value
+            // take accessor into account (should be single only)
+            // valid id should be a valid uuid (meaning, lowercase alphanumeric with dashes)
+            const validUUIdRegex = /^[a-z0-9-]+$/;
+
+            const isValidUUID = (value: unknown) => {
+                return validUUIdRegex.test(`${value}`);
+            };
+
+            const isNotSelf = field.key.toLowerCase() !== "id";
+
+            const singleOrNoAccessor =
+                !field.accessor || typeof field.accessor === "string";
+
+            // in case of multiple accessors, we can't infer a relation
+            // or if the field is the id field
+            if (!singleOrNoAccessor || !isNotSelf) {
+                return field;
+            }
+
+            const valuesToCheck = field.multiple
+                ? (record[field.key] as unknown[])
+                : [record[field.key]];
+
+            const allValid = valuesToCheck.every((value) => {
+                return isValidUUID(
+                    field.accessor
+                        ? (value as Record<string, unknown>)[
+                              field.accessor as string
+                          ]
+                        : value,
+                );
+            });
+
+            if (allValid) {
+                return {
+                    ...field,
+                    canRelation: true,
+                };
+            }
+
+            return field;
+        }
+        return field;
+    });
+
+    return mapped;
+};

--- a/packages/inferencer/src/field-transformers/index.ts
+++ b/packages/inferencer/src/field-transformers/index.ts
@@ -1,3 +1,4 @@
+import { basicToRelation } from "./basic-to-relation";
 import { imageByKey } from "./image-by-key";
 import { relationByResource } from "./relation-by-resource";
 import { relationToFieldable } from "./relation-to-fieldable";
@@ -6,4 +7,5 @@ export const defaultTransformers = [
     imageByKey,
     relationByResource,
     relationToFieldable,
+    basicToRelation,
 ];

--- a/packages/inferencer/src/inferencers/antd/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/antd/__tests__/__snapshots__/index.test.tsx.snap
@@ -366,7 +366,7 @@ exports[`AntdInferencer should match the snapshot 1`] = `
                                 <span
                                   class="ant-tag"
                                 >
-                                  9
+                                  Nobis Et Ut
                                 </span>
                               </td>
                               <td
@@ -491,12 +491,12 @@ exports[`AntdInferencer should match the snapshot 1`] = `
                                 <span
                                   class="ant-tag"
                                 >
-                                  5
+                                  Error Eos Et
                                 </span>
                                 <span
                                   class="ant-tag"
                                 >
-                                  9
+                                  Nobis Et Ut
                                 </span>
                               </td>
                               <td
@@ -1287,6 +1287,80 @@ exports[`AntdInferencer should match the snapshot 2`] = `
                                 class="ant-upload-list ant-upload-list-picture"
                               />
                             </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="ant-row ant-form-item"
+                    >
+                      <div
+                        class="ant-col ant-form-item-label"
+                      >
+                        <label
+                          class="ant-form-item-required"
+                          for="tags"
+                          title="Tags"
+                        >
+                          Tags
+                        </label>
+                      </div>
+                      <div
+                        class="ant-col ant-form-item-control"
+                      >
+                        <div
+                          class="ant-form-item-control-input"
+                        >
+                          <div
+                            class="ant-form-item-control-input-content"
+                          >
+                            <div
+                              class="ant-select ant-select-in-form-item ant-select-multiple ant-select-show-search"
+                            >
+                              <div
+                                class="ant-select-selector"
+                              >
+                                <div
+                                  class="ant-select-selection-overflow"
+                                >
+                                  <div
+                                    class="ant-select-selection-overflow-item ant-select-selection-overflow-item-suffix"
+                                    style="opacity: 1;"
+                                  >
+                                    <div
+                                      class="ant-select-selection-search"
+                                      style="width: 0px;"
+                                    >
+                                      <input
+                                        aria-activedescendant="tags_list_0"
+                                        aria-autocomplete="list"
+                                        aria-controls="tags_list"
+                                        aria-haspopup="listbox"
+                                        aria-owns="tags_list"
+                                        autocomplete="off"
+                                        class="ant-select-selection-search-input"
+                                        id="tags"
+                                        readonly=""
+                                        role="combobox"
+                                        style="opacity: 0;"
+                                        type="search"
+                                        unselectable="on"
+                                        value=""
+                                      />
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-selection-search-mirror"
+                                      >
+                                         
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  class="ant-select-selection-placeholder"
+                                />
+                              </div>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -2300,11 +2374,11 @@ exports[`AntdInferencer should match the snapshot 3`] = `
                         class="ant-col ant-form-item-label"
                       >
                         <label
-                          class=""
-                          for="tags_0"
-                          title="Tags 1"
+                          class="ant-form-item-required"
+                          for="tags"
+                          title="Tags"
                         >
-                          Tags 1
+                          Tags
                         </label>
                       </div>
                       <div
@@ -2316,12 +2390,91 @@ exports[`AntdInferencer should match the snapshot 3`] = `
                           <div
                             class="ant-form-item-control-input-content"
                           >
-                            <input
-                              class="ant-input"
-                              id="tags_0"
-                              type="number"
-                              value="9"
-                            />
+                            <div
+                              class="ant-select ant-select-in-form-item ant-select-multiple ant-select-show-search"
+                            >
+                              <div
+                                class="ant-select-selector"
+                              >
+                                <div
+                                  class="ant-select-selection-overflow"
+                                >
+                                  <div
+                                    class="ant-select-selection-overflow-item"
+                                    style="opacity: 1;"
+                                  >
+                                    <span
+                                      class="ant-select-selection-item"
+                                      title="Nobis Et Ut"
+                                    >
+                                      <span
+                                        class="ant-select-selection-item-content"
+                                      >
+                                        Nobis Et Ut
+                                      </span>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-selection-item-remove"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      >
+                                        <span
+                                          aria-label="close"
+                                          class="anticon anticon-close"
+                                          role="img"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="close"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="64 64 896 896"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="ant-select-selection-overflow-item ant-select-selection-overflow-item-suffix"
+                                    style="opacity: 1;"
+                                  >
+                                    <div
+                                      class="ant-select-selection-search"
+                                      style="width: 0px;"
+                                    >
+                                      <input
+                                        aria-activedescendant="tags_list_0"
+                                        aria-autocomplete="list"
+                                        aria-controls="tags_list"
+                                        aria-haspopup="listbox"
+                                        aria-owns="tags_list"
+                                        autocomplete="off"
+                                        class="ant-select-selection-search-input"
+                                        id="tags"
+                                        readonly=""
+                                        role="combobox"
+                                        style="opacity: 0;"
+                                        type="search"
+                                        unselectable="on"
+                                        value=""
+                                      />
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-selection-search-mirror"
+                                      >
+                                         
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -2767,7 +2920,12 @@ exports[`AntdInferencer should match the snapshot 4`] = `
                   <span
                     class="ant-tag"
                   >
-                    9
+                    Error Eos Et
+                  </span>
+                  <span
+                    class="ant-tag"
+                  >
+                    Nobis Et Ut
                   </span>
                   <h5
                     class="ant-typography"

--- a/packages/inferencer/src/inferencers/antd/index.tsx
+++ b/packages/inferencer/src/inferencers/antd/index.tsx
@@ -5,50 +5,25 @@ import { ShowInferencer } from "./show";
 import { ListInferencer } from "./list";
 import { CreateInferencer } from "./create";
 import { EditInferencer } from "./edit";
-import type { InferencerComponentProps } from "@/types";
+import type { InferencerComponentProps } from "../../types";
 
 const AntdInferencer: React.FC<InferencerComponentProps> = ({
-    resource,
-    name,
     action: actionFromProps,
     id: idFromProps,
+    ...props
 }) => {
     const { useParams } = useRouterContext();
     const { action, id } = useParams<ResourceRouterParams>();
 
     switch (actionFromProps ?? action) {
         case "show":
-            return (
-                <ShowInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <ShowInferencer {...props} id={idFromProps ?? id} />;
         case "create":
-            return (
-                <CreateInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <CreateInferencer {...props} id={idFromProps ?? id} />;
         case "edit":
-            return (
-                <EditInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <EditInferencer {...props} id={idFromProps ?? id} />;
         default:
-            return (
-                <ListInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <ListInferencer {...props} id={idFromProps ?? id} />;
     }
 };
 
@@ -57,3 +32,4 @@ export { ShowInferencer as AntdShowInferencer } from "./show";
 export { EditInferencer as AntdEditInferencer } from "./edit";
 export { ListInferencer as AntdListInferencer } from "./list";
 export { CreateInferencer as AntdCreateInferencer } from "./create";
+export * from "../../types";

--- a/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/index.test.tsx.snap
@@ -207,7 +207,7 @@ exports[`ChakraUIInferencer should match the snapshot 1`] = `
                     <span
                       class="css-1qm7lvz"
                     >
-                      9
+                      Nobis Et Ut
                     </span>
                   </div>
                 </td>
@@ -306,12 +306,12 @@ exports[`ChakraUIInferencer should match the snapshot 1`] = `
                     <span
                       class="css-1qm7lvz"
                     >
-                      5
+                      Error Eos Et
                     </span>
                     <span
                       class="css-1qm7lvz"
                     >
-                      9
+                      Nobis Et Ut
                     </span>
                   </div>
                 </td>
@@ -788,11 +788,65 @@ exports[`ChakraUIInferencer should match the snapshot 2`] = `
             for="field-:ru:"
             id="field-:ru:-label"
           >
+            Tags
+          </label>
+          <div
+            class="chakra-select__wrapper css-42b2qy"
+          >
+            <select
+              class="chakra-select css-1ik61og"
+              id="field-:ru:"
+              name="tags"
+            >
+              <option
+                value=""
+              >
+                Select tag
+              </option>
+              <option
+                value="5"
+              >
+                Error Eos Et
+              </option>
+              <option
+                value="9"
+              >
+                Nobis Et Ut
+              </option>
+            </select>
+            <div
+              class="chakra-select__icon-wrapper css-162mkon"
+            >
+              <svg
+                aria-hidden="true"
+                class="chakra-select__icon"
+                focusable="false"
+                role="presentation"
+                style="width: 1em; height: 1em; color: currentColor;"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          class="chakra-form-control css-h82jag"
+          role="group"
+        >
+          <label
+            class="chakra-form__label css-uvho5g"
+            for="field-:rv:"
+            id="field-:rv:-label"
+          >
             Language
           </label>
           <input
             class="chakra-input css-0"
-            id="field-:ru:"
+            id="field-:rv:"
             name="language"
             type="number"
           />
@@ -1147,35 +1201,17 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
         >
           <label
             class="chakra-form__label css-uvho5g"
-            for="field-:rv:"
-            id="field-:rv:-label"
+            for="field-:r10:"
+            id="field-:r10:-label"
           >
             Id
           </label>
           <input
             class="chakra-input css-0"
             disabled=""
-            id="field-:rv:"
+            id="field-:r10:"
             name="id"
             type="number"
-          />
-        </div>
-        <div
-          class="chakra-form-control css-h82jag"
-          role="group"
-        >
-          <label
-            class="chakra-form__label css-uvho5g"
-            for="field-:r10:"
-            id="field-:r10:-label"
-          >
-            Title
-          </label>
-          <input
-            class="chakra-input css-0"
-            id="field-:r10:"
-            name="title"
-            type="text"
           />
         </div>
         <div
@@ -1187,12 +1223,12 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
             for="field-:r11:"
             id="field-:r11:-label"
           >
-            Slug
+            Title
           </label>
           <input
             class="chakra-input css-0"
             id="field-:r11:"
-            name="slug"
+            name="title"
             type="text"
           />
         </div>
@@ -1205,12 +1241,13 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
             for="field-:r12:"
             id="field-:r12:-label"
           >
-            Content
+            Slug
           </label>
           <input
             class="chakra-input css-0"
             id="field-:r12:"
-            name="content"
+            name="slug"
+            type="text"
           />
         </div>
         <div
@@ -1222,13 +1259,12 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
             for="field-:r13:"
             id="field-:r13:-label"
           >
-            Hit
+            Content
           </label>
           <input
             class="chakra-input css-0"
             id="field-:r13:"
-            name="hit"
-            type="number"
+            name="content"
           />
         </div>
         <div
@@ -1240,6 +1276,24 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
             for="field-:r14:"
             id="field-:r14:-label"
           >
+            Hit
+          </label>
+          <input
+            class="chakra-input css-0"
+            id="field-:r14:"
+            name="hit"
+            type="number"
+          />
+        </div>
+        <div
+          class="chakra-form-control css-h82jag"
+          role="group"
+        >
+          <label
+            class="chakra-form__label css-uvho5g"
+            for="field-:r15:"
+            id="field-:r15:-label"
+          >
             Category
           </label>
           <div
@@ -1247,7 +1301,7 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
           >
             <select
               class="chakra-select css-1ik61og"
-              id="field-:r14:"
+              id="field-:r15:"
               name="category.id"
             >
               <option
@@ -1291,8 +1345,8 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
         >
           <label
             class="chakra-form__label css-uvho5g"
-            for="field-:r15:"
-            id="field-:r15:-label"
+            for="field-:r16:"
+            id="field-:r16:-label"
           >
             User
           </label>
@@ -1301,7 +1355,7 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
           >
             <select
               class="chakra-select css-1ik61og"
-              id="field-:r15:"
+              id="field-:r16:"
               name="user.id"
             >
               <option
@@ -1345,33 +1399,15 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
         >
           <label
             class="chakra-form__label css-uvho5g"
-            for="field-:r16:"
-            id="field-:r16:-label"
+            for="field-:r17:"
+            id="field-:r17:-label"
           >
             Status
           </label>
           <input
             class="chakra-input css-0"
-            id="field-:r16:"
-            name="status"
-            type="text"
-          />
-        </div>
-        <div
-          class="chakra-form-control css-h82jag"
-          role="group"
-        >
-          <label
-            class="chakra-form__label css-uvho5g"
-            for="field-:r17:"
-            id="field-:r17:-label"
-          >
-            Status Color
-          </label>
-          <input
-            class="chakra-input css-0"
             id="field-:r17:"
-            name="status_color"
+            name="status"
             type="text"
           />
         </div>
@@ -1384,12 +1420,13 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
             for="field-:r18:"
             id="field-:r18:-label"
           >
-            Created At
+            Status Color
           </label>
           <input
             class="chakra-input css-0"
             id="field-:r18:"
-            name="createdAt"
+            name="status_color"
+            type="text"
           />
         </div>
         <div
@@ -1401,11 +1438,28 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
             for="field-:r19:"
             id="field-:r19:-label"
           >
-            Published At
+            Created At
           </label>
           <input
             class="chakra-input css-0"
             id="field-:r19:"
+            name="createdAt"
+          />
+        </div>
+        <div
+          class="chakra-form-control css-h82jag"
+          role="group"
+        >
+          <label
+            class="chakra-form__label css-uvho5g"
+            for="field-:r1a:"
+            id="field-:r1a:-label"
+          >
+            Published At
+          </label>
+          <input
+            class="chakra-input css-0"
+            id="field-:r1a:"
             name="publishedAt"
           />
         </div>
@@ -1418,13 +1472,50 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
             for="field-:r1b:"
             id="field-:r1b:-label"
           >
-            Tags #1
+            Tags
           </label>
-          <input
-            class="chakra-input css-0"
-            id="field-:r1b:"
-            name="tags.0"
-          />
+          <div
+            class="chakra-select__wrapper css-42b2qy"
+          >
+            <select
+              class="chakra-select css-1ik61og"
+              id="field-:r1b:"
+              name="tags"
+            >
+              <option
+                value=""
+              >
+                Select tag
+              </option>
+              <option
+                value="5"
+              >
+                Error Eos Et
+              </option>
+              <option
+                value="9"
+              >
+                Nobis Et Ut
+              </option>
+            </select>
+            <div
+              class="chakra-select__icon-wrapper css-162mkon"
+            >
+              <svg
+                aria-hidden="true"
+                class="chakra-select__icon"
+                focusable="false"
+                role="presentation"
+                style="width: 1em; height: 1em; color: currentColor;"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </div>
         </div>
         <div
           class="chakra-form-control css-h82jag"
@@ -1432,14 +1523,14 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
         >
           <label
             class="chakra-form__label css-uvho5g"
-            for="field-:r1a:"
-            id="field-:r1a:-label"
+            for="field-:r1c:"
+            id="field-:r1c:-label"
           >
             Language
           </label>
           <input
             class="chakra-input css-0"
-            id="field-:r1a:"
+            id="field-:r1c:"
             name="language"
             type="number"
           />
@@ -1908,7 +1999,12 @@ exports[`ChakraUIInferencer should match the snapshot 4`] = `
           <span
             class="css-1qm7lvz"
           >
-            9
+            Error Eos Et
+          </span>
+          <span
+            class="css-1qm7lvz"
+          >
+            Nobis Et Ut
           </span>
         </div>
         <h5

--- a/packages/inferencer/src/inferencers/chakra-ui/index.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/index.tsx
@@ -6,50 +6,25 @@ import { ListInferencer } from "./list";
 import { CreateInferencer } from "./create";
 import { EditInferencer } from "./edit";
 
-import type { InferencerComponentProps } from "@/types";
+import type { InferencerComponentProps } from "../../types";
 
 const ChakraUIInferencer: React.FC<InferencerComponentProps> = ({
-    resource,
-    name,
     action: actionFromProps,
     id: idFromProps,
+    ...props
 }) => {
     const { useParams } = useRouterContext();
     const { action, id } = useParams<ResourceRouterParams>();
 
     switch (actionFromProps ?? action) {
         case "show":
-            return (
-                <ShowInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <ShowInferencer {...props} id={idFromProps ?? id} />;
         case "create":
-            return (
-                <CreateInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <CreateInferencer {...props} id={idFromProps ?? id} />;
         case "edit":
-            return (
-                <EditInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <EditInferencer {...props} id={idFromProps ?? id} />;
         default:
-            return (
-                <ListInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <ListInferencer {...props} id={idFromProps ?? id} />;
     }
 };
 
@@ -58,3 +33,4 @@ export { ListInferencer as ChakraUIListInferencer } from "./list";
 export { ShowInferencer as ChakraUIShowInferencer } from "./show";
 export { EditInferencer as ChakraUIEditInferencer } from "./edit";
 export { CreateInferencer as ChakraUICreateInferencer } from "./create";
+export * from "../../types";

--- a/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/index.test.tsx.snap
@@ -171,16 +171,16 @@ exports[`MantineInferencer should match the snapshot 1`] = `
                         >
                           <input
                             class="mantine-106387w mantine-Chip-input"
-                            id="mantine-r13"
+                            id="mantine-r17"
                             type="checkbox"
                             value=""
                           />
                           <label
                             class="__mantine-ref-label mantine-543i07 mantine-Chip-label"
                             data-variant="outline"
-                            for="mantine-r13"
+                            for="mantine-r17"
                           >
-                            9
+                            Nobis Et Ut
                           </label>
                         </div>
                       </div>
@@ -266,16 +266,16 @@ exports[`MantineInferencer should match the snapshot 1`] = `
                         >
                           <input
                             class="mantine-106387w mantine-Chip-input"
-                            id="mantine-r14"
+                            id="mantine-r18"
                             type="checkbox"
                             value=""
                           />
                           <label
                             class="__mantine-ref-label mantine-543i07 mantine-Chip-label"
                             data-variant="outline"
-                            for="mantine-r14"
+                            for="mantine-r18"
                           >
-                            5
+                            Error Eos Et
                           </label>
                         </div>
                         <div
@@ -283,16 +283,16 @@ exports[`MantineInferencer should match the snapshot 1`] = `
                         >
                           <input
                             class="mantine-106387w mantine-Chip-input"
-                            id="mantine-r15"
+                            id="mantine-r19"
                             type="checkbox"
                             value=""
                           />
                           <label
                             class="__mantine-ref-label mantine-543i07 mantine-Chip-label"
                             data-variant="outline"
-                            for="mantine-r15"
+                            for="mantine-r19"
                           >
-                            9
+                            Nobis Et Ut
                           </label>
                         </div>
                       </div>
@@ -786,12 +786,78 @@ exports[`MantineInferencer should match the snapshot 2`] = `
           </div>
         </div>
         <div
+          class="mantine-InputWrapper-root mantine-MultiSelect-root mantine-e8sh7b"
+        >
+          <label
+            class="mantine-InputWrapper-label mantine-MultiSelect-label mantine-ittua2"
+            for="mantine-rk"
+            id="mantine-rk-label"
+          >
+            Tags
+          </label>
+          <div
+            aria-controls="mantine-rk"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="mantine-qqmv3w mantine-MultiSelect-wrapper"
+            role="combobox"
+            tabindex="-1"
+          >
+            <input
+              type="hidden"
+              value=""
+            />
+            <div
+              class="mantine-Input-wrapper mantine-MultiSelect-wrapper mantine-12sbrde"
+              style="overflow: hidden;"
+            >
+              <div
+                aria-invalid="false"
+                class="mantine-Input-input mantine-MultiSelect-input mantine-zunujd"
+              >
+                <div
+                  class="mantine-j220w7 mantine-MultiSelect-values"
+                >
+                  <input
+                    autocomplete="off"
+                    class="mantine-MultiSelect-searchInput mantine-MultiSelect-searchInputEmpty mantine-zmh4e"
+                    data-mantine-stop-propagation="false"
+                    id="mantine-rk"
+                    type="search"
+                    value=""
+                  />
+                </div>
+              </div>
+              <div
+                class="mantine-uquezq mantine-Input-rightSection mantine-MultiSelect-rightSection"
+              >
+                <svg
+                  data-chevron="true"
+                  fill="none"
+                  height="18"
+                  style="color: rgb(134, 142, 150);"
+                  viewBox="0 0 15 15"
+                  width="18"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M4.93179 5.43179C4.75605 5.60753 4.75605 5.89245 4.93179 6.06819C5.10753 6.24392 5.39245 6.24392 5.56819 6.06819L7.49999 4.13638L9.43179 6.06819C9.60753 6.24392 9.89245 6.24392 10.0682 6.06819C10.2439 5.89245 10.2439 5.60753 10.0682 5.43179L7.81819 3.18179C7.73379 3.0974 7.61933 3.04999 7.49999 3.04999C7.38064 3.04999 7.26618 3.0974 7.18179 3.18179L4.93179 5.43179ZM10.0682 9.56819C10.2439 9.39245 10.2439 9.10753 10.0682 8.93179C9.89245 8.75606 9.60753 8.75606 9.43179 8.93179L7.49999 10.8636L5.56819 8.93179C5.39245 8.75606 5.10753 8.75606 4.93179 8.93179C4.75605 9.10753 4.75605 9.39245 4.93179 9.56819L7.18179 11.8182C7.35753 11.9939 7.64245 11.9939 7.81819 11.8182L10.0682 9.56819Z"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
           class="mantine-InputWrapper-root mantine-NumberInput-root mantine-e8sh7b"
         >
           <label
             class="mantine-InputWrapper-label mantine-NumberInput-label mantine-ittua2"
-            for="mantine-rk"
-            id="mantine-rk-label"
+            for="mantine-rm"
+            id="mantine-rm-label"
           >
             Language
           </label>
@@ -801,7 +867,7 @@ exports[`MantineInferencer should match the snapshot 2`] = `
             <input
               aria-invalid="false"
               class="mantine-Input-input mantine-NumberInput-input mantine-rum3t1"
-              id="mantine-rk"
+              id="mantine-rm"
               inputmode="numeric"
               step="1"
               type="text"
@@ -1121,8 +1187,8 @@ exports[`MantineInferencer should match the snapshot 3`] = `
         >
           <label
             class="mantine-InputWrapper-label mantine-NumberInput-label mantine-ittua2"
-            for="mantine-rl"
-            id="mantine-rl-label"
+            for="mantine-rn"
+            id="mantine-rn-label"
           >
             Id
           </label>
@@ -1133,7 +1199,7 @@ exports[`MantineInferencer should match the snapshot 3`] = `
               aria-invalid="false"
               class="mantine-Input-input mantine-NumberInput-input mantine-Input-disabled mantine-NumberInput-disabled mantine-13fwyki"
               disabled=""
-              id="mantine-rl"
+              id="mantine-rn"
               inputmode="numeric"
               step="1"
               type="text"
@@ -1146,8 +1212,8 @@ exports[`MantineInferencer should match the snapshot 3`] = `
         >
           <label
             class="mantine-InputWrapper-label mantine-TextInput-label mantine-ittua2"
-            for="mantine-rm"
-            id="mantine-rm-label"
+            for="mantine-ro"
+            id="mantine-ro-label"
           >
             Title
           </label>
@@ -1157,7 +1223,7 @@ exports[`MantineInferencer should match the snapshot 3`] = `
             <input
               aria-invalid="false"
               class="mantine-Input-input mantine-TextInput-input mantine-1g14e8k"
-              id="mantine-rm"
+              id="mantine-ro"
               type="text"
               value="Nobis exercitationem officia quia est."
             />
@@ -1168,8 +1234,8 @@ exports[`MantineInferencer should match the snapshot 3`] = `
         >
           <label
             class="mantine-InputWrapper-label mantine-TextInput-label mantine-ittua2"
-            for="mantine-rn"
-            id="mantine-rn-label"
+            for="mantine-rp"
+            id="mantine-rp-label"
           >
             Slug
           </label>
@@ -1179,7 +1245,7 @@ exports[`MantineInferencer should match the snapshot 3`] = `
             <input
               aria-invalid="false"
               class="mantine-Input-input mantine-TextInput-input mantine-1g14e8k"
-              id="mantine-rn"
+              id="mantine-rp"
               type="text"
               value="provident-culpa-facere"
             />
@@ -1190,8 +1256,8 @@ exports[`MantineInferencer should match the snapshot 3`] = `
         >
           <label
             class="mantine-InputWrapper-label mantine-Textarea-label mantine-ittua2"
-            for="mantine-ro"
-            id="mantine-ro-label"
+            for="mantine-rq"
+            id="mantine-rq-label"
           >
             Content
           </label>
@@ -1201,7 +1267,7 @@ exports[`MantineInferencer should match the snapshot 3`] = `
             <textarea
               aria-invalid="false"
               class="mantine-Input-input mantine-Textarea-input mantine-1cp6ct5"
-              id="mantine-ro"
+              id="mantine-rq"
             >
               Non velit blanditiis optio quo quaerat nam aperiam. Odit tempore consequatur voluptatibus molestias. Est nemo aut. Fugit aliquam enim eveniet veritatis. Magni et aut. Consequatur aliquid rerum vero. Quaerat debitis enim magnam. Dolorem est delectus architecto et accusantium. Velit quia vero. Aut necessitatibus quia at consequatur soluta accusantium.
             </textarea>
@@ -1212,8 +1278,8 @@ exports[`MantineInferencer should match the snapshot 3`] = `
         >
           <label
             class="mantine-InputWrapper-label mantine-NumberInput-label mantine-ittua2"
-            for="mantine-rp"
-            id="mantine-rp-label"
+            for="mantine-rr"
+            id="mantine-rr-label"
           >
             Hit
           </label>
@@ -1223,7 +1289,7 @@ exports[`MantineInferencer should match the snapshot 3`] = `
             <input
               aria-invalid="false"
               class="mantine-Input-input mantine-NumberInput-input mantine-rum3t1"
-              id="mantine-rp"
+              id="mantine-rr"
               inputmode="numeric"
               step="1"
               type="text"
@@ -1287,13 +1353,13 @@ exports[`MantineInferencer should match the snapshot 3`] = `
         >
           <label
             class="mantine-InputWrapper-label mantine-Select-label mantine-ittua2"
-            for="mantine-rq"
-            id="mantine-rq-label"
+            for="mantine-rs"
+            id="mantine-rs-label"
           >
             Category
           </label>
           <div
-            aria-controls="mantine-rq"
+            aria-controls="mantine-rs"
             aria-expanded="false"
             aria-haspopup="listbox"
             class=""
@@ -1313,7 +1379,7 @@ exports[`MantineInferencer should match the snapshot 3`] = `
                 autocomplete="off"
                 class="mantine-Input-input mantine-Select-input mantine-149ccxv"
                 data-mantine-stop-propagation="false"
-                id="mantine-rq"
+                id="mantine-rs"
                 type="search"
                 value="Numquam Saepe Illo"
               />
@@ -1349,13 +1415,13 @@ exports[`MantineInferencer should match the snapshot 3`] = `
         >
           <label
             class="mantine-InputWrapper-label mantine-Select-label mantine-ittua2"
-            for="mantine-rs"
-            id="mantine-rs-label"
+            for="mantine-ru"
+            id="mantine-ru-label"
           >
             User
           </label>
           <div
-            aria-controls="mantine-rs"
+            aria-controls="mantine-ru"
             aria-expanded="false"
             aria-haspopup="listbox"
             class=""
@@ -1375,7 +1441,7 @@ exports[`MantineInferencer should match the snapshot 3`] = `
                 autocomplete="off"
                 class="mantine-Input-input mantine-Select-input mantine-149ccxv"
                 data-mantine-stop-propagation="false"
-                id="mantine-rs"
+                id="mantine-ru"
                 type="search"
                 value="Eriberto"
               />
@@ -1411,8 +1477,8 @@ exports[`MantineInferencer should match the snapshot 3`] = `
         >
           <label
             class="mantine-InputWrapper-label mantine-TextInput-label mantine-ittua2"
-            for="mantine-ru"
-            id="mantine-ru-label"
+            for="mantine-r10"
+            id="mantine-r10-label"
           >
             Status
           </label>
@@ -1422,53 +1488,9 @@ exports[`MantineInferencer should match the snapshot 3`] = `
             <input
               aria-invalid="false"
               class="mantine-Input-input mantine-TextInput-input mantine-1g14e8k"
-              id="mantine-ru"
-              type="text"
-              value="draft"
-            />
-          </div>
-        </div>
-        <div
-          class="mantine-InputWrapper-root mantine-TextInput-root mantine-e8sh7b"
-        >
-          <label
-            class="mantine-InputWrapper-label mantine-TextInput-label mantine-ittua2"
-            for="mantine-rv"
-            id="mantine-rv-label"
-          >
-            Status Color
-          </label>
-          <div
-            class="mantine-Input-wrapper mantine-TextInput-wrapper mantine-12sbrde"
-          >
-            <input
-              aria-invalid="false"
-              class="mantine-Input-input mantine-TextInput-input mantine-1g14e8k"
-              id="mantine-rv"
-              type="text"
-              value="orange"
-            />
-          </div>
-        </div>
-        <div
-          class="mantine-InputWrapper-root mantine-TextInput-root mantine-e8sh7b"
-        >
-          <label
-            class="mantine-InputWrapper-label mantine-TextInput-label mantine-ittua2"
-            for="mantine-r10"
-            id="mantine-r10-label"
-          >
-            Created At
-          </label>
-          <div
-            class="mantine-Input-wrapper mantine-TextInput-wrapper mantine-12sbrde"
-          >
-            <input
-              aria-invalid="false"
-              class="mantine-Input-input mantine-TextInput-input mantine-1g14e8k"
               id="mantine-r10"
               type="text"
-              value="2022-04-02T04:25:44.933Z"
+              value="draft"
             />
           </div>
         </div>
@@ -1480,7 +1502,7 @@ exports[`MantineInferencer should match the snapshot 3`] = `
             for="mantine-r11"
             id="mantine-r11-label"
           >
-            Published At
+            Status Color
           </label>
           <div
             class="mantine-Input-wrapper mantine-TextInput-wrapper mantine-12sbrde"
@@ -1490,85 +1512,151 @@ exports[`MantineInferencer should match the snapshot 3`] = `
               class="mantine-Input-input mantine-TextInput-input mantine-1g14e8k"
               id="mantine-r11"
               type="text"
+              value="orange"
+            />
+          </div>
+        </div>
+        <div
+          class="mantine-InputWrapper-root mantine-TextInput-root mantine-e8sh7b"
+        >
+          <label
+            class="mantine-InputWrapper-label mantine-TextInput-label mantine-ittua2"
+            for="mantine-r12"
+            id="mantine-r12-label"
+          >
+            Created At
+          </label>
+          <div
+            class="mantine-Input-wrapper mantine-TextInput-wrapper mantine-12sbrde"
+          >
+            <input
+              aria-invalid="false"
+              class="mantine-Input-input mantine-TextInput-input mantine-1g14e8k"
+              id="mantine-r12"
+              type="text"
+              value="2022-04-02T04:25:44.933Z"
+            />
+          </div>
+        </div>
+        <div
+          class="mantine-InputWrapper-root mantine-TextInput-root mantine-e8sh7b"
+        >
+          <label
+            class="mantine-InputWrapper-label mantine-TextInput-label mantine-ittua2"
+            for="mantine-r13"
+            id="mantine-r13-label"
+          >
+            Published At
+          </label>
+          <div
+            class="mantine-Input-wrapper mantine-TextInput-wrapper mantine-12sbrde"
+          >
+            <input
+              aria-invalid="false"
+              class="mantine-Input-input mantine-TextInput-input mantine-1g14e8k"
+              id="mantine-r13"
+              type="text"
               value="2021-08-10T08:07:39.705Z"
             />
           </div>
         </div>
         <div
-          class="mantine-Group-root mantine-1g4q40w"
+          class="mantine-InputWrapper-root mantine-MultiSelect-root mantine-e8sh7b"
         >
-          <div
-            class="mantine-InputWrapper-root mantine-NumberInput-root mantine-e8sh7b"
+          <label
+            class="mantine-InputWrapper-label mantine-MultiSelect-label mantine-ittua2"
+            for="mantine-r14"
+            id="mantine-r14-label"
           >
-            <label
-              class="mantine-InputWrapper-label mantine-NumberInput-label mantine-ittua2"
-              for="mantine-r16"
-              id="mantine-r16-label"
-            >
-              Tags 1 
-            </label>
+            Tags
+          </label>
+          <div
+            aria-controls="mantine-r14"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="mantine-qqmv3w mantine-MultiSelect-wrapper"
+            role="combobox"
+            tabindex="-1"
+          >
+            <input
+              type="hidden"
+              value="9"
+            />
             <div
-              class="mantine-Input-wrapper mantine-NumberInput-wrapper mantine-12sbrde"
+              class="mantine-Input-wrapper mantine-MultiSelect-wrapper mantine-12sbrde"
+              style="overflow: hidden;"
             >
-              <input
-                aria-invalid="false"
-                class="mantine-Input-input mantine-NumberInput-input mantine-rum3t1"
-                id="mantine-r16"
-                inputmode="numeric"
-                step="1"
-                type="text"
-                value="9"
-              />
               <div
-                class="mantine-1cwybh2 mantine-Input-rightSection mantine-NumberInput-rightSection"
+                aria-invalid="false"
+                class="mantine-Input-input mantine-MultiSelect-input mantine-zunujd"
               >
                 <div
-                  class="mantine-1mzslog mantine-NumberInput-rightSection"
+                  class="mantine-j220w7 mantine-MultiSelect-values"
                 >
-                  <button
-                    aria-hidden="true"
-                    class="mantine-NumberInput-control mantine-NumberInput-controlUp mantine-f73we9"
-                    tabindex="-1"
-                    type="button"
+                  <div
+                    class="mantine-MultiSelect-defaultValue mantine-MultiSelect-value mantine-fqghar"
+                    value="9"
                   >
-                    <svg
-                      fill="none"
-                      height="14"
-                      style="transform: rotate(180deg);"
-                      viewBox="0 0 15 15"
-                      width="14"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <span
+                      class="mantine-rsiguj mantine-MultiSelect-defaultValueLabel"
                     >
-                      <path
-                        clip-rule="evenodd"
-                        d="M3.13523 6.15803C3.3241 5.95657 3.64052 5.94637 3.84197 6.13523L7.5 9.56464L11.158 6.13523C11.3595 5.94637 11.6759 5.95657 11.8648 6.15803C12.0536 6.35949 12.0434 6.67591 11.842 6.86477L7.84197 10.6148C7.64964 10.7951 7.35036 10.7951 7.15803 10.6148L3.15803 6.86477C2.95657 6.67591 2.94637 6.35949 3.13523 6.15803Z"
-                        fill="currentColor"
-                        fill-rule="evenodd"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    aria-hidden="true"
-                    class="mantine-NumberInput-control mantine-NumberInput-controlDown mantine-1kz3j3d"
-                    tabindex="-1"
-                    type="button"
-                  >
-                    <svg
-                      fill="none"
-                      height="14"
-                      viewBox="0 0 15 15"
-                      width="14"
-                      xmlns="http://www.w3.org/2000/svg"
+                      Nobis Et Ut
+                    </span>
+                    <button
+                      aria-hidden="true"
+                      class="mantine-UnstyledButton-root mantine-ActionIcon-root mantine-MultiSelect-defaultValueRemove mantine-zo2naa"
+                      tabindex="-1"
+                      type="button"
                     >
-                      <path
-                        clip-rule="evenodd"
-                        d="M3.13523 6.15803C3.3241 5.95657 3.64052 5.94637 3.84197 6.13523L7.5 9.56464L11.158 6.13523C11.3595 5.94637 11.6759 5.95657 11.8648 6.15803C12.0536 6.35949 12.0434 6.67591 11.842 6.86477L7.84197 10.6148C7.64964 10.7951 7.35036 10.7951 7.15803 10.6148L3.15803 6.86477C2.95657 6.67591 2.94637 6.35949 3.13523 6.15803Z"
-                        fill="currentColor"
-                        fill-rule="evenodd"
-                      />
-                    </svg>
-                  </button>
+                      <svg
+                        fill="none"
+                        height="11"
+                        viewBox="0 0 15 15"
+                        width="11"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M11.7816 4.03157C12.0062 3.80702 12.0062 3.44295 11.7816 3.2184C11.5571 2.99385 11.193 2.99385 10.9685 3.2184L7.50005 6.68682L4.03164 3.2184C3.80708 2.99385 3.44301 2.99385 3.21846 3.2184C2.99391 3.44295 2.99391 3.80702 3.21846 4.03157L6.68688 7.49999L3.21846 10.9684C2.99391 11.193 2.99391 11.557 3.21846 11.7816C3.44301 12.0061 3.80708 12.0061 4.03164 11.7816L7.50005 8.31316L10.9685 11.7816C11.193 12.0061 11.5571 12.0061 11.7816 11.7816C12.0062 11.557 12.0062 11.193 11.7816 10.9684L8.31322 7.49999L11.7816 4.03157Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                  <input
+                    autocomplete="off"
+                    class="mantine-MultiSelect-searchInput mantine-MultiSelect-searchInputInputHidden mantine-1pfwsds"
+                    data-mantine-stop-propagation="false"
+                    id="mantine-r14"
+                    type="search"
+                    value=""
+                  />
                 </div>
+              </div>
+              <div
+                class="mantine-163ph1f mantine-Input-rightSection mantine-MultiSelect-rightSection"
+              >
+                <button
+                  class="mantine-UnstyledButton-root mantine-ActionIcon-root mantine-tzgcu0"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    fill="none"
+                    height="14"
+                    viewBox="0 0 15 15"
+                    width="14"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M11.7816 4.03157C12.0062 3.80702 12.0062 3.44295 11.7816 3.2184C11.5571 2.99385 11.193 2.99385 10.9685 3.2184L7.50005 6.68682L4.03164 3.2184C3.80708 2.99385 3.44301 2.99385 3.21846 3.2184C2.99391 3.44295 2.99391 3.80702 3.21846 4.03157L6.68688 7.49999L3.21846 10.9684C2.99391 11.193 2.99391 11.557 3.21846 11.7816C3.44301 12.0061 3.80708 12.0061 4.03164 11.7816L7.50005 8.31316L10.9685 11.7816C11.193 12.0061 11.5571 12.0061 11.7816 11.7816C12.0062 11.557 12.0062 11.193 11.7816 10.9684L8.31322 7.49999L11.7816 4.03157Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </button>
               </div>
             </div>
           </div>
@@ -1578,8 +1666,8 @@ exports[`MantineInferencer should match the snapshot 3`] = `
         >
           <label
             class="mantine-InputWrapper-label mantine-NumberInput-label mantine-ittua2"
-            for="mantine-r12"
-            id="mantine-r12-label"
+            for="mantine-r16"
+            id="mantine-r16-label"
           >
             Language
           </label>
@@ -1589,7 +1677,7 @@ exports[`MantineInferencer should match the snapshot 3`] = `
             <input
               aria-invalid="false"
               class="mantine-Input-input mantine-NumberInput-input mantine-rum3t1"
-              id="mantine-r12"
+              id="mantine-r16"
               inputmode="numeric"
               step="1"
               type="text"
@@ -2044,16 +2132,33 @@ exports[`MantineInferencer should match the snapshot 4`] = `
           >
             <input
               class="mantine-106387w mantine-Chip-input"
-              id="mantine-r17"
+              id="mantine-r1a"
               type="checkbox"
               value=""
             />
             <label
               class="__mantine-ref-label mantine-543i07 mantine-Chip-label"
               data-variant="outline"
-              for="mantine-r17"
+              for="mantine-r1a"
             >
-              9
+              Error Eos Et
+            </label>
+          </div>
+          <div
+            class="mantine-Chip-root mantine-15po0m8"
+          >
+            <input
+              class="mantine-106387w mantine-Chip-input"
+              id="mantine-r1b"
+              type="checkbox"
+              value=""
+            />
+            <label
+              class="__mantine-ref-label mantine-543i07 mantine-Chip-label"
+              data-variant="outline"
+              for="mantine-r1b"
+            >
+              Nobis Et Ut
             </label>
           </div>
         </div>

--- a/packages/inferencer/src/inferencers/mantine/index.tsx
+++ b/packages/inferencer/src/inferencers/mantine/index.tsx
@@ -5,50 +5,26 @@ import { ShowInferencer } from "./show";
 import { ListInferencer } from "./list";
 import { CreateInferencer } from "./create";
 import { EditInferencer } from "./edit";
-import type { InferencerComponentProps } from "@/types";
+
+import type { InferencerComponentProps } from "../../types";
 
 const MantineInferencer: React.FC<InferencerComponentProps> = ({
-    resource,
-    name,
     action: actionFromProps,
     id: idFromProps,
+    ...props
 }) => {
     const { useParams } = useRouterContext();
     const { action, id } = useParams<ResourceRouterParams>();
 
     switch (actionFromProps ?? action) {
         case "show":
-            return (
-                <ShowInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <ShowInferencer {...props} id={idFromProps ?? id} />;
         case "create":
-            return (
-                <CreateInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <CreateInferencer {...props} id={idFromProps ?? id} />;
         case "edit":
-            return (
-                <EditInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <EditInferencer {...props} id={idFromProps ?? id} />;
         default:
-            return (
-                <ListInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <ListInferencer {...props} id={idFromProps ?? id} />;
     }
 };
 
@@ -57,3 +33,4 @@ export { ShowInferencer as MantineShowInferencer } from "./show";
 export { EditInferencer as MantineEditInferencer } from "./edit";
 export { ListInferencer as MantineListInferencer } from "./list";
 export { CreateInferencer as MantineCreateInferencer } from "./create";
+export * from "../../types";

--- a/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
@@ -121,11 +121,11 @@ exports[`MuiInferencer should match the snapshot 1`] = `
                         class="MuiDataGrid-menuIcon"
                       >
                         <button
-                          aria-controls=":r11:"
+                          aria-controls=":r15:"
                           aria-haspopup="true"
                           aria-label="Menu"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall MuiDataGrid-menuIconButton css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
-                          id=":r12:"
+                          id=":r16:"
                           tabindex="-1"
                           title="Menu"
                           type="button"
@@ -223,11 +223,11 @@ exports[`MuiInferencer should match the snapshot 1`] = `
                         class="MuiDataGrid-menuIcon"
                       >
                         <button
-                          aria-controls=":r14:"
+                          aria-controls=":r18:"
                           aria-haspopup="true"
                           aria-label="Menu"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall MuiDataGrid-menuIconButton css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
-                          id=":r15:"
+                          id=":r19:"
                           tabindex="-1"
                           title="Menu"
                           type="button"
@@ -325,11 +325,11 @@ exports[`MuiInferencer should match the snapshot 1`] = `
                         class="MuiDataGrid-menuIcon"
                       >
                         <button
-                          aria-controls=":r17:"
+                          aria-controls=":r1b:"
                           aria-haspopup="true"
                           aria-label="Menu"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall MuiDataGrid-menuIconButton css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
-                          id=":r18:"
+                          id=":r1c:"
                           tabindex="-1"
                           title="Menu"
                           type="button"
@@ -1253,13 +1253,92 @@ exports[`MuiInferencer should match the snapshot 2`] = `
             </div>
           </div>
           <div
+            class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1qqsdnr-MuiAutocomplete-root"
+            name="tags"
+          >
+            <div
+              class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root css-17vbkzs-MuiFormControl-root-MuiTextField-root"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+                data-shrink="false"
+                for=":re:"
+                id=":re:-label"
+              >
+                Tags
+                <span
+                  aria-hidden="true"
+                  class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+                >
+                   *
+                </span>
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-154xyx0-MuiInputBase-root-MuiOutlinedInput-root"
+              >
+                <input
+                  aria-autocomplete="list"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  autocapitalize="none"
+                  autocomplete="off"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+                  id=":re:"
+                  required=""
+                  role="combobox"
+                  spellcheck="false"
+                  type="text"
+                  value=""
+                />
+                <div
+                  class="MuiAutocomplete-endAdornment css-1q60rmi-MuiAutocomplete-endAdornment"
+                >
+                  <button
+                    aria-label="Open"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-qzbt6i-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                    tabindex="-1"
+                    title="Open"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      data-testid="ArrowDropDownIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 10l5 5 5-5z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-yjsfm1"
+                  >
+                    <span>
+                      Tags *
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+          <div
             class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root css-17vbkzs-MuiFormControl-root-MuiTextField-root"
           >
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":re:"
-              id=":re:-label"
+              for=":rg:"
+              id=":rg:-label"
             >
               Language
             </label>
@@ -1269,7 +1348,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":re:"
+                id=":rg:"
                 name="language"
                 type="number"
                 value=""
@@ -1295,7 +1374,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
       >
         <button
           class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-1jmqb42-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
-          id=":rf:"
+          id=":rh:"
           tabindex="0"
           type="button"
         >
@@ -1522,7 +1601,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             </a>
             <button
               class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1xanul-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
-              id=":rg:"
+              id=":ri:"
               tabindex="0"
               type="button"
             >
@@ -1562,8 +1641,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":rh:"
-              id=":rh:-label"
+              for=":rj:"
+              id=":rj:-label"
             >
               Id
             </label>
@@ -1574,7 +1653,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
                 disabled=""
-                id=":rh:"
+                id=":rj:"
                 name="id"
                 type="number"
                 value=""
@@ -1599,8 +1678,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":ri:"
-              id=":ri:-label"
+              for=":rk:"
+              id=":rk:-label"
             >
               Title
             </label>
@@ -1610,7 +1689,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":ri:"
+                id=":rk:"
                 name="title"
                 type="text"
                 value=""
@@ -1635,8 +1714,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":rj:"
-              id=":rj:-label"
+              for=":rl:"
+              id=":rl:-label"
             >
               Slug
             </label>
@@ -1646,7 +1725,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":rj:"
+                id=":rl:"
                 name="slug"
                 type="text"
                 value=""
@@ -1671,8 +1750,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":rk:"
-              id=":rk:-label"
+              for=":rm:"
+              id=":rm:-label"
             >
               Content
             </label>
@@ -1682,7 +1761,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <textarea
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":rk:"
+                id=":rm:"
                 name="content"
                 style="height: 0px; overflow: hidden;"
               />
@@ -1713,8 +1792,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":rl:"
-              id=":rl:-label"
+              for=":rn:"
+              id=":rn:-label"
             >
               Hit
             </label>
@@ -1724,7 +1803,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":rl:"
+                id=":rn:"
                 name="hit"
                 type="number"
                 value=""
@@ -1753,8 +1832,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <label
                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
-                for=":rm:"
-                id=":rm:-label"
+                for=":ro:"
+                id=":ro:-label"
               >
                 Category
                 <span
@@ -1774,7 +1853,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
                   autocapitalize="none"
                   autocomplete="off"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
-                  id=":rm:"
+                  id=":ro:"
                   required=""
                   role="combobox"
                   spellcheck="false"
@@ -1854,8 +1933,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <label
                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
-                for=":ro:"
-                id=":ro:-label"
+                for=":rq:"
+                id=":rq:-label"
               >
                 User
                 <span
@@ -1875,7 +1954,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
                   autocapitalize="none"
                   autocomplete="off"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
-                  id=":ro:"
+                  id=":rq:"
                   required=""
                   role="combobox"
                   spellcheck="false"
@@ -1951,8 +2030,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":rq:"
-              id=":rq:-label"
+              for=":rs:"
+              id=":rs:-label"
             >
               Status
             </label>
@@ -1962,7 +2041,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":rq:"
+                id=":rs:"
                 name="status"
                 type="text"
                 value=""
@@ -1987,8 +2066,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":rr:"
-              id=":rr:-label"
+              for=":rt:"
+              id=":rt:-label"
             >
               Status Color
             </label>
@@ -1998,7 +2077,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":rr:"
+                id=":rt:"
                 name="status_color"
                 type="text"
                 value=""
@@ -2023,8 +2102,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":rs:"
-              id=":rs:-label"
+              for=":ru:"
+              id=":ru:-label"
             >
               Created At
             </label>
@@ -2034,7 +2113,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":rs:"
+                id=":ru:"
                 name="createdAt"
                 type="text"
                 value=""
@@ -2059,8 +2138,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":rt:"
-              id=":rt:-label"
+              for=":rv:"
+              id=":rv:-label"
             >
               Published At
             </label>
@@ -2070,7 +2149,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":rt:"
+                id=":rv:"
                 name="publishedAt"
                 type="text"
                 value=""
@@ -2090,30 +2169,114 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             </div>
           </div>
           <div
-            class="MuiBox-root css-1i27l4i"
+            class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon css-1qqsdnr-MuiAutocomplete-root"
+            name="tags"
           >
             <div
               class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root css-17vbkzs-MuiFormControl-root-MuiTextField-root"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
-                for=":r1a:"
-                id=":r1a:-label"
+                for=":r10:"
+                id=":r10:-label"
               >
-                Tags 1
+                Tags
+                <span
+                  aria-hidden="true"
+                  class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+                >
+                   *
+                </span>
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-md26zr-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedStart MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-1gywuxd-MuiInputBase-root-MuiOutlinedInput-root"
               >
+                <div
+                  class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-deletable MuiChip-deletableColorDefault MuiChip-filledDefault MuiAutocomplete-tag MuiAutocomplete-tagSizeMedium css-1q79v3g-MuiButtonBase-root-MuiChip-root"
+                  data-tag-index="0"
+                  role="button"
+                  tabindex="-1"
+                >
+                  <span
+                    class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+                  >
+                    Nobis Et Ut
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-deleteIcon MuiChip-deleteIconMedium MuiChip-deleteIconColorDefault MuiChip-deleteIconFilledColorDefault css-i4bv87-MuiSvgIcon-root"
+                    data-testid="CancelIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+                    />
+                  </svg>
+                </div>
                 <input
+                  aria-autocomplete="list"
+                  aria-expanded="false"
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                  id=":r1a:"
-                  name="tags.0"
-                  type="number"
+                  autocapitalize="none"
+                  autocomplete="off"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-152mnda-MuiInputBase-input-MuiOutlinedInput-input"
+                  id=":r10:"
+                  required=""
+                  role="combobox"
+                  spellcheck="false"
+                  type="text"
                   value=""
                 />
+                <div
+                  class="MuiAutocomplete-endAdornment css-1q60rmi-MuiAutocomplete-endAdornment"
+                >
+                  <button
+                    aria-label="Clear"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-clearIndicator css-1glvl0p-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-clearIndicator"
+                    tabindex="-1"
+                    title="Clear"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                      data-testid="CloseIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                  <button
+                    aria-label="Open"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-qzbt6i-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                    tabindex="-1"
+                    title="Open"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      data-testid="ArrowDropDownIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 10l5 5 5-5z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
                 <fieldset
                   aria-hidden="true"
                   class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
@@ -2122,7 +2285,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
                     class="css-14lo706"
                   >
                     <span>
-                      Tags 1
+                      Tags *
                     </span>
                   </legend>
                 </fieldset>
@@ -2135,8 +2298,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":ru:"
-              id=":ru:-label"
+              for=":r12:"
+              id=":r12:-label"
             >
               Language
             </label>
@@ -2146,7 +2309,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":ru:"
+                id=":r12:"
                 name="language"
                 type="number"
                 value=""
@@ -2172,7 +2335,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
       >
         <button
           class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-1jmqb42-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
-          id=":rv:"
+          id=":r13:"
           tabindex="0"
           type="button"
         >
@@ -2399,7 +2562,7 @@ exports[`MuiInferencer should match the snapshot 4`] = `
             </a>
             <button
               class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1xanul-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
-              id=":r10:"
+              id=":r14:"
               tabindex="0"
               type="button"
             >
@@ -2559,7 +2722,16 @@ exports[`MuiInferencer should match the snapshot 4`] = `
               <span
                 class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
               >
-                9
+                Error Eos Et
+              </span>
+            </div>
+            <div
+              class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-w66kx-MuiChip-root"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+              >
+                Nobis Et Ut
               </span>
             </div>
           </div>

--- a/packages/inferencer/src/inferencers/mui/index.tsx
+++ b/packages/inferencer/src/inferencers/mui/index.tsx
@@ -5,50 +5,26 @@ import { ShowInferencer } from "./show";
 import { ListInferencer } from "./list";
 import { CreateInferencer } from "./create";
 import { EditInferencer } from "./edit";
-import type { InferencerComponentProps } from "@/types";
+
+import type { InferencerComponentProps } from "../../types";
 
 const MuiInferencer: React.FC<InferencerComponentProps> = ({
-    resource,
-    name,
     action: actionFromProps,
     id: idFromProps,
+    ...props
 }) => {
     const { useParams } = useRouterContext();
     const { action, id } = useParams<ResourceRouterParams>();
 
     switch (actionFromProps ?? action) {
         case "show":
-            return (
-                <ShowInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <ShowInferencer {...props} id={idFromProps ?? id} />;
         case "create":
-            return (
-                <CreateInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <CreateInferencer {...props} id={idFromProps ?? id} />;
         case "edit":
-            return (
-                <EditInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <EditInferencer {...props} id={idFromProps ?? id} />;
         default:
-            return (
-                <ListInferencer
-                    name={name}
-                    resource={resource}
-                    id={idFromProps ?? id}
-                />
-            );
+            return <ListInferencer {...props} id={idFromProps ?? id} />;
     }
 };
 
@@ -57,3 +33,4 @@ export { ShowInferencer as MuiShowInferencer } from "./show";
 export { EditInferencer as MuiEditInferencer } from "./edit";
 export { ListInferencer as MuiListInferencer } from "./list";
 export { CreateInferencer as MuiCreateInferencer } from "./create";
+export * from "../../types";

--- a/packages/inferencer/src/types/index.ts
+++ b/packages/inferencer/src/types/index.ts
@@ -33,6 +33,12 @@ export type InferField = {
     canRelation?: boolean;
 };
 
+export type ResourceInferenceAttempt = {
+    status: "success" | "error";
+    resource: string;
+    field: string;
+};
+
 export type FieldInferencer = (
     key: string,
     value: unknown,
@@ -140,6 +146,14 @@ export type InferencerComponentProps = {
      * The record to infer from, use this when `action` is `show` or `edit`
      * */
     id?: string | number;
+    /**
+     * Field transformer function, you can use this to transform the inferred field or ignore it by returning `undefined`, `null` or `false`
+     * Example: you can remove a field you want to hide by returning `undefined`, `null` or `false`
+     * Example: you can change the `accessor` of an element by returning a new field with the new `accessor` to update the render
+     */
+    fieldTransformer?: (
+        field: InferField,
+    ) => InferField | undefined | null | false;
     /**
      * Data accessor string to get the data from the record
      * @example your data provider returns { data: { item: { id: 1, name: "John" } } } from `getOne` then you should pass "item" as the `single` property.

--- a/packages/inferencer/src/types/index.ts
+++ b/packages/inferencer/src/types/index.ts
@@ -154,13 +154,6 @@ export type InferencerComponentProps = {
     fieldTransformer?: (
         field: InferField,
     ) => InferField | undefined | null | false;
-    /**
-     * Data accessor string to get the data from the record
-     * @example your data provider returns { data: { item: { id: 1, name: "John" } } } from `getOne` then you should pass "item" as the `single` property.
-     * @example your data provider returns { data: { items: [{ id: 1, name: "John" }] } } from `getMany` then you should pass "items" as the `many` property.
-     * @example your data provider returns { data: { items: [{ id: 1, name: "John" }], total: 1 } } from `getList` then you should pass "items" as the `many` property.
-     */
-    // dataAccessors?: Partial<Record<"single" | "list" | "many", string>>;
 };
 
 export type InferencerResultComponent = React.FC<InferencerComponentProps>;

--- a/packages/inferencer/src/utilities/component-name/index.test.ts
+++ b/packages/inferencer/src/utilities/component-name/index.test.ts
@@ -1,23 +1,23 @@
 import { componentName } from ".";
 
 describe("componentName", () => {
-    it("should return `PostList`", () => {
+    it("should turn `posts,list` into `PostList`", () => {
         expect(componentName("posts", "list")).toBe("PostList");
     });
-    it("should return `CategoryShow`", () => {
+    it("should turn `categories,show` into `CategoryShow`", () => {
         expect(componentName("categories", "show")).toBe("CategoryShow");
     });
-    it("should return UserEdit", () => {
+    it("should turn `user,edit` into `UserEdit`", () => {
         expect(componentName("user", "edit")).toBe("UserEdit");
     });
-    it("should return Edit", () => {
-        expect(componentName("12345", "edit")).toBe("ResourceEdit");
+    it("should turn `12345,edit` into `Edit12345`", () => {
+        expect(componentName("12345", "edit")).toBe("Edit12345");
     });
-    it("should return UserEdit", () => {
-        expect(componentName("12345User", "edit")).toBe("UserEdit");
-        expect(componentName("12345-User", "edit")).toBe("UserEdit");
+    it("should turn `12345User,edit` into `Edit12345User`", () => {
+        expect(componentName("12345User", "edit")).toBe("Edit12345User");
+        expect(componentName("12345-User", "edit")).toBe("Edit12345User");
     });
-    it("should return UsersAccountEdit", () => {
+    it("should turn `user/account` into `UserAccountEdit`", () => {
         expect(componentName("user/account", "edit")).toBe("UserAccountEdit");
         expect(componentName("user-account", "edit")).toBe("UserAccountEdit");
         expect(componentName("user?.account", "edit")).toBe("UserAccountEdit");

--- a/packages/inferencer/src/utilities/component-name/index.ts
+++ b/packages/inferencer/src/utilities/component-name/index.ts
@@ -9,32 +9,20 @@ export const componentName = (
     resourceName: string,
     type: "list" | "show" | "edit" | "create",
 ) => {
-    const resourcePrefix = pluralize.isSingular(resourceName)
-        ? resourceName
-        : pluralize.singular(resourceName);
+    // replace all non-alphanumeric characters with a space
+    const sanitized = resourceName.replace(/[^a-zA-Z0-9]/g, " ");
+    // convert to singular
+    const singular = pluralize.singular(sanitized);
+    // prettify the string without spaces
+    const prettified = prettyString(singular).replace(/ /g, "");
+    // get pretty type name
+    const prettyType = type.charAt(0).toUpperCase() + type.slice(1);
 
-    // if resourcePrefix is number, return Resource + capitalized type
-    // e.g. 1 => "ResourceList"
-    if (Number.isInteger(Number(resourcePrefix))) {
-        return "Resource" + type.charAt(0).toUpperCase() + type.slice(1);
+    // if resourceName is not starting with an alphabetical character, return Type + resourceName
+    // e.g. "123users" => "List123Users"
+    if (!/^[a-zA-Z]/.test(resourceName)) {
+        return `${prettyType}${prettified}`;
     }
-
-    // if resourcePrefix is start with numbers, replace the numbers with empty string
-    // e.g. 123users => "users"
-    const resourcePrefixWithoutNumbers = resourcePrefix.replace(/^\d+/, "");
-
-    // if resourcePrefix has invalid characters, replace them with empty string
-    // e.g. "users/account" => "users-account"
-    const resourcePrefixWithoutInvalidCharacters =
-        resourcePrefixWithoutNumbers.replace(/[^a-zA-Z0-9]/g, "-");
-
-    const prettyResourceName = prettyString(
-        resourcePrefixWithoutInvalidCharacters,
-    ).replace(/ /g, "");
-
-    const componentName = `${
-        prettyResourceName.charAt(0).toUpperCase() + prettyResourceName.slice(1)
-    }${type.charAt(0).toUpperCase() + type.slice(1)}`;
-
-    return componentName;
+    // e.g. "users" => "UserList"
+    return `${prettified}${prettyType}`;
 };


### PR DESCRIPTION
- Updated component naming convention to be unique between resources
- Added `fieldTransformer` prop to inferencer components to let users transform or hide the field to be rendered.
- Hide networks errors caused by the relation detection process.
- Added the ability to detect relations from basic types like `"text"` and `"number"`.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
