### PR TITLE
fix(inferencer): mark `recordItemId` as nullable

### DIFF
--- a/.changeset/heavy-rules-kick.md
+++ b/.changeset/heavy-rules-kick.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-inferencer": patch
+---
+
+Update `useInferFetch` hook logic to work without `id` in `list` and `create` type of inferencer.

--- a/packages/inferencer/src/use-infer-fetch/index.tsx
+++ b/packages/inferencer/src/use-infer-fetch/index.tsx
@@ -32,7 +32,7 @@ export const useInferFetch = (
     const [loading, setLoading] = React.useState<boolean>(false);
 
     const resolver = React.useCallback(
-        async (recordItemId: BaseKey) => {
+        async (recordItemId: BaseKey | undefined) => {
             const dataProviderName =
                 dataProviderFromResource(resource) ??
                 pickDataProvider(resourceName, undefined, resources);
@@ -50,7 +50,7 @@ export const useInferFetch = (
                         setLoading(false);
                     }, 500);
                 }
-                if (type === "edit" || (type === "show" && recordItemId)) {
+                if ((type === "edit" || type === "show") && recordItemId) {
                     const response = await dp.getOne({
                         resource: resourceName,
                         id: recordItemId,
@@ -71,7 +71,7 @@ export const useInferFetch = (
 
     React.useEffect(() => {
         setInitial(false);
-        if (!loading && !data && id) {
+        if (!loading && !data) {
             resolver(id);
         }
     }, [resolver, id]);


### PR DESCRIPTION
Update `useInferFetch` hook logic to work without `id` in `list` and `create` type of inferencer.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
