### PR TITLE
feat(examples): add `<UnsavedChangesNotifier/>` to examples starts with "f"

### DIFF
--- a/examples/field-antd-use-checkbox-group/src/App.tsx
+++ b/examples/field-antd-use-checkbox-group/src/App.tsx
@@ -1,7 +1,10 @@
 import { GitHubBanner, Refine } from "@refinedev/core";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import "@refinedev/antd/dist/reset.css";
@@ -27,6 +30,10 @@ const App: React.FC = () => {
                     },
                 ]}
                 notificationProvider={notificationProvider}
+                options={{
+                    syncWithLocation: true,
+                    warnWhenUnsavedChanges: true,
+                }}
             >
                 <Routes>
                     <Route
@@ -51,6 +58,7 @@ const App: React.FC = () => {
                         <Route path="*" element={<ErrorComponent />} />
                     </Route>
                 </Routes>
+                <UnsavedChangesNotifier />
             </Refine>
         </BrowserRouter>
     );

--- a/examples/field-antd-use-radio-group/src/App.tsx
+++ b/examples/field-antd-use-radio-group/src/App.tsx
@@ -1,7 +1,10 @@
 import { GitHubBanner, Refine } from "@refinedev/core";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import "@refinedev/antd/dist/reset.css";
@@ -27,6 +30,10 @@ const App: React.FC = () => {
                     },
                 ]}
                 notificationProvider={notificationProvider}
+                options={{
+                    syncWithLocation: true,
+                    warnWhenUnsavedChanges: true,
+                }}
             >
                 <Routes>
                     <Route
@@ -51,6 +58,7 @@ const App: React.FC = () => {
                         <Route path="*" element={<ErrorComponent />} />
                     </Route>
                 </Routes>
+                <UnsavedChangesNotifier />
             </Refine>
         </BrowserRouter>
     );

--- a/examples/field-antd-use-select-basic/src/App.tsx
+++ b/examples/field-antd-use-select-basic/src/App.tsx
@@ -1,7 +1,10 @@
 import { GitHubBanner, Refine } from "@refinedev/core";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import "@refinedev/antd/dist/reset.css";
@@ -27,6 +30,10 @@ const App: React.FC = () => {
                     },
                 ]}
                 notificationProvider={notificationProvider}
+                options={{
+                    syncWithLocation: true,
+                    warnWhenUnsavedChanges: true,
+                }}
             >
                 <Routes>
                     <Route
@@ -51,6 +58,7 @@ const App: React.FC = () => {
                         <Route path="*" element={<ErrorComponent />} />
                     </Route>
                 </Routes>
+                <UnsavedChangesNotifier />
             </Refine>
         </BrowserRouter>
     );

--- a/examples/field-antd-use-select-infinite/src/App.tsx
+++ b/examples/field-antd-use-select-infinite/src/App.tsx
@@ -1,7 +1,10 @@
 import { GitHubBanner, Refine } from "@refinedev/core";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import "@refinedev/antd/dist/reset.css";
@@ -27,6 +30,10 @@ const App: React.FC = () => {
                     },
                 ]}
                 notificationProvider={notificationProvider}
+                options={{
+                    syncWithLocation: true,
+                    warnWhenUnsavedChanges: true,
+                }}
             >
                 <Routes>
                     <Route
@@ -50,6 +57,7 @@ const App: React.FC = () => {
 
                         <Route path="*" element={<ErrorComponent />} />
                     </Route>
+                    <UnsavedChangesNotifier />
                 </Routes>
             </Refine>
         </BrowserRouter>

--- a/examples/field-mui-use-autocomplete/src/App.tsx
+++ b/examples/field-mui-use-autocomplete/src/App.tsx
@@ -7,7 +7,10 @@ import {
     SnackbarProvider,
 } from "@refinedev/mui";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import { ThemeProvider } from "@mui/material/styles";
 
@@ -33,6 +36,10 @@ const App: React.FC = () => {
                                 edit: "/posts/edit/:id",
                             },
                         ]}
