### PR TITLE
feat(docs): add props and return values description to `useCan`

### DIFF
--- a/documentation/docs/api-reference/core/hooks/accessControl/useCan.md
+++ b/documentation/docs/api-reference/core/hooks/accessControl/useCan.md
@@ -38,7 +38,7 @@ const { data } = useCan({
     queryOptions: {
         staleTime: 5 * 60 * 1000, // 5 minutes
     }
-);
+});
 ```
 
 <br/>
@@ -47,27 +47,45 @@ const { data } = useCan({
 
 ### `resource` <PropTag required />
 
-> Type: `string`
+Passes to [Access Control Provider's][access-control-provider] `can` function's `resource` parameter
 
-Resource name for API data interactions.
+```ts
+useCan({
+    resource: "resource-you-ask-for-access",
+});
+```
 
 ### `action` <PropTag required />
 
-> Type: `string`
+Passes to [Access Control Provider's][access-control-provider] `can` function's `action` parameter
 
-Intended action on resource.
+```ts
+useCan({
+    action: "resource-you-ask-for-access",
+});
+```
 
 ### `params`
 
-> Type: `{ resource? : IResourceItem, id?: BaseKey, [key: string]: any }`
+Passes to [Access Control Provider's][access-control-provider] `can` function's `params` parameter
 
-Parameters associated with the resource
+```ts
+useCan({
+    params: { foo: "optional-params" },
+});
+```
 
 ### `queryOptions`
 
-> Type: [`QueryOptions`][query-options]
-
 Query options for [TanStack Query's][tanstack-query] [`useQuery`][use-query].
+
+```ts
+useCan({
+    queryOptions: {
+        staleTime: 5 * 60 * 1000, // 5 minutes
+    },
+});
+```
 
 <br/>
 
@@ -95,7 +113,7 @@ For example if you want to check if the user can create a post return value will
     }}
 
     // ...
-/>
+/>;
 
 // inside your component
 const { data: canCreatePost } = useCan({

--- a/documentation/docs/api-reference/core/hooks/accessControl/useCan.md
+++ b/documentation/docs/api-reference/core/hooks/accessControl/useCan.md
@@ -132,7 +132,7 @@ console.log(canCreatePost); // { can: false, reason: "Unauthorized" }
 | ------------------------------------------------------------------------ | ---------------------------------------------------------------- |
 | Result of the [TanStack Query's][tanstack-query] [`useQuery`][use-query] | [`QueryObserverResult<{ data: CanReturnType; }>`][query-options] |
 
-[access-control-provider]: http://localhost:3000/docs/api-reference/core/providers/accessControl-provider/
+[access-control-provider]: /docs/api-reference/core/providers/accessControl-provider/
 [use-query]: https://tanstack.com/query/latest/docs/react/guides/queries
 [tanstack-query]: https://tanstack.com/query/latest
 [query-options]: https://tanstack.com/query/v4/docs/react/reference/useQuery

--- a/documentation/docs/api-reference/core/hooks/accessControl/useCan.md
+++ b/documentation/docs/api-reference/core/hooks/accessControl/useCan.md
@@ -83,8 +83,6 @@ useCan({
 
 ## Return values
 
-> Type: [`CanReturnType`](/docs/api-reference/core/interfaceReferences/#canreturntype)
-
 Query result of [TanStack Query's][tanstack-query] [`useQuery`][use-query].
 
 For example if you want to check if the user can create a post return value will be:

--- a/documentation/docs/api-reference/core/hooks/accessControl/useCan.md
+++ b/documentation/docs/api-reference/core/hooks/accessControl/useCan.md
@@ -4,9 +4,11 @@ title: useCan
 siderbar_label: useCan
 ---
 
-## Usage
+`useCan` uses the [Access Control Provider's][access-control-provider] `can` function as the query function for [TanStack Query's][tanstack-query] [`useQuery`][use-query]. It takes the [parameters][can-params] that `can` takes. It can also be configured with [`queryOptions`][query-options] for [`useQuery`][use-query]. Returns the result of [`useQuery`][use-query].
 
-`useCan` uses the `can` as the query function for **react-query**'s `useQuery`. It takes the parameters that `can` takes. It can also be configured with `queryOptions` for `useQuery`. Returns the result of `useQuery`.
+<br/>
+
+## Basic Usage
 
 ```tsx
 import { useCan } from "@pankod/refine-core";
