### PR TITLE
docs(use-data-grid): fix `useTable` usage

### DIFF
--- a/documentation/docs/api-reference/mui/hooks/useDataGrid/index.md
+++ b/documentation/docs/api-reference/mui/hooks/useDataGrid/index.md
@@ -284,7 +284,7 @@ method={{
 />
 
 ```tsx
-useTable({
+useDataGrid({
     resource: "categories",
 });
 ```


### PR DESCRIPTION
Fixed the typo in `useDataGrid` docs.

### Closing issues

Closes #3744

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