+                        options={{
+                            syncWithLocation: true,
+                            warnWhenUnsavedChanges: true,
+                        }}
                     >
                         <Routes>
                             <Route
@@ -64,6 +71,7 @@ const App: React.FC = () => {
                                 <Route path="*" element={<ErrorComponent />} />
                             </Route>
                         </Routes>
+                        <UnsavedChangesNotifier />
                     </Refine>
                 </SnackbarProvider>
             </ThemeProvider>

--- a/examples/finefoods-antd/src/App.tsx
+++ b/examples/finefoods-antd/src/App.tsx
@@ -5,6 +5,7 @@ import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import routerProvider, {
     CatchAllNavigate,
     NavigateToResource,
+    UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import {
@@ -201,7 +202,7 @@ const App: React.FC = () => {
                         <Route
                             element={
                                 <Authenticated fallback={<Outlet />}>
-                                    <NavigateToResource />
+                                    <NavigateToResource resource="dashboard" />
                                 </Authenticated>
                             }
                         >
@@ -259,6 +260,7 @@ const App: React.FC = () => {
                             <Route path="*" element={<ErrorComponent />} />
                         </Route>
                     </Routes>
+                    <UnsavedChangesNotifier />
                 </Refine>
             </RefineKbarProvider>
         </BrowserRouter>

--- a/examples/finefoods-mui/src/App.tsx
+++ b/examples/finefoods-mui/src/App.tsx
@@ -11,6 +11,7 @@ import dataProvider from "@refinedev/simple-rest";
 import routerProvider, {
     CatchAllNavigate,
     NavigateToResource,
+    UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import { useTranslation } from "react-i18next";
@@ -226,7 +227,7 @@ const App: React.FC = () => {
                                 <Route
                                     element={
                                         <Authenticated fallback={<Outlet />}>
-                                            <NavigateToResource />
+                                            <NavigateToResource resource="dashboard" />
                                         </Authenticated>
                                     }
                                 >
@@ -298,6 +299,7 @@ const App: React.FC = () => {
                                     />
                                 </Route>
                             </Routes>
+                            <UnsavedChangesNotifier />
                         </Refine>
                     </RefineSnackbarProvider>
                 </ColorModeContextProvider>

--- a/examples/form-antd-custom-validation/src/App.tsx
+++ b/examples/form-antd-custom-validation/src/App.tsx
@@ -1,7 +1,10 @@
 import { GitHubBanner, Refine } from "@refinedev/core";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import "@refinedev/antd/dist/reset.css";
@@ -27,6 +30,10 @@ const App: React.FC = () => {
                     },
                 ]}
                 notificationProvider={notificationProvider}
+                options={{
+                    syncWithLocation: true,
+                    warnWhenUnsavedChanges: true,
+                }}
             >
                 <Routes>
                     <Route
@@ -51,6 +58,7 @@ const App: React.FC = () => {
                         <Route path="*" element={<ErrorComponent />} />
                     </Route>
                 </Routes>
+                <UnsavedChangesNotifier />
             </Refine>
         </BrowserRouter>
     );

--- a/examples/form-antd-use-drawer-form/src/App.tsx
+++ b/examples/form-antd-use-drawer-form/src/App.tsx
@@ -1,7 +1,10 @@
 import { GitHubBanner, Refine } from "@refinedev/core";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import "@refinedev/antd/dist/reset.css";
@@ -24,6 +27,10 @@ const App: React.FC = () => {
                     },
                 ]}
                 notificationProvider={notificationProvider}
+                options={{
+                    syncWithLocation: true,
+                    warnWhenUnsavedChanges: true,
+                }}
             >
                 <Routes>
                     <Route
@@ -41,6 +48,7 @@ const App: React.FC = () => {
                         <Route path="*" element={<ErrorComponent />} />
                     </Route>
                 </Routes>
+                <UnsavedChangesNotifier />
             </Refine>
         </BrowserRouter>
     );

--- a/examples/form-antd-use-drawer-form/src/pages/posts/list.tsx
+++ b/examples/form-antd-use-drawer-form/src/pages/posts/list.tsx
@@ -192,7 +192,12 @@ export const PostList: React.FC<IResourceComponentsProps> = () => {
             >
                 <Show
                     isLoading={showIsLoading}
-                    headerButtons={<DeleteButton recordItemId={showId} />}
+                    headerButtons={
+                        <DeleteButton
+                            recordItemId={showId}
+                            onSuccess={() => setVisibleShowDrawer(false)}
+                        />
+                    }
                 >
                     <Title level={5}>Id</Title>
                     <Text>{record?.id}</Text>

--- a/examples/form-antd-use-form/src/App.tsx
+++ b/examples/form-antd-use-form/src/App.tsx
@@ -1,7 +1,10 @@
 import { GitHubBanner, Refine } from "@refinedev/core";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import "@refinedev/antd/dist/reset.css";
@@ -27,6 +30,10 @@ const App: React.FC = () => {
                     },
                 ]}
                 notificationProvider={notificationProvider}
+                options={{
+                    syncWithLocation: true,
+                    warnWhenUnsavedChanges: true,
+                }}
             >
                 <Routes>
                     <Route
@@ -50,6 +57,7 @@ const App: React.FC = () => {
 
                         <Route path="*" element={<ErrorComponent />} />
                     </Route>
+                    <UnsavedChangesNotifier />
                 </Routes>
             </Refine>
         </BrowserRouter>

--- a/examples/form-antd-use-modal-form/src/App.tsx
+++ b/examples/form-antd-use-modal-form/src/App.tsx
@@ -1,7 +1,10 @@
 import { GitHubBanner, Refine } from "@refinedev/core";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import "@refinedev/antd/dist/reset.css";
@@ -24,6 +27,10 @@ const App: React.FC = () => {
                     },
                 ]}
                 notificationProvider={notificationProvider}
+                options={{
+                    syncWithLocation: true,
+                    warnWhenUnsavedChanges: true,
+                }}
             >
                 <Routes>
                     <Route
@@ -40,6 +47,7 @@ const App: React.FC = () => {
                         <Route path="/posts" element={<PostList />} />
                         <Route path="*" element={<ErrorComponent />} />
                     </Route>
+                    <UnsavedChangesNotifier />
                 </Routes>
             </Refine>
         </BrowserRouter>

--- a/examples/form-antd-use-steps-form/src/App.tsx
+++ b/examples/form-antd-use-steps-form/src/App.tsx
@@ -1,7 +1,10 @@
 import { GitHubBanner, Refine } from "@refinedev/core";
 import { notificationProvider, Layout, ErrorComponent } from "@refinedev/antd";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import "@refinedev/antd/dist/reset.css";
@@ -26,6 +29,10 @@ const App: React.FC = () => {
                     },
                 ]}
                 notificationProvider={notificationProvider}
+                options={{
+                    syncWithLocation: true,
+                    warnWhenUnsavedChanges: true,
+                }}
             >
                 <Routes>
                     <Route
@@ -49,6 +56,7 @@ const App: React.FC = () => {
                         <Route path="*" element={<ErrorComponent />} />
                     </Route>
                 </Routes>
+                <UnsavedChangesNotifier />
             </Refine>
         </BrowserRouter>
     );

--- a/examples/form-chakra-ui-use-drawer-form/src/App.tsx
+++ b/examples/form-chakra-ui-use-drawer-form/src/App.tsx
@@ -6,7 +6,10 @@ import {
     notificationProvider,
 } from "@refinedev/chakra-ui";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import { ChakraProvider } from "@chakra-ui/react";
 
@@ -29,6 +32,10 @@ const App: React.FC = () => {
                             list: "/posts",
                         },
                     ]}