@@ -18,9 +20,11 @@ const { data } = useCan({
 });
 ```
 
+<br/>
+
 ## Performance
 
-As the number of points that checks for access control in your app increases the performance of your app may take a hit especially if its access control involves remote endpoints. Caching the access control checks helps a great deal. Since **refine** uses react-query it can be easily done configuring [`staleTime` and `cacheTime`](https://react-query.tanstack.com/reference/useQuery) properties.
+As the number of points that checks for access control in your app increases the performance of your app may take a hit especially if its access control involves remote endpoints. Caching the access control checks helps a great deal. Since **refine** uses [TanStack Query][tanstack-query] it can be easily done configuring [`staleTime` and `cacheTime`][query-options] properties.
 
 ```ts
 import { useCan } from "@pankod/refine-core";
@@ -37,6 +41,73 @@ const { data } = useCan({
 );
 ```
 
+<br/>
+
+## Properties
+
+### `resource` <PropTag required />
+
+> Type: `string`
+
+Resource name for API data interactions.
+
+### `action` <PropTag required />
+
+> Type: `string`
+
+Intended action on resource.
+
+### `params`
+
+> Type: `{ resource? : IResourceItem, id?: BaseKey, [key: string]: any }`
+
+Parameters associated with the resource
+
+### `queryOptions`
+
+> Type: [`QueryOptions`][query-options]
+
+Query options for [TanStack Query's][tanstack-query] [`useQuery`][use-query].
+
+<br/>
+
+## Return values
+
+> Type: [`CanReturnType`](/docs/api-reference/core/interfaceReferences/#canreturntype)
+
+Query result of [TanStack Query's][tanstack-query] [`useQuery`][use-query].
+
+For example if you want to check if the user can create a post return value will be:
+
+```tsx
+<Refine
+    accessControlProvider={{
+        can: async ({ resource, action }) => {
+            if (resource === "post" && action === "create") {
+                return Promise.resolve({
+                    can: false,
+                    reason: "Unauthorized",
+                });
+            }
+
+            return Promise.resolve({ can: true });
+        },
+    }}
+
+    // ...
+/>
+
+// inside your component
+const { data: canCreatePost } = useCan({
+    action: "create",
+    resource: "post",
+});
+
+console.log(canCreatePost); // { can: false, reason: "Unauthorized" }
+```
+
+<br/>
+
 ## API
 
 ### Properties
@@ -51,6 +122,12 @@ const { data } = useCan({
 
 ### Return values
 
-| Description                              | Type                                                                                                   |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| Result of the `react-query`'s `useQuery` | [`QueryObserverResult<{ data: CanReturnType; }>`](https://react-query.tanstack.com/reference/useQuery) |
+| Description                                                              | Type                                                             |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------- |
+| Result of the [TanStack Query's][tanstack-query] [`useQuery`][use-query] | [`QueryObserverResult<{ data: CanReturnType; }>`][query-options] |
+
+[access-control-provider]: http://localhost:3000/docs/api-reference/core/providers/accessControl-provider/
+[use-query]: https://tanstack.com/query/latest/docs/react/guides/queries
+[tanstack-query]: https://tanstack.com/query/latest
+[query-options]: https://tanstack.com/query/v4/docs/react/reference/useQuery
+[can-params]: /docs/api-reference/core/interfaceReferences/#canparams

--- a/documentation/docs/api-reference/core/hooks/accessControl/useCan.md
+++ b/documentation/docs/api-reference/core/hooks/accessControl/useCan.md
@@ -6,8 +6,6 @@ siderbar_label: useCan
 
 `useCan` uses the [Access Control Provider's][access-control-provider] `can` function as the query function for [TanStack Query's][tanstack-query] [`useQuery`][use-query]. It takes the [parameters][can-params] that `can` takes. It can also be configured with [`queryOptions`][query-options] for [`useQuery`][use-query]. Returns the result of [`useQuery`][use-query].
 
-<br/>
-
 ## Basic Usage
 
 ```tsx
@@ -19,8 +17,6 @@ const { data } = useCan({
     params: { foo: "optional-params" },
 });
 ```
-
-<br/>
 
 ## Performance
 
@@ -40,8 +36,6 @@ const { data } = useCan({
     }
 });
 ```
-
-<br/>
 
 ## Properties
 
@@ -87,8 +81,6 @@ useCan({
 });
 ```
 
-<br/>
-
 ## Return values
 
 > Type: [`CanReturnType`](/docs/api-reference/core/interfaceReferences/#canreturntype)
@@ -123,8 +115,6 @@ const { data: canCreatePost } = useCan({
 
 console.log(canCreatePost); // { can: false, reason: "Unauthorized" }
 ```
-
-<br/>
 
 ## API
 


### PR DESCRIPTION
added: return values and properties to [`useCan` doc](https://refine.dev/docs/api-reference/core/hooks/accessControl/useCan/)
