### PR TITLE
fix(docs): add white background to live-preview when theme is dark

### DIFF
--- a/documentation/src/components/live-preview/styles.module.css
+++ b/documentation/src/components/live-preview/styles.module.css
@@ -38,6 +38,11 @@
   background-color: var(--ifm-pre-background);
 }
 
+
+[data-theme="dark"] .playgroundPreview {
+  background-color: #fff;
+}
+
 .playgroundEditorWrapper {
   border: 3px solid var(--browser-window-bezel-color);
   background-color: var(--browser-window-bezel-color);


### PR DESCRIPTION
When live-previews are `headless`, live-preview's background color was black.
![image](https://user-images.githubusercontent.com/23058882/226529529-b2a28afb-5c3f-428a-b415-c157642eb1a4.png)

With this fix, the background will be white.
![image](https://user-images.githubusercontent.com/23058882/226529594-3e184ba1-44fa-4eb8-9b2a-21f96156e7f5.png)

Dark mode toggle example still works as expected
![image](https://user-images.githubusercontent.com/23058882/226529636-de70c08c-ece7-4a10-9578-63f9a69fd8ff.png)

