### PR TITLE
fix(v4): fix `useLogin` redirection

### DIFF
--- a/packages/core/src/hooks/auth/useLogin/index.spec.ts
+++ b/packages/core/src/hooks/auth/useLogin/index.spec.ts
@@ -402,7 +402,7 @@ describe("useLogin Hook", () => {
             });
         });
 
-        expect(mockGo).toBeCalledWith({ type: "replace", to: "/show/posts/5" });
+        expect(mockGo).not.toBeCalled();
     });
 
     it("login rejected with undefined error", async () => {

--- a/packages/core/src/hooks/auth/useLogin/index.ts
+++ b/packages/core/src/hooks/auth/useLogin/index.ts
@@ -136,7 +136,7 @@ export function useLogin<TVariables = {}>({
                 open?.(buildNotification(error));
             }
 
-            if (to) {
+            if (to && success) {
                 if (routerType === "legacy") {
                     return replace(to as string);
                 } else {


### PR DESCRIPTION
Use `to` only in success.