### PR TITLE
fix(cli): use `Buffer.from` when `btoa` is `"undefined"` for `base64` encoding

### DIFF
--- a/.changeset/thin-buckets-hammer.md
+++ b/.changeset/thin-buckets-hammer.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-cli": patch
+---
+
+Fixed: `ReferenceError: btoa is not defined`. #3366 use `Buffer.from` when `btoa` is `"undefined"` for base64 encoding.

--- a/packages/cli/src/update-notifier/index.tsx
+++ b/packages/cli/src/update-notifier/index.tsx
@@ -5,6 +5,7 @@ import { getUpdateWarningTable } from "@components/update-warning-table";
 import { RefinePackageInstalledVersionData } from "@definitions/package";
 import { getInstalledRefinePackages } from "@utils/package";
 import { ENV } from "@utils/env";
+import { stringToBase64 } from "@utils/encode";
 
 const STORE_NAME = "refine-update-notifier";
 
@@ -133,7 +134,7 @@ export const generateKeyFromPackages = async () => {
     const currentVersionsWithName = packages.map(
         (p) => `${p.name}@${p.version}`,
     );
-    const hash = btoa(currentVersionsWithName.toString());
+    const hash = stringToBase64(currentVersionsWithName.toString());
 
     return hash;
 };

--- a/packages/cli/src/utils/encode/index.ts
+++ b/packages/cli/src/utils/encode/index.ts
@@ -1,0 +1,14 @@
+export const stringToBase64 = (str: string) => {
+    if (typeof btoa !== "undefined") {
+        return btoa(str);
+    }
+
+    return Buffer.from(str).toString("base64");
+};
+
+export const base64ToString = (base64: string) => {
+    if (typeof atob !== "undefined") {
+        return atob(base64);
+    }
+    return Buffer.from(base64, "base64").toString();
+};


### PR DESCRIPTION
`closes #3366` 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