+                    options={{
+                        syncWithLocation: true,
+                        warnWhenUnsavedChanges: true,
+                    }}
                 >
                     <Routes>
                         <Route
@@ -48,6 +55,7 @@ const App: React.FC = () => {
                             <Route path="*" element={<ErrorComponent />} />
                         </Route>
                     </Routes>
+                    <UnsavedChangesNotifier />
                 </Refine>
             </ChakraProvider>
         </BrowserRouter>

--- a/examples/form-chakra-ui-use-form/src/App.tsx
+++ b/examples/form-chakra-ui-use-form/src/App.tsx
@@ -2,7 +2,10 @@ import { GitHubBanner, Refine } from "@refinedev/core";
 import { ErrorComponent, Layout, refineTheme } from "@refinedev/chakra-ui";
 import { ChakraProvider } from "@chakra-ui/react";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import { PostList, PostCreate, PostEdit, PostShow } from "./pages";
@@ -26,6 +29,10 @@ const App: React.FC = () => {
                             show: "/posts/show/:id",
                         },
                     ]}
+                    options={{
+                        syncWithLocation: true,
+                        warnWhenUnsavedChanges: true,
+                    }}
                 >
                     <Routes>
                         <Route
@@ -52,6 +59,7 @@ const App: React.FC = () => {
                             <Route path="*" element={<ErrorComponent />} />
                         </Route>
                     </Routes>
+                    <UnsavedChangesNotifier />
                 </Refine>
             </ChakraProvider>
         </BrowserRouter>

--- a/examples/form-chakra-use-modal-antd-form/src/App.tsx
+++ b/examples/form-chakra-use-modal-antd-form/src/App.tsx
@@ -6,7 +6,10 @@ import {
     notificationProvider,
 } from "@refinedev/chakra-ui";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import { ChakraProvider } from "@chakra-ui/react";
 
@@ -14,44 +17,45 @@ import { PostList } from "./pages";
 
 const API_URL = "https://api.fake-rest.refine.dev";
 
-const App: React.FC = () => {
-    return (
-        <BrowserRouter>
-            <GitHubBanner />
-            <ChakraProvider theme={refineTheme}>
-                <Refine
-                    routerProvider={routerProvider}
-                    dataProvider={dataProvider(API_URL)}
-                    notificationProvider={notificationProvider()}
-                    resources={[
-                        {
-                            name: "posts",
-                            list: "/posts",
-                        },
-                    ]}
-                >
-                    <Routes>
+const App: React.FC = () => (
+    <BrowserRouter>
+        <GitHubBanner />
+        <ChakraProvider theme={refineTheme}>
+            <Refine
+                routerProvider={routerProvider}
+                dataProvider={dataProvider(API_URL)}
+                notificationProvider={notificationProvider()}
+                resources={[
+                    {
+                        name: "posts",
+                        list: "/posts",
+                    },
+                ]}
+                options={{
+                    syncWithLocation: true,
+                    warnWhenUnsavedChanges: true,
+                }}
+            >
+                <Routes>
+                    <Route
+                        element={
+                            <Layout>
+                                <Outlet />
+                            </Layout>
+                        }
+                    >
                         <Route
-                            element={
-                                <Layout>
-                                    <Outlet />
-                                </Layout>
-                            }
-                        >
-                            <Route
-                                index
-                                element={
-                                    <NavigateToResource resource="posts" />
-                                }
-                            />
-                            <Route path="/posts" element={<PostList />} />
-                            <Route path="*" element={<ErrorComponent />} />
-                        </Route>
-                    </Routes>
-                </Refine>
-            </ChakraProvider>
-        </BrowserRouter>
-    );
-};
+                            index
+                            element={<NavigateToResource resource="posts" />}
+                        />
+                        <Route path="/posts" element={<PostList />} />
+                        <Route path="*" element={<ErrorComponent />} />
+                    </Route>
+                </Routes>
+                <UnsavedChangesNotifier />
+            </Refine>
+        </ChakraProvider>
+    </BrowserRouter>
+);
 
 export default App;

--- a/examples/form-core-use-form/src/App.tsx
+++ b/examples/form-core-use-form/src/App.tsx
@@ -1,6 +1,9 @@
 import { GitHubBanner, Refine, ErrorComponent } from "@refinedev/core";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 import { PostList, PostCreate, PostEdit, PostShow } from "pages/posts";
@@ -22,6 +25,10 @@ const App: React.FC = () => {
                         show: "/posts/show/:id",
                     },
                 ]}
