### PR TITLE
fix: update `<NumberField>`'s number conversion

### DIFF
--- a/.changeset/tricky-fishes-smile.md
+++ b/.changeset/tricky-fishes-smile.md
@@ -1,0 +1,8 @@
+---
+"@refinedev/antd": patch
+"@refinedev/chakra-ui": patch
+"@refinedev/mantine": patch
+"@refinedev/mui": patch
+---
+
+Fixed an issue where the `<NumberField />` component would throw an error if the `value` prop was set to `undefined`.

--- a/packages/antd/src/components/fields/number/index.tsx
+++ b/packages/antd/src/components/fields/number/index.tsx
@@ -24,7 +24,7 @@ export const NumberField: React.FC<NumberFieldProps> = ({
     options,
     ...rest
 }) => {
-    const number = parseFloat(value.toString());
+    const number = Number(value);
 
     return (
         <Text {...rest}>

--- a/packages/chakra-ui/src/components/fields/number/index.tsx
+++ b/packages/chakra-ui/src/components/fields/number/index.tsx
@@ -21,7 +21,7 @@ export const NumberField: React.FC<NumberFieldProps> = ({
     options,
     ...rest
 }) => {
-    const number = parseFloat(value.toString());
+    const number = Number(value);
 
     return (
         <Text {...rest}>

--- a/packages/mantine/src/components/fields/number/index.tsx
+++ b/packages/mantine/src/components/fields/number/index.tsx
@@ -21,7 +21,7 @@ export const NumberField: React.FC<NumberFieldProps> = ({
     options,
     ...rest
 }) => {
-    const number = parseFloat(value.toString());
+    const number = Number(value);
 
     return (
         <Text {...rest}>

--- a/packages/mui/src/components/fields/number/index.tsx
+++ b/packages/mui/src/components/fields/number/index.tsx
@@ -22,7 +22,7 @@ export const NumberField: React.FC<NumberFieldProps> = ({
     options,
     ...rest
 }) => {
-    const number = parseFloat(value.toString());
+    const number = Number(value);
 
     return (
         <Typography variant="body2" {...rest}>

--- a/packages/ui-tests/src/tests/fields/number.tsx
+++ b/packages/ui-tests/src/tests/fields/number.tsx
@@ -32,5 +32,19 @@ export const fieldNumberTests = function (
             // node 14 uses non-breaking space resulting in imcompatibility
             getByText(formattedTestPrice);
         });
+
+        it("should render NaN when value is undefined", () => {
+            const { getByText } = render(<NumberField value={undefined} />);
+
+            getByText("NaN");
+        });
+
+        it("should render NaN when value is string", () => {
+            const { getByText } = render(
+                <NumberField value={"not a number"} />,
+            );
+
+            getByText("NaN");
+        });
     });
 };


### PR DESCRIPTION
Fixed an issue where the `<NumberField />` component would throw an error if the `value` prop was set to `undefined`.