### PR TITLE
fix(remix): update broken prompt component

### DIFF
--- a/.changeset/chilled-seas-press.md
+++ b/.changeset/chilled-seas-press.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-remix-router": patch
+---
+
+Updated the broken `Prompt` with `useBlocker` instead of an unsafe workaround.

--- a/packages/remix/src/prompt.tsx
+++ b/packages/remix/src/prompt.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useContext } from "react";
-import { UNSAFE_NavigationContext as NavigationContext } from "react-router-dom";
-import type { History } from "history";
+import React from "react";
+import { unstable_useBlocker as useBlocker } from "@remix-run/react";
 
 import type { PromptProps } from "@pankod/refine-core";
 
@@ -9,22 +8,19 @@ export const Prompt: React.FC<PromptProps> = ({
     when,
     setWarnWhen,
 }) => {
-    const navigator = useContext(NavigationContext).navigator as History;
-
-    useEffect(() => {
-        if (!when) return;
-
-        const unblock = navigator.block((transition: any) => {
+    const blocker = React.useCallback(() => {
+        if (when) {
             if (window.confirm(message)) {
                 setWarnWhen?.(false);
-                unblock();
-                transition.retry();
+                return false;
             } else {
-                navigator.location.pathname = window.location.pathname;
+                return true;
             }
-        });
-        return unblock;
-    }, [when, message]);
+        }
+        return false;
+    }, [when, message, setWarnWhen]);
+
+    useBlocker(blocker);
 
     return null;
 };


### PR DESCRIPTION
`Prompt` component from the `@pankod/refine-remix-router`'s `routerProvider` was broken with the latest releases in the remix packages. We're now using the `useBlocker` from `@remix-run/react`

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