+                options={{
+                    syncWithLocation: true,
+                    warnWhenUnsavedChanges: true,
+                }}
             >
                 <Routes>
                     <Route
@@ -39,6 +46,7 @@ const App: React.FC = () => {
 
                     <Route path="*" element={<ErrorComponent />} />
                 </Routes>
+                <UnsavedChangesNotifier />
             </Refine>
         </BrowserRouter>
     );

--- a/examples/form-mantine-use-drawer-form/src/App.tsx
+++ b/examples/form-mantine-use-drawer-form/src/App.tsx
@@ -6,7 +6,10 @@ import {
     LightTheme,
 } from "@refinedev/mantine";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import { NotificationsProvider } from "@mantine/notifications";
 import { MantineProvider, Global } from "@mantine/core";
@@ -36,6 +39,10 @@ const App: React.FC = () => {
                                 list: "/posts",
                             },
                         ]}
+                        options={{
+                            syncWithLocation: true,
+                            warnWhenUnsavedChanges: true,
+                        }}
                     >
                         <Routes>
                             <Route
@@ -57,6 +64,7 @@ const App: React.FC = () => {
                         </Routes>
                     </Refine>
                 </NotificationsProvider>
+                <UnsavedChangesNotifier />
             </MantineProvider>
         </BrowserRouter>
     );

