### PR TITLE
fix(core-nextjs): watch for `id` changes

### DIFF
--- a/.changeset/thirty-turtles-hear.md
+++ b/.changeset/thirty-turtles-hear.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/nextjs-router": patch
+---
+
+Add `isReady` check to `parse` method for `/pages` to wait until the correct values are returned from the `router`.

--- a/.changeset/wet-vans-design.md
+++ b/.changeset/wet-vans-design.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": patch
+---
+
+Watch for `id` changes in `useForm` hook.

--- a/packages/core/src/hooks/form/useForm.ts
+++ b/packages/core/src/hooks/form/useForm.ts
@@ -246,11 +246,18 @@ export const useForm = <
     // id state is needed to determine selected record in a context for example useModal
     const [id, setId] = React.useState<BaseKey | undefined>(defaultId);
 
+    /**
+     * In some cases, `id` from the router params is not available at the first render.
+     *
+     * (e.g. when using `Next.js` and client-side-rendering, `router` is not ready to use at the first render)
+     *
+     * We're watching for `defaultId` changes and setting `id` state if it's not equal to `defaultId`.
+     */
     React.useEffect(() => {
         if (defaultId !== id) {
-            setId(idFromProps);
+            setId(defaultId);
         }
-    }, [idFromProps]);
+    }, [defaultId]);
 
     /** `resourceName` fallback value depends on the router type */
     const resourceName =

--- a/packages/nextjs-router/src/pages/bindings.tsx
+++ b/packages/nextjs-router/src/pages/bindings.tsx
@@ -91,7 +91,7 @@ export const routerBindings: RouterBindings = {
         return back;
     },
     parse: () => {
-        const { query, asPath: pathname } = useRouter();
+        const { query, asPath: pathname, isReady } = useRouter();
         const { resources } = useContext(ResourceContext);
 
         const cleanPathname = pathname.split("?")[0].split("#")[0];
@@ -101,7 +101,7 @@ export const routerBindings: RouterBindings = {
         }, [cleanPathname, resources]);
 
         const inferredParams =
-            matchedRoute && cleanPathname
+            matchedRoute && cleanPathname && isReady
                 ? paramsFromCurrentPath(cleanPathname, matchedRoute)
                 : {};
 


### PR DESCRIPTION
- [core]: Added a check for `id` to reflect `id` changes in the `useForm` hook.
- [nextjs]: Added a check for `isReady` of `useRouter` to avoid sending unwanted requests.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
