### PR TITLE
feat: `mutationOptions` in core hooks

### DIFF
--- a/.changeset/calm-schools-train.md
+++ b/.changeset/calm-schools-train.md
@@ -1,0 +1,9 @@
+---
+"@pankod/refine-antd": minor
+---
+
+Added the ability to pass mutation options to `useMutation` hooks in mutation hooks:
+- `useForm`
+- `useStepsForm`
+- `useModalForm`
+- `useDrawerForm`

--- a/.changeset/fifty-dodos-arrive.md
+++ b/.changeset/fifty-dodos-arrive.md
@@ -1,0 +1,18 @@
+---
+"@pankod/refine-core": minor
+---
+
+Added the ability to pass mutation options to `useMutation` hooks in mutation hooks:
+- `useCreate` (data)
+- `useUpdate` (data)
+- `useDelete` (data)
+- `useDeleteMany` (data)
+- `useUpdateMany` (data)
+- `useCreateMany` (data)
+- `useCustomMutation` (data)
+- `useLogin` (auth)
+- `useLogout` (auth)
+- `useRegister` (auth)
+- `useForgotPassword` (auth)
+- `useUpdatePassword` (auth)
+- `useForm` (form)

--- a/packages/antd/src/hooks/form/useForm.ts
+++ b/packages/antd/src/hooks/form/useForm.ts
@@ -76,6 +76,8 @@ export const useForm = <
     invalidates,
     undoableTimeout,
     queryOptions,
+    createMutationOptions,
+    updateMutationOptions,
     id: idFromProps,
 }: UseFormProps<TData, TError, TVariables> = {}): UseFormReturnType<
     TData,
@@ -107,6 +109,8 @@ export const useForm = <
         invalidates,
         undoableTimeout,
         queryOptions,
+        createMutationOptions,
+        updateMutationOptions,
         id: idFromProps,
     });
 

--- a/packages/core/src/hooks/auditLog/useLog/index.ts
+++ b/packages/core/src/hooks/auditLog/useLog/index.ts
@@ -30,7 +30,7 @@ export type UseLogReturnType<TLogData, TLogRenameData> = {
     >;
 };
 
