### PR TITLE
docs: fix grammar mistakes on data hook docs

### DIFF
--- a/documentation/docs/api-reference/core/hooks/data/useApiUrl.md
+++ b/documentation/docs/api-reference/core/hooks/data/useApiUrl.md
@@ -11,7 +11,7 @@ It is useful when you want to use the API URL in your custom hooks.
 
 ## Usage
 
-`useApiUrl` hook does not expect any parameter. It will run the `getApiUrl` method from the `dataProvider` and return the result.
+The `useApiUrl` hook does not expect any parameter. It will run the `getApiUrl` method from the `dataProvider` and return the result.
 
 ```tsx
 //highlight-next-line

--- a/documentation/docs/api-reference/core/hooks/data/useApiUrl.md
+++ b/documentation/docs/api-reference/core/hooks/data/useApiUrl.md
@@ -1,6 +1,7 @@
 ---
 id: useApiUrl
 title: useApiUrl
+source: packages/core/src/hooks/data/useApiUrl.ts
 ---
 
 `useApiUrl` is a React hook that returns the API URL.

--- a/documentation/docs/api-reference/core/hooks/data/useCreate/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCreate/index.md
@@ -1,6 +1,7 @@
 ---
 title: useCreate
 siderbar_label: useCreate
+source: packages/core/src/hooks/data/useCreate.ts
 ---
 
 `useCreate` is an extended version of TanStack Query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.

--- a/documentation/docs/api-reference/core/hooks/data/useCreate/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCreate/index.md
@@ -3,7 +3,7 @@ title: useCreate
 siderbar_label: useCreate
 ---
 
-`useCreate` is a extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It support all the features of `useMutation` and adds some extra features.
+`useCreate` is an extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
 
 -   It uses the `create` method as the **mutation function** from the [`dataProvider`](/docs/api-reference/core/providers/data-provider/) which is passed to `<Refine>`.
 
@@ -11,7 +11,7 @@ It is useful when you want to create a new record.
 
 ## Basic Usage
 
-`useCreate` hook returns many useful properties and methods. One of them is `mutate` method which expects `values` and `resource` as parameters. These parameters will be passed to the `create` method from the `dataProvider` as parameters.
+The `useCreate` hook returns many useful properties and methods. One of them is the `mutate` method which expects `values` and `resource` as parameters. These parameters will be passed to the `create` method from the `dataProvider` as parameters.
 
 ```tsx
 import { useCreate } from "@pankod/refine-core";
