### PR TITLE
feat(v4): add pick not deprecated

### DIFF
--- a/.changeset/friendly-actors-hear.md
+++ b/.changeset/friendly-actors-hear.md
@@ -1,0 +1,12 @@
+---
+"@pankod/refine-core": minor
+---
+
+added: A helper function for picking a not undefined first value from an array.
+
+```ts
+const sorter = undefined;
+const sorters = [{ id: 1 }];
+
+const value = pickNotDeprecated(sorter, sorters) ?? 10; // [{ id: 1 }]
+```

--- a/packages/core/src/definitions/helpers/index.ts
+++ b/packages/core/src/definitions/helpers/index.ts
@@ -16,3 +16,4 @@ export {
     getNextPageParam,
     getPreviousPageParam,
 } from "./useInfinitePagination";
+export { pickNotDeprecated } from "./pickNotDeprecated";

--- a/packages/core/src/definitions/helpers/pickNotDeprecated/index.spec.ts
+++ b/packages/core/src/definitions/helpers/pickNotDeprecated/index.spec.ts
@@ -1,0 +1,28 @@
+import { pickNotDeprecated } from ".";
+
+describe("pickNotDeprecated", () => {
+    test("should returns a first value that is not undefined", () => {
+        const testCases = [
+            {
+                args: [undefined, 1, undefined],
+                expected: 1,
+            },
+            {
+                args: [undefined, 0, true],
+                expected: 0,
+            },
+            {
+                args: [false, {}],
+                expected: false,
+            },
+            {
+                args: [{ id: 1 }, undefined],
+                expected: { id: 1 },
+            },
+        ];
+
+        testCases.forEach(({ args, expected }) => {
+            expect(pickNotDeprecated(...args)).toEqual(expected);
+        });
+    });
+});

--- a/packages/core/src/definitions/helpers/pickNotDeprecated/index.ts
+++ b/packages/core/src/definitions/helpers/pickNotDeprecated/index.ts
@@ -1,5 +1,6 @@
 /*
  * Returns first value that is not undefined.
+ * @internal This is an internal helper function. Please do not use externally.
  */
 export const pickNotDeprecated = <T extends unknown[]>(
     ...args: T

--- a/packages/core/src/definitions/helpers/pickNotDeprecated/index.ts
+++ b/packages/core/src/definitions/helpers/pickNotDeprecated/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Returns first value that is not undefined.
+ */
+export const pickNotDeprecated = <T extends unknown[]>(
+    ...args: T
+): T[never] => {
+    return args.find((arg) => typeof arg !== "undefined");
+};

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -109,5 +109,6 @@ export {
     userFriendlyResourceName,
     getNextPageParam,
     getPreviousPageParam,
+    pickNotDeprecated,
 } from "./definitions/helpers";
 export { file2Base64 } from "./definitions/upload";


### PR DESCRIPTION
Created a helper function for picking not deprecated values.

```ts
const sorter = undefined;
const sorters = [{ id: 1 }];

const value = pickNotDeprecated(sorter, sorters) ?? [{ id: 5 }]; // [{ id: 1 }]
```

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