-export type UseLogProps<
+export type UseLogMutationProps<
     TLogData,
     TLogRenameData extends LogRenameData = LogRenameData,
 > = {
@@ -60,7 +60,7 @@ export const useLog = <
 >({
     logMutationOptions,
     renameMutationOptions,
-}: UseLogProps<TLogData, TLogRenameData> = {}): UseLogReturnType<
+}: UseLogMutationProps<TLogData, TLogRenameData> = {}): UseLogReturnType<
     TLogData,
     TLogRenameData
 > => {

--- a/packages/core/src/hooks/auditLog/useLog/index.ts
+++ b/packages/core/src/hooks/auditLog/useLog/index.ts
@@ -1,6 +1,7 @@
 import { useContext } from "react";
 import {
     useMutation,
+    UseMutationOptions,
     UseMutationResult,
     useQueryClient,
 } from "@tanstack/react-query";
@@ -29,6 +30,25 @@ export type UseLogReturnType<TLogData, TLogRenameData> = {
     >;
 };
 
+export type UseLogProps<
+    TLogData,
+    TLogRenameData extends LogRenameData = LogRenameData,
+> = {
+    logMutationOptions?: Omit<
+        UseMutationOptions<TLogData, Error, LogParams, unknown>,
+        "mutationFn"
+    >;
+    renameMutationOptions?: Omit<
+        UseMutationOptions<
+            TLogRenameData,
+            Error,
+            { id: BaseKey; name: string },
+            unknown
+        >,
+        "mutationFn" | "onSuccess"
+    >;
+};
+
 /**
  * useLog is used to `create` a new and `rename` the existing audit log.
  * @see {@link https://refine.dev/docs/core/hooks/audit-log/useLog} for more details.
@@ -37,7 +57,13 @@ export type UseLogReturnType<TLogData, TLogRenameData> = {
 export const useLog = <
     TLogData,
     TLogRenameData extends LogRenameData = LogRenameData,
->(): UseLogReturnType<TLogData, TLogRenameData> => {
+>({
+    logMutationOptions,
+    renameMutationOptions,
+}: UseLogProps<TLogData, TLogRenameData> = {}): UseLogReturnType<
+    TLogData,
+    TLogRenameData
+> => {
     const queryClient = useQueryClient();
     const auditLogContext = useContext(AuditLogContext);
 
@@ -73,6 +99,7 @@ export const useLog = <
                 author: identityData ?? authorData?.data,
             });
         },
+        logMutationOptions,
     );
 
     const rename = useMutation<
@@ -91,6 +118,7 @@ export const useLog = <
                     queryClient.invalidateQueries(queryKey.logList());
                 }
             },
+            ...renameMutationOptions,
         },
     );
 

--- a/packages/core/src/hooks/auth/useForgotPassword/index.ts
+++ b/packages/core/src/hooks/auth/useForgotPassword/index.ts
@@ -1,10 +1,21 @@
 import React from "react";
-import { useMutation, UseMutationResult } from "@tanstack/react-query";
+import {
+    useMutation,
+    UseMutationOptions,
+    UseMutationResult,
+} from "@tanstack/react-query";
 
 import { AuthContext } from "@contexts/auth";
 import { useNavigation, useNotification } from "@hooks";
 
 import { IAuthContext, TForgotPasswordData } from "../../../interfaces";
+
+export type UseForgotPasswordProps<TVariables> = {
+    mutationOptions?: Omit<
+        UseMutationOptions<TForgotPasswordData, Error, TVariables, unknown>,
+        "mutationFn" | "onError" | "onSuccess"
+    >;
+};
 
 /**
  * `useForgotPassword` calls `forgotPassword` method from {@link https://refine.dev/docs/api-references/providers/auth-provider `authProvider`} under the hood.
@@ -15,7 +26,9 @@ import { IAuthContext, TForgotPasswordData } from "../../../interfaces";
  * @typeParam TVariables - Values for mutation function. default `{}`
  *
  */
-export const useForgotPassword = <TVariables = {}>(): UseMutationResult<
+export const useForgotPassword = <TVariables = {}>({
+    mutationOptions,
+}: UseForgotPasswordProps<TVariables> = {}): UseMutationResult<
     TForgotPasswordData,
     Error,
     TVariables,
@@ -49,6 +62,7 @@ export const useForgotPassword = <TVariables = {}>(): UseMutationResult<
                 type: "error",
             });
         },
+        ...mutationOptions,
     });
 
     return queryResponse;

--- a/packages/core/src/hooks/auth/useLogin/index.ts
+++ b/packages/core/src/hooks/auth/useLogin/index.ts
@@ -1,11 +1,22 @@
 import React from "react";
-import { useMutation, UseMutationResult } from "@tanstack/react-query";
+import {
+    useMutation,
+    UseMutationOptions,
+    UseMutationResult,
+} from "@tanstack/react-query";
 import qs from "qs";
 
 import { useNavigation, useRouterContext, useNotification } from "@hooks";
 import { AuthContext } from "@contexts/auth";
 
 import { IAuthContext, TLoginData } from "../../../interfaces";
+
+export type UseLoginProps<TVariables> = {
+    mutationOptions?: Omit<
+        UseMutationOptions<TLoginData, Error, TVariables, unknown>,
+        "mutationFn" | "onError" | "onSuccess"
+    >;
+};
 
 /**
  * `useLogin` calls `login` method from {@link https://refine.dev/docs/api-references/providers/auth-provider `authProvider`} under the hood.
@@ -16,7 +27,9 @@ import { IAuthContext, TLoginData } from "../../../interfaces";
  * @typeParam TVariables - Values for mutation function. default `{}`
  *
  */
