### PR TITLE
fix(mantine): reset dirty state after setting initial values

### DIFF
--- a/.changeset/chatty-squids-approve.md
+++ b/.changeset/chatty-squids-approve.md
@@ -2,4 +2,4 @@
 "@refinedev/mantine": patch
 ---
 
-Fixed an issue where the form dirty state was not reset after setting initial values. This caused the form to be dirty even though changes were not made. For this reason, the `<UnSavedChangesNotifier>` was always warn when the user tried to leave the page.
+Fixed an issue where the form dirty state was not reset after setting initial values. This caused the form to be dirty even though changes were not made. For this reason, the `<UnSavedChangesNotifier>` always warned when user tried to leave page.

--- a/.changeset/chatty-squids-approve.md
+++ b/.changeset/chatty-squids-approve.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mantine": patch
+---
+
+Fixed an issue where the form dirty state was not reset after setting initial values. This caused the form to be dirty even though changes were not made. For this reason, the `<UnSavedChangesNotifier>` was always warn when the user tried to leave the page.

--- a/packages/mantine/src/hooks/form/useForm/index.ts
+++ b/packages/mantine/src/hooks/form/useForm/index.ts
@@ -101,6 +101,7 @@ export const useForm = <
         setValues,
         onSubmit: onMantineSubmit,
         isDirty,
+        resetDirty,
     } = useMantineFormResult;
 
     useEffect(() => {
@@ -114,8 +115,8 @@ export const useForm = <
                     }
                 },
             );
-
             setValues(fields);
+            resetDirty(fields);
         }
     }, [queryResult?.data]);
 


### PR DESCRIPTION
Fixed an issue where the dirty state was not reset after setting initial values. This caused the form to be dirty even though changes were not made. For this reason, the UnSavedChangesNotifier was always shown when the user tried to leave the page.