### PR TITLE
fix(docs): live preview header button text not visible on dark mode

### DIFF
--- a/documentation/src/components/live-preview/styles.module.css
+++ b/documentation/src/components/live-preview/styles.module.css
@@ -16,7 +16,7 @@
   appearance: none;
   border: none;
   background: none;
-  color: var(--ifm-color-content);
+  color: #1c1e21;
   font-size: 0.75rem;
   text-align: center;
   text-transform: uppercase;


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/23058882/211835824-4a670d73-78c7-4246-bd80-77888bce86e7.png)

after:
![image](https://user-images.githubusercontent.com/23058882/211835959-116b101c-3879-4413-8076-f989c0313742.png)