-export const useLogin = <TVariables = {}>(): UseMutationResult<
+export const useLogin = <TVariables = {}>({
+    mutationOptions,
+}: UseLoginProps<TVariables> = {}): UseMutationResult<
     TLoginData,
     Error,
     TVariables,
@@ -60,6 +73,7 @@ export const useLogin = <TVariables = {}>(): UseMutationResult<
                     type: "error",
                 });
             },
+            ...mutationOptions,
         },
     );
 

--- a/packages/core/src/hooks/auth/useLogout/index.ts
+++ b/packages/core/src/hooks/auth/useLogout/index.ts
@@ -1,5 +1,9 @@
 import React from "react";
-import { useMutation, UseMutationResult } from "@tanstack/react-query";
+import {
+    useMutation,
+    UseMutationOptions,
+    UseMutationResult,
+} from "@tanstack/react-query";
 
 import { AuthContext } from "@contexts/auth";
 import { IAuthContext, TLogoutData } from "../../../interfaces";
@@ -9,13 +13,27 @@ type Variables = {
     redirectPath?: string | false;
 };
 
+export type UseLogoutProps<TVariables> = {
+    mutationOptions?: Omit<
+        UseMutationOptions<
+            TLogoutData,
+            Error,
+            (TVariables & Variables) | void,
+            unknown
+        >,
+        "mutationFn" | "onError" | "onSuccess"
+    >;
+};
+
 /**
  * `useLogout` calls the `logout` method from the {@link https://refine.dev/docs/api-references/providers/auth-provider `authProvider`} under the hood.
  *
  * @see {@link https://refine.dev/docs/core/hooks/auth/useLogout} for more details.
  *
  */
-export const useLogout = <TVariables = {}>(): UseMutationResult<
+export const useLogout = <TVariables = {}>({
+    mutationOptions,
+}: UseLogoutProps<TVariables> = {}): UseMutationResult<
     TLogoutData,
     Error,
     (TVariables & Variables) | void,
@@ -55,6 +73,7 @@ export const useLogout = <TVariables = {}>(): UseMutationResult<
                     error?.message || "Something went wrong during logout",
             });
         },
+        ...mutationOptions,
     });
 
     return queryResponse;

--- a/packages/core/src/hooks/auth/useRegister/index.ts
+++ b/packages/core/src/hooks/auth/useRegister/index.ts
@@ -1,10 +1,21 @@
 import React from "react";
-import { useMutation, UseMutationResult } from "@tanstack/react-query";
+import {
+    useMutation,
+    UseMutationOptions,
+    UseMutationResult,
+} from "@tanstack/react-query";
 
 import { AuthContext } from "@contexts/auth";
 import { useNavigation, useNotification } from "@hooks";
 
 import { IAuthContext, TRegisterData } from "../../../interfaces";
+
+export type UseRegisterProps<TVariables> = {
+    mutationOptions?: Omit<
+        UseMutationOptions<TRegisterData, Error, TVariables, unknown>,
+        "mutationFn" | "onError" | "onSuccess"
+    >;
+};
 
 /**
  * `useRegister` calls `register` method from {@link https://refine.dev/docs/api-references/providers/auth-provider `authProvider`} under the hood.
@@ -15,7 +26,9 @@ import { IAuthContext, TRegisterData } from "../../../interfaces";
  * @typeParam TVariables - Values for mutation function. default `{}`
  *
  */
-export const useRegister = <TVariables = {}>(): UseMutationResult<
+export const useRegister = <TVariables = {}>({
+    mutationOptions,
+}: UseRegisterProps<TVariables> = {}): UseMutationResult<
     TRegisterData,
     Error,
     TVariables,
@@ -51,6 +64,7 @@ export const useRegister = <TVariables = {}>(): UseMutationResult<
                 type: "error",
             });
         },
+        ...mutationOptions,
     });
 
     return queryResponse;

