### PR TITLE
chore: restore filter operator after clearing on filter dropdown

### DIFF
--- a/.changeset/fifty-chefs-drive.md
+++ b/.changeset/fifty-chefs-drive.md
@@ -1,5 +1,5 @@
 ---
-"@pankod/refine-core": minor
+"@pankod/refine-core": patch
 ---
 
 Restore filter operator after clear it by using filter dropdown

--- a/.changeset/fifty-chefs-drive.md
+++ b/.changeset/fifty-chefs-drive.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": minor
+---
+
+Restore filter operator after clear it by using filter dropdown

--- a/packages/antd/src/definitions/table/index.spec.ts
+++ b/packages/antd/src/definitions/table/index.spec.ts
@@ -282,9 +282,7 @@ describe("definitions/table", () => {
                     foo: "Test",
                 },
                 [],
-                {
-                    foo: { field: "foo", operator: "contains", value: "" },
-                },
+                [{ field: "foo", operator: "contains", value: "" }],
             ),
         ).toMatchInlineSnapshot(`
             Array [

--- a/packages/antd/src/definitions/table/index.spec.ts
+++ b/packages/antd/src/definitions/table/index.spec.ts
@@ -274,4 +274,26 @@ describe("definitions/table", () => {
             ]
         `);
     });
+
+    it("mapAntdFilterToCrudFilter with map initial filter to restore operator in no data on previous filters", () => {
+        expect(
+            mapAntdFilterToCrudFilter(
+                {
+                    foo: "Test",
+                },
+                [],
+                {
+                    foo: { field: "foo", operator: "contains", value: "" },
+                },
+            ),
+        ).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "field": "foo",
+                "operator": "contains",
+                "value": "Test",
+              },
+            ]
+        `);
+    });
 });

--- a/packages/antd/src/definitions/table/index.ts
+++ b/packages/antd/src/definitions/table/index.ts
@@ -79,14 +79,17 @@ export const mapAntdFilterToCrudFilter = (
         (string | number | boolean) | (string | number | boolean)[] | null
     >,
     prevFilters: CrudFilters,
+    mapInitialFilter: Record<string, CrudFilter> = {},
 ): CrudFilters => {
     const crudFilters: CrudFilters = [];
 
     Object.keys(tableFilters).map((field) => {
         const value = tableFilters[field];
-        const operator = prevFilters
-            .filter((i) => i.operator !== "or")
-            .find((p: any) => p.field === field)?.operator;
+        const operator =
+            prevFilters
+                .filter((i) => i.operator !== "or")
+                .find((p: any) => p.field === field)?.operator ||
+            mapInitialFilter[field]?.operator;
 
         if (operator !== "or" && operator !== "and") {
             crudFilters.push({

--- a/packages/antd/src/definitions/table/index.ts
+++ b/packages/antd/src/definitions/table/index.ts
@@ -5,6 +5,8 @@ import {
     CrudFilter,
     getDefaultFilter as getDefaultFilterCore,
     getDefaultSortOrder as getDefaultSortOrderCore,
+    ConditionalFilter,
+    LogicalFilter,
 } from "@pankod/refine-core";
 import { SortOrder, SorterResult } from "antd/lib/table/interface";
 
@@ -79,9 +81,16 @@ export const mapAntdFilterToCrudFilter = (
         (string | number | boolean) | (string | number | boolean)[] | null
     >,
     prevFilters: CrudFilters,
-    mapInitialFilter: Record<string, CrudFilter> = {},
+    initialFilters?: CrudFilters,
 ): CrudFilters => {
     const crudFilters: CrudFilters = [];
+    const mapInitialFilter: Record<string, CrudFilter> = (
+        initialFilters ?? []
+    ).reduce((acc, item) => {
+        const field =
+            (item as ConditionalFilter).key || (item as LogicalFilter).field;
+        return { ...acc, [field]: item };
+    }, {});
 
     Object.keys(tableFilters).map((field) => {
         const value = tableFilters[field];

--- a/packages/antd/src/hooks/table/useTable/useTable.ts
+++ b/packages/antd/src/hooks/table/useTable/useTable.ts
@@ -1,4 +1,4 @@
-import React, { Children, createElement, Fragment } from "react";
+import React, { Children, createElement, Fragment, useMemo } from "react";
 import { Grid, FormProps, Form, TablePaginationConfig, TableProps } from "antd";
 import { QueryObserverResult } from "@tanstack/react-query";
 import { useForm as useFormSF } from "sunflower-antd";
@@ -17,12 +17,15 @@ import {
     useTable as useTableCore,
     useTableProps as useTablePropsCore,
     useTableReturnType as useTableCoreReturnType,
+    CrudFilter,
+    ConditionalFilter,
+    LogicalFilter,
 } from "@pankod/refine-core";
 
 import {
     mapAntdSorterToCrudSorting,
     mapAntdFilterToCrudFilter,
-} from "../../../definitions/table";
+} from "@definitions/table";
 import { PaginationLink } from "./paginationLink";
 
 export type useTableProps<
@@ -120,6 +123,15 @@ export const useTable = <
         dataProviderName,
     });
 
+    const mapInitialFilter: Record<string, CrudFilter> = useMemo(() => {
+        return (initialFilter ?? []).reduce((acc, item) => {
+            const field =
+                (item as ConditionalFilter).key ||
+                (item as LogicalFilter).field;
+            return { ...acc, [field]: item };
+        }, {});
+    }, [initialFilter]);
+
     const breakpoint = Grid.useBreakpoint();
 
     const [form] = Form.useForm<TSearchVariables>();
@@ -144,6 +156,7 @@ export const useTable = <
             const crudFilters = mapAntdFilterToCrudFilter(
                 tableFilters,
                 filters,
+                mapInitialFilter,
             );
             setFilters(crudFilters);
         }

--- a/packages/antd/src/hooks/table/useTable/useTable.ts
+++ b/packages/antd/src/hooks/table/useTable/useTable.ts
@@ -1,4 +1,4 @@
-import React, { Children, createElement, Fragment, useMemo } from "react";
+import React, { Children, createElement, Fragment } from "react";
 import { Grid, FormProps, Form, TablePaginationConfig, TableProps } from "antd";
 import { QueryObserverResult } from "@tanstack/react-query";
 import { useForm as useFormSF } from "sunflower-antd";
@@ -17,9 +17,6 @@ import {
     useTable as useTableCore,
     useTableProps as useTablePropsCore,
     useTableReturnType as useTableCoreReturnType,
-    CrudFilter,
-    ConditionalFilter,
-    LogicalFilter,
 } from "@pankod/refine-core";
 
 import {
@@ -123,15 +120,6 @@ export const useTable = <
         dataProviderName,
     });
 
-    const mapInitialFilter: Record<string, CrudFilter> = useMemo(() => {
-        return (initialFilter ?? []).reduce((acc, item) => {
-            const field =
-                (item as ConditionalFilter).key ||
-                (item as LogicalFilter).field;
-            return { ...acc, [field]: item };
-        }, {});
-    }, [initialFilter]);
-
     const breakpoint = Grid.useBreakpoint();
 
     const [form] = Form.useForm<TSearchVariables>();
@@ -156,7 +144,7 @@ export const useTable = <
             const crudFilters = mapAntdFilterToCrudFilter(
                 tableFilters,
                 filters,
-                mapInitialFilter,
+                initialFilter,
             );
             setFilters(crudFilters);
         }

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -31,9 +31,6 @@ import {
     HttpError,
     MetaDataQuery,
     LiveModeProps,
-    ConditionalFilter,
-    LogicalFilter,
-    CrudFilter,
 } from "../../interfaces";
 
 type SetFilterBehavior = "merge" | "replace";
@@ -309,32 +306,10 @@ export function useTable<
         dataProviderName,
     });
 
-    const mapInitialFilter: Record<string, CrudFilter> = useMemo(() => {
-        return (initialFilter ?? []).reduce((acc, item) => {
-            const field =
-                (item as ConditionalFilter).key ||
-                (item as LogicalFilter).field;
-            return { ...acc, [field]: item };
-        }, {});
-    }, [initialFilter]);
-
     const setFiltersAsMerge = (newFilters: CrudFilters) => {
-        setFilters((prevFilters) => {
-            const normalizedFilters = newFilters.map((item) => {
-                const field =
-                    (item as ConditionalFilter).key ||
-                    (item as LogicalFilter).field;
-                const target = mapInitialFilter[field];
-                item.operator = target.operator;
-
-                return item;
-            });
-            return unionFilters(
-                permanentFilter,
-                normalizedFilters,
-                prevFilters,
-            );
-        });
+        setFilters((prevFilters) =>
+            unionFilters(permanentFilter, newFilters, prevFilters),
+        );
     };
 
     const setFiltersAsReplace = (newFilters: CrudFilters) => {


### PR DESCRIPTION
Explain the **details** for making this change. What existing problem does the pull request solve?

By default, "Clear" action from Filter Dropdown is handled by Ant Design by removing filter column value out from list filter. If there is a new value on the filter column again, the mapping has no context on initial filters to restore correct operator.

By providing a map of initial filters, mapping new filters can restore operator in case previous filters is empty or no data on target filter column.

### Test plan (required)

1. Initialize example "refine-airtable-example" with initial filter on column "Title" with `{ field: 'title', operator: 'contains', value: '' }`
2. Perform filter on column "Title" with keyword "Hello" to see correct results of the keyword
3. Click "Clear" button then "Filter" button to see correct results of empty filter data
4. Filter again with keyword "Melih" to see correct results of the keyword

### Closing issues

closes #1386 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
