### PR TITLE
feat(v4-router): `<CatchAllNavigate />`

### DIFF
--- a/packages/react-router-v6/src/catch-all-navigate.tsx
+++ b/packages/react-router-v6/src/catch-all-navigate.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { Navigate, useLocation } from "react-router-dom";
+
+/**
+ * A component that will navigate to the given path with `to` query parameter included with the current location.
+ */
+export const CatchAllNavigate: React.FC<{ to: string }> = ({ to }) => {
+    const { pathname, search } = useLocation();
+
+    return <Navigate to={`${to}?to=${pathname}${search}`} />;
+};

--- a/packages/react-router-v6/src/index.ts
+++ b/packages/react-router-v6/src/index.ts
@@ -2,3 +2,4 @@ export { routerBindings as default, stringifyConfig } from "./bindings";
 export { RefineRoutes } from "./refine-routes";
 export { NavigateToResource } from "./navigate-to-resource";
 export { UnsavedChangesNotifier } from "./unsaved-changes-notifier";
+export { CatchAllNavigate } from "./catch-all-navigate";


### PR DESCRIPTION
Added `CatchAllNavigate` component to handle navigation at catch-all routes and keep the current route in `to` query parameter.

**Example**

```tsx
import { CatchAllNavigate } from "@refinedev/react-router-v6"; 

<Route path="*" element={<CatchAllNavigate to="/login" />} />
```

When user is at `/posts` route, it will navigate to the `/login?to=/posts`

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
