### PR TITLE
fix: checkError hook is not called in onError of useCustomMutation

### DIFF
--- a/.changeset/five-steaks-itch.md
+++ b/.changeset/five-steaks-itch.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Fixed checkError hook is not called in onError of useCustomMutation

--- a/packages/core/src/hooks/data/useCustomMutation.ts
+++ b/packages/core/src/hooks/data/useCustomMutation.ts
@@ -4,7 +4,12 @@ import {
     UseMutationResult,
 } from "@tanstack/react-query";
 
-import { useDataProvider, useHandleNotification, useTranslate } from "@hooks";
+import {
+    useCheckError,
+    useDataProvider,
+    useHandleNotification,
+    useTranslate,
+} from "@hooks";
 import {
     CreateResponse,
     BaseRecord,
@@ -77,6 +82,7 @@ export const useCustomMutation = <
     TError,
     TVariables
 > = {}): UseCustomMutationReturnType<TData, TError, TVariables> => {
+    const { mutate: checkError } = useCheckError();
     const handleNotification = useHandleNotification();
     const dataProvider = useDataProvider();
     const translate = useTranslate();
@@ -137,6 +143,8 @@ export const useCustomMutation = <
                     metaData,
                 },
             ) => {
+                checkError(err);
+
                 const notificationConfig =
                     typeof errorNotificationFromProp === "function"
                         ? errorNotificationFromProp(err, {


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Fixed checkError hook is not called in onError of useCustomMutation

### Closing issues
- https://discord.com/channels/837692625737613362/1060823846493638676

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
