### PR TITLE
chore: support Date Picker with dayjs object value on filter dropdown

### DIFF
--- a/packages/antd/src/components/table/components/filterDropdown/index.spec.tsx
+++ b/packages/antd/src/components/table/components/filterDropdown/index.spec.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { Input } from "antd";
+import { DatePicker } from "@components/antd";
+import dayjs from "dayjs";
 
 import { render, fireEvent } from "@test";
 import { FilterDropdown, FilterDropdownProps } from "./";
@@ -88,6 +90,80 @@ describe("FilterDropdown", () => {
                 value: "test",
             },
         });
+
+        expect(mapValueFn).toHaveBeenCalled();
+    });
+
+    it("should render Date Picker successfully", () => {
+        const { getByText } = render(
+            <FilterDropdown
+                {...props}
+                mapValue={(selectedKeys) =>
+                    !selectedKeys
+                        ? ""
+                        : Array.isArray(selectedKeys)
+                        ? dayjs(selectedKeys[0])
+                        : dayjs(selectedKeys)
+                }
+            >
+                <DatePicker />
+            </FilterDropdown>,
+        );
+        getByText("Filter");
+        getByText("Clear");
+    });
+
+    it("should render with Date Picker called confirm function successfully if click the filter button", async () => {
+        const { getByText } = render(
+            <FilterDropdown
+                {...props}
+                mapValue={(selectedKeys) =>
+                    !selectedKeys
+                        ? ""
+                        : Array.isArray(selectedKeys)
+                        ? dayjs(selectedKeys[0])
+                        : dayjs(selectedKeys)
+                }
+            >
+                <DatePicker />
+            </FilterDropdown>,
+        );
+
+        fireEvent.click(getByText("Filter"));
+
+        expect(confirm).toHaveBeenCalled();
+        expect(setSelectedKeys).toHaveBeenCalled();
+    });
+
+    it("should render with Date Picker called clearFilter function successfully if click the clear button", async () => {
+        const { getByText } = render(
+            <FilterDropdown
+                {...props}
+                mapValue={(selectedKeys) =>
+                    !selectedKeys
+                        ? ""
+                        : Array.isArray(selectedKeys)
+                        ? dayjs(selectedKeys[0])
+                        : dayjs(selectedKeys)
+                }
+            >
+                <DatePicker />
+            </FilterDropdown>,
+        );
+
+        fireEvent.click(getByText("Clear"));
+
+        expect(clearFilters).toHaveBeenCalled();
+    });
+
+    it("should call mapValue with Date Picker", async () => {
+        const { getByTestId } = render(
+            <FilterDropdown {...props} mapValue={mapValueFn}>
+                <DatePicker data-testid="date-picker" />
+            </FilterDropdown>,
+        );
+
+        fireEvent.change(getByTestId("date-picker"), dayjs());
 
         expect(mapValueFn).toHaveBeenCalled();
     });

--- a/packages/antd/src/components/table/components/filterDropdown/index.tsx
+++ b/packages/antd/src/components/table/components/filterDropdown/index.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useState } from "react";
 import { Button, Space } from "antd";
 import type { FilterDropdownProps as AntdFilterDropdownProps } from "antd/lib/table/interface";
+import dayjs from "dayjs";
 import { FilterOutlined } from "@ant-design/icons";
 import { useTranslate } from "@pankod/refine-core";
 
@@ -36,7 +37,9 @@ export const FilterDropdown: React.FC<FilterDropdownProps> = (props) => {
 
     const onFilter = () => {
         const _mappedValue = mappedValue(value);
-        setSelectedKeys(_mappedValue);
+        setSelectedKeys(
+            dayjs.isDayjs(_mappedValue) ? [_mappedValue] : _mappedValue,
+        );
 
         confirm?.();
     };
@@ -53,7 +56,12 @@ export const FilterDropdown: React.FC<FilterDropdownProps> = (props) => {
                 return setSelectedKeys(_mappedValue);
             }
 
-            const { target }: React.ChangeEvent<HTMLInputElement> = e;
+            const changeEvent =
+                !e || !e.target || dayjs.isDayjs(e)
+                    ? { target: { value: e } }
+                    : e;
+
+            const { target }: React.ChangeEvent<HTMLInputElement> = changeEvent;
             const _mappedValue = mappedValue(target.value);
             setValue(_mappedValue);
             return;


### PR DESCRIPTION
Explain the **details** for making this change. What existing problem does the pull request solve?

Date Picker component from @pankod/refine-antd is currently not working properly when using with Filter Dropdown.

The root cause is because Date Picker component is built on top of `rc-picker` library therefore `onChange` event handler is using dayjs object value, not a native Change Event (with `target` property) while Filter Dropdown is currently expecting a Change Event data.

https://github.com/leapful/refine/blob/674c48c154f0c43276e1840aee6d894ad03790bb/packages/antd/src/components/antd/datePicker.tsx#L1-L7

Solution: Check is value on change is dayjs object value or not to perform correct handling on `onChange` and `onFilter` callback.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

### Test plan (required)

1. Add filter drop down on column "Published At" by using Date Picker component on example "refine-date-picker-example".
2. Perform filter on selecting a date from picker or clear value to filter.
3. API should include date value in ISO format on field "Published At".

Referring to example on https://stackblitz.com/edit/refinedev-refine-5i5gwr?file=src%2Fpages%2Fposts%2Flist.tsx&preset=node 

### Closing issues

closes #3142 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
