### PR TITLE
fix(swizzle): wrong import and usage on swizzled antd layout

### DIFF
--- a/.changeset/little-tigers-deny.md
+++ b/.changeset/little-tigers-deny.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": patch
+---
+
+Fixed: Wrong import and usage after `swizzling` `<Layout>` component.

--- a/packages/antd/refine.config.js
+++ b/packages/antd/refine.config.js
@@ -537,6 +537,16 @@ module.exports = {
                                         /Layout\.Sider/g,
                                         "AntdLayout.Sider",
                                     );
+
+                                    newContent = newContent.replace(
+                                        "<Layout>",
+                                        "<AntdLayout>",
+                                    );
+
+                                    newContent = newContent.replace(
+                                        "</Layout>",
+                                        "</AntdLayout>",
+                                    );
                                 }
 
                                 // handle @components import replacement
@@ -624,7 +634,7 @@ module.exports = {
                                     newContent = newContent.replace(
                                         importItem.statement,
                                         importItem.statement.replace(
-                                            "Layout as AntdLayout,",
+                                            "Layout as AntdLayout",
                                             "AntdLayout,",
                                         ),
                                     );


### PR DESCRIPTION
After swizzling the `Layout` component, the import name and usage were wrong. Fixed with correct values.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
