### PR TITLE
fix(v4-core): use form default action

### DIFF
--- a/packages/core/src/hooks/form/useForm.ts
+++ b/packages/core/src/hooks/form/useForm.ts
@@ -270,8 +270,9 @@ export const useForm = <
         routerType === "legacy" ? legacyActionFromRoute : actionFromRouter;
     const action =
         actionFromProps ??
-        (fallbackAction === "show" ? "create" : fallbackAction) ??
-        "create";
+        (fallbackAction === "edit" || fallbackAction === "clone"
+            ? fallbackAction
+            : "create");
 
     const resourceWithRoute = useResourceWithRoute();
     let resource: IResourceItem | undefined;


### PR DESCRIPTION
If the detected action is not `edit` or `clone`, it is set as `create`. This also allows for the detection of `create` in the list route by default.