--- a/examples/form-mantine-use-form/src/App.tsx
+++ b/examples/form-mantine-use-form/src/App.tsx
@@ -6,7 +6,10 @@ import {
     LightTheme,
 } from "@refinedev/mantine";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import { NotificationsProvider } from "@mantine/notifications";
 import { MantineProvider, Global } from "@mantine/core";
@@ -38,6 +41,10 @@ const App: React.FC = () => {
                                 edit: "/posts/edit/:id",
                             },
                         ]}
+                        options={{
+                            syncWithLocation: true,
+                            warnWhenUnsavedChanges: true,
+                        }}
                     >
                         <Routes>
                             <Route
@@ -70,6 +77,7 @@ const App: React.FC = () => {
                             </Route>
                         </Routes>
                     </Refine>
+                    <UnsavedChangesNotifier />
                 </NotificationsProvider>
             </MantineProvider>
         </BrowserRouter>

--- a/examples/form-mantine-use-modal-form/src/App.tsx
+++ b/examples/form-mantine-use-modal-form/src/App.tsx
@@ -8,7 +8,10 @@ import {
 import { NotificationsProvider } from "@mantine/notifications";
 import { MantineProvider, Global } from "@mantine/core";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
 import { PostList } from "./pages";
@@ -36,6 +39,10 @@ const App: React.FC = () => {
                                 list: "/posts",
                             },
                         ]}
+                        options={{
+                            syncWithLocation: true,
+                            warnWhenUnsavedChanges: true,
+                        }}
                     >
                         <Routes>
                             <Route
@@ -55,6 +62,7 @@ const App: React.FC = () => {
                                 <Route path="*" element={<ErrorComponent />} />
                             </Route>
                         </Routes>
+                        <UnsavedChangesNotifier />
                     </Refine>
                 </NotificationsProvider>
             </MantineProvider>

--- a/examples/form-mantine-use-steps-form/src/App.tsx
+++ b/examples/form-mantine-use-steps-form/src/App.tsx
@@ -6,7 +6,10 @@ import {
     LightTheme,
 } from "@refinedev/mantine";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import { NotificationsProvider } from "@mantine/notifications";
 import { MantineProvider, Global } from "@mantine/core";
@@ -38,6 +41,10 @@ const App: React.FC = () => {
                                 edit: "/posts/edit/:id",
                             },
                         ]}
+                        options={{
+                            syncWithLocation: true,
+                            warnWhenUnsavedChanges: true,
+                        }}
                     >
                         <Routes>
                             <Route
