### PR TITLE
fix(router): fix legacy prompts

### DIFF
--- a/packages/react-router-v6/src/legacy/prompt.tsx
+++ b/packages/react-router-v6/src/legacy/prompt.tsx
@@ -1,6 +1,4 @@
-import { useEffect, useContext } from "react";
-import { UNSAFE_NavigationContext as NavigationContext } from "react-router-dom";
-import type { History } from "history";
+import { usePrompt } from "../use-prompt-workaround";
 
 import type { PromptProps } from "@refinedev/core";
 
@@ -9,22 +7,9 @@ export const Prompt: React.FC<PromptProps> = ({
     when,
     setWarnWhen,
 }) => {
-    const navigator = useContext(NavigationContext).navigator as History;
-
-    useEffect(() => {
-        if (!when) return;
-
-        const unblock = navigator.block((transition: any) => {
-            if (window.confirm(message)) {
-                setWarnWhen?.(false);
-                unblock();
-                transition.retry();
-            } else {
-                navigator.location.pathname = window.location.pathname;
-            }
-        });
-        return unblock;
-    }, [when, location, message]);
+    usePrompt(message, when, () => {
+        setWarnWhen?.(false);
+    });
 
     return null;
 };

--- a/packages/remix/src/legacy/prompt.tsx
+++ b/packages/remix/src/legacy/prompt.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useContext } from "react";
-import { UNSAFE_NavigationContext as NavigationContext } from "react-router-dom";
-import type { History } from "history";
+import React from "react";
+import { unstable_useBlocker as useBlocker } from "@remix-run/react";
 
 import type { PromptProps } from "@refinedev/core";
 
@@ -9,22 +8,19 @@ export const Prompt: React.FC<PromptProps> = ({
     when,
     setWarnWhen,
 }) => {
-    const navigator = useContext(NavigationContext).navigator as History;
-
-    useEffect(() => {
-        if (!when) return;
-
-        const unblock = navigator.block((transition: any) => {
+    const blocker = React.useCallback(() => {
+        if (when) {
             if (window.confirm(message)) {
                 setWarnWhen?.(false);
-                unblock();
-                transition.retry();
+                return false;
             } else {
-                navigator.location.pathname = window.location.pathname;
+                return true;
             }
-        });
-        return unblock;
-    }, [when, message]);
+        }
+        return false;
+    }, [when, message, setWarnWhen]);
+
+    useBlocker(blocker);
 
     return null;
 };


### PR DESCRIPTION
- Updated broken legacy prompt in `react-router-v6` in the latest updates.
- Updated remix's legacy prompt with `useBlocker`

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
