### PR TITLE
fix(inferencer): remove repeated react import

### DIFF
--- a/.changeset/small-students-compare.md
+++ b/.changeset/small-students-compare.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-inferencer": patch
+---
+
+Remove repeated `React` import from `headless/list` inferencer.

--- a/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/index.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`ChakraUIInferencer should match the snapshot 1`] = `
         class="css-0"
       >
         <div
-          class="chakra-table__container css-1opj2lu"
+          class="chakra-table__container css-1rcznqn"
         >
           <table
             class="chakra-table css-0"

--- a/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/list.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/list.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`ChakraListInferencer should match the snapshot 1`] = `
         class="css-0"
       >
         <div
-          class="chakra-table__container css-1opj2lu"
+          class="chakra-table__container css-1rcznqn"
         >
           <table
             class="chakra-table css-0"

--- a/packages/inferencer/src/inferencers/headless/list.tsx
+++ b/packages/inferencer/src/inferencers/headless/list.tsx
@@ -665,7 +665,6 @@ export const ListInferencer: InferencerResultComponent = createInferencer({
         noOp(imports);
 
         return jsx`
-        import React from "react";
         ${printImports(imports)}
         
         export const ${COMPONENT_NAME}: React.FC<IResourceComponentsProps> = () => {


### PR DESCRIPTION
removed repeated `react` import in `headless` inferencer's `List`.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
