### PR TITLE
fix: onSubmit is set to nullable on AuthPage

### DIFF
--- a/.changeset/twenty-beers-impress.md
+++ b/.changeset/twenty-beers-impress.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mantine": patch
+---
+
+fix: `onSubmit` is set to nullable on [`<AuthPage>`](https://refine.dev/docs/api-reference/mantine/components/mantine-auth-page/)

--- a/documentation/docs/api-reference/mantine/components/auth-page.md
+++ b/documentation/docs/api-reference/mantine/components/auth-page.md
@@ -728,8 +728,7 @@ const App = () => {
                     formProps={{
                         onSubmit: (e: any) => {
                             e.preventDefault();
-                            console.log("e", e.target.email.value);
-
+                            
                             const email = e.target.email.value;
                             const password = e.target.password.value;
 
@@ -739,6 +738,10 @@ const App = () => {
                                     password,
                                 }),
                             );
+                        },
+                        initialValues: {
+                            email: "info@refine.dev",
+                            password: "i-love-refine",
                         },
                     }}
                     // highlight-end

--- a/packages/mantine/src/components/pages/auth/index.tsx
+++ b/packages/mantine/src/components/pages/auth/index.tsx
@@ -11,7 +11,7 @@ import {
 } from "./components";
 
 export type FormPropsType = UseFormInput<unknown> & {
-    onSubmit: (values: any) => void;
+    onSubmit?: (values: any) => void;
 };
 
 export type AuthProps = AuthPageProps<BoxProps, CardProps, FormPropsType>;


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

fix: `onSubmit` is set to nullable on [`<AuthPage>`](https://refine.dev/docs/api-reference/mantine/components/mantine-auth-page/)

### Closing issues

- https://discord.com/channels/837692625737613362/1063845396910178314

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
