### PR TITLE
fix: update sider's menu theme on the example

### DIFF
--- a/examples/multi-tenancy-appwrite/src/components/sider/index.tsx
+++ b/examples/multi-tenancy-appwrite/src/components/sider/index.tsx
@@ -94,6 +94,7 @@ export const CustomSider: React.FC = () => {
         >
             {Title && <Title collapsed={collapsed} />}
             <Menu
+                theme="dark"
                 selectedKeys={[selectedKey]}
                 mode="inline"
                 onClick={() => {


### PR DESCRIPTION
Fixed the `<Menu>` component theme by passing "dark". 