### PR TITLE
fix(examples): auth redirect logic

### DIFF
--- a/examples/antd-audit-log/src/App.tsx
+++ b/examples/antd-audit-log/src/App.tsx
@@ -204,7 +204,7 @@ const App: React.FC = () => {
 
                     <Route
                         element={
-                            <Authenticated fallback={<Outlet />}>
+                            <Authenticated>
                                 <Layout>
                                     <Outlet />
                                 </Layout>

--- a/examples/auth-antd/src/App.tsx
+++ b/examples/auth-antd/src/App.tsx
@@ -249,7 +249,7 @@ const App: React.FC = () => {
 
                     <Route
                         element={
-                            <Authenticated fallback={<Outlet />}>
+                            <Authenticated>
                                 <Layout>
                                     <Outlet />
                                 </Layout>

--- a/examples/auth-auth0/src/App.tsx
+++ b/examples/auth-auth0/src/App.tsx
@@ -129,7 +129,7 @@ const App: React.FC = () => {
 
                     <Route
                         element={
-                            <Authenticated fallback={<Outlet />}>
+                            <Authenticated>
                                 <Layout>
                                     <Outlet />
                                 </Layout>

--- a/examples/auth-chakra-ui/src/App.tsx
+++ b/examples/auth-chakra-ui/src/App.tsx
@@ -225,7 +225,7 @@ const App: React.FC = () => {
 
                         <Route
                             element={
-                                <Authenticated fallback={<Outlet />}>
+                                <Authenticated>
                                     <Layout>
                                         <Outlet />
                                     </Layout>

--- a/examples/auth-google-login/src/App.tsx
+++ b/examples/auth-google-login/src/App.tsx
@@ -152,7 +152,7 @@ const App: React.FC = () => {
 
                     <Route
                         element={
-                            <Authenticated fallback={<Outlet />}>
+                            <Authenticated>
                                 <Layout>
                                     <Outlet />
                                 </Layout>

--- a/examples/auth-headless/src/App.tsx
+++ b/examples/auth-headless/src/App.tsx
@@ -178,7 +178,7 @@ const App: React.FC = () => {
 
                     <Route
                         element={
-                            <Authenticated fallback={<Outlet />}>
+                            <Authenticated>
                                 <Layout>
                                     <Outlet />
                                 </Layout>

--- a/examples/auth-keycloak/src/App.tsx
+++ b/examples/auth-keycloak/src/App.tsx
@@ -142,7 +142,7 @@ const App: React.FC = () => {
 
                     <Route
                         element={
-                            <Authenticated fallback={<Outlet />}>
+                            <Authenticated>
                                 <Layout>
                                     <Outlet />
                                 </Layout>

--- a/examples/auth-mantine/src/App.tsx
+++ b/examples/auth-mantine/src/App.tsx
@@ -234,7 +234,7 @@ const App: React.FC = () => {
 
                             <Route
                                 element={
-                                    <Authenticated fallback={<Outlet />}>
+                                    <Authenticated>
                                         <Layout>
                                             <Outlet />
                                         </Layout>

--- a/examples/auth-mui/src/App.tsx
+++ b/examples/auth-mui/src/App.tsx
@@ -213,6 +213,7 @@ const App: React.FC = () => {
                                     element={
                                         <AuthPage
                                             type="login"
+                                            rememberMe={<RememeberMe />}
                                             providers={[
                                                 {
                                                     name: "google",
@@ -298,7 +299,7 @@ const App: React.FC = () => {
 
                             <Route
                                 element={
-                                    <Authenticated fallback={<Outlet />}>
+                                    <Authenticated>
                                         <Layout>
                                             <Outlet />
                                         </Layout>

--- a/examples/auth-otp/src/App.tsx
+++ b/examples/auth-otp/src/App.tsx
@@ -101,7 +101,7 @@ const App: React.FC = () => {
 
                     <Route
                         element={
-                            <Authenticated fallback={<Outlet />}>
+                            <Authenticated>
                                 <Layout>
                                     <Outlet />
                                 </Layout>

--- a/examples/customization-login/src/App.tsx
+++ b/examples/customization-login/src/App.tsx
@@ -100,7 +100,7 @@ const App: React.FC = () => {
 
                     <Route
                         element={
-                            <Authenticated fallback={<Outlet />}>
+                            <Authenticated>
                                 <Layout>
                                     <Outlet />
                                 </Layout>

--- a/examples/data-provider-appwrite/src/App.tsx
+++ b/examples/data-provider-appwrite/src/App.tsx
@@ -105,7 +105,7 @@ const App: React.FC = () => {
                 routerProvider={routerProvider}
                 resources={[
                     {
-                        name: "posts",
+                        name: "61c43ad33b857",
                         list: "/posts",
                         create: "/posts/create",
                         edit: "/posts/edit/:id",
@@ -151,7 +151,7 @@ const App: React.FC = () => {
 
                     <Route
                         element={
-                            <Authenticated fallback={<Outlet />}>
+                            <Authenticated>
                                 <Layout>
                                     <Outlet />
                                 </Layout>

--- a/examples/data-provider-nhost/src/App.tsx
+++ b/examples/data-provider-nhost/src/App.tsx
@@ -199,7 +199,7 @@ const App: React.FC = () => {
 
                         <Route
                             element={
-                                <Authenticated fallback={<Outlet />}>
+                                <Authenticated>
                                     <Layout>
                                         <Outlet />
                                     </Layout>

--- a/examples/data-provider-strapi-graphql/src/App.tsx
+++ b/examples/data-provider-strapi-graphql/src/App.tsx
@@ -177,7 +177,7 @@ const App: React.FC = () => {
 
                     <Route
                         element={
-                            <Authenticated fallback={<Outlet />}>
+                            <Authenticated>
                                 <Layout>
                                     <Outlet />
                                 </Layout>

--- a/examples/data-provider-strapi-v4/src/App.tsx
+++ b/examples/data-provider-strapi-v4/src/App.tsx
@@ -177,7 +177,7 @@ const App: React.FC = () => {
 
                     <Route
                         element={
-                            <Authenticated fallback={<Outlet />}>
+                            <Authenticated>
                                 <Layout>
                                     <Outlet />
                                 </Layout>

--- a/examples/data-provider-strapi/src/App.tsx
+++ b/examples/data-provider-strapi/src/App.tsx
@@ -172,7 +172,7 @@ const App: React.FC = () => {
 
                     <Route
                         element={
-                            <Authenticated fallback={<Outlet />}>
+                            <Authenticated>
                                 <Layout>
                                     <Outlet />
                                 </Layout>

--- a/examples/data-provider-supabase/src/App.tsx
+++ b/examples/data-provider-supabase/src/App.tsx
@@ -184,7 +184,7 @@ const authProvider: AuthBindings = {
 
         return {
             success: true,
-            redirectTo: "/",
+            redirectTo: "/login",
         };
     },
     onError: async () => ({}),
@@ -335,7 +335,7 @@ const App: React.FC = () => {
 
                     <Route
                         element={
-                            <Authenticated fallback={<Outlet />}>
+                            <Authenticated>
                                 <Layout>
                                     <Outlet />
                                 </Layout>

--- a/examples/finefoods-antd/src/App.tsx
+++ b/examples/finefoods-antd/src/App.tsx
@@ -236,7 +236,7 @@ const App: React.FC = () => {
 
                         <Route
                             element={
-                                <Authenticated fallback={<Outlet />}>
+                                <Authenticated>
                                     <Layout
                                         Header={Header}
                                         Title={Title}

--- a/examples/finefoods-antd/src/authProvider.ts
+++ b/examples/finefoods-antd/src/authProvider.ts
@@ -45,6 +45,7 @@ export const authProvider: AuthBindings = {
         localStorage.removeItem(TOKEN_KEY);
         return {
             success: true,
+            redirectTo: "/login",
         };
     },
     onError: async () => ({}),

--- a/examples/finefoods-mui/src/App.tsx
+++ b/examples/finefoods-mui/src/App.tsx
@@ -272,7 +272,7 @@ const App: React.FC = () => {
 
                                 <Route
                                     element={
-                                        <Authenticated fallback={<Outlet />}>
+                                        <Authenticated>
                                             <Layout
                                                 Header={Header}
                                                 Title={Title}

--- a/examples/finefoods-mui/src/authProvider.ts
+++ b/examples/finefoods-mui/src/authProvider.ts
@@ -36,6 +36,7 @@ export const authProvider: AuthBindings = {
         localStorage.removeItem(TOKEN_KEY);
         return {
             success: true,
+            redirectTo: "/login",
         };
     },
     onError: async () => ({}),


### PR DESCRIPTION
"When an unauthenticated user visited an undefined route, 'login?to=' was not added to the URL. It was only added if a route was defined. This has now changed and 'login?to=' is being added regardless of whether a route is defined or not."

For example as an unauthenticated user:
Let's say our defined routes are `post`, `users`, and `login`. Previously, if a user typed `localhost:3000/not-defined-route` in the URL, they would be redirected to `localhost:3000/login`. With this change, they will now be redirected to `localhost:3000/login?to=not-defined-route`.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
