### PR TITLE
feat(v4-examples): migrate router provider examples starts with "c" and "b"

### DIFF
--- a/examples/base-antd/src/App.tsx
+++ b/examples/base-antd/src/App.tsx
@@ -1,7 +1,8 @@
 import { Refine } from "@refinedev/core";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import "@refinedev/antd/dist/reset.css";
 
 import { PostList, PostCreate, PostEdit, PostShow } from "pages/posts";
@@ -10,35 +11,45 @@ const API_URL = "https://api.fake-rest.refine.dev";
 
 const App: React.FC = () => {
     return (
-        <Refine
-            legacyRouterProvider={{
-                ...routerProvider,
-                /**
-                 * By default refine uses the first route with `list` property as the initial route.
-                 * If you want to change the initial route, you can bind the `initialRoute` property to the `RouterComponent` property.
-                 *
-                 * Example:
-                 *
-                 *  RouterComponent: routerProvider.RouterComponent.bind({
-                 *     initialRoute: "/posts",
-                 *  }),
-                 */
-            }}
-            dataProvider={dataProvider(API_URL)}
-            resources={[
-                {
-                    name: "posts",
-                    list: PostList,
-                    create: PostCreate,
-                    edit: PostEdit,
-                    show: PostShow,
-                    canDelete: true,
-                },
-            ]}
-            notificationProvider={notificationProvider}
-            Layout={Layout}
-            catchAll={<ErrorComponent />}
-        />
+        <BrowserRouter>
+            <Refine
+                routerProvider={routerProvider}
+                dataProvider={dataProvider(API_URL)}
+                resources={[
+                    {
+                        name: "posts",
+                        list: "/posts",
+                        show: "/posts/show/:id",
+                        create: "/posts/create",
+                        edit: "/posts/edit/:id",
+                        meta: {
+                            canDelete: true,
+                        },
+                    },
+                ]}
+                notificationProvider={notificationProvider}
+            >
+                <Routes>
+                    <Route
+                        element={
+                            <Layout>
+                                <Outlet />
+                            </Layout>
+                        }
+                    >
+                        <Route
+                            index
+                            element={<NavigateToResource resource="posts" />}
+                        />
+                        <Route path="/posts" element={<PostList />} />
+                        <Route path="/posts/show/:id" element={<PostShow />} />
+                        <Route path="/posts/create" element={<PostCreate />} />
+                        <Route path="/posts/edit/:id" element={<PostEdit />} />
+                        <Route path="*" element={<ErrorComponent />} />
+                    </Route>
+                </Routes>
+            </Refine>
+        </BrowserRouter>
     );
 };
 

--- a/examples/base-chakra-ui/src/App.tsx
+++ b/examples/base-chakra-ui/src/App.tsx
@@ -3,36 +3,68 @@ import {
     ErrorComponent,
     Layout,
     refineTheme,
-    ReadyPage,
     notificationProvider,
 } from "@refinedev/chakra-ui";
 import { ChakraProvider } from "@chakra-ui/react";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import { PostList, PostCreate, PostEdit, PostShow } from "./pages";
 
 const App: React.FC = () => {
     return (
-        <ChakraProvider theme={refineTheme}>
-            <Refine
-                notificationProvider={notificationProvider()}
-                legacyRouterProvider={routerProvider}
-                dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
-                Layout={Layout}
-                ReadyPage={ReadyPage}
-                catchAll={<ErrorComponent />}
-                resources={[
-                    {
-                        name: "posts",
-                        list: PostList,
-                        show: PostShow,
-                        create: PostCreate,
-                        edit: PostEdit,
-                    },
-                ]}
-            />
-        </ChakraProvider>
+        <BrowserRouter>
+            <ChakraProvider theme={refineTheme}>
+                <Refine
+                    notificationProvider={notificationProvider()}
+                    routerProvider={routerProvider}
+                    dataProvider={dataProvider(
+                        "https://api.fake-rest.refine.dev",
+                    )}
+                    resources={[
+                        {
+                            name: "posts",
+                            list: "/posts",
+                            show: "/posts/show/:id",
+                            create: "/posts/create",
+                            edit: "/posts/edit/:id",
+                        },
+                    ]}
+                >
+                    <Routes>
+                        <Route
+                            element={
+                                <Layout>
+                                    <Outlet />
+                                </Layout>
+                            }
+                        >
+                            <Route
+                                index
+                                element={
+                                    <NavigateToResource resource="posts" />
+                                }
+                            />
+                            <Route path="/posts" element={<PostList />} />
+                            <Route
+                                path="/posts/show/:id"
+                                element={<PostShow />}
+                            />
+                            <Route
+                                path="/posts/create"
+                                element={<PostCreate />}
+                            />
+                            <Route
+                                path="/posts/edit/:id"
+                                element={<PostEdit />}
+                            />
+                            <Route path="*" element={<ErrorComponent />} />
+                        </Route>
+                    </Routes>
+                </Refine>
+            </ChakraProvider>
+        </BrowserRouter>
     );
 };
 

--- a/examples/base-mantine/src/App.tsx
+++ b/examples/base-mantine/src/App.tsx
@@ -2,43 +2,77 @@ import { Refine } from "@refinedev/core";
 import {
     Layout,
     ErrorComponent,
-    ReadyPage,
     notificationProvider,
     LightTheme,
 } from "@refinedev/mantine";
 import { NotificationsProvider } from "@mantine/notifications";
 import { MantineProvider, Global } from "@mantine/core";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import { PostCreate, PostEdit, PostList, PostShow } from "./pages";
 
 const App: React.FC = () => {
     return (
-        <MantineProvider theme={LightTheme} withNormalizeCSS withGlobalStyles>
-            <Global styles={{ body: { WebkitFontSmoothing: "auto" } }} />
-            <NotificationsProvider position="top-right">
-                <Refine
-                    legacyRouterProvider={routerProvider}
-                    dataProvider={dataProvider(
-                        "https://api.fake-rest.refine.dev",
-                    )}
-                    notificationProvider={notificationProvider}
-                    ReadyPage={ReadyPage}
-                    catchAll={<ErrorComponent />}
-                    Layout={Layout}
-                    resources={[
-                        {
-                            name: "posts",
-                            list: PostList,
-                            show: PostShow,
-                            edit: PostEdit,
-                            create: PostCreate,
-                        },
-                    ]}
-                />
-            </NotificationsProvider>
-        </MantineProvider>
+        <BrowserRouter>
+            <MantineProvider
+                theme={LightTheme}
+                withNormalizeCSS
+                withGlobalStyles
+            >
+                <Global styles={{ body: { WebkitFontSmoothing: "auto" } }} />
+                <NotificationsProvider position="top-right">
+                    <Refine
+                        routerProvider={routerProvider}
+                        dataProvider={dataProvider(
+                            "https://api.fake-rest.refine.dev",
+                        )}
+                        notificationProvider={notificationProvider}
+                        resources={[
+                            {
+                                name: "posts",
+                                list: "/posts",
+                                show: "/posts/show/:id",
+                                create: "/posts/create",
+                                edit: "/posts/edit/:id",
+                            },
+                        ]}
+                    >
+                        <Routes>
+                            <Route
+                                element={
+                                    <Layout>
+                                        <Outlet />
+                                    </Layout>
+                                }
+                            >
+                                <Route
+                                    index
+                                    element={
+                                        <NavigateToResource resource="posts" />
+                                    }
+                                />
+                                <Route path="/posts" element={<PostList />} />
+                                <Route
+                                    path="/posts/show/:id"
+                                    element={<PostShow />}
+                                />
+                                <Route
+                                    path="/posts/create"
+                                    element={<PostCreate />}
+                                />
+                                <Route
+                                    path="/posts/edit/:id"
+                                    element={<PostEdit />}
+                                />
+                                <Route path="*" element={<ErrorComponent />} />
+                            </Route>
+                        </Routes>
+                    </Refine>
+                </NotificationsProvider>
+            </MantineProvider>
+        </BrowserRouter>
     );
 };
 

