### PR TITLE
fix(core): add `meta` and `options` to pick `label`

### DIFF
--- a/.changeset/stupid-pears-eat.md
+++ b/.changeset/stupid-pears-eat.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": patch
+---
+
+Add fallback option for `label` from `meta` and `options`.

--- a/packages/core/src/definitions/helpers/legacy-resource-transform/index.ts
+++ b/packages/core/src/definitions/helpers/legacy-resource-transform/index.ts
@@ -17,7 +17,7 @@ export const legacyResourceTransform = (resources: ResourceProps[]) => {
     resources?.forEach((resource) => {
         _resources.push({
             ...resource,
-            label: resource.options?.label,
+            label: resource.meta?.label ?? resource.options?.label,
             route: routeGenerator(resource, resources),
             canCreate: !!resource.create,
             canEdit: !!resource.edit,


### PR DESCRIPTION
Added missing `meta.label` check to resource transform helper.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
