### PR TITLE
fix: remove `Steps` on examples and use `items` instead

### DIFF
--- a/examples/form-antd-use-steps-form/src/pages/posts/create.tsx
+++ b/examples/form-antd-use-steps-form/src/pages/posts/create.tsx
@@ -9,8 +9,6 @@ import MDEditor from "@uiw/react-md-editor";
 
 import { IPost, ICategory } from "interfaces";
 
-const { Step } = Steps;
-
 export const PostCreate: React.FC<IResourceComponentsProps> = () => {
     const { current, gotoStep, stepsProps, formProps, saveButtonProps } =
         useStepsForm<IPost>();
@@ -113,10 +111,10 @@ export const PostCreate: React.FC<IResourceComponentsProps> = () => {
                 </>
             }
         >
-            <Steps {...stepsProps}>
-                <Step title="About Post" />
-                <Step title="Content" />
-            </Steps>
+            <Steps
+                {...stepsProps}
+                items={[{ title: "About Post" }, { title: "Content" }]}
+            />
 
             <Form {...formProps} layout="vertical" style={{ marginTop: 30 }}>
                 {formList[current]}

--- a/examples/form-antd-use-steps-form/src/pages/posts/edit.tsx
+++ b/examples/form-antd-use-steps-form/src/pages/posts/edit.tsx
@@ -9,8 +9,6 @@ import MDEditor from "@uiw/react-md-editor";
 
 import { IPost, ICategory } from "interfaces";
 
-const { Step } = Steps;
-
 export const PostEdit: React.FC<IResourceComponentsProps> = () => {
     const {
         current,
@@ -121,10 +119,10 @@ export const PostEdit: React.FC<IResourceComponentsProps> = () => {
                 </>
             }
         >
-            <Steps {...stepsProps}>
-                <Step title="About Post" />
-                <Step title="Content" />
-            </Steps>
+            <Steps
+                {...stepsProps}
+                items={[{ title: "About Post" }, { title: "Content" }]}
+            />
 
             <Form {...formProps} layout="vertical" style={{ marginTop: 30 }}>
                 {formList[current]}


### PR DESCRIPTION
To fix deprecated values., remove `<Steps>` component on examples and used `items` instead. 