### PR TITLE
fix: Error translation key on `useInfiniteList` hook

### DIFF
--- a/.changeset/three-timers-pretend.md
+++ b/.changeset/three-timers-pretend.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Fix error translation key on `useInfiniteList` hook.

--- a/packages/core/src/hooks/data/useInfiniteList.ts
+++ b/packages/core/src/hooks/data/useInfiniteList.ts
@@ -187,7 +187,7 @@ export const useInfiniteList = <
                 handleNotification(notificationConfig, {
                     key: `${resource}-useInfiniteList-notification`,
                     message: translate(
-                        "common:notifications.error",
+                        "notifications.error",
                         { statusCode: err.statusCode },
                         `Error (status code: ${err.statusCode})`,
                     ),


### PR DESCRIPTION
Fix error translation key on `useInfiniteList` hook.