### PR TITLE
fix: add `next.config.js` file on nextjs examples

### DIFF
--- a/examples/with-nextjs/next.config.js
+++ b/examples/with-nextjs/next.config.js
@@ -1,9 +1,5 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-    reactStrictMode: true,
-    swcMinify: true,
+module.exports = {
     experimental: {
-        appDir: true,
         newNextLinkBehavior: true,
     },
     transpilePackages: [
@@ -18,5 +14,3 @@ const nextConfig = {
         "rc-picker",
     ],
 };
-
-module.exports = nextConfig;


### PR DESCRIPTION
Created `next.config.js` on nextjs examples.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
