### PR TITLE
feat(cli): fast swizzle for single item packages

### DIFF
--- a/.changeset/breezy-panthers-study.md
+++ b/.changeset/breezy-panthers-study.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-cli": minor
+---
+
+Do not prompt the component selection if there is only one component to swizzle.


### PR DESCRIPTION
Updated the prompt for the component selection to be skipped when there's a single item to swizzle. Such as `@pankod/refine-simple-rest` which has a single `Data Provider` item to swizzle but users are still prompted to select.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