--- a/packages/core/src/hooks/auth/useUpdatePassword/index.ts
+++ b/packages/core/src/hooks/auth/useUpdatePassword/index.ts
@@ -1,5 +1,9 @@
 import React from "react";
-import { useMutation, UseMutationResult } from "@tanstack/react-query";
+import {
+    useMutation,
+    UseMutationOptions,
+    UseMutationResult,
+} from "@tanstack/react-query";
 import qs from "qs";
 
 import { AuthContext } from "@contexts/auth";
@@ -9,6 +13,14 @@ import {
     TUpdatePasswordData,
     UpdatePasswordFormTypes,
 } from "../../../interfaces";
+
+export type UseUpdatePasswordProps<TVariables extends UpdatePasswordFormTypes> =
+    {
+        mutationOptions?: Omit<
+            UseMutationOptions<TUpdatePasswordData, Error, TVariables, unknown>,
+            "mutationFn" | "onError" | "onSuccess"
+        >;
+    };
 
 /**
  * `useUpdatePassword` calls `updatePassword` method from {@link https://refine.dev/docs/api-references/providers/auth-provider `authProvider`} under the hood.
@@ -21,7 +33,14 @@ import {
  */
 export const useUpdatePassword = <
     TVariables extends UpdatePasswordFormTypes = {},
->(): UseMutationResult<TUpdatePasswordData, Error, TVariables, unknown> => {
+>({
+    mutationOptions,
+}: UseUpdatePasswordProps<TVariables> = {}): UseMutationResult<
+    TUpdatePasswordData,
+    Error,
+    TVariables,
+    unknown
+> => {
     const { replace } = useNavigation();
     const { updatePassword: updatePasswordFromContext } =
         React.useContext<IAuthContext>(AuthContext);
@@ -66,6 +85,7 @@ export const useUpdatePassword = <
                     type: "error",
                 });
             },
+            ...mutationOptions,
         },
     );
 

--- a/packages/core/src/hooks/data/useCreate.ts
+++ b/packages/core/src/hooks/data/useCreate.ts
@@ -1,4 +1,8 @@
-import { useMutation, UseMutationResult } from "@tanstack/react-query";
+import {
+    useMutation,
+    UseMutationOptions,
+    UseMutationResult,
+} from "@tanstack/react-query";
 import pluralize from "pluralize";
 import { pickDataProvider } from "@definitions/helpers";
 
@@ -55,6 +59,22 @@ export type UseCreateReturnType<
     unknown
 >;
 
