### PR TITLE
fix(use-menu-v4): keys not properly working for legacy

### DIFF
--- a/packages/core/src/definitions/helpers/menu/__tests__/create-resource-key.test.ts
+++ b/packages/core/src/definitions/helpers/menu/__tests__/create-resource-key.test.ts
@@ -3,7 +3,7 @@ import { createResourceKey } from "../create-resource-key";
 describe("createResourceKey", () => {
     it("should return only name when no parents exist", () => {
         expect(createResourceKey({ name: "posts" }, [{ name: "posts" }])).toBe(
-            "posts",
+            "/posts",
         );
     });
 
@@ -12,7 +12,7 @@ describe("createResourceKey", () => {
             createResourceKey({ name: "posts", meta: { parent: "cms" } }, [
                 { name: "posts" },
             ]),
-        ).toBe("cms/posts");
+        ).toBe("/cms/posts");
     });
 
     it("should return the key with multiple parents", () => {
@@ -21,7 +21,7 @@ describe("createResourceKey", () => {
                 { name: "orgs", meta: { parent: "cms" } },
                 { name: "cms" },
             ]),
-        ).toBe("cms/orgs/posts");
+        ).toBe("/cms/orgs/posts");
     });
 
     it("should return the key with identifier", () => {
@@ -29,6 +29,6 @@ describe("createResourceKey", () => {
             createResourceKey({ name: "posts", identifier: "foo" }, [
                 { name: "posts", identifier: "foo" },
             ]),
-        ).toBe("foo");
+        ).toBe("/foo");
     });
 });