@@ -69,6 +76,7 @@ const App: React.FC = () => {
                                 <Route path="*" element={<ErrorComponent />} />
                             </Route>
                         </Routes>
+                        <UnsavedChangesNotifier />
                     </Refine>
                 </NotificationsProvider>
             </MantineProvider>

--- a/examples/form-mui-use-drawer-form/src/App.tsx
+++ b/examples/form-mui-use-drawer-form/src/App.tsx
@@ -7,7 +7,10 @@ import {
     RefineSnackbarProvider,
 } from "@refinedev/mui";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import { CssBaseline, GlobalStyles } from "@mui/material";
 import { ThemeProvider } from "@mui/material/styles";
@@ -36,6 +39,10 @@ const App: React.FC = () => {
                                 list: "/posts",
                             },
                         ]}
+                        options={{
+                            syncWithLocation: true,
+                            warnWhenUnsavedChanges: true,
+                        }}
                     >
                         <Routes>
                             <Route
@@ -55,6 +62,7 @@ const App: React.FC = () => {
                                 <Route path="*" element={<ErrorComponent />} />
                             </Route>
                         </Routes>
+                        <UnsavedChangesNotifier />
                     </Refine>
                 </RefineSnackbarProvider>
             </ThemeProvider>

--- a/examples/form-mui-use-form/src/App.tsx
+++ b/examples/form-mui-use-form/src/App.tsx
@@ -7,7 +7,10 @@ import {
     RefineSnackbarProvider,
 } from "@refinedev/mui";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import { CssBaseline, GlobalStyles } from "@mui/material";
 import { ThemeProvider } from "@mui/material/styles";
@@ -38,6 +41,10 @@ const App: React.FC = () => {
                                 edit: "/posts/edit/:id",
                             },
                         ]}
+                        options={{
+                            syncWithLocation: true,
+                            warnWhenUnsavedChanges: true,
+                        }}
                     >
                         <Routes>
                             <Route
@@ -69,6 +76,7 @@ const App: React.FC = () => {
                                 <Route path="*" element={<ErrorComponent />} />
                             </Route>
                         </Routes>
+                        <UnsavedChangesNotifier />
                     </Refine>
                 </RefineSnackbarProvider>
             </ThemeProvider>

--- a/examples/form-mui-use-modal-form/src/App.tsx
+++ b/examples/form-mui-use-modal-form/src/App.tsx
@@ -7,7 +7,10 @@ import {
     RefineSnackbarProvider,
 } from "@refinedev/mui";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import { CssBaseline, GlobalStyles } from "@mui/material";
 import { ThemeProvider } from "@mui/material/styles";
@@ -36,6 +39,10 @@ const App: React.FC = () => {
                                 list: "/posts",
                             },
                         ]}
+                        options={{
+                            syncWithLocation: true,
+                            warnWhenUnsavedChanges: true,
+                        }}
                     >
                         <Routes>
                             <Route
@@ -55,6 +62,7 @@ const App: React.FC = () => {
                                 <Route path="*" element={<ErrorComponent />} />
                             </Route>
                         </Routes>
+                        <UnsavedChangesNotifier />
                     </Refine>
                 </RefineSnackbarProvider>
             </ThemeProvider>

--- a/examples/form-mui-use-steps-form/src/App.tsx
+++ b/examples/form-mui-use-steps-form/src/App.tsx
@@ -7,7 +7,10 @@ import {
     RefineSnackbarProvider,
 } from "@refinedev/mui";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import { CssBaseline, GlobalStyles } from "@mui/material";
 import { ThemeProvider } from "@mui/material/styles";
@@ -38,6 +41,10 @@ const App: React.FC = () => {
                                 edit: "/posts/edit/:id",
                             },
                         ]}
+                        options={{
+                            syncWithLocation: true,
+                            warnWhenUnsavedChanges: true,
+                        }}
                     >
                         <Routes>
                             <Route