+export type UseCreateProps<
+    TData extends BaseRecord = BaseRecord,
+    TError extends HttpError = HttpError,
+    TVariables = {},
+> = {
+    mutationOptions?: Omit<
+        UseMutationOptions<
+            CreateResponse<TData>,
+            TError,
+            useCreateParams<TVariables>,
+            unknown
+        >,
+        "mutationFn" | "onError" | "onSuccess"
+    >;
+};
+
 /**
  * `useCreate` is a modified version of `react-query`'s {@link https://react-query.tanstack.com/reference/useMutation `useMutation`} for create mutations.
  *
@@ -72,7 +92,13 @@ export const useCreate = <
     TData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TVariables = {},
->(): UseCreateReturnType<TData, TError, TVariables> => {
+>({
+    mutationOptions,
+}: UseCreateProps<TData, TError, TVariables> = {}): UseCreateReturnType<
+    TData,
+    TError,
+    TVariables
+> => {
     const { mutate: checkError } = useCheckError();
     const dataProvider = useDataProvider();
     const invalidateStore = useInvalidate();
@@ -209,6 +235,7 @@ export const useCreate = <
                     type: "error",
                 });
             },
+            ...mutationOptions,
         },
     );
 

--- a/packages/core/src/hooks/data/useCreateMany.ts
+++ b/packages/core/src/hooks/data/useCreateMany.ts
@@ -1,4 +1,8 @@
-import { useMutation, UseMutationResult } from "@tanstack/react-query";
+import {
+    useMutation,
+    UseMutationOptions,
+    UseMutationResult,
+} from "@tanstack/react-query";
 import pluralize from "pluralize";
 
 import {
@@ -38,6 +42,21 @@ export type UseCreateManyReturnType<
     unknown
 >;
 
+export type UseCreateManyProps<
+    TData extends BaseRecord = BaseRecord,
+    TError extends HttpError = HttpError,
+    TVariables = {},
+> = {
+    mutationOptions?: Omit<
+        UseMutationOptions<
+            CreateManyResponse<TData>,
+            TError,
+            useCreateManyParams<TVariables>
+        >,
+        "mutationFn" | "onError" | "onSuccess"
+    >;
+};
+
 /**
  * `useCreateMany` is a modified version of `react-query`'s {@link https://react-query.tanstack.com/reference/useMutation `useMutation`} for multiple create mutations.
  *
@@ -54,7 +73,13 @@ export const useCreateMany = <
     TData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TVariables = {},
->(): UseCreateManyReturnType<TData, TError, TVariables> => {
+>({
+    mutationOptions,
+}: UseCreateManyProps<TData, TError, TVariables> = {}): UseCreateManyReturnType<
+    TData,
+    TError,
+    TVariables
+> => {
     const dataProvider = useDataProvider();
 
     const { resources } = useResource();
@@ -176,6 +201,7 @@ export const useCreateMany = <
                     type: "error",
                 });
             },
+            ...mutationOptions,
         },
     );
 

--- a/packages/core/src/hooks/data/useCustomMutation.ts
+++ b/packages/core/src/hooks/data/useCustomMutation.ts
@@ -1,4 +1,8 @@
-import { useMutation, UseMutationResult } from "@tanstack/react-query";
+import {
+    useMutation,
+    UseMutationOptions,
+    UseMutationResult,
+} from "@tanstack/react-query";
 
 import { useDataProvider, useHandleNotification, useTranslate } from "@hooks";
 import {
@@ -33,6 +37,22 @@ export type UseCustomMutationReturnType<
     unknown
 >;
 
+export type UseCustomMutationProps<
+    TData extends BaseRecord = BaseRecord,
+    TError extends HttpError = HttpError,
+    TVariables = {},
+> = {
+    mutationOptions?: Omit<
+        UseMutationOptions<
+            CreateResponse<TData>,
+            TError,
+            useCustomMutationParams<TVariables>,
+            unknown
+        >,
+        "mutationFn" | "onError" | "onSuccess"
+    >;
+};
+
 /**
  * `useCustomMutation` is a modified version of `react-query`'s {@link https://react-query.tanstack.com/reference/useMutation `useMutation`} for create mutations.
  *
@@ -50,7 +70,13 @@ export const useCustomMutation = <
     TData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TVariables = {},
->(): UseCustomMutationReturnType<TData, TError, TVariables> => {
+>({
+    mutationOptions,
+}: UseCustomMutationProps<
+    TData,
+    TError,
+    TVariables
+> = {}): UseCustomMutationReturnType<TData, TError, TVariables> => {
     const handleNotification = useHandleNotification();
     const dataProvider = useDataProvider();
     const translate = useTranslate();
@@ -130,6 +156,7 @@ export const useCustomMutation = <
                     type: "error",
                 });
             },
+            ...mutationOptions,
         },
     );
 

--- a/packages/core/src/hooks/data/useDelete.ts
+++ b/packages/core/src/hooks/data/useDelete.ts
@@ -2,6 +2,7 @@ import {
     useQueryClient,
     useMutation,
     UseMutationResult,
+    UseMutationOptions,
 } from "@tanstack/react-query";
 import pluralize from "pluralize";
 
@@ -56,6 +57,22 @@ export type UseDeleteReturnType<
     DeleteContext<TData>
 >;
 
+export type UseDeleteProps<
+    TData extends BaseRecord = BaseRecord,
+    TError extends HttpError = HttpError,
+    TVariables = {},
+> = {
+    mutationOptions?: Omit<
+        UseMutationOptions<
+            DeleteOneResponse<TData>,
+            TError,
+            DeleteParams<TVariables>,
+            DeleteContext<TData>
+        >,
+        "mutationFn" | "onError" | "onSuccess" | "onSettled" | "onMutate"
+    >;
+};
+
 /**
  * `useDelete` is a modified version of `react-query`'s {@link https://react-query.tanstack.com/reference/useMutation `useMutation`} for delete mutations.
  *
@@ -72,7 +89,13 @@ export const useDelete = <
     TData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TVariables = {},
->(): UseDeleteReturnType<TData, TError, TVariables> => {
+>({
+    mutationOptions,
+}: UseDeleteProps<TData, TError, TVariables> = {}): UseDeleteReturnType<
+    TData,
+    TError,
+    TVariables
+> => {
     const { mutate: checkError } = useCheckError();
     const dataProvider = useDataProvider();
 
@@ -369,6 +392,7 @@ export const useDelete = <
                     });
                 }
             },
+            ...mutationOptions,
         },
     );
 

--- a/packages/core/src/hooks/data/useDeleteMany.ts
+++ b/packages/core/src/hooks/data/useDeleteMany.ts
@@ -2,6 +2,7 @@ import {
     useQueryClient,
     useMutation,
     UseMutationResult,
+    UseMutationOptions,
 } from "@tanstack/react-query";
 import pluralize from "pluralize";
 
@@ -55,6 +56,22 @@ export type UseDeleteManyReturnType<
     unknown
 >;
 
+export type UseDeleteManyProps<
+    TData extends BaseRecord = BaseRecord,
+    TError extends HttpError = HttpError,
+    TVariables = {},
+> = {
+    mutationOptions?: Omit<
+        UseMutationOptions<
+            DeleteManyResponse<TData>,
+            TError,
+            DeleteManyParams<TVariables>,
+            DeleteContext<TData>
+        >,
+        "mutationFn" | "onError" | "onSuccess" | "onSettled" | "onMutate"
+    >;
+};
+
 /**
  * `useDeleteMany` is a modified version of `react-query`'s {@link https://react-query.tanstack.com/reference/useMutation `useMutation`} for multiple delete mutations.
  *
@@ -71,7 +88,13 @@ export const useDeleteMany = <
     TData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TVariables = {},
->(): UseDeleteManyReturnType<TData, TError, TVariables> => {
+>({
+    mutationOptions,
+}: UseDeleteManyProps<TData, TError, TVariables> = {}): UseDeleteManyReturnType<
+    TData,
+    TError,
+    TVariables
+> => {
     const { mutate: checkError } = useCheckError();
 
     const {
@@ -369,6 +392,7 @@ export const useDeleteMany = <
                     });
                 }
             },
+            ...mutationOptions,
         },
     );
 

--- a/packages/core/src/hooks/data/useUpdate.ts
+++ b/packages/core/src/hooks/data/useUpdate.ts
@@ -1,5 +1,6 @@
 import {
     useMutation,
+    UseMutationOptions,
     UseMutationResult,
     useQueryClient,
 } from "@tanstack/react-query";
@@ -84,6 +85,22 @@ export type UseUpdateReturnType<
     UpdateContext<TData>
 >;
 
+export type UseUpdateProps<
+    TData extends BaseRecord = BaseRecord,
+    TError extends HttpError = HttpError,
+    TVariables = {},
+> = {
+    mutationOptions?: Omit<
+        UseMutationOptions<
+            UpdateResponse<TData>,
+            TError,
+            UpdateParams<TVariables>,
+            UpdateContext<TData>
+        >,
+        "mutationFn" | "onError" | "onSuccess" | "onSettled" | "onMutate"
+    >;
+};
+
 /**
  * `useUpdate` is a modified version of `react-query`'s {@link https://react-query.tanstack.com/reference/useMutation `useMutation`} for update mutations.
  *
@@ -100,7 +117,13 @@ export const useUpdate = <
     TData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TVariables = {},
->(): UseUpdateReturnType<TData, TError, TVariables> => {
+>({
+    mutationOptions,
+}: UseUpdateProps<TData, TError, TVariables> = {}): UseUpdateReturnType<
+    TData,
+    TError,
+    TVariables
+> => {
     const { resources } = useResource();
     const queryClient = useQueryClient();
     const dataProvider = useDataProvider();
@@ -438,6 +461,7 @@ export const useUpdate = <
                     });
                 }
             },
+            ...mutationOptions,
         },
     );
 

--- a/packages/core/src/hooks/data/useUpdateMany.ts
+++ b/packages/core/src/hooks/data/useUpdateMany.ts
@@ -1,5 +1,6 @@
 import {
     useMutation,
+    UseMutationOptions,
     UseMutationResult,
     useQueryClient,
 } from "@tanstack/react-query";
@@ -59,6 +60,22 @@ type UseUpdateManyReturnType<
     UpdateContext<TData>
 >;
 
+export type UseUpdateManyProps<
+    TData extends BaseRecord = BaseRecord,
+    TError extends HttpError = HttpError,
+    TVariables = {},
+> = {
+    mutationOptions?: Omit<
+        UseMutationOptions<
+            UpdateManyResponse<TData>,
+            TError,
+            UpdateManyParams<TVariables>,
+            UpdateContext<TData>
+        >,
+        "mutationFn" | "onError" | "onSuccess" | "onSettled" | "onMutate"
+    >;
+};
+
 /**
  * `useUpdateMany` is a modified version of `react-query`'s {@link https://react-query.tanstack.com/reference/useMutation `useMutation`} for multiple update mutations.
  *
@@ -75,7 +92,13 @@ export const useUpdateMany = <
     TData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TVariables = {},
->(): UseUpdateManyReturnType<TData, TError, TVariables> => {
+>({
+    mutationOptions,
+}: UseUpdateManyProps<TData, TError, TVariables> = {}): UseUpdateManyReturnType<
+    TData,
+    TError,
+    TVariables
+> => {
     const { resources } = useResource();
     const queryClient = useQueryClient();
     const dataProvider = useDataProvider();
@@ -398,6 +421,7 @@ export const useUpdateMany = <
                     });
                 }
             },
+            ...mutationOptions,
         },
     );
 

--- a/packages/core/src/hooks/form/useForm.ts
+++ b/packages/core/src/hooks/form/useForm.ts
@@ -29,8 +29,12 @@ import {
     IQueryKeys,
     FormAction,
 } from "../../interfaces";
-import { UpdateParams, UseUpdateReturnType } from "../data/useUpdate";
-import { UseCreateReturnType } from "../data/useCreate";
+import {
+    UpdateParams,
+    UseUpdateProps,
+    UseUpdateReturnType,
+} from "../data/useUpdate";
+import { UseCreateProps, UseCreateReturnType } from "../data/useCreate";
 import { redirectPage } from "@definitions/helpers";
 
 export type ActionParams = {
@@ -106,6 +110,14 @@ type ActionFormProps<
      * react-query's [useQuery](https://tanstack.com/query/v4/docs/reference/useQuery) options of useOne hook used while in edit mode.
      */
     queryOptions?: UseQueryOptions<GetOneResponse<TData>, HttpError>;
