### PR TITLE
fix(core): add missing key in dependency array for translations in `useMenu`

### DIFF
--- a/packages/core/src/hooks/menu/useMenu.tsx
+++ b/packages/core/src/hooks/menu/useMenu.tsx
@@ -143,7 +143,7 @@ export const useMenu = (
         };
 
         return prepare(treeMenuItems);
-    }, [resources, routerType]);
+    }, [resources, routerType, prepareItem]);
 
     return {
         defaultOpenKeys,


### PR DESCRIPTION
`useMenu` not reacting to every other change in `translate` function, which causes `<Sider>` components to use wrong language in renders.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
