### PR TITLE
fix(codemod): if use-select has pagination property, dont add

### DIFF
--- a/packages/codemod/src/transformations/v4/fix-v4-deprecations.ts
+++ b/packages/codemod/src/transformations/v4/fix-v4-deprecations.ts
@@ -720,7 +720,11 @@ const fixUseSelectHasPaginationToPaginationMode = (
             (p: Property) => (p.key as Identifier).name === "pagination",
         );
 
-        if (hasPaginationProperty) {
+        const hasMode = (
+            paginationProperty as unknown as any
+        )?.value?.properties?.find((p) => (p["name"] = "mode"));
+
+        if (hasPaginationProperty && !hasMode) {
             if (paginationProperty) {
                 (paginationProperty as any).value.properties.push(
                     j.property(
@@ -761,7 +765,7 @@ const fixUseSelectHasPaginationToPaginationMode = (
             }
         }
 
-        if (!hasPaginationProperty) {
+        if (!hasPaginationProperty && !hasMode) {
             if (paginationProperty) {
                 (paginationProperty as any).value.properties.push(
                     j.property(


### PR DESCRIPTION
before:
```ts
const PostsList = () => {
    const select1 = useSelect({
        resource: "categories",
    });

    const select2 = useSelect({
        resource: "categories",
        pagination: {
            mode: "off",
        },
    });

    const select3 = useSelect({
        resource: "categories",
        pagination: {
            mode: "server",
        },
    });

    const select4 = useSelect({
        resource: "categories",
        hasPagination: true,
    });

    const select5 = useSelect({
        resource: "categories",
        hasPagination: false,
    });

    return null;
};

```


after:
```ts
const PostsList = () => {
    const select1 = useSelect({
        resource: "categories",

        pagination: {
            mode: "server"
        }
    });

    const select2 = useSelect({
        resource: "categories",
        pagination: {
            mode: "off",
        },
    });

    const select3 = useSelect({
        resource: "categories",
        pagination: {
            mode: "server",
        },
    });

    const select4 = useSelect({
        resource: "categories",

        pagination: {
            mode: "server"
        }
    });

    const select5 = useSelect({
        resource: "categories",

        pagination: {
            mode: "off"
        }
    });

    return null;
};

```