+    /**
+     * react-query's [useMutation](https://tanstack.com/query/v4/docs/reference/useMutation) options of useCreate hook used while submitting in create and clone modes.
+     */
+    createMutationOptions?: UseCreateProps<TData, TError, TVariables>;
+    /**
+     * react-query's [useMutation](https://tanstack.com/query/v4/docs/reference/useMutation) options of useUpdate hook used while submitting in edit mode.
+     */
+    updateMutationOptions?: UseUpdateProps<TData, TError, TVariables>;
 } & SuccessErrorNotification &
     ActionParams &
     LiveModeProps;
@@ -171,6 +183,8 @@ export const useForm = <
     dataProviderName,
     invalidates,
     queryOptions,
+    createMutationOptions,
+    updateMutationOptions,
 }: UseFormProps<TData, TError, TVariables> = {}): UseFormReturnType<
     TData,
     TError,
@@ -238,11 +252,15 @@ export const useForm = <
 
     const { isFetching: isFetchingQuery } = queryResult;
 
-    const mutationResultCreate = useCreate<TData, TError, TVariables>();
+    const mutationResultCreate = useCreate<TData, TError, TVariables>(
+        createMutationOptions,
+    );
     const { mutate: mutateCreate, isLoading: isLoadingCreate } =
         mutationResultCreate;
 
