### PR TITLE
fix: `@pankod/refine-mui` multi level `Sider` menu

### DIFF
--- a/.changeset/violet-months-buy.md
+++ b/.changeset/violet-months-buy.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": patch
+---
+
+Fix multi-level Sider menu. (#3505)

--- a/packages/mui/src/components/layout/sider/index.tsx
+++ b/packages/mui/src/components/layout/sider/index.tsx
@@ -58,8 +58,12 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({ render }) => {
     const [open, setOpen] = useState<{ [k: string]: any }>({});
 
     React.useEffect(() => {
-        setOpen((previousOpen) => {
-            const previousOpenKeys: string[] = Object.keys(previousOpen);
+        setOpen((previous) => {
+            const previousKeys: string[] = Object.keys(previous);
+            const previousOpenKeys = previousKeys.filter(
+                (key) => previous[key],
+            );
+
             const uniqueKeys = new Set([
                 ...previousOpenKeys,
                 ...defaultOpenKeys,


### PR DESCRIPTION
fix: `@pankod/refine-mui` multi level `Sider` menu. 

Closes #3505