### PR TITLE
fix(react-hook-form):  update steps form `reset` options and fix minor issues on the example

### DIFF
--- a/.changeset/sixty-comics-smash.md
+++ b/.changeset/sixty-comics-smash.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/react-hook-form": patch
+---
+
+Fixed a bug that the form values were not filled when the user next to steps.

--- a/examples/form-mui-use-steps-form/src/App.tsx
+++ b/examples/form-mui-use-steps-form/src/App.tsx
@@ -75,8 +75,8 @@ const App: React.FC = () => {
 
                                 <Route path="*" element={<ErrorComponent />} />
                             </Route>
-                            <UnsavedChangesNotifier />
                         </Routes>
+                        <UnsavedChangesNotifier />
                     </Refine>
                 </RefineSnackbarProvider>
             </ThemeProvider>

--- a/examples/form-mui-use-steps-form/src/pages/posts/create.tsx
+++ b/examples/form-mui-use-steps-form/src/pages/posts/create.tsx
@@ -164,7 +164,7 @@ export const PostCreate: React.FC = () => {
         <Create
             isLoading={formLoading}
             saveButtonProps={saveButtonProps}
-            headerButtons={
+            footerButtons={
                 <>
                     {currentStep > 0 && (
                         <Button

--- a/examples/form-mui-use-steps-form/src/pages/posts/edit.tsx
+++ b/examples/form-mui-use-steps-form/src/pages/posts/edit.tsx
@@ -173,7 +173,7 @@ export const PostEdit: React.FC = () => {
         <Edit
             isLoading={formLoading}
             saveButtonProps={saveButtonProps}
-            headerButtons={
+            footerButtons={
                 <>
                     {currentStep > 0 && (
                         <Button

--- a/packages/react-hook-form/src/useStepsForm/index.ts
+++ b/packages/react-hook-form/src/useStepsForm/index.ts
@@ -83,7 +83,7 @@ export const useStepsForm = <
 
             reset(fields as any, {
                 keepDirty: true,
-                keepValues: true,
+                keepDirtyValues: true,
             });
         }
     }, [queryResult?.data, current]);


### PR DESCRIPTION
With #3307 change, steps form was not working expected in "edit" mode.

The `keepValues` is prevent the change form initial values. That's why I removed it.

I reproduced the #3290 issue, if the user uses `setValue` instead of `update` it's fine.