### PR TITLE
feat(inferencer): export inferencer utilities

### DIFF
--- a/.changeset/dirty-toes-rest.md
+++ b/.changeset/dirty-toes-rest.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-inferencer": minor
+---
+
+Export utilities used in inferencer components to let users create their own inferencer components through `createInferencer` function and utilities.

--- a/packages/inferencer/src/index.tsx
+++ b/packages/inferencer/src/index.tsx
@@ -1,2 +1,35 @@
 export { createInferencer } from "./create-inferencer";
-export * from "@/inferencers";
+
+export {
+    jsx,
+    accessor,
+    componentName,
+    dataProviderFromResource,
+    dotAccessor,
+    getFieldableKeys,
+    getOptionLabel,
+    getVariableName,
+    isIDKey,
+    noOp,
+    prettyString,
+    toPlural,
+    toSingular,
+    printImports,
+    removeRelationSuffix,
+} from "./utilities";
+
+export type {
+    AdditionalScopeType,
+    CodeViewerProps,
+    CreateInferencer,
+    CreateInferencerConfig,
+    FieldInferencer,
+    FieldTransformer,
+    ImportElement,
+    InferField,
+    InferType,
+    InferencerComponentProps,
+    InferencerResultComponent,
+    RecordField,
+    RendererContext,
+} from "./types";

