### PR TITLE
fix: `useModalForm`'s `autoSubmitClose` and `autoResetForm` features

### DIFF
--- a/.changeset/odd-shoes-push.md
+++ b/.changeset/odd-shoes-push.md
@@ -2,4 +2,4 @@
 "@refinedev/antd": patch
 ---
 
-Fixed `autoSubmitClose` and `autoResetForm` props of `usseModalForm` hook to work properly.
+Fixed `autoSubmitClose` and `autoResetForm` props of `useModalForm` hook to work properly.

--- a/.changeset/odd-shoes-push.md
+++ b/.changeset/odd-shoes-push.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/antd": patch
+---
+
+Fixed `autoSubmitClose` and `autoResetForm` props of `usseModalForm` hook to work properly.

--- a/.changeset/smooth-planets-suffer.md
+++ b/.changeset/smooth-planets-suffer.md
@@ -2,5 +2,5 @@
 "@refinedev/core": patch
 ---
 
-Now, when the form is submitted successfully, the `setId` function is not called.
+In forms that use `useForm`, the `onFinish` will reset the current `id` to `undefined` when the mutation is successful. Now, the `id` will not be set to `undefined`.
 

--- a/.changeset/smooth-planets-suffer.md
+++ b/.changeset/smooth-planets-suffer.md
@@ -1,0 +1,6 @@
+---
+"@refinedev/core": patch
+---
+
+Now, when the form is submitted successfully, the `setId` function is not called.
+

--- a/.changeset/smooth-planets-suffer.md
+++ b/.changeset/smooth-planets-suffer.md
@@ -2,5 +2,5 @@
 "@refinedev/core": patch
 ---
 
-In forms that use `useForm`, the `onFinish` will reset the current `id` to `undefined` when the mutation is successful. Now, the `id` will not be set to `undefined`.
+In forms that use `useForm`, the `onFinish` was resetting the current `id` to `undefined` when the mutation is successful. Now, the `id` will not be set to `undefined`.
 

--- a/examples/form-antd-use-form/src/App.tsx
+++ b/examples/form-antd-use-form/src/App.tsx
@@ -57,8 +57,8 @@ const App: React.FC = () => {
 
                         <Route path="*" element={<ErrorComponent />} />
                     </Route>
-                    <UnsavedChangesNotifier />
                 </Routes>
+                <UnsavedChangesNotifier />
             </Refine>
         </BrowserRouter>
     );

--- a/examples/form-antd-use-modal-form/src/App.tsx
+++ b/examples/form-antd-use-modal-form/src/App.tsx
@@ -47,8 +47,8 @@ const App: React.FC = () => {
                         <Route path="/posts" element={<PostList />} />
                         <Route path="*" element={<ErrorComponent />} />
                     </Route>
-                    <UnsavedChangesNotifier />
                 </Routes>
+                <UnsavedChangesNotifier />
             </Refine>
         </BrowserRouter>
     );

--- a/packages/antd/src/hooks/form/useModalForm/index.spec.tsx
+++ b/packages/antd/src/hooks/form/useModalForm/index.spec.tsx
@@ -46,6 +46,8 @@ describe("useModalForm Hook", () => {
             },
         );
 
+        expect(result.current.modalProps.open).toBe(true);
+
         await act(async () => {
             result.current.modalProps.onCancel?.({} as any);
         });
@@ -64,6 +66,8 @@ describe("useModalForm Hook", () => {
                 wrapper: TestWrapper({}),
             },
         );