--- a/packages/core/src/definitions/helpers/menu/__tests__/create-tree.test.ts
+++ b/packages/core/src/definitions/helpers/menu/__tests__/create-tree.test.ts
@@ -15,7 +15,7 @@ describe("createTree", () => {
         expect(createTree(resources)).toEqual([
             {
                 name: "posts",
-                key: "posts",
+                key: "/posts",
                 children: [],
             },
         ]);
@@ -34,12 +34,12 @@ describe("createTree", () => {
         expect(createTree(resources)).toEqual([
             {
                 name: "posts",
-                key: "posts",
+                key: "/posts",
                 children: [],
             },
             {
                 name: "comments",
-                key: "comments",
+                key: "/comments",
                 children: [],
             },
         ]);
@@ -62,11 +62,11 @@ describe("createTree", () => {
         expect(createTree(resources)).toEqual([
             {
                 name: "posts",
-                key: "posts",
+                key: "/posts",
                 children: [
                     {
                         name: "comments",
-                        key: "posts/comments",
+                        key: "/posts/comments",
                         meta: { parent: "posts" },
                         children: [],
                     },
@@ -74,7 +74,7 @@ describe("createTree", () => {
             },
             {
                 name: "categories",
-                key: "categories",
+                key: "/categories",
                 children: [],
             },
         ]);
@@ -98,16 +98,16 @@ describe("createTree", () => {
         expect(createTree(resources)).toEqual([
             {
                 name: "cms",
-                key: "cms",
+                key: "/cms",
                 children: [
                     {
                         name: "posts",
-                        key: "cms/posts",
+                        key: "/cms/posts",
                         meta: { parent: "cms" },
                         children: [
                             {
                                 name: "comments",
-                                key: "cms/posts/comments",
+                                key: "/cms/posts/comments",
                                 meta: { parent: "posts" },
                                 children: [],
                             },
@@ -117,7 +117,7 @@ describe("createTree", () => {
             },
             {
                 name: "categories",
-                key: "categories",
+                key: "/categories",
                 children: [],
             },
         ]);
@@ -143,18 +143,18 @@ describe("createTree", () => {
         expect(createTree(resources)).toEqual([
             {
                 name: "posts",
-                key: "posts",
+                key: "/posts",
                 children: [
                     {
                         name: "posts",
-                        key: "posts/recent-posts",
+                        key: "/posts/recent-posts",
                         identifier: "recent-posts",
                         meta: { parent: "posts" },
                         children: [],
                     },
                     {
                         name: "posts",
-                        key: "posts/featured-posts",
+                        key: "/posts/featured-posts",
                         identifier: "featured-posts",
                         meta: { parent: "posts" },
                         children: [],

--- a/packages/core/src/definitions/helpers/menu/create-resource-key.ts
+++ b/packages/core/src/definitions/helpers/menu/create-resource-key.ts
@@ -7,6 +7,7 @@ import {
 export const createResourceKey = (
     resource: IResourceItem,
     resources: IResourceItem[],
+    legacy = false,
 ) => {
     const parents: IResourceItem[] = [];
 
@@ -21,8 +22,12 @@ export const createResourceKey = (
     parents.reverse();
 
     const key = [...parents, resource]
-        .map((r) => removeLeadingTrailingSlashes(r.identifier ?? r.name))
+        .map((r) =>
+            removeLeadingTrailingSlashes(
+                (legacy ? r.route : undefined) ?? r.identifier ?? r.name,
+            ),
+        )
         .join("/");
 
-    return key;
+    return `/${key.replace(/^\//, "")}`;
 };

--- a/packages/core/src/definitions/helpers/menu/create-tree.ts
+++ b/packages/core/src/definitions/helpers/menu/create-tree.ts
@@ -12,7 +12,10 @@ export type FlatTreeItem = IResourceItem & {
     children: FlatTreeItem[];
 };
 
-export const createTree = (resources: IResourceItem[]): FlatTreeItem[] => {
+export const createTree = (
+    resources: IResourceItem[],
+    legacy = false,
+): FlatTreeItem[] => {
     const root: Tree = {
         item: {
             name: "__root__",
@@ -33,7 +36,10 @@ export const createTree = (resources: IResourceItem[]): FlatTreeItem[] => {
         let currentTree = root;
 
         parents.forEach((parent) => {
-            const key = parent.identifier ?? parent.name;
+            const key =
+                (legacy ? parent.route : undefined) ??
+                parent.identifier ??
+                parent.name;
 
             if (!currentTree.children[key]) {
                 currentTree.children[key] = {
@@ -44,7 +50,10 @@ export const createTree = (resources: IResourceItem[]): FlatTreeItem[] => {
             currentTree = currentTree.children[key];
         });
 
-        const key = resource.identifier ?? resource.name;
+        const key =
+            (legacy ? resource.route : undefined) ??
+            resource.identifier ??
+            resource.name;
 
         if (!currentTree.children[key]) {
             currentTree.children[key] = {
@@ -61,6 +70,7 @@ export const createTree = (resources: IResourceItem[]): FlatTreeItem[] => {
             const itemKey = createResourceKey(
                 tree.children[key].item,
                 resources,
+                legacy,
             );
             const item: FlatTreeItem = {
                 ...tree.children[key].item,

--- a/packages/core/src/hooks/menu/useMenu.spec.tsx
+++ b/packages/core/src/hooks/menu/useMenu.spec.tsx
@@ -102,7 +102,7 @@ describe("useMenu Hook", () => {
             }),
         });
 
-        expect(result.current.selectedKey).toEqual("posts");
+        expect(result.current.selectedKey).toEqual("/posts");
     });
 
     it("should have the defaultOpenKeys = [/CMS]", async () => {
@@ -147,7 +147,7 @@ describe("useMenu Hook", () => {
         });
 
         expect(result.current.defaultOpenKeys).toEqual(
-            expect.arrayContaining(["CMS", "CMS/posts"]),
+            expect.arrayContaining(["/CMS", "/CMS/posts"]),
         );
     });
 
@@ -198,9 +198,9 @@ describe("useMenu Hook", () => {
 
         expect(result.current.defaultOpenKeys).toEqual(
             expect.arrayContaining([
-                "CMS",
-                "CMS/categories",
-                "CMS/categories/posts",
+                "/CMS",
+                "/CMS/categories",
+                "/CMS/categories/posts",
             ]),
         );
     });

--- a/packages/core/src/hooks/menu/useMenu.tsx
+++ b/packages/core/src/hooks/menu/useMenu.tsx
@@ -9,7 +9,6 @@ import {
     FlatTreeItem,
     createTree,
 } from "@definitions/helpers/menu/create-tree";
-import { ResourceRouterParams } from "src/interfaces";
 
 type UseMenuReturnType = {
     defaultOpenKeys: string[];
@@ -55,8 +54,8 @@ export const useMenu = (
     const routerType = useRouterType();
     const { resource, resources } = useResource();
     const { pathname } = useParsed();
-    const { useParams } = useRouterContext();
-    const { resource: legacyPath } = useParams<ResourceRouterParams>();
+    const { useLocation } = useRouterContext();
+    const { pathname: legacyPath } = useLocation();
 
     const cleanPathname =
         routerType === "legacy"


### PR DESCRIPTION
- Updated `selectedKey` value with `/` for both legacy and new usage.
- Fixed the `route` not being checked for legacy routers.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
