### PR TITLE
docs: remove the unreceived argument

### DIFF
--- a/documentation/docs/api-reference/core/hooks/data/useCustom/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCustom/index.md
@@ -223,7 +223,7 @@ After data is fetched successfully, `useCustom` can call `open` function from `N
 
 ```tsx
 useCustom({
-    successNotification: (data, values, resource) => {
+    successNotification: (data, values) => {
         return {
             message: `${data.title} Successfully fetched.`,
             description: "Success with no errors",
@@ -241,7 +241,7 @@ After data fetching is failed, `useCustom` will call `open` function from `Notif
 
 ```tsx
 useCustom({
-    errorNotification: (data, values, resource) => {
+    errorNotification: (data, values) => {
         return {
             message: `Something went wrong when getting ${data.id}`,
             description: "Error",

--- a/documentation/docs/api-reference/core/hooks/data/useCustomMutation/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCustomMutation/index.md
@@ -154,7 +154,7 @@ After data is fetched successfully, `useCustomMutation` can call `open` function
 const { mutate } = useCustomMutation();
 
 mutate({
-    successNotification: (data, values, resource) => {
+    successNotification: (data, values) => {
         return {
             message: `${data.title} Successfully fetched.`,
             description: "Success with no errors",
@@ -174,7 +174,7 @@ After data fetching is failed, `useCustomMutation` will call `open` function fro
 const { mutate } = useCustomMutation();
 
 mutate({
-    errorNotification: (data, values, resource) => {
+    errorNotification: (data, values) => {
         return {
             message: `Something went wrong when getting ${data.id}`,
             description: "Error",


### PR DESCRIPTION
Removed the `resource` arg on `successNotification` and `errorNotification` of the `useCustom` hook.