### PR TITLE
fix:core resource action component type

### DIFF
--- a/.changeset/chilly-mails-deny.md
+++ b/.changeset/chilly-mails-deny.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Changed `IResourceComponents` from `IResourceContext` to use `React.ComponentType` rather than `React.FunctionComponent` to make it compatible with other types and interfaces.

--- a/packages/core/src/contexts/resource/IResourceContext.ts
+++ b/packages/core/src/contexts/resource/IResourceContext.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, ComponentType } from "react";
 import { UseQueryResult } from "@tanstack/react-query";
 import { ILogData } from "src/interfaces";
 
@@ -43,10 +43,10 @@ export interface IResourceComponentsProps<
     logQueryResult?: UseQueryResult<TLogQueryResult>;
 }
 export interface IResourceComponents {
-    list?: React.FunctionComponent<IResourceComponentsProps<any, any>>;
-    create?: React.FunctionComponent<IResourceComponentsProps<any, any>>;
-    edit?: React.FunctionComponent<IResourceComponentsProps<any, any>>;
-    show?: React.FunctionComponent<IResourceComponentsProps<any, any>>;
+    list?: ComponentType<IResourceComponentsProps<any, any>>;
+    create?: ComponentType<IResourceComponentsProps<any, any>>;
+    edit?: ComponentType<IResourceComponentsProps<any, any>>;
+    show?: ComponentType<IResourceComponentsProps<any, any>>;
 }
 
 export interface IResourceItem extends IResourceComponents {


### PR DESCRIPTION
Replaced `React.FunctionComponent` with `React.ComponentType` for wider compatibility. Such as cases in #3357 with `next/dynamic`

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
