### PR TITLE
fix(cli): wrong version output, added unknown project type, added parcel support

### DIFF
--- a/.changeset/thin-candles-jump.md
+++ b/.changeset/thin-candles-jump.md
@@ -2,8 +2,8 @@
 "@refinedev/cli": patch
 ---
 
+feat: added parcel support
+
 fixed: refine --version doesn't return refine cli's version.
 fixed: add error message if user tries to run script with unsupported package.
 fixed: added "unknown" project type as fallback.
-
-feat: added parcel support

--- a/.changeset/thin-candles-jump.md
+++ b/.changeset/thin-candles-jump.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/cli": patch
+---
+
+fixed: refine --version doesn't return refine cli's version.
+fixed: add error message if user tries to run script with unsupported package.
+fixed: added "unknown" project type as fallback.
+
+feat: added parcel support

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,27 +10,17 @@ import update from "@commands/update";
 import swizzle from "@commands/swizzle";
 import { dev, build, start, run } from "@commands/runner";
 import "@utils/env";
-import { getPackageJson } from "@utils/package";
 import { telemetryHook } from "@telemetryindex";
 
+// It reads and updates from package.json during build. ref: tsup.config.ts
+const REFINE_CLI_VERSION = "1.0.0";
+
 const bootstrap = () => {
-    let packageJson;
-
-    // check package json if exists
-    try {
-        packageJson = getPackageJson();
-    } catch (e) {
-        console.error(
-            "The `package.json` file required to run could not be found.",
-        );
-        process.exit(1);
-    }
-
     const program = new Command();
 
     program
         .version(
-            packageJson.version,
+            `@refinedev/cli@${REFINE_CLI_VERSION}`,
             "-v, --version",
             "Output the current version.",
         )

--- a/packages/cli/src/commands/runner/projectScripts.ts
+++ b/packages/cli/src/commands/runner/projectScripts.ts
@@ -39,4 +39,18 @@ export const projectScripts = {
         build: ["build"],
         getBin: () => `${binPath}/craco`,
     },
+    [ProjectTypes.PARCEL]: {
+        dev: ["start"],
+        start: ["start"],
+        build: ["build"],
+        getBin: () => `${binPath}/parcel`,
+    },
+    [ProjectTypes.UNKNOWN]: {
+        dev: [],
+        start: [],
+        build: [],
+        getBin: () => {
+            return "unknown";
+        },
+    },
 };