+
+        expect(result.current.modalProps.open).toBe(false);
 
         await act(async () => {
             result.current.show();

--- a/packages/antd/src/hooks/form/useModalForm/index.spec.tsx
+++ b/packages/antd/src/hooks/form/useModalForm/index.spec.tsx
@@ -1,0 +1,181 @@
+import { renderHook, waitFor } from "@testing-library/react";
+
+import { act, TestWrapper } from "@test";
+
+import { useModalForm } from "./";
+
+describe("useModalForm Hook", () => {
+    it("should return correct initial value of 'open'", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    action: "create",
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        expect(result.current.modalProps.open).toBe(false);
+    });
+
+    it("'open' initial value should be set with 'defaultVisible'", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    action: "create",
+                    defaultVisible: true,
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        expect(result.current.modalProps.open).toBe(true);
+    });
+
+    it("'open' value should be false when 'onCancel' is called", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    action: "edit",
+                    defaultVisible: true,
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        await act(async () => {
+            result.current.modalProps.onCancel?.({} as any);
+        });
+
+        expect(result.current.modalProps.open).toBe(false);
+    });
+
+    it("'open' value should be true when 'show' is called", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    action: "edit",
+                    defaultVisible: false,
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        await act(async () => {
+            result.current.show();
+        });
+
+        expect(result.current.modalProps.open).toBe(true);
+    });
+
+    it("'id' should be updated when 'show' is called with 'id'", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    action: "edit",
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        const id = "5";
+
+        await act(async () => {
+            result.current.show(id);
+        });
+
+        expect(result.current.id).toBe(id);
+    });
+
+    it("'title' should be set with 'action' and 'resource'", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    resource: "test",
+                    action: "edit",
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        expect(result.current.modalProps.title).toBe("Edit test");
+    });
+
+    it("when 'autoSubmitClose' is true, the modal should be closed when 'submit' is called", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    action: "edit",
+                    id: "1",
+                    resource: "posts",
+                    autoSubmitClose: true,
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        await act(async () => {
+            result.current.show();
+            result.current.modalProps.onOk?.({} as any);
+        });
+
+        expect(result.current.modalProps.open).toBe(false);
+    });
+
+    it("when 'autoSubmitClose' is false, 'close' should not be called when 'submit' is called", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    action: "edit",
+                    resource: "posts",
+                    autoSubmitClose: false,
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        await act(async () => {
+            result.current.show();
+            result.current.modalProps.onOk?.({} as any);
+        });
+
+        expect(result.current.modalProps.open).toBe(true);
+    });
+
+    it("autoResetForm is true, 'reset' should be called when the form is submitted", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    resource: "posts",
+                    action: "edit",
+                    autoResetForm: true,
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        await act(async () => {
+            result.current.show();
+            result.current.formProps.form?.setFieldsValue({
+                test: "test",
+                foo: "bar",
+            });
+            result.current.modalProps.onOk?.({} as any);
+        });
+
+        await waitFor(() => result.current.mutationResult.isSuccess);
+
+        expect(result.current.formProps.form?.getFieldsValue()).toStrictEqual(
+            {},
+        );
+    });
+});

--- a/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
+++ b/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import React, { useCallback } from "react";
 import { FormInstance, FormProps, ModalProps } from "antd";
 import {
     useModalForm as useModalFormSF,
@@ -6,7 +6,6 @@ import {
 } from "sunflower-antd";
 
 import {
-    useMutationMode,
     useTranslate,
     useWarnAboutChange,
     HttpError,
@@ -21,7 +20,6 @@ import {
     useGo,
 } from "@refinedev/core";
 import { useForm, UseFormProps, UseFormReturnType } from "../useForm";
-import React from "react";
 
 export type useModalFormFromSFReturnType<TData, TVariables> = {
     open: boolean;
@@ -80,7 +78,6 @@ export const useModalForm = <
     TError extends HttpError = HttpError,
     TVariables = {},
 >({
-    mutationMode: mutationModeProp,
     syncWithLocation,
     ...rest
 }: UseModalFormProps<TData, TError, TVariables>): UseModalFormReturnType<
@@ -92,11 +89,9 @@ export const useModalForm = <
 
     const useFormProps = useForm<TData, TError, TVariables>({
         ...rest,
-        mutationMode: mutationModeProp,
     });
 
-    const { form, formProps, id, setId, formLoading, mutationResult } =
-        useFormProps;
+    const { form, formProps, id, setId, formLoading, onFinish } = useFormProps;
 
     const { resource, action: actionFromParams } = useResource(rest.resource);
 
@@ -122,13 +117,12 @@ export const useModalForm = <
     const sunflowerUseModal = useModalFormSF<TData, TVariables>({
         ...rest,
         form: form,
+        submit: onFinish as any,
     });
 
     const {
         visible,
-        close,
         show,
-        form: modalForm,
         formProps: modalFormProps,
         modalProps,
     } = sunflowerUseModal;
@@ -183,41 +177,8 @@ export const useModalForm = <
         }
     }, [id, visible, show, syncWithLocationKey, syncingId]);
 