-    const mutationResultUpdate = useUpdate<TData, TError, TVariables>();
+    const mutationResultUpdate = useUpdate<TData, TError, TVariables>(
+        updateMutationOptions,
+    );
     const { mutate: mutateUpdate, isLoading: isLoadingUpdate } =
         mutationResultUpdate;
 

--- a/packages/core/src/hooks/form/useForm.ts
+++ b/packages/core/src/hooks/form/useForm.ts
@@ -113,11 +113,19 @@ type ActionFormProps<
     /**
      * react-query's [useMutation](https://tanstack.com/query/v4/docs/reference/useMutation) options of useCreate hook used while submitting in create and clone modes.
      */
-    createMutationOptions?: UseCreateProps<TData, TError, TVariables>;
+    createMutationOptions?: UseCreateProps<
+        TData,
+        TError,
+        TVariables
+    >["mutationOptions"];
     /**
      * react-query's [useMutation](https://tanstack.com/query/v4/docs/reference/useMutation) options of useUpdate hook used while submitting in edit mode.
      */
-    updateMutationOptions?: UseUpdateProps<TData, TError, TVariables>;
+    updateMutationOptions?: UseUpdateProps<
+        TData,
+        TError,
+        TVariables
+    >["mutationOptions"];
 } & SuccessErrorNotification &
     ActionParams &
     LiveModeProps;
