### PR TITLE
fix: add missing `contains` value handlers to `@pankod/refine-hasura`

### DIFF
--- a/.changeset/rare-feet-walk.md
+++ b/.changeset/rare-feet-walk.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-hasura": patch
+---
+
+`contains`, `ncontains`, `containss` and `ncontainss` filters were passing the value without wrapping it to `%` characters. This caused the filters to not work as expected. Added a case to the filter value handler to wrap the value with `%` characters. (Resolves #3245)

--- a/packages/hasura/src/dataProvider/index.ts
+++ b/packages/hasura/src/dataProvider/index.ts
@@ -103,6 +103,11 @@ export const handleFilterValue = (operator: CrudOperators, value: any) => {
             return `(?<!${value})$`;
         case "nnull":
             return false;
+        case "contains":
+        case "containss":
+        case "ncontains":
+        case "ncontainss":
+            return `%${value}%`;
         default:
             return value;
     }


### PR DESCRIPTION
`contains`, `ncontains`, `containss` and `ncontainss` filters were passing the value without wrapping it to `%` characters. This caused the filters to not work as expected. Added a case to the filter value handler to wrap the value with `%` characters.

### Closing issues

Resolves #3245 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
