### PR TITLE
feat(v4-codemod): `resourceName` or `resourceNameOrRouteName` transformation for buttons

### DIFF
--- a/packages/codemod/src/transformations/refine3-to-refine4.ts
+++ b/packages/codemod/src/transformations/refine3-to-refine4.ts
@@ -7,7 +7,7 @@ import { authProviderToLegacyAuthProvider } from "./v4/authProvider-to-legacyAut
 import { metaDataToMeta } from "./v4/metadata-to-meta";
 import { moveDeprecatedAccessControlProps } from "./v4/move-deprecated-access-control";
 import { routerToLegacyRouter } from "./v4/router-to-legacy-router";
-import { renameResourcePropInButtons } from "./v4/rename-buttons-resource-prop";
+import { resourceNameToResourceForButtons } from "./v4/resourceName-to-resource";
 import { separateImportsAntD } from "./v4/separate-imports-antd";
 import { separateImportsChakra } from "./v4/separate-imports-chakra";
 import { separateImportsMantine } from "./v4/separate-imports-mantine";
@@ -103,7 +103,8 @@ export default function transformer(file: FileInfo, api: API): string {
     authProviderToLegacyAuthProvider(j, source);
     metaDataToMeta(j, source);
     moveDeprecatedAccessControlProps(j, source);
-    renameResourcePropInButtons(j, source);
+    // renameResourcePropInButtons(j, source);
+    resourceNameToResourceForButtons(j, source);
     routerToLegacyRouter(j, source);
     separateImportsAntD(j, source);
     separateImportsChakra(j, source);

--- a/packages/codemod/src/transformations/v4/resourceName-to-resource.ts
+++ b/packages/codemod/src/transformations/v4/resourceName-to-resource.ts
@@ -1,0 +1,48 @@
+import { Collection, JSCodeshift } from "jscodeshift";
+
+const COMPONENT_NAMES = [
+    "ShowButton",
+    "EditButton",
+    "DeleteButton",
+    "CloneButton",
+    "ListButton",
+    "RefreshButton",
+    "CreateButton",
+];
+
+const DEPRECATED_PROP_NAMES = ["resourceName", "resourceNameOrRouteName"];
+const NEW_PROP_NAME = "resource";
+
+export const resourceNameToResourceForButtons = (
+    j: JSCodeshift,
+    source: Collection,
+) => {
+    // find all JSX elements that are named in COMPONENT_NAMES
+    const elements = source.find(j.JSXElement, {
+        openingElement: {
+            name: {
+                name: (name: string) => COMPONENT_NAMES.includes(name),
+            },
+        },
+    });
+
+    elements.forEach((path) => {
+        const attributes = path.node.openingElement.attributes;
+        if (!attributes) return;
+
+        // if they have a NEW_PROP_NAME attribute, skip them.
+        const hasNewAttribute = attributes.some(
+            (attribute) => attribute?.["name"]?.["name"] === NEW_PROP_NAME,
+        );
+
+        if (hasNewAttribute) return;
+
+        // if they have a metaData change it to meta.
+        path.node.openingElement.attributes.forEach((attribute) => {
+            if (DEPRECATED_PROP_NAMES.includes(attribute?.["name"]?.["name"])) {
+                attribute["name"]["name"] = NEW_PROP_NAME;
+                return;
+            }
+        });
+    });
+};


### PR DESCRIPTION
ast explorer for debug
https://astexplorer.net/#/gist/f18703c7479f27c6b7c1579541add9c0/6e5d216a1a9d0168633a7254797e26a835e34ca4

before: 
```ts
const TestComponent = ({ resourceName }) => {
    return (
        <div>
            <DeleteButton
                size="small"
                recordItemId={row.id}
                resource={otherMockName}
            ></DeleteButton>

            <ShowButton resourceNameOrRouteName="testname"></ShowButton>
            <EditButton resourceNameOrRouteName={MOCK_NAME}></EditButton>

            <CloneButton resourceName="testname"></CloneButton>
            <ListButton resourceName={MOCK_NAME}></ListButton>
 			<RefreshButton resourceName={`${MOCK_NAME}-1`}/>


			<OtherComponent resourceName="otherResource"/> 
        </div>
    );
};
```

after:
```ts
const TestComponent = ({ resourceName }) => {
    return (
        <div>
            <DeleteButton
                size="small"
                recordItemId={row.id}
                resource={otherMockName}
            ></DeleteButton>

            <ShowButton resource="testname"></ShowButton>
            <EditButton resource={MOCK_NAME}></EditButton>

            <CloneButton resource="testname"></CloneButton>
            <ListButton resource={MOCK_NAME}></ListButton>
 			<RefreshButton resource={`${MOCK_NAME}-1`}/>


			<OtherComponent resourceName="otherResource"/> 
        </div>
    );
};
```
