### PR TITLE
fix(inferencer-mui): syntax error at relation data fields in data grid

### DIFF
--- a/.changeset/small-dolphins-unite.md
+++ b/.changeset/small-dolphins-unite.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-inferencer": patch
+---
+
+Fixed the syntax error at `MuiListInferencer` in `@pankod/refine-inferencer/mui`

--- a/packages/inferencer/src/inferencers/mui/list.tsx
+++ b/packages/inferencer/src/inferencers/mui/list.tsx
@@ -606,7 +606,7 @@ export const renderer = ({
             if (!field.multiple && Array.isArray(field.accessor)) {
                 renderCell = `
                 renderCell: function render({ row }) {
-                    return 
+                    return (
                         <>{${accessor("row", field.key, field.accessor)}}</>
                     );
                 }


### PR DESCRIPTION
We had a syntax error at relational data fields with multiple values and an accessor.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
