### PR TITLE
fix : typo in graphql index.ts

### DIFF
--- a/packages/graphql/src/dataProvider/index.ts
+++ b/packages/graphql/src/dataProvider/index.ts
@@ -9,7 +9,7 @@ import * as gql from "gql-query-builder";
 import pluralize from "pluralize";
 import camelCase from "camelcase";
 
-export const genereteSort = (sort?: CrudSorting) => {
+export const generateSort = (sort?: CrudSorting) => {
     if (sort && sort.length > 0) {
         const sortQuery = sort.map((i) => {
             return `${i.field}:${i.order}`;


### PR DESCRIPTION
Fixing a typo from `generete` to `generate`. As it's an exported function I don't know the impacted code. Regards.

