### PR TITLE
fix(demo-sidebar): handler prop changed to extra

### DIFF
--- a/.changeset/tidy-turkeys-float.md
+++ b/.changeset/tidy-turkeys-float.md
@@ -1,5 +1,5 @@
 ---
-"@pankod/refine-demo-sidebar": major
+"@pankod/refine-demo-sidebar": patch
 ---
 
 Fixed: antd `<Drawer>` `handler` prop changed to `extra`.

--- a/.changeset/tidy-turkeys-float.md
+++ b/.changeset/tidy-turkeys-float.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-demo-sidebar": major
+---
+
+Fixed: antd `<Drawer>` `handler` prop changed to `extra`.

--- a/examples/blog-refineflix/src/pages/admin/movies/create.tsx
+++ b/examples/blog-refineflix/src/pages/admin/movies/create.tsx
@@ -74,7 +74,7 @@ export const AdminMovieCreate: React.FC<IResourceComponentsProps> = () => {
                                     const xhr = new XMLHttpRequest();
                                     onSuccess &&
                                         onSuccess(
-                                            { url: data?.publicURL },
+                                            { url: data?.publicUrl },
                                             xhr,
                                         );
                                 } catch (error) {

--- a/examples/blog-refineflix/src/pages/admin/movies/edit.tsx
+++ b/examples/blog-refineflix/src/pages/admin/movies/edit.tsx
@@ -79,7 +79,7 @@ export const AdminMovieEdit: React.FC<IResourceComponentsProps> = () => {
                                     const xhr = new XMLHttpRequest();
                                     onSuccess &&
                                         onSuccess(
-                                            { url: data?.publicURL },
+                                            { url: data?.publicUrl },
                                             xhr,
                                         );
                                 } catch (error) {

--- a/packages/demo-sidebar/src/components/DemoSidebar/index.tsx
+++ b/packages/demo-sidebar/src/components/DemoSidebar/index.tsx
@@ -31,7 +31,7 @@ export const DemoSidebar: React.FC<DemoSidebarProps> = ({
             width={300}
             onClose={() => setShow(false)}
             placement="right"
-            handler={
+            extra={
                 <div
                     style={handlerStyles}
                     className="ant-drawer-handle"


### PR DESCRIPTION
Antd [<Drawer>](https://ant.design/components/drawer) `handler` prop changed to extra

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
