### PR TITLE
fix(antd-mantine): `disabled` state in `DeleteButton`s

### DIFF
--- a/.changeset/popular-toys-run.md
+++ b/.changeset/popular-toys-run.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mantine": patch
+---
+
+Fixed the issue with `disabled` state in `DeleteButton`'s still opening the popover.

--- a/.changeset/strong-seahorses-kiss.md
+++ b/.changeset/strong-seahorses-kiss.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": patch
+---
+
+Fixed the issue with `disabled` state in `DeleteButton`'s still opening the popover.

--- a/packages/antd/src/components/buttons/delete/index.tsx
+++ b/packages/antd/src/components/buttons/delete/index.tsx
@@ -99,7 +99,11 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
                     },
                 );
             }}
-            disabled={data?.can === false}
+            disabled={
+                typeof rest?.disabled !== "undefined"
+                    ? rest.disabled
+                    : data?.can === false
+            }
         >
             <Button
                 danger

--- a/packages/mantine/src/components/buttons/delete/index.tsx
+++ b/packages/mantine/src/components/buttons/delete/index.tsx
@@ -92,7 +92,17 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     }
 
     return (
-        <Popover opened={opened} onChange={setOpened} withArrow withinPortal>
+        <Popover
+            opened={opened}
+            onChange={setOpened}
+            withArrow
+            withinPortal
+            disabled={
+                typeof rest?.disabled !== "undefined"
+                    ? rest.disabled
+                    : data?.can === false
+            }
+        >
             <Popover.Target>
                 {hideText ? (
                     <ActionIcon


### PR DESCRIPTION
Fixed the `disabled` state not reflected in popovers in `DeleteButton` components in `@pankod/refine-antd` and `@pankod/refine-mantine` packages.

### Closing issues

Resolves #3605 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
