### PR TITLE
docs(custom-page): add sider trick tip

### DIFF
--- a/documentation/docs/advanced-tutorials/custom-pages.md
+++ b/documentation/docs/advanced-tutorials/custom-pages.md
@@ -19,6 +19,21 @@ This document is related to how to create custom pages for **react** application
 
 **refine** allows us to add custom pages to our application. To do this, it is necessary to create an object array with [react-router-dom](https://reactrouter.com/web/api/Route) `<Route>` properties. Then, pass this array as `routes` property in `routerProvider` property.
 
+:::tip
+When you create a custom page, it will not be visible in the `<Sider />` component. You can trick the `<Sider/>` by passing an empty resource to show your custom page.
+
+```tsx title="Example"
+const App = () => (
+    <Refine
+        resources={[
+            // This will add an item to `<Sider/>` with route `/my-custom-item`
+            { name: "my-custom-item", list: () => null }
+        ]}
+    />
+);
+```
+:::
+
 ## Public Custom Pages
 
 Allows creating custom pages that everyone can access via path.

--- a/documentation/docs/advanced-tutorials/ssr/nextjs.md
+++ b/documentation/docs/advanced-tutorials/ssr/nextjs.md
@@ -118,6 +118,21 @@ interface IUser {
 export default UserList;
 ```
 
+:::tip
+If you want to handle your `resource` with a custom page or create a custom page with or without a resource, these will not be visible in the `<Sider />` component. You can trick the `<Sider/>` by passing an empty resource to show your custom route in it.
+
+```tsx title="Example"
+const App = () => (
+    <Refine
+        resources={[
+            // This will add an item to `<Sider/>` with route `/my-custom-item`
+            { name: "my-custom-item", list: () => null }
+        ]}
+    />
+);
+```
+:::
+
 :::caution
 Notice how we passed `resource` prop to [`useTable`][usetable]. This is necessary since for `useTable` to be able to get `resource` name from route, it needs to be a route parameter in a dynamic route. [Refer here](#standard-crud-page) where standard CRUD pages can be built with dynamic routing.
 :::

--- a/documentation/docs/advanced-tutorials/ssr/remix.md
+++ b/documentation/docs/advanced-tutorials/ssr/remix.md
@@ -119,6 +119,21 @@ interface IPost {
 export default PostList;
 ```
 
+:::tip
+If you want to handle your `resource` with a custom route or create a custom route with or without a resource, these will not be visible in the `<Sider />` component. You can trick the `<Sider/>` by passing an empty resource to show your custom route in it.
+
+```tsx title="Example"
+const App = () => (
+    <Refine
+        resources={[
+            // This will add an item to `<Sider/>` with route `/my-custom-item`
+            { name: "my-custom-item", list: () => null }
+        ]}
+    />
+);
+```
+:::
+
 :::caution
 Notice how we passed `resource` prop to [`useTable`][usetable]. This is necessary since for `useTable` to be able to get `resource` name from route, it needs to be a route parameter in a dynamic route. [Refer here](#standard-crud-page) where standard CRUD pages can be built with dynamic routing.
 :::


### PR DESCRIPTION
Added a small tip for showing custom pages/routes in `<Sider/>` without customizing it. 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
