### PR TITLE
fix(create-refine-app): fix hard coded `--project` command

### DIFF
--- a/packages/create-refine-app/src/index.ts
+++ b/packages/create-refine-app/src/index.ts
@@ -61,7 +61,9 @@ const bootstrap = () => {
                     superplateExecutable,
                     [
                         ...command.args,
-                        "--project=refine",
+                        command.getOptionValue("project")
+                            ? "--project=" + command.getOptionValue("project")
+                            : "--project=refine",
                         "--download=zip",
                         command.getOptionValue("source")
                             ? "--source=" + command.getOptionValue("source")


### PR DESCRIPTION
Fixed hard coded `--project` command on `create-refine-app`.