@@ -31,13 +31,13 @@ mutate({
 
 > This feature is only available if you use a [Live Provider](/docs/api-reference/core/providers/live-provider).
 
-When `useCreate` mutation runs successfully, it will call the `publish` method from `liveProvider` with some parameters such as `channel`, `type` etc. It is useful when you want to publish the changes to the subscribers on client side.
+When the `useCreate` mutation runs successfully, it will call the `publish` method from `liveProvider` with some parameters such as `channel`, `type` etc. It is useful when you want to publish the changes to the subscribers on the client side.
 
 [Refer to the `liveProvider` documentation for more information &#8594](/docs/api-reference/core/providers/live-provider)
 
 ## Invalidating Queries
 
-When `useCreate` mutation runs successfully, by default it will invalidate the following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks in the same page, they will refetch the data after the mutation is completed. You can change this behavior by passing [`invalidates`](#invalidates) prop.
+When the `useCreate` mutation runs successfully, by default it will invalidate the following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks in the same page, they will refetch the data after the mutation is completed. You can change this behavior by passing [`invalidates`](#invalidates) prop.
 
 [Refer to the query invalidation documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/guides/query-invalidation)
 
@@ -45,7 +45,7 @@ When `useCreate` mutation runs successfully, by default it will invalidate the f
 
 > This feature is only available if you use a [Audit Log Provider](/docs/api-reference/core/providers/audit-log-provider/).
 
-When `useCreate` mutation runs successfully, it will call the `log` method from `auditLogProvider` with some parameters such as `resource`, `action`, `data` etc. It is useful when you want to log the changes to the database.
+When the `useCreate` mutation runs successfully, it will call the `log` method from `auditLogProvider` with some parameters such as `resource`, `action`, `data` etc. It is useful when you want to log the changes to the database.
 
 [Refer to the `auditLogProvider` documentation for more information &#8594](/docs/api-reference/core/providers/audit-log-provider/)
 
@@ -67,7 +67,7 @@ useCreate({
 
 :::tip
 
-`mutationOptions` does not support `onSuccess` and `onError` props because they override the default `onSuccess` and `onError` functions. If you want to use these props, you can pass them to mutate function like this:
+`mutationOptions` does not support `onSuccess` and `onError` props because they override the default `onSuccess` and `onError` functions. If you want to use these props, you can pass them to mutate functions like this:
 
 ```tsx
 const { mutate } = useCreate();
@@ -97,7 +97,7 @@ mutate(
 
 ### `resource` <PropTag required />
 
-It will be passed to the `create` method from the `dataProvider` as parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `create` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resource are handled.
+It will be passed to the `create` method from the `dataProvider` as a parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `create` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resource are handled.
 
 ```tsx
 const { mutate } = useCreate();
@@ -109,7 +109,7 @@ mutate({
 
 ### `values` <PropTag required />
 
-It will be passed to the `create` method from the `dataProvider` as parameter. The parameter is usually used as the data to be created. It contains the data that will be sent to the server.
+It will be passed to the `create` method from the `dataProvider` as a parameter. The parameter is usually used as the data to be created. It contains the data that will be sent to the server.
 
 ```tsx
 const { mutate } = useCreate();
@@ -146,7 +146,7 @@ mutate({
 
 > [`NotificationProvider`](/docs/api-reference/core/providers/notification-provider/) is required for this prop to work.
 
-After data fetching is failed, `useCreate` will call `open` function from `NotificationProvider` to show a error notification. With this prop, you can customize the error notification.
+After data fetching is failed, `useCreate` will call `open` function from `NotificationProvider` to show an error notification. With this prop, you can customize the error notification.
 
 ```tsx
 const { mutate } = useCreate();
@@ -224,7 +224,7 @@ mutate({
 
 `invalidates` is used to specify which queries should be invalidated after the mutation is completed.
 
-By default it's invalidates following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks in the same page, they will refetch the data after the mutation is completed.
+By default, it invalidates the following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks on the same page, they will refetch the data after the mutation is completed.
 
 ```tsx
 const { mutate } = useCreate();

--- a/documentation/docs/api-reference/core/hooks/data/useCreate/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCreate/index.md
@@ -3,7 +3,7 @@ title: useCreate
 siderbar_label: useCreate
 ---
 
-`useCreate` is an extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
+`useCreate` is an extended version of TanStack Query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
 
 -   It uses the `create` method as the **mutation function** from the [`dataProvider`](/docs/api-reference/core/providers/data-provider/) which is passed to `<Refine>`.
 
@@ -236,7 +236,7 @@ mutate({
 
 ## Return Values
 
-Returns an object with react-query's `useMutation` return values.
+Returns an object with TanStack Query's `useMutation` return values.
 
 [Refer to the `useMutation` documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/reference/useMutation)
 
@@ -264,6 +264,6 @@ Returns an object with react-query's `useMutation` return values.
 
 ### Return value
 
-| Description                               | Type                                                                                                                                                                                          |
-| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Result of the `react-query`'s useMutation | [`UseMutationResult<`<br/>`{ data: TData },`<br/>`TError,`<br/>` { resource: string; values: TVariables; },`<br/>` unknown>`](https://tanstack.com/query/v4/docs/react/reference/useMutation) |
+| Description                                | Type                                                                                                                                                                                          |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Result of the TanStack Query's useMutation | [`UseMutationResult<`<br/>`{ data: TData },`<br/>`TError,`<br/>` { resource: string; values: TVariables; },`<br/>` unknown>`](https://tanstack.com/query/v4/docs/react/reference/useMutation) |

--- a/documentation/docs/api-reference/core/hooks/data/useCreateMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCreateMany/index.md
@@ -1,6 +1,7 @@
 ---
 title: useCreateMany
 siderbar_label: useCreateMany
+source: packages/core/src/hooks/data/useCreateMany.ts
 ---
 
 `useCreateMany` is an extended version of TanStack Query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.

--- a/documentation/docs/api-reference/core/hooks/data/useCreateMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCreateMany/index.md
@@ -3,7 +3,7 @@ title: useCreateMany
 siderbar_label: useCreateMany
 ---
 
-`useCreateMany` is a extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It support all the features of `useMutation` and adds some extra features.
+`useCreateMany` is an extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
 
 -   It uses the `createMany` method as the **mutation function** from the [`dataProvider`](/docs/api-reference/core/providers/data-provider/) which is passed to `<Refine>`.
 
@@ -15,7 +15,7 @@ If your data provider does not have a `createMany` method, `useCreateMany` will 
 
 ## Basic Usage
 
-`useCreateMany` hook returns many useful properties and methods. One of them is `mutate` method which expects `values` and `resource` as parameters. These parameters will be passed to the `createMany` method from the `dataProvider` as parameters.
+The `useCreateMany` hook returns many useful properties and methods. One of them is the `mutate` method which expects `values` and `resource` as parameters. These parameters will be passed to the `createMany` method from the `dataProvider` as parameters.
 
 ```tsx
 import { useCreateMany } from "@pankod/refine-core";
@@ -41,13 +41,13 @@ mutate({
 
 > This feature is only available if you use a [Live Provider](/docs/api-reference/core/providers/live-provider).
 
-When `useCreateMany` mutation runs successfully, it will call the `publish` method from `liveProvider` with some parameters such as `channel`, `type` etc. It is useful when you want to publish the changes to the subscribers on client side.
+When the `useCreateMany` mutation runs successfully, it will call the `publish` method from `liveProvider` with some parameters such as `channel`, `type` etc. It is useful when you want to publish the changes to the subscribers on the client side.
 
 [Refer to the `liveProvider` documentation for more information &#8594](/docs/api-reference/core/providers/live-provider)
 
 ## Invalidating Queries
 
-When `useCreateMany` mutation runs successfully, by default it will invalidate the following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks in the same page, they will refetch the data after the mutation is completed. You can change this behavior by passing [`invalidates`](#invalidates) prop.
+When the `useCreateMany` mutation runs successfully, by default it will invalidate the following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks in the same page, they will refetch the data after the mutation is completed. You can change this behavior by passing [`invalidates`](#invalidates) prop.
 
 [Refer to the query invalidation documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/guides/query-invalidation)
 
@@ -55,7 +55,7 @@ When `useCreateMany` mutation runs successfully, by default it will invalidate t
 
 > This feature is only available if you use a [Audit Log Provider](/docs/api-reference/core/providers/audit-log-provider/).
 
-When `useCreateMany` mutation runs successfully, it will call the `log` method from `auditLogProvider` with some parameters such as `resource`, `action`, `data` etc. It is useful when you want to log the changes to the database.
+When the `useCreateMany` mutation runs successfully, it will call the `log` method from `auditLogProvider` with some parameters such as `resource`, `action`, `data` etc. It is useful when you want to log the changes to the database.
 
 [Refer to the `auditLogProvider` documentation for more information &#8594](/docs/api-reference/core/providers/audit-log-provider/)
 
@@ -77,7 +77,7 @@ useCreateMany({
 
 :::tip
 
-`mutationOptions` does not support `onSuccess` and `onError` props because they override the default `onSuccess` and `onError` functions. If you want to use these props, you can pass them to mutate function like this:
+`mutationOptions` does not support `onSuccess` and `onError` props because they override the default `onSuccess` and `onError` functions. If you want to use these props, you can pass them to mutate functions like this:
 
 ```tsx
 const { mutate } = useCreateMany();
@@ -113,7 +113,7 @@ mutate(
 
 ### `resource` <PropTag required />
 
-It will be passed to the `create` method from the `dataProvider` as parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `create` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resource are handled.
+It will be passed to the `create` method from the `dataProvider` as a parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `create` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resources are handled.
 
 ```tsx
 const { mutate } = useCreateMany();
@@ -125,7 +125,7 @@ mutate({
 
 ### `values` <PropTag required />
 
-It will be passed to the `create` method from the `dataProvider` as parameter. The parameter is usually used as the data to be created. It contains the data that will be sent to the server.
+It will be passed to the `create` method from the `dataProvider` as a parameter. The parameter is usually used as the data to be created. It contains the data that will be sent to the server.
 
 ```tsx
 const { mutate } = useCreateMany();
@@ -168,7 +168,7 @@ mutate({
 
 > [`NotificationProvider`](/docs/api-reference/core/providers/notification-provider/) is required for this prop to work.
 
-After data fetching is failed, `useCreateMany` will call `open` function from `NotificationProvider` to show a error notification. With this prop, you can customize the error notification.
+After data fetching is failed, `useCreateMany` will call `open` function from `NotificationProvider` to show an error notification. With this prop, you can customize the error notification.
 
 ```tsx
 const { mutate } = useCreateMany();
@@ -246,7 +246,7 @@ mutate({
 
 `invalidates` is used to specify which queries should be invalidated after the mutation is completed.
 
-By default it's invalidates following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks in the same page, they will refetch the data after the mutation is completed.
+By default, it invalidates the following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks on the same page, they will refetch the data after the mutation is completed.
 
 ```tsx
 const { mutate } = useCreateMany();
@@ -286,6 +286,6 @@ Returns an object with react-query's `useMutation` return values.
 
 ### Return value
 
-| Description                               | Type                                                                                                                                                                                     |
-| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Description                               | Type                                                                                                                                                                                             |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Result of the `react-query`'s useMutation | [`UseMutationResult<`<br/>`{ data: TData[]},`<br/>`TError,`<br/>` { resource: string; values: TVariables[]; },`<br/>` unknown>`](https://tanstack.com/query/v4/docs/react/reference/useMutation) |

--- a/documentation/docs/api-reference/core/hooks/data/useCreateMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCreateMany/index.md
@@ -3,7 +3,7 @@ title: useCreateMany
 siderbar_label: useCreateMany
 ---
 
-`useCreateMany` is an extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
+`useCreateMany` is an extended version of TanStack Query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
 
 -   It uses the `createMany` method as the **mutation function** from the [`dataProvider`](/docs/api-reference/core/providers/data-provider/) which is passed to `<Refine>`.
 
@@ -258,7 +258,7 @@ mutate({
 
 ## Return Values
 
-Returns an object with react-query's `useMutation` return values.
+Returns an object with TanStack Query's `useMutation` return values.
 
 [Refer to the `useMutation` documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/reference/useMutation)
 
@@ -286,6 +286,6 @@ Returns an object with react-query's `useMutation` return values.
 
 ### Return value
 
-| Description                               | Type                                                                                                                                                                                             |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Result of the `react-query`'s useMutation | [`UseMutationResult<`<br/>`{ data: TData[]},`<br/>`TError,`<br/>` { resource: string; values: TVariables[]; },`<br/>` unknown>`](https://tanstack.com/query/v4/docs/react/reference/useMutation) |
+| Description                                | Type                                                                                                                                                                                             |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Result of the TanStack Query's useMutation | [`UseMutationResult<`<br/>`{ data: TData[]},`<br/>`TError,`<br/>` { resource: string; values: TVariables[]; },`<br/>` unknown>`](https://tanstack.com/query/v4/docs/react/reference/useMutation) |

--- a/documentation/docs/api-reference/core/hooks/data/useCustom/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCustom/index.md
@@ -1,6 +1,7 @@
 ---
 title: useCustom
 siderbar_label: useCustom
+source: packages/core/src/hooks/data/useCustom.ts
 ---
 
 `useCustom` is an extended version of TanStack Query's [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It supports all the features of `useQuery` and adds some extra features.

--- a/documentation/docs/api-reference/core/hooks/data/useCustom/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCustom/index.md
@@ -3,14 +3,14 @@ title: useCustom
 siderbar_label: useCustom
 ---
 
-`useCustom` is a extended version of react-query's [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It support all the features of `useQuery` and adds some extra features.
+`useCustom` is an extended version of react-query's [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It supports all the features of `useQuery` and adds some extra features.
 
 -   It uses the `custom` method as the **query function** from the [`dataProvider`](/api-reference/core/providers/data-provider.md) which is passed to `<Refine>`.
 
-It is useful when you want to send a custom query request with using the react-query advantages.
+It is useful when you want to send a custom query request using the react-query advantages.
 
 :::danger attention
-`useCustom` should **not** be used when creating, updating or deleting a resource. To do these; [useCreate](/docs/api-reference/core/hooks/data/useCreate/), [useUpdate](/docs/api-reference/core/hooks/data/useUpdate/) or [useDelete](/docs/api-reference/core/hooks/data/useDelete/) hooks should be used instead.
+`useCustom` should **not** be used when creating, updating, or deleting a resource. To do these; [useCreate](/docs/api-reference/core/hooks/data/useCreate/), [useUpdate](/docs/api-reference/core/hooks/data/useUpdate/) or [useDelete](/docs/api-reference/core/hooks/data/useDelete/) hooks should be used instead.
 
 This is because `useCustom`, unlike other data hooks, does not [invalidate queries](https://react-query.tanstack.com/guides/query-invalidation) and therefore will not update the application state either.
 
@@ -19,9 +19,9 @@ If you need to custom mutation request, use the [useCustomMutation](/docs/api-re
 
 ## Basic Usage
 
-`useCustom` hook expects a `url` and `method` property. These parameters will be passed to the `custom` method from the `dataProvider` as parameter.
+The `useCustom` hook expects a `url` and `method` properties. These parameters will be passed to the `custom` method from the `dataProvider` as a parameter.
 
-When properties are changed, `useCustom` hook will trigger a new request.
+When properties are changed, the `useCustom` hook will trigger a new request.
 
 ```tsx
 import { useCustom, useApiUrl } from "@pankod/refine-core";
@@ -50,7 +50,7 @@ const { data, isLoading } = useCustom<PostUniqueCheckResponse>({
 
 ### `url` <PropTag required />
 
-It will be passed to the `custom` method from the `dataProvider` as a parameter. It usually used to specify the endpoint of the request.
+It will be passed to the `custom` method from the `dataProvider` as a parameter. It is usually used to specify the endpoint of the request.
 
 ```tsx
 useCustom({
@@ -60,7 +60,7 @@ useCustom({
 
 ### `method` <PropTag required />
 
-It will be passed to the `custom` method from the `dataProvider` as a parameter. It usually used to specify the HTTP method of the request.
+It will be passed to the `custom` method from the `dataProvider` as a parameter. It is usually used to specify the HTTP method of the request.
 
 ```tsx
 useCustom({
@@ -230,7 +230,7 @@ useCustom({
 
 > [`NotificationProvider`](/docs/api-reference/core/providers/notification-provider/) is required for this prop to work.
 
-After data fetching is failed, `useCustom` will call `open` function from `NotificationProvider` to show a error notification. With this prop, you can customize the error notification.
+After data fetching is failed, `useCustom` will call `open` function from `NotificationProvider` to show an error notification. With this prop, you can customize the error notification.
 
 ```tsx
 useCustom({

--- a/documentation/docs/api-reference/core/hooks/data/useCustom/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCustom/index.md
@@ -3,16 +3,16 @@ title: useCustom
 siderbar_label: useCustom
 ---
 
-`useCustom` is an extended version of react-query's [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It supports all the features of `useQuery` and adds some extra features.
+`useCustom` is an extended version of TanStack Query's [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It supports all the features of `useQuery` and adds some extra features.
 
 -   It uses the `custom` method as the **query function** from the [`dataProvider`](/api-reference/core/providers/data-provider.md) which is passed to `<Refine>`.
 
-It is useful when you want to send a custom query request using the react-query advantages.
+It is useful when you want to send a custom query request using the TanStack Query advantages.
 
 :::danger attention
 `useCustom` should **not** be used when creating, updating, or deleting a resource. To do these; [useCreate](/docs/api-reference/core/hooks/data/useCreate/), [useUpdate](/docs/api-reference/core/hooks/data/useUpdate/) or [useDelete](/docs/api-reference/core/hooks/data/useDelete/) hooks should be used instead.
 
-This is because `useCustom`, unlike other data hooks, does not [invalidate queries](https://react-query.tanstack.com/guides/query-invalidation) and therefore will not update the application state either.
+This is because `useCustom`, unlike other data hooks, does not [invalidate queries](https://tanstack.com/query/latest/docs/react/guides/query-invalidation) and therefore will not update the application state either.
 
 If you need to custom mutation request, use the [useCustomMutation](/docs/api-reference/core/hooks/data/useCustomMutation/) hook.
 :::
@@ -261,6 +261,6 @@ useCustom({
 
 ### Return value
 
-| Description                            | Type                                                                                                                |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| Result of the `react-query`'s useQuery | [`QueryObserverResult<CustomResponse<TData>, TError>`](https://tanstack.com/query/v4/docs/react/reference/useQuery) |
+| Description                             | Type                                                                                                                |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Result of the TanStack Query's useQuery | [`QueryObserverResult<CustomResponse<TData>, TError>`](https://tanstack.com/query/v4/docs/react/reference/useQuery) |

--- a/documentation/docs/api-reference/core/hooks/data/useCustomMutation/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCustomMutation/index.md
@@ -3,16 +3,16 @@ title: useCustomMutation
 siderbar_label: useCustomMutation
 ---
 
-`useCustomMutation` is an extended version of react-query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
+`useCustomMutation` is an extended version of TanStack Query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
 
 -   It uses the `custom` method as the **mutation function** from the [`dataProvider`](/docs/api-reference/core/providers/data-provider/) which is passed to `<Refine>`.
 
-It is useful when you want to send a custom mutation request using the react-query advantages.
+It is useful when you want to send a custom mutation request using the TanStack Query advantages.
 
 :::danger attention
 `useCustomMutation` should **not** be used when creating, updating, or deleting a resource. To do these; [useCreate](/docs/api-reference/core/hooks/data/useCreate/), [useCustomMutation](/docs/api-reference/core/hooks/data/useCustomMutation/) or [useDelete](/docs/api-reference/core/hooks/data/useDelete/) hooks should be used instead.
 
-This is because `useCustomMutation`, unlike other data hooks, does not [invalidate queries](https://react-query.tanstack.com/guides/query-invalidation) and therefore will not update the application state either.
+This is because `useCustomMutation`, unlike other data hooks, does not [invalidate queries](https://tanstack.com/query/latest/docs/react/guides/query-invalidation) and therefore will not update the application state either.
 
 If you need to custom query request, use the [useCustom](/docs/api-reference/core/hooks/data/useCustomMutation/) hook.
 :::
@@ -237,7 +237,7 @@ mutate({
 
 ## Return Values
 
-Returns an object with react-query's `useMutation` return values.
+Returns an object with TanStack Query's `useMutation` return values.
 
 [Refer to the `useMutation` documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/reference/useMutation)
 
@@ -269,4 +269,4 @@ Returns an object with react-query's `useMutation` return values.
 
 | Description                               | Type                                                                                                                                                                                          |
 | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Result of the `react-query`'s useMutation | [`UseMutationResult<`<br/>`{ data: TData },`<br/>`TError,`<br/>` { resource: string; values: TVariables; },`<br/>` unknown>`](https://tanstack.com/query/v4/docs/react/reference/useMutation) |
+| Result of the TanStack Query's useMutation | [`UseMutationResult<`<br/>`{ data: TData },`<br/>`TError,`<br/>` { resource: string; values: TVariables; },`<br/>` unknown>`](https://tanstack.com/query/v4/docs/react/reference/useMutation) |

--- a/documentation/docs/api-reference/core/hooks/data/useCustomMutation/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCustomMutation/index.md
@@ -1,6 +1,7 @@
 ---
 title: useCustomMutation
 siderbar_label: useCustomMutation
+source: packages/core/src/hooks/data/useCustomMutation.ts
 ---
 
 `useCustomMutation` is an extended version of TanStack Query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.

--- a/documentation/docs/api-reference/core/hooks/data/useCustomMutation/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCustomMutation/index.md
@@ -3,14 +3,14 @@ title: useCustomMutation
 siderbar_label: useCustomMutation
 ---
 
-`useCustomMutation` is a extended version of react-query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It support all the features of `useMutation` and adds some extra features.
+`useCustomMutation` is an extended version of react-query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
 
 -   It uses the `custom` method as the **mutation function** from the [`dataProvider`](/docs/api-reference/core/providers/data-provider/) which is passed to `<Refine>`.
 
-It is useful when you want to send a custom mutation request with using the react-query advantages.
+It is useful when you want to send a custom mutation request using the react-query advantages.
 
 :::danger attention
-`useCustomMutation` should **not** be used when creating, updating or deleting a resource. To do these; [useCreate](/docs/api-reference/core/hooks/data/useCreate/), [useCustomMutation](/docs/api-reference/core/hooks/data/useCustomMutation/) or [useDelete](/docs/api-reference/core/hooks/data/useDelete/) hooks should be used instead.
+`useCustomMutation` should **not** be used when creating, updating, or deleting a resource. To do these; [useCreate](/docs/api-reference/core/hooks/data/useCreate/), [useCustomMutation](/docs/api-reference/core/hooks/data/useCustomMutation/) or [useDelete](/docs/api-reference/core/hooks/data/useDelete/) hooks should be used instead.
 
 This is because `useCustomMutation`, unlike other data hooks, does not [invalidate queries](https://react-query.tanstack.com/guides/query-invalidation) and therefore will not update the application state either.
 
@@ -19,7 +19,7 @@ If you need to custom query request, use the [useCustom](/docs/api-reference/cor
 
 ## Basic Usage
 
-`useCustomMutation` hook returns many useful properties and methods. One of them is `mutate` method which expects `values`, `method` and `url` as parameters. These parameters will be passed to the `custom` method from the `dataProvider` as parameters.
+The `useCustomMutation` hook returns many useful properties and methods. One of them is the `mutate` method which expects `values`, `method`, and `url` as parameters. These parameters will be passed to the `custom` method from the `dataProvider` as parameters.
 
 ```tsx
 import { useCustomMutation, useApiUrl } from "@pankod/refine-core";
@@ -60,7 +60,7 @@ useCustomMutation({
 
 :::tip
 
-`mutationOptions` does not support `onSuccess` and `onError` props because they override the default `onSuccess` and `onError` functions. If you want to use these props, you can pass them to mutate function like this:
+`mutationOptions` does not support `onSuccess` and `onError` props because they override the default `onSuccess` and `onError` functions. If you want to use these props, you can pass them to mutate functions like this:
 
 ```tsx
 const { mutate } = useCustomMutation();
@@ -90,7 +90,7 @@ mutate(
 
 ### `url` <PropTag required />
 
-It will be passed to the `custom` method from the `dataProvider` as a parameter. It usually used to specify the endpoint of the request.
+It will be passed to the `custom` method from the `dataProvider` as a parameter. It is usually used to specify the endpoint of the request.
 
 ```tsx
 const { mutate } = useCustomMutation();
@@ -102,7 +102,7 @@ mutate({
 
 ### `method` <PropTag required />
 
-It will be passed to the `custom` method from the `dataProvider` as a parameter. It usually used to specify the HTTP method of the request.
+It will be passed to the `custom` method from the `dataProvider` as a parameter. It is usually used to specify the HTTP method of the request.
 
 ```tsx
 const { mutate } = useCustomMutation();
@@ -114,7 +114,7 @@ mutate({
 
 ### `values` <PropTag required />
 
-It will be passed to the `custom` method from the `dataProvider` as parameter. The parameter is usually used as the data to be sent with the request.
+It will be passed to the `custom` method from the `dataProvider` as a parameter. The parameter is usually used as the data to be sent with the request.
 
 ```tsx
 const { mutate } = useCustomMutation();
@@ -167,7 +167,7 @@ mutate({
 
 > [`NotificationProvider`](/docs/api-reference/core/providers/notification-provider/) is required for this prop to work.
 
-After data fetching is failed, `useCustomMutation` will call `open` function from `NotificationProvider` to show a error notification. With this prop, you can customize the error notification.
+After data fetching is failed, `useCustomMutation` will call `open` function from `NotificationProvider` to show an error notification. With this prop, you can customize the error notification.
 
 ```tsx
 const { mutate } = useCustomMutation();
@@ -245,16 +245,16 @@ Returns an object with react-query's `useMutation` return values.
 
 ### Mutation Parameters
 
-| Property                                         | Description                                                                                                    | Type                                                                                                                                                                                       |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| url <div className="required">Required</div>     | URL                                                                                                            | string                                                                                                                                                                                     |
-| method <div className="required">Required</div>  | Method                                                                                                         | `post`, `put`, `patch`, `delete`                                                                                                                                                           |
-| values <div className=" required">Required</div> | Values for mutation function                                                                                   | `TVariables`                                                                                                                                                                               |
-| config                                           | The config of your request. You can send `headers` using this field. | { headers?: {}; } |
-| successNotification                              | Successful mutation notification                                                                               | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification)                                                                                                   |
-| errorNotification                                | Unsuccessful mutation notification                                                                             | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification)                                                                                                   |
-| metaData                                         | Metadata query for `dataProvider`                                                                              | [`MetaDataQuery`](/api-reference/core/interfaces.md#metadataquery)                                                                                                                         |
-| dataProviderName                                 | If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.             | `string`                                                                                                                                                                                   |
+| Property                                         | Description                                                                                        | Type                                                                                     |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| url <div className="required">Required</div>     | URL                                                                                                | string                                                                                   |
+| method <div className="required">Required</div>  | Method                                                                                             | `post`, `put`, `patch`, `delete`                                                         |
+| values <div className=" required">Required</div> | Values for mutation function                                                                       | `TVariables`                                                                             |
+| config                                           | The config of your request. You can send `headers` using this field.                               | { headers?: {}; }                                                                        |
+| successNotification                              | Successful mutation notification                                                                   | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification) |
+| errorNotification                                | Unsuccessful mutation notification                                                                 | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification) |
+| metaData                                         | Metadata query for `dataProvider`                                                                  | [`MetaDataQuery`](/api-reference/core/interfaces.md#metadataquery)                       |
+| dataProviderName                                 | If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use. | `string`                                                                                 |
 
 ### Type Parameters
 

--- a/documentation/docs/api-reference/core/hooks/data/useDataProvider.md
+++ b/documentation/docs/api-reference/core/hooks/data/useDataProvider.md
@@ -1,6 +1,7 @@
 ---
 id: useDataProvider
 title: useDataProvider
+source: packages/core/src/hooks/data/useDataProvider.tsx
 ---
 
 `useDataProvider` is a React hook that returns the `dataProvider` which is passed to [`<Refine>`][refine] component.

--- a/documentation/docs/api-reference/core/hooks/data/useDataProvider.md
+++ b/documentation/docs/api-reference/core/hooks/data/useDataProvider.md
@@ -29,7 +29,7 @@ const App = () => {
 export default App;
 ```
 
-Now we can access the data providers with `useDataProvider` hook:
+Now we can access the data providers with the `useDataProvider` hook:
 
 ```tsx
 import { useDataProvider } from "@pankod/refine-core";

--- a/documentation/docs/api-reference/core/hooks/data/useDelete/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useDelete/index.md
@@ -1,6 +1,7 @@
 ---
 title: useDelete
 siderbar_label: useDelete
+source: packages/core/src/hooks/data/useDelete.ts
 ---
 
 `useDelete` is an extended version of TanStack Query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.

--- a/documentation/docs/api-reference/core/hooks/data/useDelete/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useDelete/index.md
@@ -3,7 +3,7 @@ title: useDelete
 siderbar_label: useDelete
 ---
 
-`useDelete` is a extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It support all the features of `useMutation` and adds some extra features.
+`useDelete` is an extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
 
 -   It uses the `deleteOne` method as the **mutation function** from the [`dataProvider`](/docs/api-reference/core/providers/data-provider/) which is passed to `<Refine>`.
 
@@ -11,7 +11,7 @@ It is useful when you want to update a record.
 
 ## Basic Usage
 
-`useDelete` hook returns many useful properties and methods. One of them is `mutate` method which expects `resource` and `id` as parameters. These parameters will be passed to the `deleteOne` method from the `dataProvider` as parameters.
+The `useDelete` hook returns many useful properties and methods. One of them is the `mutate` method which expects `resource` and `id` as parameters. These parameters will be passed to the `deleteOne` method from the `dataProvider` as parameters.
 
 ```tsx
 import { useDelete } from "@pankod/refine-core";
@@ -28,13 +28,13 @@ mutate({
 
 > This feature is only available if you use a [Live Provider](/docs/api-reference/core/providers/live-provider).
 
-When `useDelete` mutation runs successfully, it will call the `publish` method from `liveProvider` with some parameters such as `channel`, `type` etc. It is useful when you want to publish the changes to the subscribers on client side.
+When the `useDelete` mutation runs successfully, it will call the `publish` method from `liveProvider` with some parameters such as `channel`, `type` etc. It is useful when you want to publish the changes to the subscribers on the client side.
 
 [Refer to the `liveProvider` documentation for more information &#8594](/docs/api-reference/core/providers/live-provider)
 
 ## Invalidating Queries
 
-When `useDelete` mutation runs successfully, by default it will invalidate the following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks in the same page, they will refetch the data after the mutation is completed. You can change this behavior by passing [`invalidates`](#invalidates) prop.
+When the `useDelete` mutation runs successfully, by default it will invalidate the following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks on the same page, they will refetch the data after the mutation is completed. You can change this behavior by passing [`invalidates`](#invalidates) prop.
 
 [Refer to the query invalidation documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/guides/query-invalidation)
 
@@ -42,7 +42,7 @@ When `useDelete` mutation runs successfully, by default it will invalidate the f
 
 > This feature is only available if you use a [Audit Log Provider](/docs/api-reference/core/providers/audit-log-provider/).
 
-When `useDelete` mutation runs successfully, it will call the `log` method from `auditLogProvider` with some parameters such as `resource`, `action`, `data`, `previousData` etc. It is useful when you want to log the changes to the database.
+When the `useDelete` mutation runs successfully, it will call the `log` method from `auditLogProvider` with some parameters such as `resource`, `action`, `data`, `previousData` etc. It is useful when you want to log the changes to the database.
 
 [Refer to the `auditLogProvider` documentation for more information &#8594](/docs/api-reference/core/providers/audit-log-provider/)
 
@@ -64,7 +64,7 @@ useDelete({
 
 :::tip
 
-`mutationOptions` does not support `onSuccess` and `onError` props because they override the default `onSuccess` and `onError` functions. If you want to use these props, you can pass them to mutate function like this:
+`mutationOptions` does not support `onSuccess` and `onError` props because they override the default `onSuccess` and `onError` functions. If you want to use these props, you can pass them to mutate functions like this:
 
 ```tsx
 const { mutate } = useDelete();
@@ -91,7 +91,7 @@ mutate(
 
 ### `resource` <PropTag required />
 
-It will be passed to the `deleteOne` method from the `dataProvider` as parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `deleteOne` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resource are handled.
+It will be passed to the `deleteOne` method from the `dataProvider` as a parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `deleteOne` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resources are handled.
 
 ```tsx
 const { mutate } = useDelete();
@@ -103,7 +103,7 @@ mutate({
 
 ### `id` <PropTag required />
 
-It will be passed to the `deleteOne` method from the `dataProvider` as parameter. It is used to determine which record to delete.
+It will be passed to the `deleteOne` method from the `dataProvider` as a parameter. It is used to determine which record to delete.
 
 ```tsx
 const { mutate } = useDelete();
@@ -115,7 +115,7 @@ mutate({
 
 ### `mutationMode`
 
-Mutation mode determines which mode the mutation runs with. Mutations can run under three different modes: `pessimistic`, `optimistic` and `undoable`. Default mode is `pessimistic`.
+Mutation mode determines which mode the mutation runs with. Mutations can run under three different modes: `pessimistic`, `optimistic`, and `undoable`. The default mode is `pessimistic`.
 Each mode corresponds to a different type of user experience.
 
 [Refer to the mutation mode documentation for more information &#8594](/docs/advanced-tutorials/mutation-mode)
@@ -130,7 +130,7 @@ mutate({
 
 ### `undoableTimeout`
 
-When `mutationMode` is set to `undoable`, `undoableTimeout` is used to determine duration to wait before executing the mutation. Default value is `5000` milliseconds.
+When `mutationMode` is set to `undoable`, `undoableTimeout` is used to determine the duration to wait before executing the mutation. The default value is `5000` milliseconds.
 
 ```tsx
 const { mutate } = useDelete();
@@ -181,7 +181,7 @@ mutate({
 
 > [`NotificationProvider`](/docs/api-reference/core/providers/notification-provider/) is required for this prop to work.
 
-After data fetching is failed, `useDelete` will call `open` function from `NotificationProvider` to show a error notification. With this prop, you can customize the error notification.
+After data fetching is failed, `useDelete` will call `open` function from `NotificationProvider` to show an error notification. With this prop, you can customize the error notification.
 
 ```tsx
 const { mutate } = useDelete();
@@ -259,7 +259,7 @@ mutate({
 
 `invalidates` is used to specify which queries should be invalidated after the mutation is completed.
 
-By default it's invalidates following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks in the same page, they will refetch the data after the mutation is completed.
+By default, it invalidates the following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks on the same page, they will refetch the data after the mutation is completed.
 
 ```tsx
 const { mutate } = useDelete();

--- a/documentation/docs/api-reference/core/hooks/data/useDelete/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useDelete/index.md
@@ -3,7 +3,7 @@ title: useDelete
 siderbar_label: useDelete
 ---
 
-`useDelete` is an extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
+`useDelete` is an extended version of TanStack Query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
 
 -   It uses the `deleteOne` method as the **mutation function** from the [`dataProvider`](/docs/api-reference/core/providers/data-provider/) which is passed to `<Refine>`.
 
@@ -271,7 +271,7 @@ mutate({
 
 ## Return Values
 
-Returns an object with react-query's `useMutation` return values.
+Returns an object with TanStack Query's `useMutation` return values.
 
 [Refer to the `useMutation` documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/reference/useMutation)
 
@@ -306,6 +306,6 @@ Returns an object with react-query's `useMutation` return values.
 
 ### Return value
 
-| Description                               | Type                                                                                                                                                                       |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Result of the `react-query`'s useMutation | [`UseMutationResult<`<br/>`{ data: TData },`<br/>`TError,`<br/>` { id: BaseKey; },`<br/>` DeleteContext>`](https://tanstack.com/query/v4/docs/react/reference/useMutation) |
+| Description                                | Type                                                                                                                                                                       |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Result of the TanStack Query's useMutation | [`UseMutationResult<`<br/>`{ data: TData },`<br/>`TError,`<br/>` { id: BaseKey; },`<br/>` DeleteContext>`](https://tanstack.com/query/v4/docs/react/reference/useMutation) |

--- a/documentation/docs/api-reference/core/hooks/data/useDeleteMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useDeleteMany/index.md
@@ -1,6 +1,7 @@
 ---
 title: useDeleteMany
 siderbar_label: useDeleteMany
+source: packages/core/src/hooks/data/useDeleteMany.ts
 ---
 
 `useDeleteMany` is an extended version of TanStack Query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.

--- a/documentation/docs/api-reference/core/hooks/data/useDeleteMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useDeleteMany/index.md
@@ -3,7 +3,7 @@ title: useDeleteMany
 siderbar_label: useDeleteMany
 ---
 
-`useDeleteMany` is a extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It support all the features of `useMutation` and adds some extra features.
+`useDeleteMany` is an extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
 
 -   It uses the `deleteMany` method as the **mutation function** from the [`dataProvider`](/docs/api-reference/core/providers/data-provider/) which is passed to `<Refine>`.
 
@@ -15,7 +15,7 @@ If your data provider does not have a `deleteMany` method, `useDeleteMany` will 
 
 ## Basic Usage
 
-`useDeleteMany` hook returns many useful properties and methods. One of them is `mutate` method which expects `resource` and `ids` as parameters. These parameters will be passed to the `deleteMany` method from the `dataProvider` as parameters.
+The `useDeleteMany` hook returns many useful properties and methods. One of them is the `mutate` method which expects `resource` and `ids` as parameters. These parameters will be passed to the `deleteMany` method from the `dataProvider` as parameters.
 
 ```tsx
 import { useDeleteMany } from "@pankod/refine-core";
@@ -32,13 +32,13 @@ mutate({
 
 > This feature is only available if you use a [Live Provider](/docs/api-reference/core/providers/live-provider).
 
-When `useDeleteMany` mutation runs successfully, it will call the `publish` method from `liveProvider` with some parameters such as `channel`, `type` etc. It is useful when you want to publish the changes to the subscribers on client side.
+When the `useDeleteMany` mutation runs successfully, it will call the `publish` method from `liveProvider` with some parameters such as `channel`, `type` etc. It is useful when you want to publish the changes to the subscribers on the client side.
 
 [Refer to the `liveProvider` documentation for more information &#8594](/docs/api-reference/core/providers/live-provider)
 
 ## Invalidating Queries
 
-When `useDeleteMany` mutation runs successfully, by default it will invalidate the following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks in the same page, they will refetch the data after the mutation is completed. You can change this behavior by passing [`invalidates`](#invalidates) prop.
+When the `useDeleteMany` mutation runs successfully, by default it will invalidate the following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks on the same page, they will refetch the data after the mutation is completed. You can change this behavior by passing [`invalidates`](#invalidates) prop.
 
 [Refer to the query invalidation documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/guides/query-invalidation)
 
@@ -60,7 +60,7 @@ useDeleteMany({
 
 :::tip
 
-`mutationOptions` does not support `onSuccess` and `onError` props because they override the default `onSuccess` and `onError` functions. If you want to use these props, you can pass them to mutate function like this:
+`mutationOptions` does not support `onSuccess` and `onError` props because they override the default `onSuccess` and `onError` functions. If you want to use these props, you can pass them to mutate functions like this:
 
 ```tsx
 const { mutate } = useDeleteMany();
@@ -87,7 +87,7 @@ mutate(
 
 ### `resource` <PropTag required />
 
-It will be passed to the `deleteMany` method from the `dataProvider` as parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `deleteMany` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resource are handled.
+It will be passed to the `deleteMany` method from the `dataProvider` as a parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `deleteMany` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resources are handled.
 
 ```tsx
 const { mutate } = useDeleteMany();
@@ -99,7 +99,7 @@ mutate({
 
 ### `ids` <PropTag required />
 
-It will be passed to the `deleteMany` method from the `dataProvider` as parameter. It is used to determine which records will be deleted.
+It will be passed to the `deleteMany` method from the `dataProvider` as a parameter. It is used to determine which records will be deleted.
 
 ```tsx
 const { mutate } = useDeleteMany();
@@ -111,7 +111,7 @@ mutate({
 
 ### `mutationMode`
 
-Mutation mode determines which mode the mutation runs with. Mutations can run under three different modes: `pessimistic`, `optimistic` and `undoable`. Default mode is `pessimistic`.
+Mutation mode determines which mode the mutation runs with. Mutations can run under three different modes: `pessimistic`, `optimistic`, and `undoable`. The default mode is `pessimistic`.
 Each mode corresponds to a different type of user experience.
 
 [Refer to the mutation mode documentation for more information &#8594](/docs/advanced-tutorials/mutation-mode)
@@ -126,7 +126,7 @@ mutate({
 
 ### `undoableTimeout`
 
-When `mutationMode` is set to `undoable`, `undoableTimeout` is used to determine duration to wait before executing the mutation. Default value is `5000` milliseconds.
+When `mutationMode` is set to `undoable`, `undoableTimeout` is used to determine the duration to wait before executing the mutation. The default value is `5000` milliseconds.
 
 ```tsx
 const { mutate } = useDeleteMany();
@@ -177,7 +177,7 @@ mutate({
 
 > [`NotificationProvider`](/docs/api-reference/core/providers/notification-provider/) is required for this prop to work.
 
-After data fetching is failed, `useDeleteMany` will call `open` function from `NotificationProvider` to show a error notification. With this prop, you can customize the error notification.
+After data fetching is failed, `useDeleteMany` will call `open` function from `NotificationProvider` to show an error notification. With this prop, you can customize the error notification.
 
 ```tsx
 const { mutate } = useDeleteMany();
@@ -256,7 +256,7 @@ mutate({
 
 `invalidates` is used to specify which queries should be invalidated after the mutation is completed.
 
-By default it's invalidates following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks in the same page, they will refetch the data after the mutation is completed.
+By default, it invalidates the following queries from the current `resource`: `"list"` and `"many"`. That means, if you use `useList` or `useMany` hooks on the same page, they will refetch the data after the mutation is completed.
 
 ```tsx
 const { mutate } = useDeleteMany();

--- a/documentation/docs/api-reference/core/hooks/data/useDeleteMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useDeleteMany/index.md
@@ -3,7 +3,7 @@ title: useDeleteMany
 siderbar_label: useDeleteMany
 ---
 
-`useDeleteMany` is an extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
+`useDeleteMany` is an extended version of TanStack Query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
 
 -   It uses the `deleteMany` method as the **mutation function** from the [`dataProvider`](/docs/api-reference/core/providers/data-provider/) which is passed to `<Refine>`.
 
@@ -268,7 +268,7 @@ mutate({
 
 ## Return Values
 
-Returns an object with react-query's `useMutation` return values.
+Returns an object with TanStack Query's `useMutation` return values.
 
 [Refer to the `useMutation` documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/reference/useMutation)
 
@@ -303,6 +303,6 @@ Returns an object with react-query's `useMutation` return values.
 
 ### Return value
 
-| Description                               | Type                                                                                                                                                                                              |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Result of the `react-query`'s useMutation | [`UseMutationResult<`<br/>`{ data: TData },`<br/>`TError,`<br/>` { resource: string; ids: BaseKey[]; },`<br/>` DeleteContext>`](https://tanstack.com/query/v4/docs/react/reference/useMutation)\* |
+| Description                                | Type                                                                                                                                                                                              |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Result of the TanStack Query's useMutation | [`UseMutationResult<`<br/>`{ data: TData },`<br/>`TError,`<br/>` { resource: string; ids: BaseKey[]; },`<br/>` DeleteContext>`](https://tanstack.com/query/v4/docs/react/reference/useMutation)\* |

--- a/documentation/docs/api-reference/core/hooks/data/useInfiniteList/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useInfiniteList/index.md
@@ -13,19 +13,19 @@ import FilteringLivePreview from "./filtering-live-preview.md";
 
 -   It uses the `getList` method as the query function from the [`dataProvider`](/docs/api-reference/core/providers/data-provider.md) which is passed to `<Refine>`.
 
--   It uses query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the `react-query` devtools.
+-   It uses a query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the `react-query` devtools.
 
 ## Basic Usage
 
-Here is a basic example of how to use `useInfiniteList` hook.
+Here is a basic example of how to use the `useInfiniteList` hook.
 
 <BasicUsageLivePreview />
 
 ## Pagination
 
-`useInfiniteList` hook supports pagination properties just like [`useList`](/docs/api-reference/core/hooks/data/useList/). In order to handle pagination, `useInfiniteList` hook passes `pagination` property to the `getList` method from the `dataProvider`.
+`useInfiniteList` hook supports pagination properties just like [`useList`](/docs/api-reference/core/hooks/data/useList/). To handle pagination, the `useInfiniteList` hook passes the `pagination` property to the `getList` method from the `dataProvider`.
 
-Dynamically changing the `pagination` properties will trigger a new request. Also `fetchNextPage` method will increase the `pagination.current` property by one and trigger a new request.
+Dynamically changing the `pagination` properties will trigger a new request. Also, the `fetchNextPage` method will increase the `pagination.current` property by one and trigger a new request.
 
 ```ts
 import { useInfiniteList } from "@pankod/refine-core";
@@ -40,7 +40,7 @@ const postListQueryResult = useInfiniteList({
 
 ## Sorting
 
-`useInfiniteList` hook supports sorting feature. You can pass `sort` property to enable sorting. In order to handle sorting, `useInfiniteList` hook passes `sort` property to the `getList` method from the `dataProvider`.
+The `useInfiniteList` hook supports the sorting feature. You can pass the `sort` property to enable sorting. To handle sorting, the `useInfiniteList` hook passes the `sort` property to the `getList` method from the `dataProvider`.
 
 Dynamically changing the `sort` property will trigger a new request.
 
@@ -48,7 +48,7 @@ Dynamically changing the `sort` property will trigger a new request.
 
 ## Filtering
 
-`useInfiniteList` hook supports filtering feature. You can pass `filters` property to enable filtering. In order to handle filtering, `useInfiniteList` hook passes `filters` property to the `getList` method from the `dataProvider`.
+The `useInfiniteList` hook supports the filtering feature. You can pass the `filters` property to enable filtering. To handle filtering, the `useInfiniteList` hook passes the `filters` property to the `getList` method from the `dataProvider`.
 
 Dynamically changing the `filters` property will trigger a new request.
 
@@ -58,7 +58,7 @@ Dynamically changing the `filters` property will trigger a new request.
 
 > This feature is only available if you use a [Live Provider](/docs/api-reference/core/providers/live-provider).
 
-When `useInfiniteList` hook is mounted, it will call the `subscribe` method from the `liveProvider` with some parameters such as `channel`, `resource` etc. It is useful when you want to subscribe to the live updates.
+When the `useInfiniteList` hook is mounted, it will call the `subscribe` method from the `liveProvider` with some parameters such as `channel`, `resource` etc. It is useful when you want to subscribe to live updates.
 
 [Refer to the `liveProvider` documentation for more information &#8594](/docs/api-reference/core/providers/live-provider)
 
@@ -66,7 +66,7 @@ When `useInfiniteList` hook is mounted, it will call the `subscribe` method from
 
 ### `resource` <PropTag required />
 
-It will be passed to the `getList` method from the `dataProvider` as parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `getList` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resource are handled.
+It will be passed to the `getList` method from the `dataProvider` as a parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `getList` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resources are handled.
 
 ```tsx
 useInfiniteList({
@@ -86,7 +86,7 @@ useInfiniteList({
 
 ### `config.filters`
 
-`filters` will be passed to the `getList` method from the `dataProvider` as parameter. It is used to send filter query parameters to the API.
+`filters` will be passed to the `getList` method from the `dataProvider` as a parameter. It is used to send filter query parameters to the API.
 
 [Refer to the `CrudFilters` interface for more information &#8594](/docs/api-reference/core/interfaceReferences#crudfilters)
 
@@ -106,7 +106,7 @@ useInfiniteList({
 
 ### `config.sort`
 
-`sort` will be passed to the `getList` method from the `dataProvider` as parameter. It is used to send sort query parameters to the API.
+`sort` will be passed to the `getList` method from the `dataProvider` as a parameter. It is used to send sort query parameters to the API.
 
 [Refer to the `CrudSorting` interface for more information &#8594](docs/api-reference/core/interfaceReferences#crudsorting)
 
@@ -125,7 +125,7 @@ useInfiniteList({
 
 ### `config.pagination`
 
-`pagination` will be passed to the `getList` method from the `dataProvider` as parameter. It is used to send pagination query parameters to the API.
+`pagination` will be passed to the `getList` method from the `dataProvider` as a parameter. It is used to send pagination query parameters to the API.
 
 #### `current`
 
@@ -157,7 +157,7 @@ useInfiniteList({
 
 ### `config.hasPagination`
 
-`hasPagination` will be passed to the `getList` method from the `dataProvider` as parameter. It is used to determine whether to use server-side pagination or not.
+`hasPagination` will be passed to the `getList` method from the `dataProvider` as a parameter. It is used to determine whether to use server-side pagination or not.
 
 ```tsx
 useInfiniteList({
@@ -250,7 +250,7 @@ useInfiniteList({
 
 > [`NotificationProvider`](/docs/api-reference/core/providers/notification-provider/) is required for this prop to work.
 
-After data fetching is failed, `useInfiniteList` will call `open` function from `NotificationProvider` to show a error notification. With this prop, you can customize the error notification.
+After data fetching is failed, `useInfiniteList` will call `open` function from `NotificationProvider` to show an error notification. With this prop, you can customize the error notification.
 
 ```tsx
 useInfiniteList({
@@ -269,7 +269,7 @@ useInfiniteList({
 > [`LiveProvider`](/docs/api-reference/core/providers/live-provider/) is required for this prop to work.
 
 Determines whether to update data automatically ("auto") or not ("manual") if a related live event is received. It can be used to update and show data in Realtime throughout your app.
-For more information about live mode, please check [Live / Realtime](/docs/api-reference/core/providers/live-provider/#livemode) page.
+For more information about live mode, please check the [Live / Realtime](/docs/api-reference/core/providers/live-provider/#livemode) page.
 
 ```tsx
 useInfiniteList({
@@ -281,7 +281,7 @@ useInfiniteList({
 
 > [`LiveProvider`](/docs/api-reference/core/providers/live-provider/) is required for this prop to work.
 
-The callback function that is executed when new events from a subscription are arrived.
+The callback function is executed when new events from a subscription have arrived.
 
 ```tsx
 useInfiniteList({
@@ -305,13 +305,13 @@ Returns an object with react-query's `useInfiniteQuery` return values.
 
 ## FAQ
 
-### How to use cursor based pagination?
+### How to use cursor-based pagination?
 
 Some APIs use the `cursor-pagination` method for its benefits. This method uses a `cursor` object to determine the next set of data. The cursor can be a number or a string and is passed to the API as a query parameter.
 
 **Preparing the data provider:**
 
-Consumes data from data provider `useInfiniteList` with `getList` method. First of all, we need to make the this method in the data provider convenient for this API. The `cursor` data is kept in `pagination` and should be set to `0` by default.
+Consumes data from data provider `useInfiniteList` with the `getList` method. First of all, we need to make this method in the data provider convenient for this API. The `cursor` data is kept in `pagination` and should be set to `0` by default.
 
 ```ts
 getList: async ({ resource, pagination }) => {
@@ -331,7 +331,7 @@ getList: async ({ resource, pagination }) => {
 As the `total` data is only needed in the `offset-pagination` method, define it as `0` here.
 :::
 
-After this process, we have successfully retrieved the first page data. Let's fill the `cursor` object for the next page.
+After this process, we successfully retrieved the first page of data. Let's fill the `cursor` object for the next page.
 
 ```ts
 getList: async ({ resource, pagination }) => {
@@ -381,6 +381,7 @@ const {
     // highlight-end
 });
 ```
+
 :::tip
 When you override this method, you can access the `lastPage` and `allPages`.
 :::

--- a/documentation/docs/api-reference/core/hooks/data/useInfiniteList/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useInfiniteList/index.md
@@ -2,18 +2,18 @@
 title: useInfiniteList
 siderbar_label: useInfiniteList
 source: https://github.com/refinedev/refine/blob/next/packages/core/src/hooks/data/useInfiniteList.ts
-description: useInfiniteList data hook from refine is a modified version of react-query's useInfiniteQuery for retrieving items from a resource with pagination, search, sort, and filter configurations.
+description: useInfiniteList data hook from refine is a modified version of TanStack Query's useInfiniteQuery for retrieving items from a resource with pagination, search, sort, and filter configurations.
 ---
 
 import BasicUsageLivePreview from "./basic-usage-live-preview.md";
 import SortingLivePreview from "./sorting-live-preview.md";
 import FilteringLivePreview from "./filtering-live-preview.md";
 
-`useInfiniteList` is an extended version of `react-query`'s [`useInfiniteQuery`](https://react-query.tanstack.com/guides/useInfiniteQuery) used for retrieving items from a `resource` with pagination, sort, and filter configurations. It is ideal for lists where the total number of records is unknown and the user loads the next pages with a button.
+`useInfiniteList` is an extended version of TanStack Query's [`useInfiniteQuery`](https://.tanstack.com/guides/useInfiniteQuery) used for retrieving items from a `resource` with pagination, sort, and filter configurations. It is ideal for lists where the total number of records is unknown and the user loads the next pages with a button.
 
 -   It uses the `getList` method as the query function from the [`dataProvider`](/docs/api-reference/core/providers/data-provider.md) which is passed to `<Refine>`.
 
--   It uses a query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the `react-query` devtools.
+-   It uses a query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the TanStack Query devtools.
 
 ## Basic Usage
 
@@ -299,9 +299,9 @@ Params to pass to liveProvider's [subscribe](/docs/api-reference/core/providers/
 
 ## Return Values
 
-Returns an object with react-query's `useInfiniteQuery` return values.
+Returns an object with TanStack Query's `useInfiniteQuery` return values.
 
-[Refer to the `useInfiniteQuery` documentation for more information &#8594](https://react-query.tanstack.com/reference/useInfiniteQuery)
+[Refer to the `useInfiniteQuery` documentation for more information &#8594](https://tanstack.com/query/latest/docs/react/reference/useInfiniteQuery)
 
 ## FAQ
 
@@ -425,9 +425,9 @@ interface UseInfiniteListConfig {
 
 ### Return Values
 
-| Description                                      | Type                                                                                                                                                         |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Result of the `react-query`'s `useInfiniteQuery` | [`InfiniteQueryObserverResult<{`<br/>` data: TData[];`<br/>` total: number; },`<br/>` TError>`](https://react-query.tanstack.com/reference/useInfiniteQuery) |
+| Description                                       | Type                                                                                                                                                                     |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Result of the TanStack Query's `useInfiniteQuery` | [`InfiniteQueryObserverResult<{`<br/>` data: TData[];`<br/>` total: number; },`<br/>` TError>`](https://tanstack.com/query/latest/docs/react/reference/useInfiniteQuery) |
 
 ## Example
 

--- a/documentation/docs/api-reference/core/hooks/data/useList/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useList/index.md
@@ -9,11 +9,11 @@ import PaginationLivePreview from "./pagination-live-preview.md";
 import FilteringLivePreview from "./filtering-live-preview.md";
 import SortingLivePreview from "./sorting-live-preview.md";
 
-`useList` is an extended version of `react-query`'s [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It supports all the features of `useQuery` and adds some extra features.
+`useList` is an extended version of TanStack Query's [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It supports all the features of `useQuery` and adds some extra features.
 
 -   It uses the `getList` method as the **query function** from the [`dataProvider`](/api-reference/core/providers/data-provider.md) which is passed to `<Refine>`.
 
--   It uses a query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the `react-query` devtools.
+-   It uses a query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the TanStack Query devtools.
 
 When you need to fetch data according to sort, filter, pagination, etc. from a resource, you can use the `useList` hook. It will return the data and some functions to control the query.
 
@@ -292,7 +292,7 @@ Params to pass to liveProvider's [subscribe](/docs/api-reference/core/providers/
 
 ## Return Values
 
-Returns an object with react-query's `useQuery` return values.
+Returns an object with TanStack Query's `useQuery` return values.
 
 [Refer to the `useQuery` documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/reference/useQuery)
 
@@ -337,4 +337,4 @@ interface UseListConfig {
 
 | Description                              | Type                                                                                                                                                 |
 | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Result of the `react-query`'s `useQuery` | [`QueryObserverResult<{`<br/>` data: TData[];`<br/>` total: number; },`<br/>` TError>`](https://tanstack.com/query/v4/docs/react/reference/useQuery) |
+| Result of the TanStack Query's `useQuery` | [`QueryObserverResult<{`<br/>` data: TData[];`<br/>` total: number; },`<br/>` TError>`](https://tanstack.com/query/v4/docs/react/reference/useQuery) |

--- a/documentation/docs/api-reference/core/hooks/data/useList/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useList/index.md
@@ -9,23 +9,23 @@ import PaginationLivePreview from "./pagination-live-preview.md";
 import FilteringLivePreview from "./filtering-live-preview.md";
 import SortingLivePreview from "./sorting-live-preview.md";
 
-`useList` is an extended version of `react-query`'s [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It support all the features of `useQuery` and adds some extra features.
+`useList` is an extended version of `react-query`'s [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It supports all the features of `useQuery` and adds some extra features.
 
 -   It uses the `getList` method as the **query function** from the [`dataProvider`](/api-reference/core/providers/data-provider.md) which is passed to `<Refine>`.
 
--   It uses query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the `react-query` devtools.
+-   It uses a query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the `react-query` devtools.
 
-When you need to fetch data according to sort, filter, pagination etc. from a resource, you can use `useList` hook. It will return the data and some functions to control the query.
+When you need to fetch data according to sort, filter, pagination, etc. from a resource, you can use the `useList` hook. It will return the data and some functions to control the query.
 
 ## Basic Usage
 
-Here is a basic example of how to use `useList` hook.
+Here is a basic example of how to use the `useList` hook.
 
 <BasicUsageLivePreview />
 
 ## Pagination
 
-`useList` hook supports pagination feature. You can pass `pagination` property to enable pagination. In order to handle pagination, `useList` hook passes `pagination` property to the `getList` method from the `dataProvider`.
+The `useList` hook supports the pagination feature. You can pass the `pagination` property to enable pagination. To handle pagination, the `useList` hook passes the `pagination` property to the `getList` method from the `dataProvider`.
 
 Dynamically changing the `pagination` properties will trigger a new request.
 
@@ -33,7 +33,7 @@ Dynamically changing the `pagination` properties will trigger a new request.
 
 ## Sorting
 
-`useList` hook supports sorting feature. You can pass `sort` property to enable sorting. In order to handle sorting, `useList` hook passes `sort` property to the `getList` method from the `dataProvider`.
+The `useList` hook supports the sorting feature. You can pass the `sort` property to enable sorting. To handle sorting, the `useList` hook passes the `sort` property to the `getList` method from the `dataProvider`.
 
 Dynamically changing the `sort` property will trigger a new request.
 
@@ -41,7 +41,7 @@ Dynamically changing the `sort` property will trigger a new request.
 
 ## Filtering
 
-`useList` hook supports filtering feature. You can pass `filters` property to enable filtering. In order to handle filtering, `useList` hook passes `filters` property to the `getList` method from the `dataProvider`.
+The `useList` hook supports the filtering feature. You can pass the `filters` property to enable filtering. To handle filtering, the `useList` hook passes the `filters` property to the `getList` method from the `dataProvider`.
 
 Dynamically changing the `filters` property will trigger a new request.
 
@@ -51,7 +51,7 @@ Dynamically changing the `filters` property will trigger a new request.
 
 > This feature is only available if you use a [Live Provider](/docs/api-reference/core/providers/live-provider).
 
-When `useList` hook is mounted, it will call the `subscribe` method from the `liveProvider` with some parameters such as `channel`, `resource` etc. It is useful when you want to subscribe to the live updates.
+When the `useList` hook is mounted, it will call the `subscribe` method from the `liveProvider` with some parameters such as `channel`, `resource` etc. It is useful when you want to subscribe to live updates.
 
 [Refer to the `liveProvider` documentation for more information &#8594](/docs/api-reference/core/providers/live-provider)
 
@@ -59,7 +59,7 @@ When `useList` hook is mounted, it will call the `subscribe` method from the `li
 
 ### `resource` <PropTag required />
 
-It will be passed to the `getList` method from the `dataProvider` as parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `getList` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resource are handled.
+It will be passed to the `getList` method from the `dataProvider` as a parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `getList` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resources are handled.
 
 ```tsx
 useList({
@@ -79,7 +79,7 @@ useList({
 
 ### `config.filters`
 
-`filters` will be passed to the `getList` method from the `dataProvider` as parameter. It is used to send filter query parameters to the API.
+`filters` will be passed to the `getList` method from the `dataProvider` as a parameter. It is used to send filter query parameters to the API.
 
 [Refer to the `CrudFilters` interface for more information &#8594](/docs/api-reference/core/interfaceReferences#crudfilters)
 
@@ -99,7 +99,7 @@ useList({
 
 ### `config.sort`
 
-`sort` will be passed to the `getList` method from the `dataProvider` as parameter. It is used to send sort query parameters to the API.
+`sort` will be passed to the `getList` method from the `dataProvider` as a parameter. It is used to send sort query parameters to the API.
 
 [Refer to the `CrudSorting` interface for more information &#8594](docs/api-reference/core/interfaceReferences#crudsorting)
 
@@ -118,7 +118,7 @@ useList({
 
 ### `config.pagination`
 
-`pagination` will be passed to the `getList` method from the `dataProvider` as parameter. It is used to send pagination query parameters to the API.
+`pagination` will be passed to the `getList` method from the `dataProvider` as a parameter. It is used to send pagination query parameters to the API.
 
 #### `current`
 
@@ -150,7 +150,7 @@ useList({
 
 ### `config.hasPagination`
 
-`hasPagination` will be passed to the `getList` method from the `dataProvider` as parameter. It is used to determine whether to use server-side pagination or not.
+`hasPagination` will be passed to the `getList` method from the `dataProvider` as a parameter. It is used to determine whether to use server-side pagination or not.
 
 ```tsx
 useList({
@@ -243,7 +243,7 @@ useList({
 
 > [`NotificationProvider`](/docs/api-reference/core/providers/notification-provider/) is required for this prop to work.
 
-After data fetching is failed, `useList` will call `open` function from `NotificationProvider` to show a error notification. With this prop, you can customize the error notification.
+After data fetching is failed, `useList` will call `open` function from `NotificationProvider` to show an error notification. With this prop, you can customize the error notification.
 
 ```tsx
 useList({
@@ -274,7 +274,7 @@ useList({
 
 > [`LiveProvider`](/docs/api-reference/core/providers/live-provider/) is required for this prop to work.
 
-The callback function that is executed when new events from a subscription are arrived.
+The callback function is executed when new events from a subscription have arrived.
 
 ```tsx
 useList({

--- a/documentation/docs/api-reference/core/hooks/data/useMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useMany/index.md
@@ -5,11 +5,11 @@ siderbar_label: useMany
 
 import BasicUsageLivePreview from "./basic-usage-live-preview.md";
 
-`useMany` is a extended version of `react-query`'s [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It support all the features of `useQuery` and adds some extra features.
+`useMany` is an extended version of `react-query`'s [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It supports all the features of `useQuery` and adds some extra features.
 
 -   It uses the `getMany` method as the **query function** from the [`dataProvider`](/api-reference/core/providers/data-provider.md) which is passed to `<Refine>`.
 
--   It uses query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the `react-query` devtools.
+-   It uses a query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the `react-query` devtools.
 
 It is useful when you want to fetch multiple records from the API. It will return the data and some functions to control the query.
 
@@ -19,9 +19,9 @@ If your data provider does not have a `getMany` method, `useMany` will use the `
 
 ## Basic Usage
 
-`useMany` hook expects a `resource` and `ids` property. It will be passed to the `getMany` method from the `dataProvider` as parameter.
+The `useMany` hook expects a `resource` and `ids` property. It will be passed to the `getMany` method from the `dataProvider` as a parameter.
 
-When these properties are changed, `useMany` hook will trigger a new request.
+When these properties are changed, the `useMany` hook will trigger a new request.
 
 <BasicUsageLivePreview />
 
@@ -29,7 +29,7 @@ When these properties are changed, `useMany` hook will trigger a new request.
 
 > This feature is only available if you use a [Live Provider](/docs/api-reference/core/providers/live-provider).
 
-When `useMany` hook is mounted, it will call the `subscribe` method from the `liveProvider` with some parameters such as `channel`, `resource` etc. It is useful when you want to subscribe to the live updates.
+When the `useMany` hook is mounted, it will call the `subscribe` method from the `liveProvider` with some parameters such as `channel`, `resource` etc. It is useful when you want to subscribe to live updates.
 
 [Refer to the `liveProvider` documentation for more information &#8594](/docs/api-reference/core/providers/live-provider)
 
@@ -37,7 +37,7 @@ When `useMany` hook is mounted, it will call the `subscribe` method from the `li
 
 ### `resource` <PropTag required />
 
-It will be passed to the `getMany` method from the `dataProvider` as parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `getMany` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resource are handled.
+It will be passed to the `getMany` method from the `dataProvider` as a parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `getMany` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resources are handled.
 
 ```tsx
 useMany({
@@ -47,7 +47,7 @@ useMany({
 
 ### `ids` <PropTag required />
 
-It will be passed to the `getMany` method from the `dataProvider` as parameter. It is used to determine which records to fetch.
+It will be passed to the `getMany` method from the `dataProvider` as a parameter. It is used to determine which records to fetch.
 
 ```tsx
 useMany({
@@ -148,7 +148,7 @@ useMany({
 
 > [`NotificationProvider`](/docs/api-reference/core/providers/notification-provider/) is required for this prop to work.
 
-After data fetching is failed, `useMany` will call `open` function from `NotificationProvider` to show a error notification. With this prop, you can customize the error notification.
+After data fetching is failed, `useMany` will call the `open` function from `NotificationProvider` to show an error notification. With this prop, you can customize the error notification.
 
 ```tsx
 useMany({
@@ -167,7 +167,7 @@ useMany({
 > [`LiveProvider`](/docs/api-reference/core/providers/live-provider/) is required for this prop to work.
 
 Determines whether to update data automatically ("auto") or not ("manual") if a related live event is received. It can be used to update and show data in Realtime throughout your app.
-For more information about live mode, please check [Live / Realtime](/docs/api-reference/core/providers/live-provider/#livemode) page.
+For more information about live mode, please check the [Live / Realtime](/docs/api-reference/core/providers/live-provider/#livemode) page.
 
 ```tsx
 useMany({
@@ -179,7 +179,7 @@ useMany({
 
 > [`LiveProvider`](/docs/api-reference/core/providers/live-provider/) is required for this prop to work.
 
-The callback function that is executed when new events from a subscription are arrived.
+The callback function is executed when new events from a subscription have arrived.
 
 ```tsx
 useMany({

--- a/documentation/docs/api-reference/core/hooks/data/useMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useMany/index.md
@@ -1,6 +1,7 @@
 ---
 title: useMany
 siderbar_label: useMany
+source: packages/core/src/hooks/data/useMany.ts
 ---
 
 import BasicUsageLivePreview from "./basic-usage-live-preview.md";

--- a/documentation/docs/api-reference/core/hooks/data/useMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useMany/index.md
@@ -5,11 +5,11 @@ siderbar_label: useMany
 
 import BasicUsageLivePreview from "./basic-usage-live-preview.md";
 
-`useMany` is an extended version of `react-query`'s [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It supports all the features of `useQuery` and adds some extra features.
+`useMany` is an extended version of TanStack Query's [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It supports all the features of `useQuery` and adds some extra features.
 
 -   It uses the `getMany` method as the **query function** from the [`dataProvider`](/api-reference/core/providers/data-provider.md) which is passed to `<Refine>`.
 
--   It uses a query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the `react-query` devtools.
+-   It uses a query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the TanStack Query devtools.
 
 It is useful when you want to fetch multiple records from the API. It will return the data and some functions to control the query.
 
@@ -197,7 +197,7 @@ Params to pass to liveProvider's [subscribe](/docs/api-reference/core/providers/
 
 ## Return Values
 
-Returns an object with react-query's `useQuery` return values.
+Returns an object with TanStack Query's `useQuery` return values.
 
 [Refer to the `useQuery` documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/reference/useQuery)
 
@@ -221,4 +221,4 @@ errorNotification-default='"Error (status code: `statusCode`)"'
 
 | Description                              | Type                                                                                                     |
 | ---------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| Result of the `react-query`'s `useQuery` | [`QueryObserverResult<{ data: TData[]; }>`](https://tanstack.com/query/v4/docs/react/reference/useQuery) |
+| Result of the TanStack Query's `useQuery` | [`QueryObserverResult<{ data: TData[]; }>`](https://tanstack.com/query/v4/docs/react/reference/useQuery) |

--- a/documentation/docs/api-reference/core/hooks/data/useOne/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useOne/index.md
@@ -1,6 +1,7 @@
 ---
 title: useOne
 siderbar_label: useOne
+source: packages/core/src/hooks/data/useOne.ts
 ---
 
 import BasicUsageLivePreview from "./basic-usage-live-preview.md";

--- a/documentation/docs/api-reference/core/hooks/data/useOne/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useOne/index.md
@@ -5,11 +5,11 @@ siderbar_label: useOne
 
 import BasicUsageLivePreview from "./basic-usage-live-preview.md";
 
-`useOne` is an extended version of `react-query`'s [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It supports all the features of `useQuery` and adds some extra features.
+`useOne` is an extended version of TanStack Query's [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It supports all the features of `useQuery` and adds some extra features.
 
 -   It uses the `getOne` method as the **query function** from the [`dataProvider`](/api-reference/core/providers/data-provider.md) which is passed to `<Refine>`.
 
--   It uses a query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the `react-query` devtools.
+-   It uses a query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the TanStack Query devtools.
 
 It is useful when you want to fetch a single record from the API. It will return the data and some functions to control the query.
 
@@ -191,7 +191,7 @@ Params to pass to liveProvider's [subscribe](/docs/api-reference/core/providers/
 
 ## Return Values
 
-Returns an object with react-query's `useQuery` return values.
+Returns an object with TanStack Query's `useQuery` return values.
 
 [Refer to the `useQuery` documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/reference/useQuery)
 
@@ -215,4 +215,4 @@ errorNotification-default='"Error (status code: `statusCode`)"'
 
 | Description                              | Type                                                                                                   |
 | ---------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| Result of the `react-query`'s `useQuery` | [`QueryObserverResult<{ data: TData; }>`](https://tanstack.com/query/v4/docs/react/reference/useQuery) |
+| Result of the TanStack Query's `useQuery` | [`QueryObserverResult<{ data: TData; }>`](https://tanstack.com/query/v4/docs/react/reference/useQuery) |

--- a/documentation/docs/api-reference/core/hooks/data/useOne/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useOne/index.md
@@ -5,19 +5,19 @@ siderbar_label: useOne
 
 import BasicUsageLivePreview from "./basic-usage-live-preview.md";
 
-`useOne` is a extended version of `react-query`'s [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It support all the features of `useQuery` and adds some extra features.
+`useOne` is an extended version of `react-query`'s [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery). It supports all the features of `useQuery` and adds some extra features.
 
 -   It uses the `getOne` method as the **query function** from the [`dataProvider`](/api-reference/core/providers/data-provider.md) which is passed to `<Refine>`.
 
--   It uses query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the `react-query` devtools.
+-   It uses a query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the `react-query` devtools.
 
 It is useful when you want to fetch a single record from the API. It will return the data and some functions to control the query.
 
 ## Basic Usage
 
-`useOne` hook expects a `resource` and `id` property. It will be passed to the `getOne` method from the `dataProvider` as parameter.
+The `useOne` hook expects a `resource` and `id` property. It will be passed to the `getOne` method from the `dataProvider` as a parameter.
 
-When these properties are changed, `useOne` hook will trigger a new request.
+When these properties are changed, the `useOne` hook will trigger a new request.
 
 <BasicUsageLivePreview />
 
@@ -25,7 +25,7 @@ When these properties are changed, `useOne` hook will trigger a new request.
 
 > This feature is only available if you use a [Live Provider](/docs/api-reference/core/providers/live-provider).
 
-When `useOne` hook is mounted, it will call the `subscribe` method from the `liveProvider` with some parameters such as `channel`, `resource` etc. It is useful when you want to subscribe to the live updates.
+When the `useOne` hook is mounted, it will call the `subscribe` method from the `liveProvider` with some parameters such as `channel`, `resource` etc. It is useful when you want to subscribe to live updates.
 
 [Refer to the `liveProvider` documentation for more information &#8594](/docs/api-reference/core/providers/live-provider)
 
@@ -33,7 +33,7 @@ When `useOne` hook is mounted, it will call the `subscribe` method from the `liv
 
 ### `resource` <PropTag required />
 
-It will be passed to the `getOne` method from the `dataProvider` as parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `getOne` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resource are handled.
+It will be passed to the `getOne` method from the `dataProvider` as a parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `getOne` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resources are handled.
 
 ```tsx
 useOne({
@@ -43,7 +43,7 @@ useOne({
 
 ### `id` <PropTag required />
 
-It will be passed to the `getOne` method from the `dataProvider` as parameter. It is used to determine which record to fetch.
+It will be passed to the `getOne` method from the `dataProvider` as a parameter. It is used to determine which record to fetch.
 
 ```tsx
 useOne({
@@ -142,7 +142,7 @@ useOne({
 
 > [`NotificationProvider`](/docs/api-reference/core/providers/notification-provider/) is required for this prop to work.
 
-After data fetching is failed, `useOne` will call `open` function from `NotificationProvider` to show a error notification. With this prop, you can customize the error notification.
+After data fetching is failed, `useOne` will call the `open` function from `NotificationProvider` to show an error notification. With this prop, you can customize the error notification.
 
 ```tsx
 useOne({
@@ -161,7 +161,7 @@ useOne({
 > [`LiveProvider`](/docs/api-reference/core/providers/live-provider/) is required for this prop to work.
 
 Determines whether to update data automatically ("auto") or not ("manual") if a related live event is received. It can be used to update and show data in Realtime throughout your app.
-For more information about live mode, please check [Live / Realtime](/docs/api-reference/core/providers/live-provider/#livemode) page.
+For more information about live mode, please check the [Live / Realtime](/docs/api-reference/core/providers/live-provider/#livemode) page.
 
 ```tsx
 useOne({
@@ -173,7 +173,7 @@ useOne({
 
 > [`LiveProvider`](/docs/api-reference/core/providers/live-provider/) is required for this prop to work.
 
-The callback function that is executed when new events from a subscription are arrived.
+The callback function is executed when new events from a subscription have arrived.
 
 ```tsx
 useOne({

--- a/documentation/docs/api-reference/core/hooks/data/useUpdate/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useUpdate/index.md
@@ -1,6 +1,7 @@
 ---
 title: useUpdate
 siderbar_label: useUpdate
+source: packages/core/src/hooks/data/useUpdate.ts
 ---
 
 `useUpdate` is an extended version of TanStack Query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.

--- a/documentation/docs/api-reference/core/hooks/data/useUpdate/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useUpdate/index.md
@@ -3,7 +3,7 @@ title: useUpdate
 siderbar_label: useUpdate
 ---
 
-`useUpdate` is an extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
+`useUpdate` is an extended version of TanStack Query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
 
 -   It uses the `update` method as the **mutation function** from the [`dataProvider`](/docs/api-reference/core/providers/data-provider/) which is passed to `<Refine>`.
 
@@ -295,7 +295,7 @@ mutate({
 
 ## Return Values
 
-Returns an object with react-query's `useMutation` return values.
+Returns an object with TanStack Query's `useMutation` return values.
 
 [Refer to the `useMutation` documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/reference/useMutation)
 
@@ -333,6 +333,6 @@ Returns an object with react-query's `useMutation` return values.
 
 | Description                               | Type                                                                                                                                                                                                              |
 | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Result of the `react-query`'s useMutation | [`UseMutationResult<`<br/>`{ data: TData },`<br/>`TError,`<br/>` { resource:string; id: BaseKey; values: TVariables; },`<br/>` UpdateContext>`](https://tanstack.com/query/v4/docs/react/reference/useMutation)\* |
+| Result of the TanStack Query's useMutation | [`UseMutationResult<`<br/>`{ data: TData },`<br/>`TError,`<br/>` { resource:string; id: BaseKey; values: TVariables; },`<br/>` UpdateContext>`](https://tanstack.com/query/v4/docs/react/reference/useMutation)\* |
 
 > `*` `UpdateContext` is an internal type.

--- a/documentation/docs/api-reference/core/hooks/data/useUpdate/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useUpdate/index.md
@@ -3,7 +3,7 @@ title: useUpdate
 siderbar_label: useUpdate
 ---
 
-`useUpdate` is a extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It support all the features of `useMutation` and adds some extra features.
+`useUpdate` is an extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
 
 -   It uses the `update` method as the **mutation function** from the [`dataProvider`](/docs/api-reference/core/providers/data-provider/) which is passed to `<Refine>`.
 
@@ -11,7 +11,7 @@ It is useful when you want to update a record.
 
 ## Basic Usage
 
-`useUpdate` hook returns many useful properties and methods. One of them is `mutate` method which expects `values`, `resource` and `id` as parameters. These parameters will be passed to the `update` method from the `dataProvider` as parameters.
+The `useUpdate` hook returns many useful properties and methods. One of them is the `mutate` method which expects `values`, `resource`, and `id` as parameters. These parameters will be passed to the `update` method from the `dataProvider` as parameters.
 
 ```tsx
 import { useUpdate } from "@pankod/refine-core";
@@ -32,13 +32,13 @@ mutate({
 
 > This feature is only available if you use a [Live Provider](/docs/api-reference/core/providers/live-provider).
 
-When `useUpdate` mutation runs successfully, it will call the `publish` method from `liveProvider` with some parameters such as `channel`, `type` etc. It is useful when you want to publish the changes to the subscribers on client side.
+When the `useUpdate` mutation runs successfully, it will call the `publish` method from `liveProvider` with some parameters such as `channel`, `type` etc. It is useful when you want to publish the changes to the subscribers on the client side.
 
 [Refer to the `liveProvider` documentation for more information &#8594](/docs/api-reference/core/providers/live-provider)
 
 ## Invalidating Queries
 
-When `useUpdate` mutation runs successfully, by default it will invalidate the following queries from the current `resource`: `"list"`, `"many"` and `"detail"`. That means, if you use `useList`, `useMany` or `useOne` hooks in the same page, they will refetch the data after the mutation is completed. You can change this behavior by passing [`invalidates`](#invalidates) prop.
+When the `useUpdate` mutation runs successfully, by default it will invalidate the following queries from the current `resource`: `"list"`, `"many"`, and `"detail"`. That means, if you use `useList`, `useMany`, or `useOne` hooks on the same page, they will refetch the data after the mutation is completed. You can change this behavior by passing [`invalidates`](#invalidates) prop.
 
 [Refer to the query invalidation documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/guides/query-invalidation)
 
@@ -46,7 +46,7 @@ When `useUpdate` mutation runs successfully, by default it will invalidate the f
 
 > This feature is only available if you use a [Audit Log Provider](/docs/api-reference/core/providers/audit-log-provider/).
 
-When `useUpdate` mutation runs successfully, it will call the `log` method from `auditLogProvider` with some parameters such as `resource`, `action`, `data`, `previousData` etc. It is useful when you want to log the changes to the database.
+When the `useUpdate` mutation runs successfully, it will call the `log` method from `auditLogProvider` with some parameters such as `resource`, `action`, `data`, `previousData` etc. It is useful when you want to log the changes to the database.
 
 [Refer to the `auditLogProvider` documentation for more information &#8594](/docs/api-reference/core/providers/audit-log-provider/)
 
@@ -68,7 +68,7 @@ useUpdate({
 
 :::tip
 
-`mutationOptions` does not support `onSuccess` and `onError` props because they override the default `onSuccess` and `onError` functions. If you want to use these props, you can pass them to mutate function like this:
+`mutationOptions` does not support `onSuccess` and `onError` props because they override the default `onSuccess` and `onError` functions. If you want to use these props, you can pass them to mutate functions like this:
 
 ```tsx
 const { mutate } = useUpdate();
@@ -99,7 +99,7 @@ mutate(
 
 ### `resource` <PropTag required />
 
-It will be passed to the `update` method from the `dataProvider` as parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `update` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resource are handled.
+It will be passed to the `update` method from the `dataProvider` as a parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `update` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resources are handled.
 
 ```tsx
 const { mutate } = useUpdate();
@@ -111,7 +111,7 @@ mutate({
 
 ### `id` <PropTag required />
 
-It will be passed to the `update` method from the `dataProvider` as parameter. It is used to determine which record to update.
+It will be passed to the `update` method from the `dataProvider` as a parameter. It is used to determine which record to update.
 
 ```tsx
 const { mutate } = useUpdate();
@@ -123,7 +123,7 @@ mutate({
 
 ### `values` <PropTag required />
 
-It will be passed to the `update` method from the `dataProvider` as parameter. The parameter is usually used as the data to be updated. It contains the new values of the record.
+It will be passed to the `update` method from the `dataProvider` as a parameter. The parameter is usually used as the data to be updated. It contains the new values of the record.
 
 ```tsx
 const { mutate } = useUpdate();
@@ -138,7 +138,7 @@ mutate({
 
 ### `mutationMode`
 
-Mutation mode determines which mode the mutation runs with. Mutations can run under three different modes: `pessimistic`, `optimistic` and `undoable`. Default mode is `pessimistic`.
+Mutation mode determines which mode the mutation runs with. Mutations can run under three different modes: `pessimistic`, `optimistic`, and `undoable`. The default mode is `pessimistic`.
 Each mode corresponds to a different type of user experience.
 
 [Refer to the mutation mode documentation for more information &#8594](/docs/advanced-tutorials/mutation-mode)
@@ -153,7 +153,7 @@ mutate({
 
 ### `undoableTimeout`
 
-When `mutationMode` is set to `undoable`, `undoableTimeout` is used to determine duration to wait before executing the mutation. Default value is `5000` milliseconds.
+When `mutationMode` is set to `undoable`, `undoableTimeout` is used to determine the duration to wait before executing the mutation. The default value is `5000` milliseconds.
 
 ```tsx
 const { mutate } = useUpdate();
@@ -204,7 +204,7 @@ mutate({
 
 > [`NotificationProvider`](/docs/api-reference/core/providers/notification-provider/) is required for this prop to work.
 
-After data fetching is failed, `useUpdate` will call `open` function from `NotificationProvider` to show a error notification. With this prop, you can customize the error notification.
+After data fetching is failed, `useUpdate` will call the `open` function from `NotificationProvider` to show an error notification. With this prop, you can customize the error notification.
 
 ```tsx
 const { mutate } = useUpdate();
@@ -283,7 +283,7 @@ mutate({
 
 `invalidates` is used to specify which queries should be invalidated after the mutation is completed.
 
-By default it's invalidates following queries from the current `resource`: `"list"`, `"many"` and `"detail"`. That means, if you use `useList`, `useMany` or `useOne` hooks in the same page, they will refetch the data after the mutation is completed.
+By default, it invalidates the following queries from the current `resource`: `"list"`, `"many"` and `"detail"`. That means, if you use `useList`, `useMany`, or `useOne` hooks on the same page, they will refetch the data after the mutation is completed.
 
 ```tsx
 const { mutate } = useUpdate();

--- a/documentation/docs/api-reference/core/hooks/data/useUpdateMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useUpdateMany/index.md
@@ -3,7 +3,7 @@ title: useUpdateMany
 siderbar_label: useUpdateMany
 ---
 
-`useUpdateMany` is an extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
+`useUpdateMany` is an extended version of TanStack Query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
 
 -   It uses the `updateMany` method as the **mutation function** from the [`dataProvider`](/docs/api-reference/core/providers/data-provider/) which is passed to `<Refine>`.
 
@@ -296,7 +296,7 @@ mutate({
 
 ## Return Values
 
-Returns an object with react-query's `useMutation` return values.
+Returns an object with TanStack Query's `useMutation` return values.
 
 [Refer to the `useMutation` documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/reference/useMutation)
 
@@ -332,8 +332,8 @@ Returns an object with react-query's `useMutation` return values.
 
 ### Return value
 
-| Description                               | Type                                                                                                                                                                                                                 |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Result of the `react-query`'s useMutation | [`UseMutationResult<`<br/>`{ data: TData },`<br/>`TError,`<br/>` { resource:string; ids: BaseKey[]; values: TVariables; },`<br/>` UpdateContext>`](https://tanstack.com/query/v4/docs/react/reference/useMutation)\* |
+| Description                                | Type                                                                                                                                                                                                                 |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Result of the TanStack Query's useMutation | [`UseMutationResult<`<br/>`{ data: TData },`<br/>`TError,`<br/>` { resource:string; ids: BaseKey[]; values: TVariables; },`<br/>` UpdateContext>`](https://tanstack.com/query/v4/docs/react/reference/useMutation)\* |
 
 > `*` `UpdateContext` is an internal type.

--- a/documentation/docs/api-reference/core/hooks/data/useUpdateMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useUpdateMany/index.md
@@ -3,7 +3,7 @@ title: useUpdateMany
 siderbar_label: useUpdateMany
 ---
 
-`useUpdateMany` is a extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It support all the features of `useMutation` and adds some extra features.
+`useUpdateMany` is an extended version of `react-query`'s [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.
 
 -   It uses the `updateMany` method as the **mutation function** from the [`dataProvider`](/docs/api-reference/core/providers/data-provider/) which is passed to `<Refine>`.
 
@@ -15,7 +15,7 @@ If your data provider does not have a `updateMany` method, `useUpdateMany` will 
 
 ## Basic Usage
 
-`useUpdateMany` hook returns many useful properties and methods. One of them is `mutate` method which expects `values`, `resource` and `ids` as parameters. These parameters will be passed to the `updateMany` method from the `dataProvider` as parameters.
+The `useUpdateMany` hook returns many useful properties and methods. One of them is the `mutate` method which expects `values`, `resource`, and `ids` as parameters. These parameters will be passed to the `updateMany` method from the `dataProvider` as parameters.
 
 ```tsx
 import { useUpdateMany } from "@pankod/refine-core";
@@ -36,13 +36,13 @@ mutate({
 
 > This feature is only available if you use a [Live Provider](/docs/api-reference/core/providers/live-provider).
 
-When `useUpdateMany` mutation runs successfully, it will call the `publish` method from `liveProvider` with some parameters such as `channel`, `type` etc. It is useful when you want to publish the changes to the subscribers on client side.
+When the `useUpdateMany` mutation runs successfully, it will call the `publish` method from `liveProvider` with some parameters such as `channel`, `type` etc. It is useful when you want to publish the changes to the subscribers on the client side.
 
 [Refer to the `liveProvider` documentation for more information &#8594](/docs/api-reference/core/providers/live-provider)
 
 ## Invalidating Queries
 
-When `useUpdateMany` mutation runs successfully, by default it will invalidate the following queries from the current `resource`: `"list"`, `"many"` and `"detail"`. That means, if you use `useList`, `useMany` or `useOne` hooks in the same page, they will refetch the data after the mutation is completed. You can change this behavior by passing [`invalidates`](#invalidates) prop.
+When the `useUpdateMany` mutation runs successfully, by default it will invalidate the following queries from the current `resource`: `"list"`, `"many"`, and `"detail"`. That means, if you use `useList`, `useMany`, or `useOne` hooks on the same page, they will refetch the data after the mutation is completed. You can change this behavior by passing [`invalidates`](#invalidates) prop.
 
 [Refer to the query invalidation documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/guides/query-invalidation)
 
@@ -64,7 +64,7 @@ useUpdateMany({
 
 :::tip
 
-`mutationOptions` does not support `onSuccess` and `onError` props because they override the default `onSuccess` and `onError` functions. If you want to use these props, you can pass them to mutate function like this:
+`mutationOptions` does not support `onSuccess` and `onError` props because they override the default `onSuccess` and `onError` functions. If you want to use these props, you can pass them to mutate functions like this:
 
 ```tsx
 const { mutate } = useUpdateMany();
@@ -95,7 +95,7 @@ mutate(
 
 ### `resource` <PropTag required />
 
-It will be passed to the `updateMany` method from the `dataProvider` as parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `updateMany` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resource are handled.
+It will be passed to the `updateMany` method from the `dataProvider` as a parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `updateMany` method. See the [creating a data provider](/docs/api-reference/core/providers/data-provider#creating-a-data-provider) section for an example of how resources are handled.
 
 ```tsx
 const { mutate } = useUpdateMany();
@@ -107,7 +107,7 @@ mutate({
 
 ### `ids` <PropTag required />
 
-It will be passed to the `updateMany` method from the `dataProvider` as parameter. It is used to determine which records will be updated.
+It will be passed to the `updateMany` method from the `dataProvider` as a parameter. It is used to determine which records will be updated.
 
 ```tsx
 const { mutate } = useUpdateMany();
@@ -119,7 +119,7 @@ mutate({
 
 ### `values` <PropTag required />
 
-It will be passed to the `updateMany` method from the `dataProvider` as parameter. The parameter is usually used as the data to be updated. It contains the new values of the record.
+It will be passed to the `updateMany` method from the `dataProvider` as a parameter. The parameter is usually used as the data to be updated. It contains the new values of the record.
 
 ```tsx
 const { mutate } = useUpdateMany();
@@ -134,7 +134,7 @@ mutate({
 
 ### `mutationMode`
 
-Mutation mode determines which mode the mutation runs with. Mutations can run under three different modes: `pessimistic`, `optimistic` and `undoable`. Default mode is `pessimistic`.
+Mutation mode determines which mode the mutation runs with. Mutations can run under three different modes: `pessimistic`, `optimistic`, and `undoable`. The default mode is `pessimistic`.
 Each mode corresponds to a different type of user experience.
 
 [Refer to the mutation mode documentation for more information &#8594](/docs/advanced-tutorials/mutation-mode)
@@ -180,7 +180,7 @@ mutate({
 
 > [`NotificationProvider`](/docs/api-reference/core/providers/notification-provider/) is required for this prop to work.
 
-After data is fetched successfully, `useUpdateMany` can call `open` function from `NotificationProvider` to show a success notification. With this prop, you can customize the success notification.
+After data is fetched successfully, `useUpdateMany` can call the `open` function from `NotificationProvider` to show a success notification. With this prop, you can customize the success notification.
 
 ```tsx
 const { mutate } = useUpdateMany();
@@ -200,7 +200,7 @@ mutate({
 
 > [`NotificationProvider`](/docs/api-reference/core/providers/notification-provider/) is required for this prop to work.
 
-After data fetching is failed, `useUpdateMany` will call `open` function from `NotificationProvider` to show a error notification. With this prop, you can customize the error notification.
+After data fetching is failed, `useUpdateMany` will call the `open` function from `NotificationProvider` to show an error notification. With this prop, you can customize the error notification.
 
 ```tsx
 const { mutate } = useUpdateMany();
@@ -284,7 +284,7 @@ mutate({
 
 `invalidates` is used to specify which queries should be invalidated after the mutation is completed.
 
-By default it's invalidates following queries from the current `resource`: `"list"`, `"many"` and `"detail"`. That means, if you use `useList`, `useMany` or `useOne` hooks in the same page, they will refetch the data after the mutation is completed.
+By default, it invalidates the following queries from the current `resource`: `"list"`, `"many"` and `"detail"`. That means, if you use `useList`, `useMany`, or `useOne` hooks on the same page, they will refetch the data after the mutation is completed.
 
 ```tsx
 const { mutate } = useUpdateMany();

--- a/documentation/docs/api-reference/core/hooks/data/useUpdateMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useUpdateMany/index.md
@@ -1,6 +1,7 @@
 ---
 title: useUpdateMany
 siderbar_label: useUpdateMany
+source: packages/core/src/hooks/data/useUpdateMany.ts
 ---
 
 `useUpdateMany` is an extended version of TanStack Query's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation). It supports all the features of `useMutation` and adds some extra features.


### PR DESCRIPTION
- Fixed grammar mistakes
- Rename react-query to Tanstack Query
- Add source-code button to data hook docs