### PR TITLE
fix(antd): themed title font size

### DIFF
--- a/.changeset/selfish-sloths-itch.md
+++ b/.changeset/selfish-sloths-itch.md
@@ -2,4 +2,4 @@
 "@refinedev/antd": patch
 ---
 
-Fixed: `<ThemedTitle>` font size was can't be changed from parent because `<Space>` has the default font size.
+Fixed: `<ThemedTitle>` font size was overridden by parent because `<Space>` has the default font size.

--- a/.changeset/selfish-sloths-itch.md
+++ b/.changeset/selfish-sloths-itch.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/antd": patch
+---
+
+Fixed: `<ThemedTitle>` font size was can't be changed from parent because `<Space>` has the default font size.

--- a/packages/antd/src/components/themedLayout/title/index.tsx
+++ b/packages/antd/src/components/themedLayout/title/index.tsx
@@ -52,6 +52,7 @@ export const ThemedTitle: React.FC<RefineLayoutThemedTitleProps> = ({
                 style={{
                     display: "flex",
                     alignItems: "center",
+                    fontSize: "inherit",
                 }}
             >
                 <div


### PR DESCRIPTION
Fixed: `<ThemedTitle>` font size was can't be changed from parent because `<Space>` has the default font size.
