### PR TITLE
fix: make `getPermissions` of auth provider optional

### DIFF
--- a/.changeset/young-plums-fold.md
+++ b/.changeset/young-plums-fold.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Made the auth provider's `usePermissions` method optional.

--- a/packages/cloud/src/hooks/useAuthProviderWithCloudConfig/index.spec.tsx
+++ b/packages/cloud/src/hooks/useAuthProviderWithCloudConfig/index.spec.tsx
@@ -53,7 +53,7 @@ describe("useAuthProviderWithCloudConfig Hook", () => {
         const { generateCloudAuthProvider } = result.current;
         const { getPermissions } = generateCloudAuthProvider();
 
-        const response = await getPermissions();
+        const response = await getPermissions?.();
         expect(response).toContain("admin");
     });
 

--- a/packages/core/src/contexts/auth/IAuthContext.ts
+++ b/packages/core/src/contexts/auth/IAuthContext.ts
@@ -12,7 +12,7 @@ export interface AuthProvider {
     logout: (params: any) => Promise<TLogoutData>;
     checkAuth: (params?: any) => Promise<any>;
     checkError: (error: any) => Promise<void>;
-    getPermissions: (params?: any) => Promise<any>;
+    getPermissions?: (params?: any) => Promise<any>;
     getUserIdentity?: (params?: any) => Promise<any>;
 }
 


### PR DESCRIPTION
Made the auth provider's `usePermissions` method optional.