### PR TITLE
docs(inferencer): add dependency warning to headless inferencer

### DIFF
--- a/documentation/docs/api-reference/core/components/inferencer.md
+++ b/documentation/docs/api-reference/core/components/inferencer.md
@@ -5,6 +5,15 @@ title: Inferencer
 
 You can automatically generate views for your resources using `@pankod/refine-inferencer`. Inferencer exports `HeadlessListInferencer`, `HeadlessShowInferencer`, `HeadlessEditInferencer`, `HeadlessCreateInferencer` and `HeadlessInferencer` (which combines all in one place) components.
 
+:::caution Dependencies
+
+`@pankod/refine-inferencer/headless` uses [`@pankod/refine-react-hook-form`](/docs/packages/documentation/react-hook-form/useForm) and [`@pankod/refine-react-table`](/docs/packages/documentation/react-table) to create views.
+
+Make sure you include them in your dependencies.
+
+:::
+
+
 ## Usage
 
 Ant Design components can be imported from `@pankod/refine-inferencer/headless`. You can directly use the components in `resources` prop of `Refine` component or you can use them in your custom components by passing the `resource` prop as the resource name.


### PR DESCRIPTION
Added dependency warning to headless inferencer docs.

<img width="854" alt="Screen Shot 2023-01-10 at 17 02 37" src="https://user-images.githubusercontent.com/11361964/211572074-6edb6e7c-7644-4d7d-8c4d-ff4eaaf142fe.png">


### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
