### PR TITLE
feat(v4): `parseTableParams` helper in SSR routers

### DIFF
--- a/.changeset/big-dingos-fix.md
+++ b/.changeset/big-dingos-fix.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-remix-router": minor
+---
+
+`parseTableParams` helper is added to let users parse the query params in loaders to persist `syncWithLocation` feature in tables.

--- a/.changeset/slimy-planets-walk.md
+++ b/.changeset/slimy-planets-walk.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-nextjs-router": minor
+---
+
+`parseTableParams` helper is added to let users parse the query params in SSR methods to persist `syncWithLocation` feature in tables.

--- a/packages/nextjs-router/src/app/index.ts
+++ b/packages/nextjs-router/src/app/index.ts
@@ -4,3 +4,5 @@
 export { routerBindings as default, stringifyConfig } from "./bindings";
 export { RefineRoutes } from "../pages/refine-routes";
 export { NavigateToResource } from "./navigate-to-resource";
+export { parseTableParams } from "../common/parse-table-params";
+export { paramsFromCurrentPath } from "../common/params-from-current-path";

--- a/packages/nextjs-router/src/common/parse-table-params.ts
+++ b/packages/nextjs-router/src/common/parse-table-params.ts
@@ -1,0 +1,19 @@
+import { parse } from "qs";
+import type { ParsedParams } from "@pankod/refine-core";
+
+export const parseTableParams = (search: string) => {
+    const parsed: ParsedParams = parse(search, { ignoreQueryPrefix: true });
+
+    const tableReady = {
+        ...parsed,
+        pagination: {
+            current: parsed.current,
+            pageSize: parsed.pageSize,
+        },
+    };
+
+    delete tableReady.current;
+    delete tableReady.pageSize;
+
+    return tableReady;
+};

--- a/packages/nextjs-router/src/pages/index.ts
+++ b/packages/nextjs-router/src/pages/index.ts
@@ -2,3 +2,5 @@ export { routerBindings as default, stringifyConfig } from "./bindings";
 export { RefineRoutes } from "./refine-routes";
 export { NavigateToResource } from "./navigate-to-resource";
 export { UnsavedChangesNotifier } from "./unsaved-changes-notifier";
+export { parseTableParams } from "../common/parse-table-params";
+export { paramsFromCurrentPath } from "../common/params-from-current-path";

--- a/packages/remix/src/index.ts
+++ b/packages/remix/src/index.ts
@@ -2,3 +2,5 @@ export { routerBindings as default, stringifyConfig } from "./bindings";
 export { RefineRoutes } from "./refine-routes";
 export { UnsavedChangesNotifier } from "./unsaved-changes-notifier";
 export { NavigateToResource } from "./navigate-to-resource";
+export { parseTableParams } from "./parse-table-params";
+export { paramsFromCurrentPath } from "./params-from-current-path";

--- a/packages/remix/src/parse-table-params.ts
+++ b/packages/remix/src/parse-table-params.ts
@@ -1,0 +1,19 @@
+import { parse } from "qs";
+import type { ParsedParams } from "@pankod/refine-core";
+
+export const parseTableParams = (search: string) => {
+    const parsed: ParsedParams = parse(search, { ignoreQueryPrefix: true });
+
+    const tableReady = {
+        ...parsed,
+        pagination: {
+            current: parsed.current,
+            pageSize: parsed.pageSize,
+        },
+    };
+
+    delete tableReady.current;
+    delete tableReady.pageSize;
+
+    return tableReady;
+};


### PR DESCRIPTION
Added `parseTableParams` helper export to let users handle persisting the `syncWithLocation` feature in tables.

- In Remix, users can use it in `loader`s.
- In Next.js, users can use it in `getServerSideProps` functions.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