@@ -68,6 +75,7 @@ const App: React.FC = () => {
 
                                 <Route path="*" element={<ErrorComponent />} />
                             </Route>
+                            <UnsavedChangesNotifier />
                         </Routes>
                     </Refine>
                 </RefineSnackbarProvider>

--- a/examples/form-react-hook-form-use-form/src/App.tsx
+++ b/examples/form-react-hook-form-use-form/src/App.tsx
@@ -1,6 +1,9 @@
 import { GitHubBanner, Refine, ErrorComponent } from "@refinedev/core";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 import { PostCreate, PostEdit, PostList } from "pages/posts";
@@ -22,6 +25,10 @@ const App: React.FC = () => {
                         edit: "/posts/edit/:id",
                     },
                 ]}
+                options={{
+                    syncWithLocation: true,
+                    warnWhenUnsavedChanges: true,
+                }}
             >
                 <Routes>
                     <Route
@@ -36,6 +43,7 @@ const App: React.FC = () => {
 
                     <Route path="*" element={<ErrorComponent />} />
                 </Routes>
+                <UnsavedChangesNotifier />
             </Refine>
         </BrowserRouter>
     );

--- a/examples/form-react-hook-form-use-modal-form/src/App.tsx
+++ b/examples/form-react-hook-form-use-modal-form/src/App.tsx
@@ -1,6 +1,9 @@
 import { GitHubBanner, Refine, ErrorComponent } from "@refinedev/core";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 import "./styles.css";
@@ -22,6 +25,10 @@ const App: React.FC = () => {
                         list: "/posts",
                     },
                 ]}
+                options={{
+                    syncWithLocation: true,
+                    warnWhenUnsavedChanges: true,
+                }}
             >
                 <Routes>
                     <Route
@@ -31,6 +38,7 @@ const App: React.FC = () => {
                     <Route path="/posts" element={<PostList />} />
                     <Route path="*" element={<ErrorComponent />} />
                 </Routes>
+                <UnsavedChangesNotifier />
             </Refine>
         </BrowserRouter>
     );

--- a/examples/form-react-hook-form-use-steps-form/src/App.tsx
+++ b/examples/form-react-hook-form-use-steps-form/src/App.tsx
@@ -1,6 +1,9 @@
 import { GitHubBanner, Refine, ErrorComponent } from "@refinedev/core";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 import { PostCreate, PostEdit, PostList } from "pages/posts";
@@ -20,6 +23,10 @@ const App: React.FC = () => {
                         edit: "/posts/edit/:id",
                     },
                 ]}
+                options={{
+                    syncWithLocation: true,
+                    warnWhenUnsavedChanges: true,
+                }}
             >
                 <Routes>
                     <Route
@@ -34,6 +41,7 @@ const App: React.FC = () => {
                     </Route>
 
                     <Route path="*" element={<ErrorComponent />} />
+                    <UnsavedChangesNotifier />
                 </Routes>
             </Refine>
         </BrowserRouter>

--- a/examples/form-save-and-continue/src/App.tsx
+++ b/examples/form-save-and-continue/src/App.tsx
@@ -1,6 +1,9 @@
 import { GitHubBanner, Refine, ErrorComponent } from "@refinedev/core";
 import dataProvider from "@refinedev/simple-rest";
-import routerProvider, { NavigateToResource } from "@refinedev/react-router-v6";
+import routerProvider, {
+    NavigateToResource,
+    UnsavedChangesNotifier,
+} from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 import "./styles.css";
@@ -14,7 +17,6 @@ const App: React.FC = () => {
             <Refine
                 dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
                 routerProvider={routerProvider}
-                options={{ mutationMode: "pessimistic" }}
                 resources={[
                     {
                         name: "posts",
@@ -23,6 +25,11 @@ const App: React.FC = () => {
                         edit: "/posts/edit/:id",
                     },
                 ]}
+                options={{
+                    mutationMode: "pessimistic",
+                    syncWithLocation: true,
+                    warnWhenUnsavedChanges: true,
+                }}
             >
                 <Routes>
                     <Route
@@ -38,6 +45,7 @@ const App: React.FC = () => {
 
                     <Route path="*" element={<ErrorComponent />} />
                 </Routes>
+                <UnsavedChangesNotifier />
             </Refine>
         </BrowserRouter>
     );


### PR DESCRIPTION
added: `<UnsavedChangesNotifier/>` to examples starts with "f"

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
