### PR TITLE
chore(live-previews): disable sourcemaps in production

### DIFF
--- a/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/create.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/create.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`MantineCreateInferencer should match the snapshot 1`] = `
         class="mantine-Group-root mantine-1dn2tzg"
       >
         <div
-          class="mantine-Stack-root mantine-1xft3nm"
+          class="mantine-Stack-root mantine-zyu68o"
         >
           <div
             class="mantine-Group-root mantine-1g4q40w"

--- a/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/edit.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/edit.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`MantineEditInferencer should match the snapshot 1`] = `
         class="mantine-Group-root mantine-1dn2tzg"
       >
         <div
-          class="mantine-Stack-root mantine-1xft3nm"
+          class="mantine-Stack-root mantine-zyu68o"
         >
           <div
             class="mantine-Group-root mantine-1g4q40w"

--- a/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/index.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`MantineInferencer should match the snapshot 1`] = `
         class="mantine-Group-root mantine-1dn2tzg"
       >
         <div
-          class="mantine-Stack-root mantine-1xft3nm"
+          class="mantine-Stack-root mantine-zyu68o"
         >
           <div
             aria-label="breadcrumb"
@@ -378,7 +378,7 @@ exports[`MantineInferencer should match the snapshot 2`] = `
         class="mantine-Group-root mantine-1dn2tzg"
       >
         <div
-          class="mantine-Stack-root mantine-1xft3nm"
+          class="mantine-Stack-root mantine-zyu68o"
         >
           <div
             aria-label="breadcrumb"
@@ -997,7 +997,7 @@ exports[`MantineInferencer should match the snapshot 3`] = `
         class="mantine-Group-root mantine-1dn2tzg"
       >
         <div
-          class="mantine-Stack-root mantine-1xft3nm"
+          class="mantine-Stack-root mantine-zyu68o"
         >
           <div
             aria-label="breadcrumb"
@@ -1807,7 +1807,7 @@ exports[`MantineInferencer should match the snapshot 4`] = `
         class="mantine-Group-root mantine-1dn2tzg"
       >
         <div
-          class="mantine-Stack-root mantine-1xft3nm"
+          class="mantine-Stack-root mantine-zyu68o"
         >
           <div
             aria-label="breadcrumb"

--- a/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/list.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/list.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`MantineListInferencer should match the snapshot 1`] = `
         class="mantine-Group-root mantine-1dn2tzg"
       >
         <div
-          class="mantine-Stack-root mantine-1xft3nm"
+          class="mantine-Stack-root mantine-zyu68o"
         >
           <h3
             class="mantine-Text-root mantine-Title-root mantine-6hw97m"

--- a/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/show.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/show.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`MantineShowInferencer should match the snapshot 1`] = `
         class="mantine-Group-root mantine-1dn2tzg"
       >
         <div
-          class="mantine-Stack-root mantine-1xft3nm"
+          class="mantine-Stack-root mantine-zyu68o"
         >
           <div
             class="mantine-Group-root mantine-1g4q40w"

--- a/packages/live-previews/next.config.js
+++ b/packages/live-previews/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     reactStrictMode: true,
-    productionBrowserSourceMaps: true,
+    // productionBrowserSourceMaps: true, // Disabled for now, as it causes build to hang on deploy
     swcMinify: false,
 };
 


### PR DESCRIPTION
We've added production source maps to live-previews so we can identify the errors if any happens in the documentation which uses the production build but now for some reason, enabling `productionBrowserSourceMaps` hangs the live-previews build process and fails the pipelines. 

Disabled for now but will be looking for a workaround for this.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
