### PR TITLE
feat(v4-core): add "expects resolved promise"  warning to `authProvider`

### DIFF
--- a/packages/core/src/contexts/auth/index.tsx
+++ b/packages/core/src/contexts/auth/index.tsx
@@ -112,6 +112,10 @@ export const AuthBindingsContextProvider: React.FC<
 
             return Promise.resolve(result);
         } catch (error) {
+            console.warn(
+                "Unhandled Error in login: refine always expects a resolved promise.",
+                error,
+            );
             return Promise.reject(error);
         }
     };
@@ -124,6 +128,10 @@ export const AuthBindingsContextProvider: React.FC<
 
             return Promise.resolve(result);
         } catch (error) {
+            console.warn(
+                "Unhandled Error in register: refine always expects a resolved promise.",
+                error,
+            );
             return Promise.reject(error);
         }
     };
@@ -136,6 +144,10 @@ export const AuthBindingsContextProvider: React.FC<
 
             return Promise.resolve(result);
         } catch (error) {
+            console.warn(
+                "Unhandled Error in logout: refine always expects a resolved promise.",
+                error,
+            );
             return Promise.reject(error);
         }
     };
@@ -146,6 +158,37 @@ export const AuthBindingsContextProvider: React.FC<
 
             return Promise.resolve(result);
         } catch (error) {
+            console.warn(
+                "Unhandled Error in check: refine always expects a resolved promise.",
+                error,
+            );
+            return Promise.reject(error);
+        }
+    };
+
+    const handleForgotPassword = async (params: unknown) => {
+        try {
+            const result = await authBindings.forgotPassword?.(params);
+
+            return Promise.resolve(result);
+        } catch (error) {
+            console.warn(
+                "Unhandled Error in forgotPassword: refine always expects a resolved promise.",
+                error,
+            );
+            return Promise.reject(error);
+        }
+    };
+
+    const handleUpdatePassword = async (params: unknown) => {
+        try {
+            const result = await authBindings.updatePassword?.(params);
+            return Promise.resolve(result);
+        } catch (error) {
+            console.warn(
+                "Unhandled Error in updatePassword: refine always expects a resolved promise.",
+                error,
+            );
             return Promise.reject(error);
         }
     };
@@ -158,6 +201,10 @@ export const AuthBindingsContextProvider: React.FC<
                 logout: handleLogout as IAuthBindingsContext["logout"],
                 check: handleCheck as IAuthBindingsContext["check"],
                 register: handleRegister as IAuthBindingsContext["register"],
+                forgotPassword:
+                    handleForgotPassword as IAuthBindingsContext["forgotPassword"],
+                updatePassword:
+                    handleUpdatePassword as IAuthBindingsContext["updatePassword"],
                 isProvided,
             }}
         >


### PR DESCRIPTION
If auth provider methods return a rejected promise, auth hook function logic does not work.
A console warning has been added to inform the user.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