@@ -252,15 +260,15 @@ export const useForm = <
 
     const { isFetching: isFetchingQuery } = queryResult;
 
-    const mutationResultCreate = useCreate<TData, TError, TVariables>(
-        createMutationOptions,
-    );
+    const mutationResultCreate = useCreate<TData, TError, TVariables>({
+        mutationOptions: createMutationOptions,
+    });
     const { mutate: mutateCreate, isLoading: isLoadingCreate } =
         mutationResultCreate;
 
-    const mutationResultUpdate = useUpdate<TData, TError, TVariables>(
-        updateMutationOptions,
-    );
+    const mutationResultUpdate = useUpdate<TData, TError, TVariables>({
+        mutationOptions: updateMutationOptions,
+    });
     const { mutate: mutateUpdate, isLoading: isLoadingUpdate } =
         mutationResultUpdate;
 


### PR DESCRIPTION
Added the ability to pass mutation options to `useMutation` hooks in mutation hooks:
- `useCreate` (data)
- `useUpdate` (data)
- `useDelete` (data)
- `useDeleteMany` (data)
- `useUpdateMany` (data)
- `useCreateMany` (data)
- `useCustomMutation` (data)
- `useLogin` (auth)
- `useLogout` (auth)
- `useRegister` (auth)
- `useForgotPassword` (auth)
- `useUpdatePassword` (auth)
- `useForm` (form)
- `useLog` (audit log)

Also includes changes in `@pankod/refine-antd` for:
- `useForm`
- `useStepsForm`
- `useModalForm`
- `useDrawerForm`

hooks.

Users now can pass `mutationOptions` config property to pass custom options to the `useMutation` hooks.

**Warning**

This PR is marked as draft to make sure buttons in UI packages are also compatible with the latest changes.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [ ] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [ ] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
