### PR TITLE
fix: resource's icon parameter sanitized on useCan hook

### DIFF
--- a/.changeset/five-bats-chew.md
+++ b/.changeset/five-bats-chew.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": patch
+---
+
+fix: resource's icon parameter sanitized on useCan hook

--- a/packages/core/src/hooks/accessControl/useCan/index.spec.ts
+++ b/packages/core/src/hooks/accessControl/useCan/index.spec.ts
@@ -81,4 +81,31 @@ describe("useCan Hook", () => {
         expect(result.current?.data?.can).toBeFalsy();
         expect(result.current?.data?.reason).toBe("Access Denied");
     });
+
+    it("can should sanitize resource icon ", async () => {
+        const mockFn = jest.fn();
+        renderHook(
+            () =>
+                useCan({
+                    action: "list",
+                    resource: "posts",
+                    params: { id: 1, resource: { icon: "test" } as any },
+                }),
+            {
+                wrapper: TestWrapper({
+                    accessControlProvider: {
+                        can: mockFn,
+                    },
+                }),
+            },
+        );
+
+        expect(mockFn).toBeCalledWith({
+            action: "list",
+            params: {
+                id: 1,
+            },
+            resource: "posts",
+        });
+    });
 });

--- a/packages/core/src/hooks/accessControl/useCan/index.ts
+++ b/packages/core/src/hooks/accessControl/useCan/index.ts
@@ -1,13 +1,13 @@
-import { useContext } from "react";
 import {
     useQuery,
-    UseQueryResult,
     UseQueryOptions,
+    UseQueryResult,
 } from "@tanstack/react-query";
+import { useContext } from "react";
 
 import { AccessControlContext } from "@contexts/accessControl";
-import { CanParams, CanReturnType } from "../../../interfaces";
 import { sanitizeResource } from "@definitions/helpers/sanitize-resource";
+import { CanParams, CanReturnType } from "../../../interfaces";
 
 export type UseCanProps = CanParams & {
     /**
@@ -40,8 +40,8 @@ export const useCan = ({
 
     /* eslint-disable @typescript-eslint/no-unused-vars */
     const sanitizedResource = sanitizeResource(_resource ?? {});
-    /* eslint-enable @typescript-eslint/no-unused-vars */
 
+    /* eslint-enable @typescript-eslint/no-unused-vars */
     const queryResponse = useQuery<CanReturnType>(
         [
             "useCan",
@@ -54,7 +54,7 @@ export const useCan = ({
         ],
         // Enabled check for `can` is enough to be sure that it's defined in the query function but TS is not smart enough to know that.
         () =>
-            can?.({ action, resource, params }) ??
+            can?.({ action, resource, params: paramsRest }) ??
             Promise.resolve({ can: true }),
         {
             enabled: typeof can !== "undefined",


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

resource's icon parameter sanitized on useCan hook

### Test plan (required)

![Screen Shot 2023-03-15 at 20 55 32](https://user-images.githubusercontent.com/1110414/225400508-26416048-bd6e-4e62-8ae0-f8e16307fc47.png)

<!-- Make sure tests pass. -->

### Closing issues

- #3681

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
