### PR TITLE
Add missing 's' to filters

### DIFF
--- a/documentation/docs/api-reference/mui/hooks/useAutocomplete/index.md
+++ b/documentation/docs/api-reference/mui/hooks/useAutocomplete/index.md
@@ -77,7 +77,7 @@ It is used to show options by filtering them. `filters` will be passed to the `g
 
 ```tsx
 useAutocomplete({
-    filter: [
+    filters: [
         {
             field: "isActive",
             operator: "eq",


### PR DESCRIPTION
Very basic typo fix.

I tried to use filters here (Refine 4) and it needs to be "filters" not "filter".
