### PR TITLE
chore: support filter dropdown number value

### DIFF
--- a/.changeset/silly-numbers-camp.md
+++ b/.changeset/silly-numbers-camp.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": minor
+---
+
+Support filter dropdown on number value of single Select component

--- a/packages/antd/src/components/table/components/filterDropdown/index.spec.tsx
+++ b/packages/antd/src/components/table/components/filterDropdown/index.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Input } from "antd";
-import { DatePicker } from "@components/antd";
+import { DatePicker, Select } from "@components/antd";
 import dayjs from "dayjs";
 
 import { render, fireEvent } from "@test";
@@ -166,5 +166,39 @@ describe("FilterDropdown", () => {
         fireEvent.change(getByTestId("date-picker"), dayjs());
 
         expect(mapValueFn).toHaveBeenCalled();
+    });
+
+    it("should render Select successfully", () => {
+        const { getByText } = render(
+            <FilterDropdown
+                {...props}
+                mapValue={(val) =>
+                    Array.isArray(val) ? val.map((i) => Number(i)) : Number(val)
+                }
+            >
+                <Select />
+            </FilterDropdown>,
+        );
+        getByText("Filter");
+        getByText("Clear");
+    });
+
+    it("should render with Select called confirm function successfully if click the filter button", async () => {
+        const { getByText } = render(
+            <FilterDropdown
+                {...props}
+                selectedKeys={["1"]}
+                mapValue={(val) =>
+                    Array.isArray(val) ? val.map((i) => Number(i)) : Number(val)
+                }
+            >
+                <Select />
+            </FilterDropdown>,
+        );
+
+        fireEvent.click(getByText("Filter"));
+
+        expect(confirm).toHaveBeenCalled();
+        expect(setSelectedKeys).toHaveBeenCalledWith([1]);
     });
 });

--- a/packages/antd/src/components/table/components/filterDropdown/index.tsx
+++ b/packages/antd/src/components/table/components/filterDropdown/index.tsx
@@ -37,11 +37,17 @@ export const FilterDropdown: React.FC<FilterDropdownProps> = (props) => {
 
     const onFilter = () => {
         const _mappedValue = mappedValue(value);
-        setSelectedKeys(
-            dayjs.isDayjs(_mappedValue)
-                ? [_mappedValue.toISOString()]
-                : _mappedValue,
-        );
+
+        let keys;
+        if (typeof _mappedValue === "number") {
+            keys = [_mappedValue];
+        } else if (dayjs.isDayjs(_mappedValue)) {
+            keys = [_mappedValue.toISOString()];
+        } else {
+            keys = _mappedValue;
+        }
+
+        setSelectedKeys(keys);
 
         confirm?.();
     };

--- a/packages/antd/src/components/table/components/filterDropdown/index.tsx
+++ b/packages/antd/src/components/table/components/filterDropdown/index.tsx
@@ -40,7 +40,7 @@ export const FilterDropdown: React.FC<FilterDropdownProps> = (props) => {
 
         let keys;
         if (typeof _mappedValue === "number") {
-            keys = [_mappedValue];
+            keys = `${_mappedValue}`;
         } else if (dayjs.isDayjs(_mappedValue)) {
             keys = [_mappedValue.toISOString()];
         } else {


### PR DESCRIPTION
Explain the **details** for making this change. What existing problem does the pull request solve?

By default, Ant Design expected filtered keys should be an array or string but in case value is a number, it will be treated as invalid and stop on filtering.

https://github.com/ant-design/ant-design/blob/77ea4038d169d033dcd4d29da1df9ab21b23ebb9/components/table/hooks/useFilter/FilterDropdown.tsx#L229-L233

### Test plan (required)

1. Apply filter dropdown on Select component with mode "single" and list option included number value
   For example: `{ label: "A", value: 1 }`
2. Perform select and filter on multiple items of Select component
3. Check API for filtering is called with correct selected value

Referer: https://stackblitz.com/edit/refinedev-refine-jydkgh?file=src%2Fpages%2Fposts%2Flist.tsx&preset=node

### Closing issues

closes #3124 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
