### PR TITLE
fix(chakra-ui): when title prop is false in crud components, should not render

### DIFF
--- a/.changeset/few-mirrors-think.md
+++ b/.changeset/few-mirrors-think.md
@@ -1,0 +1,6 @@
+---
+"@refinedev/ui-tests": patch
+---
+
+-   New test added to crud components:
+    -   "should not render `title` when is false"

--- a/.changeset/strange-rivers-learn.md
+++ b/.changeset/strange-rivers-learn.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/chakra-ui": patch
+---
+
+-   Fixed: When `title` prop is `false` in crud components, the default `title` was rendered. It should not render anything.

--- a/examples/form-chakra-ui-use-drawer-form/src/components/createPostDrawer/index.tsx
+++ b/examples/form-chakra-ui-use-drawer-form/src/components/createPostDrawer/index.tsx
@@ -41,7 +41,6 @@ export const CreatePostDrawer: React.FC<UseModalFormReturnType> = ({
 
                 <DrawerBody>
                     <Create
-                        headerButtons={false}
                         title={false}
                         goBack={null}
                         saveButtonProps={saveButtonProps}

--- a/examples/form-chakra-ui-use-drawer-form/src/components/editPostDrawer/index.tsx
+++ b/examples/form-chakra-ui-use-drawer-form/src/components/editPostDrawer/index.tsx
@@ -24,6 +24,7 @@ export const EditPostDrawer: React.FC<UseModalFormReturnType> = ({
     modal: { visible, close },
     register,
     formState: { errors },
+    refineCore: { id },
 }) => {
     const { options } = useSelect<ICategory>({
         resource: "categories",
@@ -41,7 +42,7 @@ export const EditPostDrawer: React.FC<UseModalFormReturnType> = ({
 
                 <DrawerBody>
                     <Edit
-                        headerButtons={false}
+                        recordItemId={id}
                         title={false}
                         goBack={null}
                         saveButtonProps={saveButtonProps}

--- a/examples/form-chakra-use-modal-antd-form/src/components/editPostModal/index.tsx
+++ b/examples/form-chakra-use-modal-antd-form/src/components/editPostModal/index.tsx
@@ -24,6 +24,7 @@ export const EditPostModal: React.FC<UseModalFormReturnType> = ({
     modal: { visible, close },
     register,
     formState: { errors },
+    refineCore: { id },
 }) => {
     const { options } = useSelect<ICategory>({
         resource: "categories",
@@ -41,7 +42,7 @@ export const EditPostModal: React.FC<UseModalFormReturnType> = ({
 
                 <ModalBody>
                     <Edit
-                        headerButtons={false}
+                        recordItemId={id}
                         title={false}
                         goBack={null}
                         saveButtonProps={saveButtonProps}

--- a/packages/chakra-ui/src/components/crud/create/index.tsx
+++ b/packages/chakra-ui/src/components/crud/create/index.tsx
@@ -92,6 +92,8 @@ export const Create: React.FC<CreateProps> = (props) => {
         : defaultFooterButtons;
 
     const renderTitle = () => {
+        if (title === false) return null;
+
         if (title) {
             if (typeof title === "string" || typeof title === "number") {
                 return (

--- a/packages/chakra-ui/src/components/crud/edit/index.tsx
+++ b/packages/chakra-ui/src/components/crud/edit/index.tsx
@@ -177,6 +177,8 @@ export const Edit: React.FC<EditProps> = (props) => {
         : defaultFooterButtons;
 
     const renderTitle = () => {
+        if (title === false) return null;
+
         if (title) {
             if (typeof title === "string" || typeof title === "number") {
                 return (

--- a/packages/chakra-ui/src/components/crud/list/index.tsx
+++ b/packages/chakra-ui/src/components/crud/list/index.tsx
@@ -63,6 +63,8 @@ export const List: React.FC<ListProps> = (props) => {
         : defaultHeaderButtons;
 
     const renderTitle = () => {
+        if (title === false) return null;
+
         if (title) {
             if (typeof title === "string" || typeof title === "number") {
                 return (

--- a/packages/chakra-ui/src/components/crud/show/index.tsx
+++ b/packages/chakra-ui/src/components/crud/show/index.tsx
@@ -170,6 +170,8 @@ export const Show: React.FC<ShowProps> = (props) => {
         : null;
 
     const renderTitle = () => {
+        if (title === false) return null;
+
         if (title) {
             if (typeof title === "string" || typeof title === "number") {
                 return (

--- a/packages/core/src/components/authenticated/index.tsx
+++ b/packages/core/src/components/authenticated/index.tsx
@@ -229,7 +229,6 @@ export function Authenticated({
         }
     }
 
-
     /**
      * If there's no `authProvider` set, we don't need to check whether user is logged in or not.
      */

--- a/packages/ui-tests/src/tests/crud/create.tsx
+++ b/packages/ui-tests/src/tests/crud/create.tsx
@@ -66,6 +66,13 @@ export const crudCreateTests = function (
             getByText("Create Post");
         });
 
+        it("should not render title when is false", async () => {
+            const { queryByText } = renderCreate(<Create title={false} />);
+
+            const text = queryByText("Create Post");
+            expect(text).not.toBeInTheDocument();
+        });
+
         it("should render with label instead of resource name successfully", async () => {
             const { getByText } = renderCreate(<Create />, {
                 resources: [

--- a/packages/ui-tests/src/tests/crud/edit.tsx
+++ b/packages/ui-tests/src/tests/crud/edit.tsx
@@ -81,6 +81,13 @@ export const crudEditTests = function (
             getByText("Edit Post");
         });
 
+        it("should not render title when is false", async () => {
+            const { queryByText } = renderEdit(<Edit title={false} />);
+
+            const text = queryByText("Edit Post");
+            expect(text).not.toBeInTheDocument();
+        });
+
         it("should render custom title successfuly", async () => {
             const { getByText } = renderEdit(<Edit title="Custom Title" />);
 

--- a/packages/ui-tests/src/tests/crud/list.tsx
+++ b/packages/ui-tests/src/tests/crud/list.tsx
@@ -51,6 +51,25 @@ export const crudListTests = function (
             getByText("New Title");
         });
 
+        it("should not render title when is false", async () => {
+            const { queryByText } = renderList(
+                <List title={false} />,
+                undefined,
+                {
+                    resources: [
+                        {
+                            name: "posts",
+                            meta: { route: "posts" },
+                        },
+                    ],
+                    routerInitialEntries: ["/posts"],
+                },
+            );
+
+            const text = queryByText("Posts");
+            expect(text).not.toBeInTheDocument();
+        });
+
         it("should render with label instead of resource name successfully", async () => {
             const { getByText } = renderList(<List />, undefined, {
                 resources: [

--- a/packages/ui-tests/src/tests/crud/show.tsx
+++ b/packages/ui-tests/src/tests/crud/show.tsx
@@ -74,6 +74,13 @@ export const crudShowTests = function (
             getByText("Show Post");
         });
 
+        it("should not render title when is false", async () => {
+            const { queryByText } = renderShow(<Show title={false} />);
+
+            const text = queryByText("Show Post");
+            expect(text).not.toBeInTheDocument();
+        });
+
         it("should render optional title with title prop", async () => {
             const { getByText } = renderShow(<Show title="Test Title" />);
 


### PR DESCRIPTION
fixed(chakra-ui): When `title` prop is `false` in crud components, the default `title` was rendered. It should not render anything.

### Test plan (required)

All test passed. 
<img width="744" alt="image" src="https://user-images.githubusercontent.com/23058882/226097358-219d8219-d3af-4a43-8359-e578d9eb9544.png">


### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