--- a/packages/inferencer/src/index.tsx
+++ b/packages/inferencer/src/index.tsx
@@ -5,6 +5,8 @@ export {
     accessor,
     componentName,
     dataProviderFromResource,
+    shouldDotAccess,
+    getAccessorKey,
     dotAccessor,
     getFieldableKeys,
     getOptionLabel,

--- a/packages/inferencer/src/inferencers/antd/create.tsx
+++ b/packages/inferencer/src/inferencers/antd/create.tsx
@@ -26,6 +26,10 @@ import {
 } from "@/types";
 import { shouldDotAccess } from "@/utilities/accessor";
 
+/**
+ * a renderer function for create page in Ant Design
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/antd/edit.tsx
+++ b/packages/inferencer/src/inferencers/antd/edit.tsx
@@ -25,6 +25,10 @@ import {
 } from "@/types";
 import { shouldDotAccess } from "@/utilities/accessor";
 
+/**
+ * a renderer function for edit page in Ant Design
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/antd/index.tsx
+++ b/packages/inferencer/src/inferencers/antd/index.tsx
@@ -28,8 +28,20 @@ const AntdInferencer: React.FC<InferencerComponentProps> = ({
 };
 
 export { AntdInferencer };
-export { ShowInferencer as AntdShowInferencer } from "./show";
-export { EditInferencer as AntdEditInferencer } from "./edit";
-export { ListInferencer as AntdListInferencer } from "./list";
-export { CreateInferencer as AntdCreateInferencer } from "./create";
+export {
+    ShowInferencer as AntdShowInferencer,
+    renderer as AntdShowRenderer,
+} from "./show";
+export {
+    EditInferencer as AntdEditInferencer,
+    renderer as AntdEditRenderer,
+} from "./edit";
+export {
+    ListInferencer as AntdListInferencer,
+    renderer as AntdListRenderer,
+} from "./list";
+export {
+    CreateInferencer as AntdCreateInferencer,
+    renderer as AntdCreateRenderer,
+} from "./create";
 export * from "../../types";

--- a/packages/inferencer/src/inferencers/antd/list.tsx
+++ b/packages/inferencer/src/inferencers/antd/list.tsx
@@ -22,6 +22,10 @@ import {
     RendererContext,
 } from "@/types";
 
+/**
+ * a renderer function for list page in Ant Design
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/antd/show.tsx
+++ b/packages/inferencer/src/inferencers/antd/show.tsx
@@ -23,6 +23,10 @@ import {
     RendererContext,
 } from "@/types";
 
+/**
+ * a renderer function for show page in Ant Design
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/chakra-ui/create.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/create.tsx
@@ -28,6 +28,10 @@ import {
     RendererContext,
 } from "@/types";
 
+/**
+ * a renderer function for create page in Chakra UI
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/chakra-ui/edit.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/edit.tsx
@@ -28,6 +28,10 @@ import {
     RendererContext,
 } from "@/types";
 
+/**
+ * a renderer function for edit page in Chakra UI
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/chakra-ui/index.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/index.tsx
@@ -29,8 +29,20 @@ const ChakraUIInferencer: React.FC<InferencerComponentProps> = ({
 };
 
 export { ChakraUIInferencer };
-export { ListInferencer as ChakraUIListInferencer } from "./list";
-export { ShowInferencer as ChakraUIShowInferencer } from "./show";
-export { EditInferencer as ChakraUIEditInferencer } from "./edit";
-export { CreateInferencer as ChakraUICreateInferencer } from "./create";
+export {
+    ListInferencer as ChakraUIListInferencer,
+    renderer as ChakraUIListRenderer,
+} from "./list";
+export {
+    ShowInferencer as ChakraUIShowInferencer,
+    renderer as ChakraUIShowRenderer,
+} from "./show";
+export {
+    EditInferencer as ChakraUIEditInferencer,
+    renderer as ChakraUIEditRenderer,
+} from "./edit";
+export {
+    CreateInferencer as ChakraUICreateInferencer,
+    renderer as ChakraUICreateRenderer,
+} from "./create";
 export * from "../../types";

--- a/packages/inferencer/src/inferencers/chakra-ui/list.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/list.tsx
@@ -32,6 +32,10 @@ const getAccessorKey = (field: InferField) => {
         : `accessorKey: "${field.key}"`;
 };
 
+/**
+ * a renderer function for list page in Chakra UI
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/chakra-ui/show.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/show.tsx
@@ -21,6 +21,10 @@ import {
     RendererContext,
 } from "@/types";
 
+/**
+ * a renderer function for show page in Chakra UI
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/index.test.tsx.snap
@@ -93,10 +93,10 @@ exports[`ChakraUIInferencer should match the snapshot 1`] = `
                 orange
               </td>
               <td>
-                4/2/2022, 4:25:44 AM
+                4/2/2022, 4:25:44 AM
               </td>
               <td>
-                8/10/2021, 8:07:39 AM
+                8/10/2021, 8:07:39 AM
               </td>
               <td>
                 <ul>
@@ -148,10 +148,10 @@ exports[`ChakraUIInferencer should match the snapshot 1`] = `
                 lime
               </td>
               <td>
-                9/24/2022, 8:33:21 AM
+                9/24/2022, 8:33:21 AM
               </td>
               <td>
-                9/1/2021, 3:33:43 AM
+                9/1/2021, 3:33:43 AM
               </td>
               <td>
                 <ul>
@@ -1158,7 +1158,7 @@ exports[`ChakraUIInferencer should match the snapshot 4`] = `
             Created At
           </h5>
           <div>
-            4/2/2022, 4:25:44 AM
+            4/2/2022, 4:25:44 AM
           </div>
         </div>
         <div
@@ -1168,7 +1168,7 @@ exports[`ChakraUIInferencer should match the snapshot 4`] = `
             Published At
           </h5>
           <div>
-            8/10/2021, 8:07:39 AM
+            8/10/2021, 8:07:39 AM
           </div>
         </div>
         <div

--- a/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/index.test.tsx.snap
@@ -93,10 +93,10 @@ exports[`ChakraUIInferencer should match the snapshot 1`] = `
                 orange
               </td>
               <td>
-                4/2/2022, 4:25:44 AM
+                4/2/2022, 4:25:44 AM
               </td>
               <td>
-                8/10/2021, 8:07:39 AM
+                8/10/2021, 8:07:39 AM
               </td>
               <td>
                 <ul>
@@ -148,10 +148,10 @@ exports[`ChakraUIInferencer should match the snapshot 1`] = `
                 lime
               </td>
               <td>
-                9/24/2022, 8:33:21 AM
+                9/24/2022, 8:33:21 AM
               </td>
               <td>
-                9/1/2021, 3:33:43 AM
+                9/1/2021, 3:33:43 AM
               </td>
               <td>
                 <ul>
@@ -1158,7 +1158,7 @@ exports[`ChakraUIInferencer should match the snapshot 4`] = `
             Created At
           </h5>
           <div>
-            4/2/2022, 4:25:44 AM
+            4/2/2022, 4:25:44 AM
           </div>
         </div>
         <div
@@ -1168,7 +1168,7 @@ exports[`ChakraUIInferencer should match the snapshot 4`] = `
             Published At
           </h5>
           <div>
-            8/10/2021, 8:07:39 AM
+            8/10/2021, 8:07:39 AM
           </div>
         </div>
         <div

--- a/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/list.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/list.test.tsx.snap
@@ -93,10 +93,10 @@ exports[`HeadlessListInferencer should match the snapshot 1`] = `
                 orange
               </td>
               <td>
-                4/2/2022, 4:25:44 AM
+                4/2/2022, 4:25:44 AM
               </td>
               <td>
-                8/10/2021, 8:07:39 AM
+                8/10/2021, 8:07:39 AM
               </td>
               <td>
                 <ul>
@@ -148,10 +148,10 @@ exports[`HeadlessListInferencer should match the snapshot 1`] = `
                 lime
               </td>
               <td>
-                9/24/2022, 8:33:21 AM
+                9/24/2022, 8:33:21 AM
               </td>
               <td>
-                9/1/2021, 3:33:43 AM
+                9/1/2021, 3:33:43 AM
               </td>
               <td>
                 <ul>

--- a/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/list.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/list.test.tsx.snap
@@ -93,10 +93,10 @@ exports[`HeadlessListInferencer should match the snapshot 1`] = `
                 orange
               </td>
               <td>
-                4/2/2022, 4:25:44 AM
+                4/2/2022, 4:25:44 AM
               </td>
               <td>
-                8/10/2021, 8:07:39 AM
+                8/10/2021, 8:07:39 AM
               </td>
               <td>
                 <ul>
@@ -148,10 +148,10 @@ exports[`HeadlessListInferencer should match the snapshot 1`] = `
                 lime
               </td>
               <td>
-                9/24/2022, 8:33:21 AM
+                9/24/2022, 8:33:21 AM
               </td>
               <td>
-                9/1/2021, 3:33:43 AM
+                9/1/2021, 3:33:43 AM
               </td>
               <td>
                 <ul>

--- a/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/show.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/show.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`HeadlessShowInferencer should match the snapshot 1`] = `
             Created At
           </h5>
           <div>
-            4/2/2022, 4:25:44 AM
+            4/2/2022, 4:25:44 AM
           </div>
         </div>
         <div
@@ -128,7 +128,7 @@ exports[`HeadlessShowInferencer should match the snapshot 1`] = `
             Published At
           </h5>
           <div>
-            8/10/2021, 8:07:39 AM
+            8/10/2021, 8:07:39 AM
           </div>
         </div>
         <div

--- a/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/show.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/show.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`HeadlessShowInferencer should match the snapshot 1`] = `
             Created At
           </h5>
           <div>
-            4/2/2022, 4:25:44 AM
+            4/2/2022, 4:25:44 AM
           </div>
         </div>
         <div
@@ -128,7 +128,7 @@ exports[`HeadlessShowInferencer should match the snapshot 1`] = `
             Published At
           </h5>
           <div>
-            8/10/2021, 8:07:39 AM
+            8/10/2021, 8:07:39 AM
           </div>
         </div>
         <div

--- a/packages/inferencer/src/inferencers/headless/create.tsx
+++ b/packages/inferencer/src/inferencers/headless/create.tsx
@@ -28,6 +28,10 @@ import {
     RendererContext,
 } from "@/types";
 
+/**
+ * a renderer function for create page with unstyled html elements
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/headless/edit.tsx
+++ b/packages/inferencer/src/inferencers/headless/edit.tsx
@@ -28,6 +28,10 @@ import {
     RendererContext,
 } from "@/types";
 
+/**
+ * a renderer function for edit page with unstyled html elements
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/headless/index.tsx
+++ b/packages/inferencer/src/inferencers/headless/index.tsx
@@ -29,8 +29,20 @@ const HeadlessInferencer: React.FC<InferencerComponentProps> = ({
 };
 
 export { HeadlessInferencer };
-export { ListInferencer as HeadlessListInferencer } from "./list";
-export { ShowInferencer as HeadlessShowInferencer } from "./show";
-export { EditInferencer as HeadlessEditInferencer } from "./edit";
-export { CreateInferencer as HeadlessCreateInferencer } from "./create";
+export {
+    ListInferencer as HeadlessListInferencer,
+    renderer as HeadlessListRenderer,
+} from "./list";
+export {
+    ShowInferencer as HeadlessShowInferencer,
+    renderer as HeadlessShowRenderer,
+} from "./show";
+export {
+    EditInferencer as HeadlessEditInferencer,
+    renderer as HeadlessEditRenderer,
+} from "./edit";
+export {
+    CreateInferencer as HeadlessCreateInferencer,
+    renderer as HeadlessCreateRenderer,
+} from "./create";
 export * from "../../types";

--- a/packages/inferencer/src/inferencers/headless/list.tsx
+++ b/packages/inferencer/src/inferencers/headless/list.tsx
@@ -31,6 +31,10 @@ const getAccessorKey = (field: InferField) => {
         : `accessorKey: "${field.key}"`;
 };
 
+/**
+ * a renderer function for list page with unstyled html elements
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/headless/show.tsx
+++ b/packages/inferencer/src/inferencers/headless/show.tsx
@@ -22,6 +22,10 @@ import {
     RendererContext,
 } from "@/types";
 
+/**
+ * a renderer function for show page with unstyled html elements
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/mantine/create.tsx
+++ b/packages/inferencer/src/inferencers/mantine/create.tsx
@@ -23,6 +23,10 @@ import {
     RendererContext,
 } from "@/types";
 
+/**
+ * a renderer function for create page in Mantine
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/mantine/edit.tsx
+++ b/packages/inferencer/src/inferencers/mantine/edit.tsx
@@ -24,6 +24,10 @@ import {
     RendererContext,
 } from "@/types";
 
+/**
+ * a renderer function for edit page in Mantine
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/mantine/index.tsx
+++ b/packages/inferencer/src/inferencers/mantine/index.tsx
@@ -29,8 +29,20 @@ const MantineInferencer: React.FC<InferencerComponentProps> = ({
 };
 
 export { MantineInferencer };
-export { ShowInferencer as MantineShowInferencer } from "./show";
-export { EditInferencer as MantineEditInferencer } from "./edit";
-export { ListInferencer as MantineListInferencer } from "./list";
-export { CreateInferencer as MantineCreateInferencer } from "./create";
+export {
+    ShowInferencer as MantineShowInferencer,
+    renderer as MantineShowRenderer,
+} from "./show";
+export {
+    EditInferencer as MantineEditInferencer,
+    renderer as MantineEditRenderer,
+} from "./edit";
+export {
+    ListInferencer as MantineListInferencer,
+    renderer as MantineListRenderer,
+} from "./list";
+export {
+    CreateInferencer as MantineCreateInferencer,
+    renderer as MantineCreateRenderer,
+} from "./create";
 export * from "../../types";

--- a/packages/inferencer/src/inferencers/mantine/list.tsx
+++ b/packages/inferencer/src/inferencers/mantine/list.tsx
@@ -31,6 +31,10 @@ const getAccessorKey = (field: InferField) => {
         : `accessorKey: "${field.key}"`;
 };
 
+/**
+ * a renderer function for list page in Mantine
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/mantine/show.tsx
+++ b/packages/inferencer/src/inferencers/mantine/show.tsx
@@ -22,6 +22,10 @@ import {
     RendererContext,
 } from "@/types";
 
+/**
+ * a renderer function for show page in Mantine
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
@@ -407,6 +407,7 @@ exports[`MuiInferencer should match the snapshot 1`] = `
                       >
                         <div
                           class="MuiDataGrid-cellContent"
+                          title="11"
                         >
                           11
                         </div>
@@ -423,6 +424,7 @@ exports[`MuiInferencer should match the snapshot 1`] = `
                       >
                         <div
                           class="MuiDataGrid-cellContent"
+                          title="Nobis exercitationem officia quia est."
                         >
                           Nobis exercitationem officia quia est.
                         </div>
@@ -439,6 +441,7 @@ exports[`MuiInferencer should match the snapshot 1`] = `
                       >
                         <div
                           class="MuiDataGrid-cellContent"
+                          title="provident-culpa-facere"
                         >
                           provident-culpa-facere
                         </div>
@@ -465,6 +468,7 @@ exports[`MuiInferencer should match the snapshot 1`] = `
                       >
                         <div
                           class="MuiDataGrid-cellContent"
+                          title="21"
                         >
                           21
                         </div>
@@ -481,6 +485,7 @@ exports[`MuiInferencer should match the snapshot 1`] = `
                       >
                         <div
                           class="MuiDataGrid-cellContent"
+                          title="Eaque in nesciunt."
                         >
                           Eaque in nesciunt.
                         </div>
@@ -497,6 +502,7 @@ exports[`MuiInferencer should match the snapshot 1`] = `
                       >
                         <div
                           class="MuiDataGrid-cellContent"
+                          title="quod-quos-commodi"
                         >
                           quod-quos-commodi
                         </div>

--- a/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/list.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/list.test.tsx.snap
@@ -401,6 +401,7 @@ exports[`MuiListInferencer should match the snapshot 1`] = `
                       >
                         <div
                           class="MuiDataGrid-cellContent"
+                          title="11"
                         >
                           11
                         </div>
@@ -417,6 +418,7 @@ exports[`MuiListInferencer should match the snapshot 1`] = `
                       >
                         <div
                           class="MuiDataGrid-cellContent"
+                          title="Nobis exercitationem officia quia est."
                         >
                           Nobis exercitationem officia quia est.
                         </div>
@@ -433,6 +435,7 @@ exports[`MuiListInferencer should match the snapshot 1`] = `
                       >
                         <div
                           class="MuiDataGrid-cellContent"
+                          title="provident-culpa-facere"
                         >
                           provident-culpa-facere
                         </div>
@@ -459,6 +462,7 @@ exports[`MuiListInferencer should match the snapshot 1`] = `
                       >
                         <div
                           class="MuiDataGrid-cellContent"
+                          title="21"
                         >
                           21
                         </div>
@@ -475,6 +479,7 @@ exports[`MuiListInferencer should match the snapshot 1`] = `
                       >
                         <div
                           class="MuiDataGrid-cellContent"
+                          title="Eaque in nesciunt."
                         >
                           Eaque in nesciunt.
                         </div>
@@ -491,6 +496,7 @@ exports[`MuiListInferencer should match the snapshot 1`] = `
                       >
                         <div
                           class="MuiDataGrid-cellContent"
+                          title="quod-quos-commodi"
                         >
                           quod-quos-commodi
                         </div>

--- a/packages/inferencer/src/inferencers/mui/create.tsx
+++ b/packages/inferencer/src/inferencers/mui/create.tsx
@@ -25,6 +25,10 @@ import {
     RendererContext,
 } from "@/types";
 
+/**
+ * a renderer function for create page in Material UI
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/mui/edit.tsx
+++ b/packages/inferencer/src/inferencers/mui/edit.tsx
@@ -25,6 +25,10 @@ import {
     RendererContext,
 } from "@/types";
 
+/**
+ * a renderer function for edit page in Material UI
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/mui/index.tsx
+++ b/packages/inferencer/src/inferencers/mui/index.tsx
@@ -29,8 +29,20 @@ const MuiInferencer: React.FC<InferencerComponentProps> = ({
 };
 
 export { MuiInferencer };
-export { ShowInferencer as MuiShowInferencer } from "./show";
-export { EditInferencer as MuiEditInferencer } from "./edit";
-export { ListInferencer as MuiListInferencer } from "./list";
-export { CreateInferencer as MuiCreateInferencer } from "./create";
+export {
+    ShowInferencer as MuiShowInferencer,
+    renderer as MuiShowRenderer,
+} from "./show";
+export {
+    EditInferencer as MuiEditInferencer,
+    renderer as MuiEditRenderer,
+} from "./edit";
+export {
+    ListInferencer as MuiListInferencer,
+    renderer as MuiListRenderer,
+} from "./list";
+export {
+    CreateInferencer as MuiCreateInferencer,
+    renderer as MuiCreateRenderer,
+} from "./create";
 export * from "../../types";

--- a/packages/inferencer/src/inferencers/mui/list.tsx
+++ b/packages/inferencer/src/inferencers/mui/list.tsx
@@ -23,6 +23,10 @@ import {
     RendererContext,
 } from "@/types";
 
+/**
+ * a renderer function for list page in Material UI
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/inferencers/mui/show.tsx
+++ b/packages/inferencer/src/inferencers/mui/show.tsx
@@ -22,6 +22,10 @@ import {
     RendererContext,
 } from "@/types";
 
+/**
+ * a renderer function for show page in Material UI
+ * @internal used internally from inferencer components
+ */
 export const renderer = ({
     resource,
     fields,

--- a/packages/inferencer/src/utilities/accessor/index.ts
+++ b/packages/inferencer/src/utilities/accessor/index.ts
@@ -1,3 +1,5 @@
+import { InferField } from "@/types";
+
 const dotAccessableRegex = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
 
 export const shouldDotAccess = (property: string) => {
@@ -76,4 +78,12 @@ export const dotAccessor = (
     }
 
     return str;
+};
+
+export const getAccessorKey = (field: InferField) => {
+    return Array.isArray(field.accessor) || field.multiple
+        ? `accessorKey: "${field.key}"`
+        : field.accessor
+        ? `accessorKey: "${dotAccessor(field.key, undefined, field.accessor)}"`
+        : `accessorKey: "${field.key}"`;
 };

--- a/packages/inferencer/src/utilities/index.ts
+++ b/packages/inferencer/src/utilities/index.ts
@@ -23,7 +23,12 @@ export { jsx } from "./jsx";
 export { prepareLiveCode } from "./prepare-live-code";
 export { removeHiddenCode } from "./remove-hidden-code";
 
-export { accessor, dotAccessor } from "./accessor";
+export {
+    accessor,
+    dotAccessor,
+    shouldDotAccess,
+    getAccessorKey,
+} from "./accessor";
 export { printImports } from "./print-imports";
 
 export { toSingular } from "./to-singular";


### PR DESCRIPTION
Exported utility functions used in inferencers to let users use it when they're using `createInferencer` function to create their own inferencer components.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
