### PR TITLE
refactor(v4): remove unused `keepParentPrefix` meta

### DIFF
--- a/packages/core/src/interfaces/bindings/resource.ts
+++ b/packages/core/src/interfaces/bindings/resource.ts
@@ -62,11 +62,6 @@ export interface KnownResourceMeta {
      */
     parent?: string;
     /**
-     * Whether to keep parent prefixes applied to the resource.
-     * @default true
-     */
-    keepParentPrefix?: boolean;
-    /**
      * To determine if the resource has ability to delete or not.
      */
     canDelete?: boolean;


### PR DESCRIPTION
Removed the `keepParentPrefix` from the interface of the resource `meta`. It was not used in the app.

No changesets are required because it wasn't released already.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
