### PR TITLE
feat(docs): update all documentation of form hooks in same format

### DIFF
--- a/documentation/docs/api-reference/antd/hooks/form/useForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useForm.md
@@ -126,7 +126,7 @@ const PostCreate = () => {
 
 <GeneralConceptsLink />
 
-## Usage
+## Basic Usage
 
 > For more detailed usage examples please refer to the [Ant Design Form](https://ant.design/components/form/) documentation.
 

--- a/documentation/docs/api-reference/antd/hooks/form/useModalForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useModalForm.md
@@ -11,22 +11,6 @@ title: useModalForm
 
 ## Basic Usage
 
-```tsx
-import { useModalForm } from "@pankod/refine-antd";
-
-interface IPost {
-    id: number;
-    title: string;
-    status: "published" | "draft" | "rejected";
-}
-
-const { modalProps, formProps } = useModalForm<IPost>({
-    action: "create", // or "edit" or clone
-});
-```
-
-All we have to do is to pass the `formProps` to [`<Form>`][antd-form] and `modalProps` to [`<Modal>`][antd-modal] components.
-
 We'll show three examples, `"create"`, `"edit"` and `"clone"`. Let's see how `useModalForm` is used in all.
 
 <Tabs

--- a/documentation/docs/api-reference/antd/hooks/form/useModalForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useModalForm.md
@@ -6,7 +6,7 @@ title: useModalForm
 `useModalForm` hook allows you to manage a form within a [`<Modal>`][antd-modal]. It returns Ant Design [`<Form>`][antd-form] and [Modal][antd-modal] components props.
 
 :::info
-`useModalForm` hook is extended from [`useForm`][antd-use-form] from the [`@pankod/refine-antd`][@pankod/refine-antd] package. Which means that you can use all the features of [`useForm`][antd-use-form] hook.
+`useModalForm` hook is extended from [`useForm`][antd-use-form] from the [`@pankod/refine-antd`][@pankod/refine-antd] package. This means that you can use all the features of [`useForm`][antd-use-form] hook.
 :::
 
 ## Basic Usage

--- a/documentation/docs/api-reference/antd/hooks/form/useStepsForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useStepsForm.md
@@ -324,12 +324,6 @@ const PostCreate = () => {
 
 ## Basic Usage
 
-```ts
-import { useStepsForm } from "@pankod/refine-antd";
-
-const { stepsProps, formProps } = useStepsForm();
-```
-
 We'll do two examples, one for creating and one for editing a post. Let's see how `useStepsForm` is used in both.
 
 <Tabs

--- a/documentation/docs/api-reference/antd/hooks/form/useStepsForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useStepsForm.md
@@ -318,19 +318,17 @@ const PostCreate = () => {
 
 `useStepsForm` hook allows you to split your form under an Ant Design based [Steps](https://ant.design/components/steps/) component and provides you with a few useful functionalities that will help you manage your form.
 
+:::info
+`useStepsForm` hook is extended from [`useForm`][antd-use-form] under the hood. This means that you can use all the functionalities of [`useForm`][antd-use-form] in your `useStepsForm`.
+:::
+
+## Basic Usage
+
 ```ts
 import { useStepsForm } from "@pankod/refine-antd";
 
 const { stepsProps, formProps } = useStepsForm();
 ```
-
-All we have to do is to pass the props it returns to our `<Steps>` and `<Form>` components.
-
-:::tip
-`useStepsForm` is using [`useForm`](/api-reference/antd/hooks/form/useForm.md) under the hood. This means that you can use all the functionalities of `useForm` in your `useStepsForm`.
-:::
-
-## Basic Usage
 
 We'll do two examples, one for creating and one for editing a post. Let's see how `useStepsForm` is used in both.
 
@@ -1150,7 +1148,4 @@ When `action` is `"edit"` or `"clone"`, `useStepsForm` will fetch the data from 
 
 [baserecord]: /api-reference/core/interfaces.md#baserecord
 [httperror]: /api-reference/core/interfaces.md#httperror
-
-```
-
-```
+[antd-use-form]: /docs/api-reference/antd/hooks/form/useForm

--- a/documentation/docs/api-reference/mantine/hooks/form/useForm.md
+++ b/documentation/docs/api-reference/mantine/hooks/form/useForm.md
@@ -224,7 +224,7 @@ const PostCreate: React.FC = () => {
 
 <GeneralConceptsLink />
 
-## Usage
+## Basic Usage
 
 > For more detailed usage examples please refer to the [Mantine Form](https://mantine.dev/form/use-form/) documentation.
 

--- a/documentation/docs/api-reference/mantine/hooks/form/useModalForm.md
+++ b/documentation/docs/api-reference/mantine/hooks/form/useModalForm.md
@@ -6,7 +6,7 @@ title: useModalForm
 `useModalForm` hook also allows you to manage a form inside a modal component. It provides some useful methods to handle the form modal.
 
 :::info
-`useModalForm` hook is extended from [`useForm`][use-form-refine-mantine] hook from the [`@pankod/refine-mantine`](https://github.com/refinedev/refine/tree/next/packages/mantine) package. Which means that you can use all the features of [`useForm`][use-form-refine-mantine] hook.
+`useModalForm` hook is extended from [`useForm`][use-form-refine-mantine] hook from the [`@pankod/refine-mantine`](https://github.com/refinedev/refine/tree/next/packages/mantine) package. This means that you can use all the features of [`useForm`][use-form-refine-mantine] hook.
 :::
 
 ## Basic Usage

--- a/documentation/docs/api-reference/mantine/hooks/form/useModalForm.md
+++ b/documentation/docs/api-reference/mantine/hooks/form/useModalForm.md
@@ -11,21 +11,6 @@ title: useModalForm
 
 ## Basic Usage
 
-```tsx
-const createModalForm = useModalForm({
-    modal: { show: showCreateModal, close, submit, title, visible },
-    refineCoreProps: { action: "create" },
-    initialValues: {
-        title: "",
-        content: "",
-    },
-    validate: {
-        title: (value) => (value.length < 2 ? "Too short title" : null),
-        content: (value) => (value.length < 10 ? "Too short content" : null),
-    },
-});
-```
-
 We'll show three examples, `"create"`, `"edit"` and `"clone"`. Let's see how `useModalForm` is used in all.
 
 <Tabs

--- a/documentation/docs/api-reference/mantine/hooks/form/useStepsForm.md
+++ b/documentation/docs/api-reference/mantine/hooks/form/useStepsForm.md
@@ -471,7 +471,7 @@ const PostEdit: React.FC = () => {
 `useStepsForm` allows you to manage a form with multiple steps. It provides features such as which step is currently active, the ability to go to a specific step and validation when changing steps etc.
 
 :::info
-`useStepsForm` hook is extended from [`useForm`][use-form-refine-mantine] under the hood. This means that you can use all the functionalities of [`useForm`][use-form-refine-mantine] in your `useStepsForm`.
+`useStepsForm` hook is extended from [`useForm`][use-form-refine-mantine] from the [`@pankod/refine-mantine`](https://github.com/refinedev/refine/tree/next/packages/mantine) package. This means that you can use all the functionalities of [`useForm`][use-form-refine-mantine] in your `useStepsForm`.
 :::
 
 ## Basic Usage

--- a/documentation/docs/api-reference/mantine/hooks/form/useStepsForm.md
+++ b/documentation/docs/api-reference/mantine/hooks/form/useStepsForm.md
@@ -470,8 +470,8 @@ const PostEdit: React.FC = () => {
 
 `useStepsForm` allows you to manage a form with multiple steps. It provides features such as which step is currently active, the ability to go to a specific step and validation when changing steps etc.
 
-:::tip
-`useStepsForm` hook based on [`useForm`][use-form-refine-mantine] hook provided by `@pankod/refine-mantine`. It means that you can use all the features of [`useForm`][use-form-refine-mantine] in your `useStepsForm`.
+:::info
+`useStepsForm` hook is extended from [`useForm`][use-form-refine-mantine] under the hood. This means that you can use all the functionalities of [`useForm`][use-form-refine-mantine] in your `useStepsForm`.
 :::
 
 ## Basic Usage
@@ -1077,6 +1077,3 @@ stepsProps-default="`defaultStep = 0` `isBackValidate = false`"
 
 [use-form-refine-mantine]: /api-reference/mantine/hooks/form/useForm.md
 [use-form-core]: /api-reference/core/hooks/useForm.md
-
-Array relationship, `tags` from `posts` table using `tags` :: `post_id` -> `id`
-Object relationship, `post` from `tags` table using `post_id`-> `posts` :: ``id`

--- a/documentation/docs/packages/documentation/react-hook-form/useModalForm.md
+++ b/documentation/docs/packages/documentation/react-hook-form/useModalForm.md
@@ -94,7 +94,7 @@ textarea {
 `useModalForm` hook allows you to manage a form within a modal. It provides some useful methods to handle the form modal.
 
 :::info
-`useModalForm` hook is extended from [`useForm`][refine-react-hook-form-use-form] from the [`@pankod/refine-react-hook-form`][@pankod/refine-react-hook-form] package. Which means that you can use all the features of [`useForm`][refine-react-hook-form-use-form] hook.
+`useModalForm` hook is extended from [`useForm`][refine-react-hook-form-use-form] from the [`@pankod/refine-react-hook-form`][@pankod/refine-react-hook-form] package. This means that you can use all the features of [`useForm`][refine-react-hook-form-use-form] hook.
 :::
 
 ## Basic Usage

--- a/documentation/docs/packages/documentation/react-hook-form/useStepsForm.md
+++ b/documentation/docs/packages/documentation/react-hook-form/useStepsForm.md
@@ -349,7 +349,7 @@ const PostEdit: React.FC = () => {
 
 `useStepsForm` allows you to manage a form with multiple steps. It provides features such as which step is currently active, the ability to go to a specific step and validation when changing steps etc.
 
-:::tip
+:::info
 `useStepsForm` hook is extended from [`useForm`][refine-react-hook-form-use-form] from the [`@pankod/refine-react-hook-form`][@pankod/refine-react-hook-form] package. It means you can use all the features of [`useForm`][refine-react-hook-form-use-form].
 :::
 

--- a/documentation/docs/packages/documentation/react-hook-form/useStepsForm.md
+++ b/documentation/docs/packages/documentation/react-hook-form/useStepsForm.md
@@ -350,7 +350,7 @@ const PostEdit: React.FC = () => {
 `useStepsForm` allows you to manage a form with multiple steps. It provides features such as which step is currently active, the ability to go to a specific step and validation when changing steps etc.
 
 :::info
-`useStepsForm` hook is extended from [`useForm`][refine-react-hook-form-use-form] from the [`@pankod/refine-react-hook-form`][@pankod/refine-react-hook-form] package. It means you can use all the features of [`useForm`][refine-react-hook-form-use-form].
+`useStepsForm` hook is extended from [`useForm`][refine-react-hook-form-use-form] from the [`@pankod/refine-react-hook-form`][@pankod/refine-react-hook-form] package. This means you can use all the features of [`useForm`][refine-react-hook-form-use-form].
 :::
 
 ## Basic Usage


### PR DESCRIPTION
The documentation of form hooks differed from each other. Updated to be in the same format as each other.