### PR TITLE
docs(remix): fix links in remix examples

### DIFF
--- a/documentation/docs/examples/remix/antd.md
+++ b/documentation/docs/examples/remix/antd.md
@@ -1,9 +1,9 @@
 ---
 id: remix-antd
 title: Ant Design
-example-tags: [remix,router-provider,antd]
+example-tags: [remix, router-provider, antd]
 ---
 
 **refine** allows you to build your **SSR** supported web applications using [Remix](https://remix.run/). With this example, you can see how to make a simple SSR supported CMS Admin panel using [Ant Design](https://ant.design/).
 
-<CodeSandboxExample path="remix-antd" />
+<CodeSandboxExample path="with-remix-antd" />

--- a/documentation/docs/examples/remix/headless.md
+++ b/documentation/docs/examples/remix/headless.md
@@ -1,9 +1,9 @@
 ---
 id: remix-headless
 title: Headless
-example-tags: [remix,router-provider,headless]
+example-tags: [remix, router-provider, headless]
 ---
 
 **refine** allows you to build your **SSR** supported web applications using [Remix](https://remix.run/). With this example, you can see how to make a simple SSR supported headless (without any style/component) CRUD App.
 
-<CodeSandboxExample path="remix-headless" />
+<CodeSandboxExample path="with-remix-headless" />


### PR DESCRIPTION
fixed: **remix** example links

https://refine.dev/docs/examples/remix/remix-headless/
https://refine.dev/docs/examples/remix/remix-antd/