--- a/examples/base-mui/src/App.tsx
+++ b/examples/base-mui/src/App.tsx
@@ -1,9 +1,7 @@
 import { Refine } from "@refinedev/core";
 import {
     Layout,
-    LoginPage,
     ErrorComponent,
-    ReadyPage,
     LightTheme,
     notificationProvider,
     RefineSnackbarProvider,
@@ -11,37 +9,65 @@ import {
 import { CssBaseline, GlobalStyles } from "@mui/material";
 import { ThemeProvider } from "@mui/material/styles";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import { PostsList, PostCreate, PostEdit } from "pages/posts";
 
 const App: React.FC = () => {
     return (
-        <ThemeProvider theme={LightTheme}>
-            <CssBaseline />
-            <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
-            <RefineSnackbarProvider>
-                <Refine
-                    legacyRouterProvider={routerProvider}
-                    dataProvider={dataProvider(
-                        "https://api.fake-rest.refine.dev",
-                    )}
-                    notificationProvider={notificationProvider}
-                    ReadyPage={ReadyPage}
-                    Layout={Layout}
-                    LoginPage={LoginPage}
-                    catchAll={<ErrorComponent />}
-                    resources={[
-                        {
-                            name: "posts",
-                            list: PostsList,
-                            create: PostCreate,
-                            edit: PostEdit,
-                        },
-                    ]}
+        <BrowserRouter>
+            <ThemeProvider theme={LightTheme}>
+                <CssBaseline />
+                <GlobalStyles
+                    styles={{ html: { WebkitFontSmoothing: "auto" } }}
                 />
-            </RefineSnackbarProvider>
-        </ThemeProvider>
+                <RefineSnackbarProvider>
+                    <Refine
+                        routerProvider={routerProvider}
+                        dataProvider={dataProvider(
+                            "https://api.fake-rest.refine.dev",
+                        )}
+                        notificationProvider={notificationProvider}
+                        resources={[
+                            {
+                                name: "posts",
+                                list: "/posts",
+                                create: "/posts/create",
+                                edit: "/posts/edit/:id",
+                            },
+                        ]}
+                    >
+                        <Routes>
+                            <Route
+                                element={
+                                    <Layout>
+                                        <Outlet />
+                                    </Layout>
+                                }
+                            >
+                                <Route
+                                    index
+                                    element={
+                                        <NavigateToResource resource="posts" />
+                                    }
+                                />
+                                <Route path="/posts" element={<PostsList />} />
+                                <Route
+                                    path="/posts/create"
+                                    element={<PostCreate />}
+                                />
+                                <Route
+                                    path="/posts/edit/:id"
+                                    element={<PostEdit />}
+                                />
+                                <Route path="*" element={<ErrorComponent />} />
+                            </Route>
+                        </Routes>
+                    </Refine>
+                </RefineSnackbarProvider>
+            </ThemeProvider>
+        </BrowserRouter>
     );
 };
 

--- a/examples/calendar-app/src/App.tsx
+++ b/examples/calendar-app/src/App.tsx
@@ -1,7 +1,8 @@
 import { Refine } from "@refinedev/core";
-import { Layout } from "@refinedev/antd";
+import { ErrorComponent, Layout } from "@refinedev/antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import "@refinedev/antd/dist/reset.css";
 
 import { CalendarPage } from "pages/calendar";
@@ -10,17 +11,35 @@ const API_URL = "https://api.fake-rest.refine.dev";
 
 const App: React.FC = () => {
     return (
-        <Refine
-            legacyRouterProvider={routerProvider}
-            dataProvider={dataProvider(API_URL)}
-            resources={[
-                {
-                    name: "events",
-                    list: CalendarPage,
-                },
-            ]}
-            Layout={Layout}
-        />
+        <BrowserRouter>
+            <Refine
+                routerProvider={routerProvider}
+                dataProvider={dataProvider(API_URL)}
+                resources={[
+                    {
+                        name: "events",
+                        list: CalendarPage,
+                    },
+                ]}
+            >
+                <Routes>
+                    <Route
+                        element={
+                            <Layout>
+                                <Outlet />
+                            </Layout>
+                        }
+                    >
+                        <Route
+                            index
+                            element={<NavigateToResource resource="events" />}
+                        />
+                        <Route path="/events" element={<CalendarPage />} />
+                        <Route path="*" element={<ErrorComponent />} />
+                    </Route>
+                </Routes>
+            </Refine>
+        </BrowserRouter>
     );
 };
 

--- a/examples/calendar-app/src/App.tsx
+++ b/examples/calendar-app/src/App.tsx
@@ -18,7 +18,7 @@ const App: React.FC = () => {
                 resources={[
                     {
                         name: "events",
-                        list: CalendarPage,
+                        list: "/events",
                     },
                 ]}
             >

--- a/examples/command-palette-kbar/src/App.tsx
+++ b/examples/command-palette-kbar/src/App.tsx
@@ -32,8 +32,8 @@ const App: React.FC = () => {
                             show: "/posts/show/:id",
                             create: "/posts/create",
                             edit: "/posts/edit/:id",
-                            icon: <StarOutlined />,
                             meta: {
+                                icon: <StarOutlined />,
                                 canDelete: true,
                             },
                         },

--- a/examples/command-palette-kbar/src/App.tsx
+++ b/examples/command-palette-kbar/src/App.tsx
@@ -3,7 +3,8 @@ import { RefineKbarProvider } from "@refinedev/kbar";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import { StarOutlined } from "@ant-design/icons";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import "@refinedev/antd/dist/reset.css";
 
 import { PostList, PostCreate, PostEdit, PostShow } from "pages/posts";
@@ -19,34 +20,83 @@ const API_URL = "https://api.fake-rest.refine.dev";
 
 const App: React.FC = () => {
     return (
-        <RefineKbarProvider>
-            <Refine
-                legacyRouterProvider={routerProvider}
-                dataProvider={dataProvider(API_URL)}
-                resources={[
-                    {
-                        name: "posts",
-                        list: PostList,
-                        create: PostCreate,
-                        edit: PostEdit,
-                        show: PostShow,
-                        icon: <StarOutlined />,
-                        canDelete: true,
-                    },
-                    {
-                        name: "categories",
-                        list: CategoriesList,
-                        create: CategoriesCreate,
-                        edit: CategoriesEdit,
-                        canDelete: true,
-                    },
-                ]}
-                notificationProvider={notificationProvider}
-                Layout={Layout}
-                OffLayoutArea={OffLayoutArea}
-                catchAll={<ErrorComponent />}
-            />
-        </RefineKbarProvider>
+        <BrowserRouter>
+            <RefineKbarProvider>
+                <Refine
+                    routerProvider={routerProvider}
+                    dataProvider={dataProvider(API_URL)}
+                    resources={[
+                        {
+                            name: "posts",
+                            list: "/posts",
+                            show: "/posts/show/:id",
+                            create: "/posts/create",
+                            edit: "/posts/edit/:id",
+                            icon: <StarOutlined />,
+                            meta: {
+                                canDelete: true,
+                            },
+                        },
+                        {
+                            name: "categories",
+                            list: "/categories",
+                            create: "/categories/create",
+                            edit: "/categories/edit/:id",
+                            meta: {
+                                canDelete: true,
+                            },
+                        },
+                    ]}
+                    notificationProvider={notificationProvider}
+                    OffLayoutArea={OffLayoutArea}
+                >
+                    <Routes>
+                        <Route
+                            element={
+                                <Layout>
+                                    <Outlet />
+                                </Layout>
+                            }
+                        >
+                            <Route
+                                index
+                                element={
+                                    <NavigateToResource resource="posts" />
+                                }
+                            />
+                            <Route path="/posts" element={<PostList />} />
+                            <Route
+                                path="/posts/show/:id"
+                                element={<PostShow />}
+                            />
+                            <Route
+                                path="/posts/create"
+                                element={<PostCreate />}
+                            />
+                            <Route
+                                path="/posts/edit/:id"
+                                element={<PostEdit />}
+                            />
+
+                            <Route
+                                path="/categories"
+                                element={<CategoriesList />}
+                            />
+                            <Route
+                                path="/categories/create"
+                                element={<CategoriesCreate />}
+                            />
+                            <Route
+                                path="/categories/edit/:id"
+                                element={<CategoriesEdit />}
+                            />
+
+                            <Route path="*" element={<ErrorComponent />} />
+                        </Route>
+                    </Routes>
+                </Refine>
+            </RefineKbarProvider>
+        </BrowserRouter>
     );
 };
 

--- a/examples/command-palette-kbar/tsconfig.json
+++ b/examples/command-palette-kbar/tsconfig.json
@@ -1,21 +1,21 @@
 {
-    "compilerOptions": {
-        "baseUrl": "src",
-        "target": "es5",
-        "lib": ["dom", "dom.iterable", "esnext"],
-        "allowJs": true,
-        "skipLibCheck": true,
-        "esModuleInterop": true,
-        "allowSyntheticDefaultImports": true,
-        "strict": true,
-        "forceConsistentCasingInFileNames": true,
-        "noFallthroughCasesInSwitch": true,
-        "module": "esnext",
-        "moduleResolution": "node",
-        "resolveJsonModule": true,
-        "isolatedModules": true,
-        "noEmit": true,
-        "jsx": "react-jsx"
-    },
-    "include": ["antd/src"]
+  "compilerOptions": {
+    "baseUrl": "src",
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
 }

--- a/examples/core-use-import/src/App.tsx
+++ b/examples/core-use-import/src/App.tsx
@@ -1,16 +1,30 @@
-import { Refine } from "@refinedev/core";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import { ErrorComponent, Refine } from "@refinedev/core";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import dataProvider from "@refinedev/simple-rest";
 
 import { DummyList } from "pages/posts";
 
 const App: React.FC = () => {
     return (
-        <Refine
-            dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
-            legacyRouterProvider={routerProvider}
-            resources={[{ name: "posts", list: DummyList }]}
-        />
+        <BrowserRouter>
+            <Refine
+                dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
+                routerProvider={routerProvider}
+                resources={[{ name: "posts", list: "/posts" }]}
+            >
+                <Routes>
+                    <Route element={<Outlet />}>
+                        <Route
+                            index
+                            element={<NavigateToResource resource="posts" />}
+                        />
+                        <Route path="/posts" element={<DummyList />} />
+                        <Route path="*" element={<ErrorComponent />} />
+                    </Route>
+                </Routes>
+            </Refine>
+        </BrowserRouter>
     );
 };
 

--- a/examples/core-use-import/src/App.tsx
+++ b/examples/core-use-import/src/App.tsx
@@ -1,6 +1,6 @@
 import { ErrorComponent, Refine } from "@refinedev/core";
 import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
-import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import dataProvider from "@refinedev/simple-rest";
 
 import { DummyList } from "pages/posts";
@@ -14,14 +14,12 @@ const App: React.FC = () => {
                 resources={[{ name: "posts", list: "/posts" }]}
             >
                 <Routes>
-                    <Route element={<Outlet />}>
-                        <Route
-                            index
-                            element={<NavigateToResource resource="posts" />}
-                        />
-                        <Route path="/posts" element={<DummyList />} />
-                        <Route path="*" element={<ErrorComponent />} />
-                    </Route>
+                    <Route
+                        index
+                        element={<NavigateToResource resource="posts" />}
+                    />
+                    <Route path="/posts" element={<DummyList />} />
+                    <Route path="*" element={<ErrorComponent />} />
                 </Routes>
             </Refine>
         </BrowserRouter>

--- a/examples/core-use-menu/src/App.tsx
+++ b/examples/core-use-menu/src/App.tsx
@@ -1,5 +1,6 @@
-import { Refine } from "@refinedev/core";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import { ErrorComponent, Refine } from "@refinedev/core";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import dataProvider from "@refinedev/simple-rest";
 
 import { Layout } from "components/layout";
@@ -8,21 +9,44 @@ const API_URL = "https://api.fake-rest.refine.dev";
 
 const App: React.FC = () => {
     return (
-        <Refine
-            legacyRouterProvider={routerProvider}
-            dataProvider={dataProvider(API_URL)}
-            resources={[
-                {
-                    name: "posts",
-                    list: () => <div>dummy posts page</div>,
-                },
-                {
-                    name: "categories",
-                    list: () => <div>dummy categories page</div>,
-                },
-            ]}
-            Layout={Layout}
-        />
+        <BrowserRouter>
+            <Refine
+                dataProvider={dataProvider(API_URL)}
+                routerProvider={routerProvider}
+                resources={[
+                    {
+                        name: "posts",
+                        list: "/posts",
+                    },
+                    { name: "categories", list: "/categories" },
+                ]}
+            >
+                <Routes>
+                    <Route
+                        element={
+                            <Layout>
+                                <Outlet />
+                            </Layout>
+                        }
+                    >
+                        <Route
+                            index
+                            element={<NavigateToResource resource="posts" />}
+                        />
+
+                        <Route
+                            path="/posts"
+                            element={<div>dummy posts page</div>}
+                        />
+                        <Route
+                            path="/categories"
+                            element={<div>dummy categories page</div>}
+                        />
+                        <Route path="*" element={<ErrorComponent />} />
+                    </Route>
+                </Routes>
+            </Refine>
+        </BrowserRouter>
     );
 };
 

--- a/examples/core-use-menu/src/components/layout/index.tsx
+++ b/examples/core-use-menu/src/components/layout/index.tsx
@@ -2,14 +2,13 @@ import React from "react";
 import {
     useMenu,
     LayoutProps,
-    useRouterContext,
     useRefineContext,
     ITreeMenu,
 } from "@refinedev/core";
+import { Link } from "react-router-dom";
 
 export const Layout: React.FC<LayoutProps> = ({ children }) => {
     const { menuItems, selectedKey } = useMenu();
-    const { Link } = useRouterContext();
     const { hasDashboard } = useRefineContext();
 
     const renderMenuItems = (items: ITreeMenu[]) => {
@@ -17,17 +16,27 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
             <>
                 {items.map(({ name, label, icon, route }) => {
                     const isSelected = route === selectedKey;
+
                     return (
                         <li key={name}>
-                            <Link
-                                to={route}
-                                style={{
-                                    fontWeight: isSelected ? "bold" : "normal",
-                                }}
-                            >
-                                {icon}
-                                <span>{label ?? name}</span>
-                            </Link>
+                            {route ? (
+                                <Link
+                                    to={route}
+                                    style={{
+                                        fontWeight: isSelected
+                                            ? "bold"
+                                            : "normal",
+                                    }}
+                                >
+                                    {icon}
+                                    <span>{label ?? name}</span>
+                                </Link>
+                            ) : (
+                                <div>
+                                    {icon}
+                                    <span>{label ?? name}</span>
+                                </div>
+                            )}
                         </li>
                     );
                 })}

--- a/examples/core-use-modal/src/App.tsx
+++ b/examples/core-use-modal/src/App.tsx
@@ -14,7 +14,7 @@ const App: React.FC = () => {
                 resources={[{ name: "posts", list: "/posts" }]}
             >
                 <Routes>
-                    <Route element={<Outlet />}>
+                    <Route>
                         <Route
                             index
                             element={<NavigateToResource resource="posts" />}

--- a/examples/core-use-modal/src/App.tsx
+++ b/examples/core-use-modal/src/App.tsx
@@ -1,16 +1,30 @@
-import { Refine } from "@refinedev/core";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import { Refine, ErrorComponent } from "@refinedev/core";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import dataProvider from "@refinedev/simple-rest";
 
 import { DummyList } from "pages/posts";
 
 const App: React.FC = () => {
     return (
-        <Refine
-            dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
-            legacyRouterProvider={routerProvider}
-            resources={[{ name: "posts", list: DummyList }]}
-        />
+        <BrowserRouter>
+            <Refine
+                dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
+                routerProvider={routerProvider}
+                resources={[{ name: "posts", list: "/posts" }]}
+            >
+                <Routes>
+                    <Route element={<Outlet />}>
+                        <Route
+                            index
+                            element={<NavigateToResource resource="posts" />}
+                        />
+                        <Route path="/posts" element={<DummyList />} />
+                        <Route path="*" element={<ErrorComponent />} />
+                    </Route>
+                </Routes>
+            </Refine>
+        </BrowserRouter>
     );
 };
 

--- a/examples/core-use-select/src/App.tsx
+++ b/examples/core-use-select/src/App.tsx
@@ -1,6 +1,6 @@
 import { Refine, ErrorComponent } from "@refinedev/core";
 import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
-import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import dataProvider from "@refinedev/simple-rest";
 
 import { DummyList } from "pages/posts";
@@ -14,7 +14,7 @@ const App: React.FC = () => {
                 resources={[{ name: "posts", list: "/posts" }]}
             >
                 <Routes>
-                    <Route element={<Outlet />}>
+                    <Route>
                         <Route
                             index
                             element={<NavigateToResource resource="posts" />}

--- a/examples/core-use-select/src/App.tsx
+++ b/examples/core-use-select/src/App.tsx
@@ -1,16 +1,30 @@
-import { Refine } from "@refinedev/core";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import { Refine, ErrorComponent } from "@refinedev/core";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import dataProvider from "@refinedev/simple-rest";
 
 import { DummyList } from "pages/posts";
 
 const App: React.FC = () => {
     return (
-        <Refine
-            dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
-            legacyRouterProvider={routerProvider}
-            resources={[{ name: "posts", list: DummyList }]}
-        />
+        <BrowserRouter>
+            <Refine
+                dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
+                routerProvider={routerProvider}
+                resources={[{ name: "posts", list: "/posts" }]}
+            >
+                <Routes>
+                    <Route element={<Outlet />}>
+                        <Route
+                            index
+                            element={<NavigateToResource resource="posts" />}
+                        />
+                        <Route path="/posts" element={<DummyList />} />
+                        <Route path="*" element={<ErrorComponent />} />
+                    </Route>
+                </Routes>
+            </Refine>
+        </BrowserRouter>
     );
 };
 

--- a/examples/customization-footer/src/App.tsx
+++ b/examples/customization-footer/src/App.tsx
@@ -1,7 +1,8 @@
 import { Refine } from "@refinedev/core";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import "@refinedev/antd/dist/reset.css";
 
@@ -11,32 +12,45 @@ const API_URL = "https://api.fake-rest.refine.dev";
 
 const App: React.FC = () => {
     return (
-        <Refine
-            dataProvider={dataProvider(API_URL)}
-            legacyRouterProvider={routerProvider}
-            Footer={() => (
-                <div
-                    style={{
-                        backgroundColor: "white",
-                        height: "64px",
-                        display: "flex",
-                        justifyContent: "center",
-                        alignItems: "center",
-                    }}
-                >
-                    Custom Footer Content
-                </div>
-            )}
-            resources={[
-                {
-                    name: "posts",
-                    list: PostList,
-                },
-            ]}
-            notificationProvider={notificationProvider}
-            Layout={Layout}
-            catchAll={<ErrorComponent />}
-        />
+        <BrowserRouter>
+            <Refine
+                dataProvider={dataProvider(API_URL)}
+                routerProvider={routerProvider}
+                resources={[{ name: "posts", list: "/posts" }]}
+                notificationProvider={notificationProvider}
+            >
+                <Routes>
+                    <Route
+                        element={
+                            <Layout
+                                Footer={() => (
+                                    <div
+                                        style={{
+                                            backgroundColor: "white",
+                                            height: "64px",
+                                            display: "flex",
+                                            justifyContent: "center",
+                                            alignItems: "center",
+                                        }}
+                                    >
+                                        Custom Footer Content
+                                    </div>
+                                )}
+                            >
+                                <Outlet />
+                            </Layout>
+                        }
+                    >
+                        <Route
+                            index
+                            element={<NavigateToResource resource="posts" />}
+                        />
+                        <Route path="/posts" element={<PostList />} />
+                        <Route path="*" element={<ErrorComponent />} />
+                    </Route>
+                </Routes>
+            </Refine>
+        </BrowserRouter>
     );
 };
 

--- a/examples/customization-login/src/App.tsx
+++ b/examples/customization-login/src/App.tsx
@@ -1,8 +1,11 @@
-import { Refine, AuthBindings } from "@refinedev/core";
+import { Refine, AuthBindings, Authenticated } from "@refinedev/core";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider from "@refinedev/react-router-v6/legacy";
-
+import routerProvider, {
+    NavigateToResource,
+    CatchAllNavigate,
+} from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import "@refinedev/antd/dist/reset.css";
 
 import { PostList, PostCreate, PostEdit, PostShow } from "pages/posts";
@@ -47,24 +50,68 @@ const App: React.FC = () => {
     };
 
     return (
-        <Refine
-            dataProvider={dataProvider(API_URL)}
-            authProvider={authProvider}
-            legacyRouterProvider={routerProvider}
-            LoginPage={Login}
-            resources={[
-                {
-                    name: "posts",
-                    list: PostList,
-                    create: PostCreate,
-                    edit: PostEdit,
-                    show: PostShow,
-                },
-            ]}
-            notificationProvider={notificationProvider}
-            Layout={Layout}
-            catchAll={<ErrorComponent />}
-        />
+        <BrowserRouter>
+            <Refine
+                dataProvider={dataProvider(API_URL)}
+                authProvider={authProvider}
+                routerProvider={routerProvider}
+                resources={[
+                    {
+                        name: "posts",
+                        list: "/posts",
+                        show: "/posts/show/:id",
+                        create: "/posts/create",
+                        edit: "/posts/edit/:id",
+                    },
+                ]}
+                notificationProvider={notificationProvider}
+            >
+                <Routes>
+                    <Route
+                        element={
+                            <Authenticated
+                                fallback={<CatchAllNavigate to="/login" />}
+                            >
+                                <Layout>
+                                    <Outlet />
+                                </Layout>
+                            </Authenticated>
+                        }
+                    >
+                        <Route
+                            index
+                            element={<NavigateToResource resource="posts" />}
+                        />
+                        <Route path="/posts" element={<PostList />} />
+                        <Route path="/posts/create" element={<PostCreate />} />
+                        <Route path="/posts/show/:id" element={<PostShow />} />
+                        <Route path="/posts/edit/:id" element={<PostEdit />} />
+                    </Route>
+
+                    <Route
+                        element={
+                            <Authenticated fallback={<Outlet />}>
+                                <NavigateToResource resource="posts" />
+                            </Authenticated>
+                        }
+                    >
+                        <Route path="/login" element={<Login />} />
+                    </Route>
+
+                    <Route
+                        element={
+                            <Authenticated fallback={<Outlet />}>
+                                <Layout>
+                                    <Outlet />
+                                </Layout>
+                            </Authenticated>
+                        }
+                    >
+                        <Route path="*" element={<ErrorComponent />} />
+                    </Route>
+                </Routes>
+            </Refine>
+        </BrowserRouter>
     );
 };
 

--- a/examples/customization-rtl/src/App.tsx
+++ b/examples/customization-rtl/src/App.tsx
@@ -2,7 +2,8 @@ import { Refine } from "@refinedev/core";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import { ConfigProvider } from "antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import "@refinedev/antd/dist/reset.css";
 
@@ -12,24 +13,55 @@ const API_URL = "https://api.fake-rest.refine.dev";
 
 const App: React.FC = () => {
     return (
-        <ConfigProvider direction={"rtl"}>
-            <Refine
-                dataProvider={dataProvider(API_URL)}
-                legacyRouterProvider={routerProvider}
-                resources={[
-                    {
-                        name: "posts",
-                        list: PostList,
-                        create: PostCreate,
-                        edit: PostEdit,
-                        show: PostShow,
-                    },
-                ]}
-                notificationProvider={notificationProvider}
-                Layout={Layout}
-                catchAll={<ErrorComponent />}
-            />
-        </ConfigProvider>
+        <BrowserRouter>
+            <ConfigProvider direction={"rtl"}>
+                <Refine
+                    dataProvider={dataProvider(API_URL)}
+                    routerProvider={routerProvider}
+                    resources={[
+                        {
+                            name: "posts",
+                            list: "/posts",
+                            show: "/posts/show/:id",
+                            create: "/posts/create",
+                            edit: "/posts/edit/:id",
+                        },
+                    ]}
+                    notificationProvider={notificationProvider}
+                >
+                    <Routes>
+                        <Route
+                            element={
+                                <Layout>
+                                    <Outlet />
+                                </Layout>
+                            }
+                        >
+                            <Route
+                                index
+                                element={
+                                    <NavigateToResource resource="posts" />
+                                }
+                            />
+                            <Route path="/posts" element={<PostList />} />
+                            <Route
+                                path="/posts/show/:id"
+                                element={<PostShow />}
+                            />
+                            <Route
+                                path="/posts/create"
+                                element={<PostCreate />}
+                            />
+                            <Route
+                                path="/posts/edit/:id"
+                                element={<PostEdit />}
+                            />
+                            <Route path="*" element={<ErrorComponent />} />
+                        </Route>
+                    </Routes>
+                </Refine>
+            </ConfigProvider>
+        </BrowserRouter>
     );
 };
 

--- a/examples/customization-sider/src/App.tsx
+++ b/examples/customization-sider/src/App.tsx
@@ -1,7 +1,8 @@
 import { Refine } from "@refinedev/core";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import "@refinedev/antd/dist/reset.css";
 import "./index.css";
@@ -9,51 +10,40 @@ import "./index.css";
 import { PostList } from "pages/posts";
 import { CustomSider } from "components";
 
-const { Link } = routerProvider;
-
 const API_URL = "https://api.fake-rest.refine.dev";
 
 const App: React.FC = () => {
     return (
-        <Refine
-            dataProvider={dataProvider(API_URL)}
-            legacyRouterProvider={routerProvider}
-            Sider={CustomSider}
-            Title={({ collapsed }) => (
-                <Link to="/">
-                    {collapsed ? (
-                        <img
-                            src="/refine-collapsed.svg"
-                            alt="Refine"
-                            style={{
-                                display: "flex",
-                                alignItems: "center",
-                                justifyContent: "center",
-                                padding: "12px 24px",
-                            }}
+        <BrowserRouter>
+            <Refine
+                dataProvider={dataProvider(API_URL)}
+                routerProvider={routerProvider}
+                resources={[
+                    {
+                        name: "posts",
+                        list: "/posts",
+                    },
+                ]}
+                notificationProvider={notificationProvider}
+            >
+                <Routes>
+                    <Route
+                        element={
+                            <Layout Sider={CustomSider}>
+                                <Outlet />
+                            </Layout>
+                        }
+                    >
+                        <Route
+                            index
+                            element={<NavigateToResource resource="posts" />}
                         />
-                    ) : (
-                        <img
-                            src="/refine.svg"
-                            alt="Refine"
-                            style={{
-                                width: "200px",
-                                padding: "12px 24px",
-                            }}
-                        />
-                    )}
-                </Link>
-            )}
-            resources={[
-                {
-                    name: "posts",
-                    list: PostList,
-                },
-            ]}
-            notificationProvider={notificationProvider}
-            Layout={Layout}
-            catchAll={<ErrorComponent />}
-        />
+                        <Route path="/posts" element={<PostList />} />
+                        <Route path="*" element={<ErrorComponent />} />
+                    </Route>
+                </Routes>
+            </Refine>
+        </BrowserRouter>
     );
 };
 

--- a/examples/customization-sider/src/components/sider/index.tsx
+++ b/examples/customization-sider/src/components/sider/index.tsx
@@ -1,16 +1,14 @@
 import React, { useState } from "react";
 import {
-    useTitle,
     ITreeMenu,
     CanAccess,
-    useRouterContext,
     useRefineContext,
     useIsExistAuthentication,
     useTranslate,
     useLogout,
     useMenu,
 } from "@refinedev/core";
-
+import { Link } from "react-router-dom";
 import { Sider } from "@refinedev/antd";
 import { Layout as AntdLayout, Menu, Grid } from "antd";
 import {
@@ -23,11 +21,9 @@ import { antLayoutSider, antLayoutSiderMobile } from "./styles";
 export const CustomSider: typeof Sider = ({ render }) => {
     const [collapsed, setCollapsed] = useState<boolean>(false);
     const isExistAuthentication = useIsExistAuthentication();
-    const { Link } = useRouterContext();
     const { mutate: mutateLogout } = useLogout({
         v3LegacyAuthProviderCompatible: true,
     });
-    const Title = useTitle();
     const translate = useTranslate();
     const { menuItems, selectedKey, defaultOpenKeys } = useMenu();
     const { hasDashboard } = useRefineContext();
@@ -71,7 +67,7 @@ export const CustomSider: typeof Sider = ({ render }) => {
                         }}
                         icon={icon ?? (isRoute && <UnorderedListOutlined />)}
                     >
-                        <Link to={route}>{label}</Link>
+                        {route ? <Link to={route}>{label}</Link> : label}
                         {!collapsed && isSelected && (
                             <div className="ant-menu-tree-arrow" />
                         )}
@@ -135,7 +131,29 @@ export const CustomSider: typeof Sider = ({ render }) => {
             onCollapse={(collapsed: boolean): void => setCollapsed(collapsed)}
             style={isMobile ? antLayoutSiderMobile : antLayoutSider}
         >
-            {Title && <Title collapsed={collapsed} />}
+            <Link to="/">
+                {collapsed ? (
+                    <img
+                        src="/refine-collapsed.svg"
+                        alt="Refine"
+                        style={{
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            padding: "12px 24px",
+                        }}
+                    />
+                ) : (
+                    <img
+                        src="/refine.svg"
+                        alt="Refine"
+                        style={{
+                            width: "200px",
+                            padding: "12px 24px",
+                        }}
+                    />
+                )}
+            </Link>
             <Menu
                 defaultOpenKeys={defaultOpenKeys}
                 selectedKeys={[selectedKey]}

--- a/examples/customization-theme-antd/src/App.tsx
+++ b/examples/customization-theme-antd/src/App.tsx
@@ -2,7 +2,8 @@ import { Refine } from "@refinedev/core";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import { ConfigProvider, theme } from "antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import { PostList, PostCreate, PostEdit, PostShow } from "pages/posts";
 
@@ -17,45 +18,80 @@ const App: React.FC = () => {
     const [currentTheme, setCurrentTheme] = useState<"light" | "dark">("dark");
 
     return (
-        <ConfigProvider
-            theme={{
-                algorithm:
-                    currentTheme === "light"
-                        ? theme.defaultAlgorithm
-                        : theme.darkAlgorithm,
-                components: {
-                    Button: {
-                        borderRadius: 0,
+        <BrowserRouter>
+            <ConfigProvider
+                theme={{
+                    algorithm:
+                        currentTheme === "light"
+                            ? theme.defaultAlgorithm
+                            : theme.darkAlgorithm,
+                    components: {
+                        Button: {
+                            borderRadius: 0,
+                        },
+                        Typography: {
+                            colorTextHeading: "#1890ff",
+                        },
                     },
-                    Typography: {
-                        colorTextHeading: "#1890ff",
+                    token: {
+                        colorPrimary: "#f0f",
                     },
-                },
-                token: {
-                    colorPrimary: "#f0f",
-                },
-            }}
-        >
-            <Refine
-                dataProvider={dataProvider(API_URL)}
-                legacyRouterProvider={routerProvider}
-                Header={() => (
-                    <Header theme={currentTheme} setTheme={setCurrentTheme} />
-                )}
-                resources={[
-                    {
-                        name: "posts",
-                        list: PostList,
-                        create: PostCreate,
-                        edit: PostEdit,
-                        show: PostShow,
-                    },
-                ]}
-                notificationProvider={notificationProvider}
-                Layout={Layout}
-                catchAll={<ErrorComponent />}
-            />
-        </ConfigProvider>
+                }}
+            >
+                <Refine
+                    dataProvider={dataProvider(API_URL)}
+                    routerProvider={routerProvider}
+                    resources={[
+                        {
+                            name: "posts",
+                            list: "/posts",
+                            show: "/posts/show/:id",
+                            create: "/posts/create",
+                            edit: "/posts/edit/:id",
+                        },
+                    ]}
+                    notificationProvider={notificationProvider}
+                >
+                    <Routes>
+                        <Route
+                            element={
+                                <Layout
+                                    Header={() => (
+                                        <Header
+                                            theme={currentTheme}
+                                            setTheme={setCurrentTheme}
+                                        />
+                                    )}
+                                >
+                                    <Outlet />
+                                </Layout>
+                            }
+                        >
+                            <Route
+                                index
+                                element={
+                                    <NavigateToResource resource="posts" />
+                                }
+                            />
+                            <Route path="/posts" element={<PostList />} />
+                            <Route
+                                path="/posts/show/:id"
+                                element={<PostShow />}
+                            />
+                            <Route
+                                path="/posts/create"
+                                element={<PostCreate />}
+                            />
+                            <Route
+                                path="/posts/edit/:id"
+                                element={<PostEdit />}
+                            />
+                            <Route path="*" element={<ErrorComponent />} />
+                        </Route>
+                    </Routes>
+                </Refine>
+            </ConfigProvider>
+        </BrowserRouter>
     );
 };
 

--- a/examples/customization-theme-chakra-ui/src/App.tsx
+++ b/examples/customization-theme-chakra-ui/src/App.tsx
@@ -3,38 +3,69 @@ import {
     ErrorComponent,
     Layout,
     refineTheme,
-    ReadyPage,
     notificationProvider,
 } from "@refinedev/chakra-ui";
 import { ChakraProvider } from "@chakra-ui/react";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import { PostList, PostCreate, PostEdit, PostShow } from "./pages";
 import { Header } from "./components/header";
 
 const App: React.FC = () => {
     return (
-        <ChakraProvider theme={refineTheme}>
-            <Refine
-                legacyRouterProvider={routerProvider}
-                dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
-                notificationProvider={notificationProvider()}
-                ReadyPage={ReadyPage}
-                catchAll={<ErrorComponent />}
-                Layout={Layout}
-                Header={Header}
-                resources={[
-                    {
-                        name: "posts",
-                        list: PostList,
-                        show: PostShow,
-                        create: PostCreate,
-                        edit: PostEdit,
-                    },
-                ]}
-            />
-        </ChakraProvider>
+        <BrowserRouter>
+            <ChakraProvider theme={refineTheme}>
+                <Refine
+                    routerProvider={routerProvider}
+                    dataProvider={dataProvider(
+                        "https://api.fake-rest.refine.dev",
+                    )}
+                    notificationProvider={notificationProvider()}
+                    resources={[
+                        {
+                            name: "posts",
+                            list: "/posts",
+                            show: "/posts/show/:id",
+                            create: "/posts/create",
+                            edit: "/posts/edit/:id",
+                        },
+                    ]}
+                >
+                    <Routes>
+                        <Route
+                            element={
+                                <Layout Header={Header}>
+                                    <Outlet />
+                                </Layout>
+                            }
+                        >
+                            <Route
+                                index
+                                element={
+                                    <NavigateToResource resource="posts" />
+                                }
+                            />
+                            <Route path="/posts" element={<PostList />} />
+                            <Route
+                                path="/posts/show/:id"
+                                element={<PostShow />}
+                            />
+                            <Route
+                                path="/posts/create"
+                                element={<PostCreate />}
+                            />
+                            <Route
+                                path="/posts/edit/:id"
+                                element={<PostEdit />}
+                            />
+                            <Route path="*" element={<ErrorComponent />} />
+                        </Route>
+                    </Routes>
+                </Refine>
+            </ChakraProvider>
+        </BrowserRouter>
     );
 };
 

--- a/examples/customization-theme-mantine/src/App.tsx
+++ b/examples/customization-theme-mantine/src/App.tsx
@@ -2,7 +2,6 @@ import { Refine } from "@refinedev/core";
 import {
     Layout,
     ErrorComponent,
-    ReadyPage,
     notificationProvider,
     LightTheme,
     DarkTheme,
@@ -12,7 +11,8 @@ import { ColorSchemeProvider } from "@mantine/styles";
 import { NotificationsProvider } from "@mantine/notifications";
 import { MantineProvider, ColorScheme, Global } from "@mantine/core";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import { PostCreate, PostEdit, PostList, PostShow } from "./pages";
 import { Header } from "./components";
@@ -28,42 +28,77 @@ const App: React.FC = () => {
         setColorScheme(value || (colorScheme === "dark" ? "light" : "dark"));
 
     return (
-        <ColorSchemeProvider
-            colorScheme={colorScheme}
-            toggleColorScheme={toggleColorScheme}
-        >
-            <MantineProvider
-                theme={colorScheme === "dark" ? DarkTheme : LightTheme}
-                withNormalizeCSS
-                withGlobalStyles
+        <BrowserRouter>
+            <ColorSchemeProvider
+                colorScheme={colorScheme}
+                toggleColorScheme={toggleColorScheme}
             >
-                <Global
-                    styles={{ body: { "-webkit-font-smoothing": "auto" } }}
-                />
-                <NotificationsProvider position="top-right">
-                    <Refine
-                        legacyRouterProvider={routerProvider}
-                        dataProvider={dataProvider(
-                            "https://api.fake-rest.refine.dev",
-                        )}
-                        notificationProvider={notificationProvider}
-                        ReadyPage={ReadyPage}
-                        catchAll={<ErrorComponent />}
-                        Layout={Layout}
-                        Header={Header}
-                        resources={[
-                            {
-                                name: "posts",
-                                show: PostShow,
-                                list: PostList,
-                                edit: PostEdit,
-                                create: PostCreate,
-                            },
-                        ]}
+                <MantineProvider
+                    theme={colorScheme === "dark" ? DarkTheme : LightTheme}
+                    withNormalizeCSS
+                    withGlobalStyles
+                >
+                    <Global
+                        styles={{ body: { "-webkit-font-smoothing": "auto" } }}
                     />
-                </NotificationsProvider>
-            </MantineProvider>
-        </ColorSchemeProvider>
+                    <NotificationsProvider position="top-right">
+                        <Refine
+                            routerProvider={routerProvider}
+                            dataProvider={dataProvider(
+                                "https://api.fake-rest.refine.dev",
+                            )}
+                            notificationProvider={notificationProvider}
+                            resources={[
+                                {
+                                    name: "posts",
+                                    list: "/posts",
+                                    show: "/posts/show/:id",
+                                    create: "/posts/create",
+                                    edit: "/posts/edit/:id",
+                                },
+                            ]}
+                        >
+                            <Routes>
+                                <Route
+                                    element={
+                                        <Layout Header={Header}>
+                                            <Outlet />
+                                        </Layout>
+                                    }
+                                >
+                                    <Route
+                                        index
+                                        element={
+                                            <NavigateToResource resource="posts" />
+                                        }
+                                    />
+                                    <Route
+                                        path="/posts"
+                                        element={<PostList />}
+                                    />
+                                    <Route
+                                        path="/posts/show/:id"
+                                        element={<PostShow />}
+                                    />
+                                    <Route
+                                        path="/posts/create"
+                                        element={<PostCreate />}
+                                    />
+                                    <Route
+                                        path="/posts/edit/:id"
+                                        element={<PostEdit />}
+                                    />
+                                    <Route
+                                        path="*"
+                                        element={<ErrorComponent />}
+                                    />
+                                </Route>
+                            </Routes>
+                        </Refine>
+                    </NotificationsProvider>
+                </MantineProvider>
+            </ColorSchemeProvider>
+        </BrowserRouter>
     );
 };
 

--- a/examples/customization-theme-mui/src/App.tsx
+++ b/examples/customization-theme-mui/src/App.tsx
@@ -2,13 +2,13 @@ import { Refine } from "@refinedev/core";
 import {
     Layout,
     ErrorComponent,
-    ReadyPage,
     RefineSnackbarProvider,
     notificationProvider,
 } from "@refinedev/mui";
 import { CssBaseline, GlobalStyles } from "@mui/material";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import { PostsList, PostCreate, PostEdit } from "pages/posts";
 import { Header } from "./components/header";
@@ -16,31 +16,59 @@ import { ColorModeContextProvider } from "./contexts";
 
 const App: React.FC = () => {
     return (
-        <ColorModeContextProvider>
-            <CssBaseline />
-            <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
-            <RefineSnackbarProvider>
-                <Refine
-                    notificationProvider={notificationProvider}
-                    legacyRouterProvider={routerProvider}
-                    dataProvider={dataProvider(
-                        "https://api.fake-rest.refine.dev",
-                    )}
-                    ReadyPage={ReadyPage}
-                    Layout={Layout}
-                    catchAll={<ErrorComponent />}
-                    Header={Header}
-                    resources={[
-                        {
-                            name: "posts",
-                            list: PostsList,
-                            create: PostCreate,
-                            edit: PostEdit,
-                        },
-                    ]}
+        <BrowserRouter>
+            <ColorModeContextProvider>
+                <CssBaseline />
+                <GlobalStyles
+                    styles={{ html: { WebkitFontSmoothing: "auto" } }}
                 />
-            </RefineSnackbarProvider>
-        </ColorModeContextProvider>
+                <RefineSnackbarProvider>
+                    <Refine
+                        notificationProvider={notificationProvider}
+                        routerProvider={routerProvider}
+                        dataProvider={dataProvider(
+                            "https://api.fake-rest.refine.dev",
+                        )}
+                        resources={[
+                            {
+                                name: "posts",
+                                list: "/posts",
+                                create: "/posts/create",
+                                edit: "/posts/edit/:id",
+                            },
+                        ]}
+                    >
+                        <Routes>
+                            <Route
+                                element={
+                                    <Layout Header={Header}>
+                                        <Outlet />
+                                    </Layout>
+                                }
+                            >
+                                <Route
+                                    index
+                                    element={
+                                        <NavigateToResource resource="posts" />
+                                    }
+                                />
+                                <Route path="/posts" element={<PostsList />} />
+
+                                <Route
+                                    path="/posts/create"
+                                    element={<PostCreate />}
+                                />
+                                <Route
+                                    path="/posts/edit/:id"
+                                    element={<PostEdit />}
+                                />
+                                <Route path="*" element={<ErrorComponent />} />
+                            </Route>
+                        </Routes>
+                    </Refine>
+                </RefineSnackbarProvider>
+            </ColorModeContextProvider>
+        </BrowserRouter>
     );
 };
 

--- a/examples/customization-top-menu-layout/src/App.tsx
+++ b/examples/customization-top-menu-layout/src/App.tsx
@@ -1,57 +1,77 @@
 import { Refine } from "@refinedev/core";
-import { notificationProvider, ErrorComponent } from "@refinedev/antd";
+import { notificationProvider, ErrorComponent, Layout } from "@refinedev/antd";
 import { Layout as AntdLayout } from "antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider from "@refinedev/react-router-v6/legacy";
+import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import { BrowserRouter, Routes, Route, Outlet, Link } from "react-router-dom";
 
 import "@refinedev/antd/dist/reset.css";
 
 import { PostList } from "pages/posts";
 import { CustomSider } from "components";
 
-const { Link } = routerProvider;
-
 const API_URL = "https://api.fake-rest.refine.dev";
 
 const App: React.FC = () => {
     return (
-        <Refine
-            dataProvider={dataProvider(API_URL)}
-            legacyRouterProvider={routerProvider}
-            Layout={({ children, Footer, OffLayoutArea }) => (
-                <AntdLayout>
-                    <AntdLayout.Header>
-                        <CustomSider />
-                    </AntdLayout.Header>
-                    <AntdLayout.Content>
-                        <AntdLayout.Content>
-                            <div style={{ padding: 24, minHeight: 360 }}>
-                                {children}
-                            </div>
-                        </AntdLayout.Content>
-                        {Footer && <Footer />}
-                    </AntdLayout.Content>
-                    {OffLayoutArea && <OffLayoutArea />}
-                </AntdLayout>
-            )}
-            Title={() => (
-                <Link to="/" style={{ float: "left", marginRight: "10px" }}>
-                    <img
-                        src="/refine.svg"
-                        alt="Refine"
-                        style={{ width: "100px" }}
-                    />
-                </Link>
-            )}
-            resources={[
-                {
-                    name: "posts",
-                    list: PostList,
-                },
-            ]}
-            notificationProvider={notificationProvider}
-            catchAll={<ErrorComponent />}
-        />
+        <BrowserRouter>
+            <Refine
+                dataProvider={dataProvider(API_URL)}
+                routerProvider={routerProvider}
+                resources={[
+                    {
+                        name: "posts",
+                        list: "/posts",
+                    },
+                ]}
+                notificationProvider={notificationProvider}
+            >
+                <Routes>
+                    <Route
+                        element={
+                            <Layout
+                                Sider={() => null}
+                                Header={() => {
+                                    return (
+                                        <AntdLayout.Header>
+                                            <Link
+                                                to="/"
+                                                style={{
+                                                    float: "left",
+                                                    marginRight: "10px",
+                                                }}
+                                            >
+                                                <img
+                                                    src="/refine.svg"
+                                                    alt="Refine"
+                                                    style={{ width: "100px" }}
+                                                />
+                                            </Link>
+                                            <CustomSider />
+                                        </AntdLayout.Header>
+                                    );
+                                }}
+                            >
+                                <AntdLayout.Content>
+                                    <div
+                                        style={{ padding: 24, minHeight: 360 }}
+                                    >
+                                        <Outlet />
+                                    </div>
+                                </AntdLayout.Content>
+                            </Layout>
+                        }
+                    >
+                        <Route
+                            index
+                            element={<NavigateToResource resource="posts" />}
+                        />
+                        <Route path="/posts" element={<PostList />} />
+                        <Route path="*" element={<ErrorComponent />} />
+                    </Route>
+                </Routes>
+            </Refine>
+        </BrowserRouter>
     );
 };
 

--- a/examples/customization-top-menu-layout/src/components/sider/index.tsx
+++ b/examples/customization-top-menu-layout/src/components/sider/index.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import { useTitle, useMenu } from "@refinedev/core";
 import { Menu } from "antd";
-import routerProvider from "@refinedev/react-router-v6/legacy";
-
-const { Link } = routerProvider;
+import { Link } from "react-router-dom";
 
 export const CustomSider: React.FC = () => {
     const Title = useTitle();


### PR DESCRIPTION
- base-antd
- base-chakra-ui
- base-headless
- base-mantine
- base-mui
- calendar-app
- command-palette-kbar
- core-use-import
- core-use-menu
- core-use-modal
- core-use-select
- customization-footer
- customization-login
- customization-offlayout-area
- customization-rtl
- customization-sider
- customization-theme-antd
- customization-theme-chakra-ui
- customization-theme-mantine
- customization-theme-mui
- customization-top-menu-layout

---------- 

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
