### PR TITLE
fix: `@pankod/refine-inferencer` `BaseKey` type issue

### DIFF
--- a/.changeset/sixty-spiders-thank.md
+++ b/.changeset/sixty-spiders-thank.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-inferencer": patch
+---
+
+Fix type inconsistency in `useInferFetch` due to changes in `@pankod/refine-core`'s `useResource` hook.

--- a/packages/inferencer/src/use-infer-fetch/index.tsx
+++ b/packages/inferencer/src/use-infer-fetch/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useDataProvider, useResource } from "@pankod/refine-core";
+import { useDataProvider, useResource, BaseKey } from "@pankod/refine-core";
 
 import { pickDataProvider, dataProviderFromResource } from "@/utilities";
 
@@ -32,7 +32,7 @@ export const useInferFetch = (
     const [loading, setLoading] = React.useState<boolean>(false);
 
     const resolver = React.useCallback(
-        async (recordItemId: number) => {
+        async (recordItemId: BaseKey) => {
             const dataProviderName =
                 dataProviderFromResource(resource) ??
                 pickDataProvider(resourceName, undefined, resources);
@@ -71,7 +71,7 @@ export const useInferFetch = (
 
     React.useEffect(() => {
         setInitial(false);
-        if (!loading && !data) {
+        if (!loading && !data && id) {
             resolver(id);
         }
     }, [resolver, id]);


### PR DESCRIPTION
Fix type inconsistency in `useInferFetch` due to changes in `@pankod/refine-core`'s `useResource` hook.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
