### PR TITLE
docs(tutorials): fix headless install command

### DIFF
--- a/documentation/docs/tutorials/core.md
+++ b/documentation/docs/tutorials/core.md
@@ -75,7 +75,7 @@ This tutorial assumes your project is configured for absolute imports. Since CRA
 First, run the **create refine-app** with the following command:
 
 ```
-npm create refine-app@latest -o refine-headless tutorial
+npm create refine-app@latest -- -o refine-headless tutorial
 ```
 </TabItem>
 </Tabs>


### PR DESCRIPTION
The first command in https://refine.dev/docs/tutorials/headless-tutorial/#setting-up is missing `--` before the arguments.