### PR TITLE
docs: add source code link option

### DIFF
--- a/documentation/src/components/live-preview/styles.module.css
+++ b/documentation/src/components/live-preview/styles.module.css
@@ -16,7 +16,7 @@
   appearance: none;
   border: none;
   background: none;
-  color: #1c1e21;
+  color: var(--ifm-color-content);
   font-size: 0.75rem;
   text-align: center;
   text-transform: uppercase;

--- a/documentation/src/css/custom.css
+++ b/documentation/src/css/custom.css
@@ -1080,3 +1080,37 @@ background: var(--ifm-menu-link-sublist-icon) 50% / 1.25rem 1.25rem;
 .tutorial--framework-select--button {
     @apply underline;
 }
+
+.sourcecode-badge {
+    @apply appearance-none no-underline text-xs font-bold bg-slate-800 text-white;
+    font-size: 12px;
+    line-height: 13px;
+    padding-top: 4px;
+    padding-bottom: 5px;
+    vertical-align: middle;
+
+    text-decoration: none;
+    background-color: #24292f;
+    color: white;
+}
+
+.sourcecode-badge:hover,
+.sourcecode-badge:active,
+.sourcecode-badge:focus,
+.sourcecode-badge:visited {
+    text-decoration: none;
+    background-color: #24292f;
+    color: white;
+}
+
+html[data-theme="dark"] .sourcecode-badge {
+    background-color: var(--ifm-color-secondary);
+    color: #24292f;
+}
+
+.sourcecode-badge svg {
+    margin-right: 6px;
+    height: 13px;
+    width: 13px;
+    margin-bottom: -2px;
+}

--- a/documentation/src/theme/DocItem/Layout/index.js
+++ b/documentation/src/theme/DocItem/Layout/index.js
@@ -12,6 +12,24 @@ import styles from "./styles.module.css";
 import { useDocTOCwithTutorial } from "../../../components/tutorial-toc/index";
 import { useCurrentTutorial } from "../../../hooks/use-current-tutorial";
 
+const GithubIcon = (props) => (
+    <svg
+        width={12}
+        height={12}
+        viewBox="0 0 22 22"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        {...props}
+    >
+        <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M11.053 0A10.904 10.904 0 0 0 3.89 2.685 11.34 11.34 0 0 0 .142 9.472a11.48 11.48 0 0 0 1.456 7.65 11.087 11.087 0 0 0 5.964 4.86c.556.103.752-.25.752-.547v-1.918C5.23 20.202 4.58 18 4.58 18a3.012 3.012 0 0 0-1.227-1.655c-.997-.692.081-.692.081-.692.35.05.683.18.975.382.293.202.536.469.713.78.15.278.352.523.595.721a2.312 2.312 0 0 0 2.618.221c.042-.57.283-1.105.678-1.509-2.454-.284-5.03-1.253-5.03-5.539a4.415 4.415 0 0 1 1.132-3.025A4.194 4.194 0 0 1 5.224 4.7s.928-.305 3.036 1.156c1.81-.508 3.72-.508 5.531 0 2.108-1.46 3.03-1.156 3.03-1.156.406.936.455 1.993.135 2.963a4.415 4.415 0 0 1 1.132 3.026c0 4.334-2.582 5.282-5.043 5.538.264.271.468.597.598.955.13.358.182.741.155 1.122V21.4c0 .367.196.65.759.54a11.093 11.093 0 0 0 5.88-4.878 11.481 11.481 0 0 0 1.419-7.6 11.34 11.34 0 0 0-3.71-6.746A10.907 10.907 0 0 0 11.053 0Z"
+            fill="currentColor"
+        />
+    </svg>
+);
+
 function SwizzleBadge({ className }) {
     return (
         <span
@@ -23,6 +41,29 @@ function SwizzleBadge({ className }) {
         >
             Swizzle Ready
         </span>
+    );
+}
+
+function SourceCodeBadge({ className, path }) {
+    const sourcePath = path.startsWith("https://")
+        ? path
+        : `https://github.com/refinedev/refine/blob/next${
+              path.startsWith("/") ? "" : "/"
+          }${path}`;
+    return (
+        <a
+            className={clsx(
+                className,
+                ThemeClassNames.docs.docVersionBadge,
+                "badge sourcecode-badge",
+            )}
+            href={sourcePath}
+            target="_blank"
+            rel="noreferrer noopener"
+        >
+            <GithubIcon />
+            Source Code
+        </a>
     );
 }
 
@@ -41,6 +82,9 @@ export default function DocItemLayout({ children }) {
                         <div className="flex flex-row gap-1 items-center">
                             <DocVersionBadge />
                             {frontMatter.swizzle && <SwizzleBadge />}
+                            {frontMatter.source && (
+                                <SourceCodeBadge path={frontMatter.source} />
+                            )}
                         </div>
                         {docTOC.mobile}
                         <DocItemContent>{children}</DocItemContent>


### PR DESCRIPTION
Added a simple button at top of the articles to add a link to the source code.

Also fixed the invisible "Show Code" label in dark mode for `BrowserWindow` component.

**Usage**

```md
---
id: useApiUrl
title: useApiUrl
source: https://github.com/refinedev/refine/blob/next/packages/core/src/hooks/data/useApiUrl.ts
---
```

or

```md
---
id: useCreate
title: useCreate
source: packages/core/src/hooks/data/useCreate.ts
siderbar_label: useCreate
description: useCreate data hook from refine is a modified version of react-query's useMutation for create mutations
---
```

**Output**

<img width="804" alt="Screen Shot 2023-01-26 at 12 31 42" src="https://user-images.githubusercontent.com/11361964/214802311-4d32b6a8-321c-4ecc-84bb-87a0c49686d9.png">

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
