### PR TITLE
fix(react-router-v6): fix legacy route rendering invalidation issue

### DIFF
--- a/packages/react-router-v6/src/legacy/routeProvider.tsx
+++ b/packages/react-router-v6/src/legacy/routeProvider.tsx
@@ -206,6 +206,9 @@ export const RouteProvider = ({
         data: authData,
     } = useIsAuthenticated({
         v3LegacyAuthProviderCompatible: Boolean(authProvider?.isLegacy),
+        params: {
+            type: "routeProvider",
+        },
     });
 
     const isAuthenticated = useMemo(() => {


### PR DESCRIPTION
With no params to identify the request as the route provider call, use of `Authenticated` component in the route causes the invalidation of the `useIsAuthenticated` hook, which refreshes the router. Which eventually causes the `Authenticated` to re-render and loop.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
