### PR TITLE
fix: mapping nnul crud operator to notNull

### DIFF
--- a/.changeset/modern-tips-hang.md
+++ b/.changeset/modern-tips-hang.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-strapi-v4": patch
+---
+
+patch: mapping nnul crud operator to notNull

--- a/packages/strapi-v4/src/dataProvider.ts
+++ b/packages/strapi-v4/src/dataProvider.ts
@@ -40,6 +40,8 @@ const mapOperator = (operator: CrudOperators) => {
             return "containsi";
         case "ncontainss":
             return "notContainsi";
+        case "nnull":
+            return "notNull";
     }
 
     return operator;


### PR DESCRIPTION
Mapping of nnul crud operator to notNull in strapi-v4 is missing