### PR TITLE
fix(v4-examples): remove use router context on examples

### DIFF
--- a/examples/customization-offlayout-area/src/components/sider/index.tsx
+++ b/examples/customization-offlayout-area/src/components/sider/index.tsx
@@ -1,19 +1,13 @@
 import React, { useState } from "react";
-import {
-    useTitle,
-    ITreeMenu,
-    CanAccess,
-    useRouterContext,
-    useMenu,
-} from "@refinedev/core";
+import { useTitle, ITreeMenu, CanAccess, useMenu } from "@refinedev/core";
 
 import { UnorderedListOutlined } from "@ant-design/icons";
 import { Layout as AntdLayout, Menu } from "antd";
+import { Link } from "react-router-dom";
 
 export const FixedSider: React.FC = () => {
     const [collapsed, setCollapsed] = useState<boolean>(false);
     const Title = useTitle();
-    const { Link } = useRouterContext();
     const { SubMenu } = Menu;
     const { menuItems, selectedKey } = useMenu();
 
@@ -50,7 +44,7 @@ export const FixedSider: React.FC = () => {
                         }}
                         icon={icon ?? (isRoute && <UnorderedListOutlined />)}
                     >
-                        <Link to={route}>{label}</Link>
+                        <Link to={route || "/"}>{label}</Link>
                         {!collapsed && isSelected && (
                             <div className="ant-menu-tree-arrow" />
                         )}

--- a/examples/pixels-admin/src/pages/auth/index.tsx
+++ b/examples/pixels-admin/src/pages/auth/index.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { useRouterContext } from "@refinedev/core";
 import { AuthPage as AntdAuthPage, AuthProps } from "@refinedev/antd";
 
 import { Image } from "antd";
 
 import { StackBanner } from "components/banners";
+import { Link } from "react-router-dom";
 
 const authWrapperProps = {
     style: {
@@ -25,8 +25,6 @@ const contentProps = {
 };
 
 const renderAuthContent = (content: React.ReactNode) => {
-    const { Link } = useRouterContext();
-
     return (
         <div
             style={{


### PR DESCRIPTION
link from useRouterContext is deprecated

Please check all items below before review.

-   [ ] Corresponding issues are created/updated or not needed
-   [ ] Docs are updated/provided or not needed
-   [ ] Examples are updated/provided or not needed
-   [ ] TypeScript definitions are updated/provided or not needed
-   [ ] Tests are updated/provided or not needed
-   [ ] Changesets are provided or not needed
