### PR TITLE
fix(examples): access control casbin mjs not resolved

### DIFF
--- a/examples/access-control-casbin/config-overrides.js
+++ b/examples/access-control-casbin/config-overrides.js
@@ -20,5 +20,11 @@ module.exports = function override(config) {
             Buffer: ["buffer", "Buffer"],
         }),
     ]);
+    config.module.rules.push({
+        test: /\.m?js/,
+        resolve: {
+            fullySpecified: false,
+        },
+    });
     return config;
 };


### PR DESCRIPTION
access-control-casbin example was giving following error:
```ts
Module not found: Error: Can't resolve 'process/browser' in '/Users/alicanerdurmaz/Desktop/refine/node_modules/uvu/node_modules/kleur'
Did you mean 'browser.js'?
BREAKING CHANGE: The request 'process/browser' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```

added: webpack rule solve this issue.

---

Thanks @DoguhanOzgurAkca for this issue 🚀 