### PR TITLE
feat(cli): npm ls should not throw error

### DIFF
--- a/.changeset/serious-beers-hope.md
+++ b/.changeset/serious-beers-hope.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-cli": patch
+---
+
+Added: `npm -ls` was always throws an error. From now returns `null`, with this way `error` handling can be done when needed.

--- a/packages/cli/src/commands/whoami/index.ts
+++ b/packages/cli/src/commands/whoami/index.ts
@@ -21,7 +21,7 @@ const action = async () => {
         { showNotFound: true, markdown: true },
     );
 
-    const packages = await getInstalledRefinePackages();
+    const packages = (await getInstalledRefinePackages()) || [];
     const packagesMarkdown = packages
         .map((pkg) => {
             return ` - ${pkg.name}: ${pkg.version}`;

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -28,7 +28,7 @@ export const getTelemetryData = async (): Promise<TelemetryData> => {
         os: os.name,
         osVersion: os.version,
         command: process.argv[2],
-        packages: await getInstalledRefinePackages(),
+        packages: (await getInstalledRefinePackages()) || [],
         projectFramework: getProjectType(),
     };
 

--- a/packages/cli/src/update-notifier/index.tsx
+++ b/packages/cli/src/update-notifier/index.tsx
@@ -119,24 +119,23 @@ export const validateKey = async () => {
  * @returns `string` if key is generated
  */
 export const generateKeyFromPackages = async () => {
-    try {
-        const packages = await getInstalledRefinePackages();
-
-        const currentVersionsWithName = packages.map(
-            (p) => `${p.name}@${p.version}`,
-        );
-        const hash = btoa(currentVersionsWithName.toString());
-
-        return hash;
-    } catch (error: any) {
+    const packages = await getInstalledRefinePackages();
+    if (!packages) {
         console.error(
             chalk.red(
-                `Something went wrong when trying to get installed \`refine\` packages: ${error.shortMessage}`,
+                `Something went wrong when trying to get installed \`refine\` packages.`,
             ),
         );
 
-        return Promise.resolve(null);
+        return null;
     }
+
+    const currentVersionsWithName = packages.map(
+        (p) => `${p.name}@${p.version}`,
+    );
+    const hash = btoa(currentVersionsWithName.toString());
+
+    return hash;
 };
 
 export const isUpdateNotifierDisabled = () => {

--- a/packages/cli/src/utils/package/index.ts
+++ b/packages/cli/src/utils/package/index.ts
@@ -57,7 +57,7 @@ export const getInstalledRefinePackages = async () => {
 
         return normalize;
     } catch (error) {
-        return Promise.reject(error);
+        return Promise.resolve(null);
     }
 };
 
@@ -92,7 +92,7 @@ export const getInstalledRefinePackagesFromNodeModules = async () => {
 
         return refinePackages;
     } catch (err) {
-        return [];
+        return Promise.resolve(null);
     }
 };
 export const isPackageHaveRefineConfig = async (packagePath: string) => {

--- a/packages/cli/src/utils/package/index.ts
+++ b/packages/cli/src/utils/package/index.ts
@@ -92,7 +92,7 @@ export const getInstalledRefinePackagesFromNodeModules = async () => {
 
         return refinePackages;
     } catch (err) {
-        return Promise.resolve(null);
+        return [];
     }
 };
 export const isPackageHaveRefineConfig = async (packagePath: string) => {


### PR DESCRIPTION
`npm -ls` always throws an error. now returns `null` and `error` handling can be done anywhere

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
