### PR TITLE
fix(core):`listUrl` returns show url string

### DIFF
--- a/packages/core/src/hooks/navigation/index.ts
+++ b/packages/core/src/hooks/navigation/index.ts
@@ -275,17 +275,17 @@ export const useNavigation = () => {
                     ? pickResource(resource, resources) ?? { name: resource }
                     : resource;
 
-            const showActionRoute = getActionRoutesFromResource(
+            const listActionRoute = getActionRoutesFromResource(
                 resourceItem,
                 resources,
-            ).find((r) => r.action === "show")?.route;
+            ).find((r) => r.action === "list")?.route;
 
-            if (!showActionRoute) {
+            if (!listActionRoute) {
                 return "";
             }
 
             return go({
-                to: composeRoute(showActionRoute, parsed, meta),
+                to: composeRoute(listActionRoute, parsed, meta),
                 type: "path",
             }) as string;
         }


### PR DESCRIPTION
fixed: The`listUrl` function had a typo. "show" was returning URL instead of "list"

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