-    const { mutationMode: mutationModeContext } = useMutationMode();
-    const mutationMode = mutationModeProp ?? mutationModeContext;
-
-    const {
-        isLoading: isLoadingMutation,
-        isSuccess: isSuccessMutation,
-        reset: resetMutation,
-    } = mutationResult ?? {};
-
-    useEffect(() => {
-        if (visible && mutationMode === "pessimistic") {
-            if (isSuccessMutation && !isLoadingMutation) {
-                close();
-                resetMutation?.();
-                // Prevents resetting form values before closing modal in UI
-                setTimeout(() => {
-                    form.resetFields();
-                });
-            }
-        }
-    }, [isSuccessMutation, isLoadingMutation]);
-
     const saveButtonPropsSF = {
         disabled: formLoading,
-        onClick: () => {
-            modalForm.submit();
-
-            if (!(mutationMode === "pessimistic")) {
-                close();
-                // Prevents resetting form values before closing modal in UI
-                setTimeout(() => {
-                    form.resetFields();
-                });
-            }
-        },
         loading: formLoading,
     };
 

--- a/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
+++ b/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
@@ -208,6 +208,9 @@ export const useModalForm = <
         sunflowerUseModal.show();
     }, []);
 
+    const { visible: _visible, ...otherModalProps } = modalProps;
+    const newModalProps = { open: _visible, ...otherModalProps };
+
     return {
         ...useFormProps,
         ...sunflowerUseModal,
@@ -222,7 +225,7 @@ export const useModalForm = <
             onFinish: formProps.onFinish,
         },
         modalProps: {
-            ...modalProps,
+            ...newModalProps,
             width: "1000px",
             okButtonProps: saveButtonPropsSF,
             title: translate(

--- a/packages/antd/src/types/sunflower.d.ts
+++ b/packages/antd/src/types/sunflower.d.ts
@@ -54,7 +54,6 @@ declare module "sunflower-antd" {
         config: Omit<UseModalFormConfig, "defaultFormValues">,
     ) => {
         form: FormInstance<TVariables>;
-        open: boolean;
         show: () => void;
         close: () => void;
         modalProps: {
@@ -62,18 +61,11 @@ declare module "sunflower-antd" {
             visible: boolean;
             onCancel: () => void;
         };
-        formProps:
-            | {
-                  form: FormInstance<TVariables>;
-                  onFinish: (formValue: TVariables) => Promise<TData>;
-                  initialValues: {};
-              }
-            | {
-                  onSubmit(e: any): void;
-                  form?: undefined;
-                  onFinish?: undefined;
-                  initialValues?: undefined;
-              };
+        formProps: {
+            form: FormInstance<TVariables>;
+            onFinish: (formValue: TVariables) => Promise<TData>;
+            initialValues: {};
+        };
         formLoading: boolean;
         defaultFormValuesLoading: boolean;
         formValues: {};

--- a/packages/core/src/hooks/form/useForm.ts
+++ b/packages/core/src/hooks/form/useForm.ts
@@ -442,8 +442,6 @@ export const useForm = <
         };
 
         const onSuccess = () => {
-            // If it is in modal mode set it to undefined. Otherwise set it to current id from route.
-            setId(defaultId);
             handleSubmitWithRedirect({
                 redirect: designatedRedirectAction,
                 resource,


### PR DESCRIPTION
`autoSubmitClose` and `autoResetForm` were not working even though they had these properties.

Now, both of them work properly.