### PR TITLE
typo: add type to toast message

### DIFF
--- a/documentation/docs/api-reference/core/providers/notification-provider.md
+++ b/documentation/docs/api-reference/core/providers/notification-provider.md
@@ -332,6 +332,7 @@ import { useNotification } from "@pankod/refine-core";
 const { open } = useNotification();
 
 open?.({
+    type: "success",
     message: "Hey",
     description: "I <3 Refine",
     key: "unique-id",


### PR DESCRIPTION
Fixing typo: "type" parameter not defined in example message.