### PR TITLE
fix: keepValues true for react-hook-form

### DIFF
--- a/.changeset/friendly-mails-smile.md
+++ b/.changeset/friendly-mails-smile.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-react-hook-form": patch
+---
+
+Fixed resetting values on step changes - #3290

--- a/packages/react-hook-form/src/useStepsForm/index.ts
+++ b/packages/react-hook-form/src/useStepsForm/index.ts
@@ -81,7 +81,12 @@ export const useStepsForm = <
                 }
             });
 
-            reset(fields as any, { keepDirty: true });
+            console.log("rest");
+
+            reset(fields as any, {
+                keepDirty: true,
+                keepValues: true,
+            });
         }
     }, [queryResult?.data, current]);
 

--- a/packages/react-hook-form/src/useStepsForm/index.ts
+++ b/packages/react-hook-form/src/useStepsForm/index.ts
@@ -81,7 +81,6 @@ export const useStepsForm = <
                 }
             });
 
-
             reset(fields as any, {
                 keepDirty: true,
                 keepValues: true,

--- a/packages/react-hook-form/src/useStepsForm/index.ts
+++ b/packages/react-hook-form/src/useStepsForm/index.ts
@@ -81,7 +81,6 @@ export const useStepsForm = <
                 }
             });
 
-            console.log("rest");
 
             reset(fields as any, {
                 keepDirty: true,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Fixed resetting values on step changes

### Closing issues

- #3290

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