--- a/packages/cli/src/commands/runner/runScript.ts
+++ b/packages/cli/src/commands/runner/runScript.ts
@@ -1,6 +1,19 @@
+import { ProjectTypes } from "@definitions/projectTypes";
 import execa from "execa";
 
 export const runScript = async (binPath: string, args: string[]) => {
+    if (binPath === "unknown") {
+        const supportedProjectTypes = Object.values(ProjectTypes)
+            .filter((v) => v !== "unknown")
+            .join(", ");
+
+        console.error(
+            `We couldn't find executable for your project. Supported executables are ${supportedProjectTypes}.\nPlease use your own script directly. If you think this is an issue, please report it at: https://github.com/refinedev/refine/issues`,
+        );
+
+        return;
+    }
+
     const execution = execa(binPath, args, {
         stdio: "pipe",
         windowsHide: false,

--- a/packages/cli/src/definitions/projectTypes.ts
+++ b/packages/cli/src/definitions/projectTypes.ts
@@ -4,4 +4,6 @@ export enum ProjectTypes {
     NEXTJS = "nextjs",
     VITE = "vite",
     CRACO = "craco",
+    PARCEL = "parcel",
+    UNKNOWN = "unknown",
 }

--- a/packages/cli/src/utils/project/index.ts
+++ b/packages/cli/src/utils/project/index.ts
@@ -4,35 +4,42 @@ import { getDependencies, getDevDependencies } from "@utils/package";
 export const getProjectType = (): ProjectTypes => {
     // read dependencies from package.json
     const dependencies = getDependencies();
+    const devDependencies = getDevDependencies();
 
     // check for craco
     // craco and react-scripts installs together. We need to check for craco first
-    if (dependencies.includes("@craco/craco")) {
+    if (
+        dependencies.includes("@craco/craco") ||
+        devDependencies.includes("@craco/craco")
+    ) {
         return ProjectTypes.CRACO;
     }
 
     // check for react-scripts
-    if (dependencies.includes("react-scripts")) {
+    if (
+        dependencies.includes("react-scripts") ||
+        devDependencies.includes("react-scripts")
+    ) {
         return ProjectTypes.REACT_SCRIPT;
     }
 
     // check for next
-    if (dependencies.includes("next")) {
+    if (dependencies.includes("next") || devDependencies.includes("next")) {
         return ProjectTypes.NEXTJS;
     }
 
     // check for remix
-    if (dependencies.includes("@remix-run/react")) {
+    if (
+        dependencies.includes("@remix-run/react") ||
+        devDependencies.includes("@remix-run/react")
+    ) {
         return ProjectTypes.REMIX;
     }
 
     // check for vite
-    const devDependencies = getDevDependencies();
-    if (devDependencies.includes("vite")) {
+    if (dependencies.includes("vite") || devDependencies.includes("vite")) {
         return ProjectTypes.VITE;
     }
-
-    throw new Error("Project type not found");
 };
 
 export const getUIFramework = (): UIFrameworks | undefined => {

--- a/packages/cli/src/utils/project/index.ts
+++ b/packages/cli/src/utils/project/index.ts
@@ -40,6 +40,12 @@ export const getProjectType = (): ProjectTypes => {
     if (dependencies.includes("vite") || devDependencies.includes("vite")) {
         return ProjectTypes.VITE;
     }
+
+    if (dependencies.includes("parcel") || devDependencies.includes("parcel")) {
+        return ProjectTypes.PARCEL;
+    }
+
+    return ProjectTypes.UNKNOWN;
 };
 
 export const getUIFramework = (): UIFrameworks | undefined => {

--- a/packages/cli/src/utils/resource/index.ts
+++ b/packages/cli/src/utils/resource/index.ts
@@ -31,6 +31,8 @@ export const getFilesPathByProject = (projectType?: ProjectTypes) => {
         case ProjectTypes.REACT_SCRIPT:
         case ProjectTypes.VITE:
         case ProjectTypes.CRACO:
+        case ProjectTypes.PARCEL:
+        case ProjectTypes.UNKNOWN:
         default:
             return "./src";
     }

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,5 +1,15 @@
 import { defineConfig } from "tsup";
 import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
+import fs from "fs";
+import path from "path";
+
+const JS_EXTENSIONS = new Set(["js", "cjs", "mjs"]);
+
+const getRefineCLIVersion = async () => {
+    const packages = await fs.promises.readFile("./package.json", "utf8");
+    const { version } = JSON.parse(packages);
+    return version;
+};
 
 export default defineConfig({
     entry: ["src/index.ts", "src/cli.ts"],
@@ -9,6 +19,42 @@ export default defineConfig({
     clean: false,
     platform: "node",
     esbuildPlugins: [
+        {
+            name: "textReplace",
+            setup: (build) => {
+                build.onLoad({ filter: /\.ts$/ }, async (args) => {
+                    const contents = await fs.promises.readFile(
+                        args.path,
+                        "utf8",
+                    );
+
+                    const extension = path.extname(args.path).replace(".", "");
+                    const loader = JS_EXTENSIONS.has(extension)
+                        ? "jsx"
+                        : (extension as any);
+
+                    const versionRegex =
+                        /const REFINE_CLI_VERSION = "\d.\d.\d";/gm;
+                    const hasVersion = contents.match(versionRegex);
+
+                    if (!hasVersion) {
+                        return {
+                            loader,
+                            contents,
+                        };
+                    }
+
+                    const version = await getRefineCLIVersion();
+                    return {
+                        loader,
+                        contents: contents.replace(
+                            versionRegex,
+                            `const REFINE_CLI_VERSION = "${version}";`,
+                        ),
+                    };
+                });
+            },
+        },
         NodeResolvePlugin({
             extensions: [".js", "ts", "tsx", "jsx"],
             onResolved: (resolved) => {


### PR DESCRIPTION
fixed: refine --version doesn't return refine cli's version.
fixed: add error message if user tries to run script with unsupported package.
fixed: added "unknown" project type as fallback.

feat: added parcel support

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
