### PR TITLE
docs(data-provider): fix `DataProvider` type import

### DIFF
--- a/documentation/docs/api-reference/core/providers/data-provider.md
+++ b/documentation/docs/api-reference/core/providers/data-provider.md
@@ -298,7 +298,7 @@ Let's build a method that returns our data provider:
 
 ```ts title="dataProvider.ts"
 import axios, { AxiosInstance } from "axios";
-import { DataProvider } from "@pankod/refine-core";
+import type { DataProvider } from "@pankod/refine-core";
 
 const axiosInstance = axios.create();
 

--- a/documentation/docs/api-reference/core/providers/data-provider.md
+++ b/documentation/docs/api-reference/core/providers/data-provider.md
@@ -298,7 +298,7 @@ Let's build a method that returns our data provider:
 
 ```ts title="dataProvider.ts"
 import axios, { AxiosInstance } from "axios";
-import { DataProvider } from "./interfaces/dataProvider.ts";
+import { DataProvider } from "@pankod/refine-core";
 
 const axiosInstance = axios.create();
 


### PR DESCRIPTION
Replaced the `DataProvider` type import with `@pankod/refine-core` instead of the local file.