### PR TITLE
docs(version-dropdown): fix arrow on hover

### DIFF
--- a/documentation/src/css/custom.css
+++ b/documentation/src/css/custom.css
@@ -410,8 +410,13 @@
     @apply relative;
 }
 
-.with-hoverline.hoverline-link:hover::after,
-.with-hoverline.navbar__link--active::after {
+.with-hoverline.hoverline-link:not([role=button]):hover::after,
+.with-hoverline.navbar__link--active:not([role=button])::after {
+    content: "";
+    @apply absolute bottom-[-5px] left-[calc(50%-12px)] h-1 w-6 rounded-sm bg-[#1890ff] transition-opacity duration-200 ease-in-out;
+}
+
+.with-hoverline.hoverline-link[role=button]:hover::before {
     content: "";
     @apply absolute bottom-[-5px] left-[calc(50%-12px)] h-1 w-6 rounded-sm bg-[#1890ff] transition-opacity duration-200 ease-in-out;
 }


### PR DESCRIPTION
Fixed broken arrow in navbar version dropdown caused by `::after` style conflict between arrow and hover line

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
