### PR TITLE
Fix(cli): ctrl+c not killing running server on Windows

### DIFF
--- a/.changeset/nervous-planets-deny.md
+++ b/.changeset/nervous-planets-deny.md
@@ -1,0 +1,6 @@
+---
+"@pankod/refine-cli": patch
+---
+
+Fixed: `Ctrl+c` not killing running dev; leaving ports open - #3175
+Fixed: terminal output color w/ env `FORCE_COLOR=true`

--- a/packages/cli/src/commands/runner/runScript.ts
+++ b/packages/cli/src/commands/runner/runScript.ts
@@ -4,6 +4,10 @@ export const runScript = async (binPath: string, args: string[]) => {
     const execution = execa(binPath, args, {
         stdio: "pipe",
         windowsHide: false,
+        env: {
+            FORCE_COLOR: "true",
+            ...process.env,
+        },
     });
 
     execution.stdout?.pipe(process.stdout);

--- a/packages/cli/src/commands/runner/runScript.ts
+++ b/packages/cli/src/commands/runner/runScript.ts
@@ -3,6 +3,7 @@ import execa from "execa";
 export const runScript = async (binPath: string, args: string[]) => {
     const execution = execa(binPath, args, {
         stdio: "pipe",
+        windowsHide: false,
     });
 
     execution.stdout?.pipe(process.stdout);


### PR DESCRIPTION
### Please provide enough information so that others can review your pull request:

I create this PR to fix :

1. dev server keeps running after exiting on Windows 
2. Terminal output log has no color 

### Test plan (required)

I've patched **refine-cli** to test this change and it works well

### Closing issues

- #3175 

### Self Check before Merge

Please check all items below before review.

-   [ ] Corresponding issues are created/updated or not needed
-   [ ] Docs are updated/provided or not needed
-   [ ] Examples are updated/provided or not needed
-   [ ] TypeScript definitions are updated/provided or not needed
-   [ ] Tests are updated/provided or not needed
-   [ ] Changesets are provided or not needed
