### PR TITLE
docs: add FAQ section about how to invalidate a custom query

### DIFF
--- a/documentation/docs/api-reference/core/hooks/data/useCustom/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCustom/index.md
@@ -303,7 +303,3 @@ By default, the query key is generated based on the properties passed to `useCus
 | Description                             | Type                                                                                                                |
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | Result of the TanStack Query's useQuery | [`QueryObserverResult<CustomResponse<TData>, TError>`](https://tanstack.com/query/v4/docs/react/reference/useQuery) |
-
-```
-
-```

--- a/documentation/docs/api-reference/core/hooks/data/useCustom/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCustom/index.md
@@ -251,6 +251,38 @@ useCustom({
 });
 ```
 
+## FAQ
+
+### How to invalidate the custom query?
+
+To invalidate a query, you can use the `invalidateQueries` method from the `useQueryClient` hook provided by the `@tanstack/react-query` library.
+
+```tsx
+import { useQueryClient } from "@tanstack/react-query";
+
+const queryClient = useQueryClient();
+
+queryClient.invalidateQueries(["custom-key"]);
+```
+
+Note that you'll need to know the query key to invalidate the query. If you don't know the query key, you can use the `queryOptions` property of the `useCustom` hook.
+
+```tsx
+import { useCustom } from "@refinedev/core";
+
+useCustom({
+    queryOptions: {
+        queryKey: ["custom-key"],
+    },
+});
+```
+
+:::tip
+
+By default, the query key is generated based on the properties passed to `useCustom` hook, you can see it in the `@tanstack/react-query` devtools panel.
+
+:::
+
 ## API
 
 ### Properties
@@ -271,3 +303,7 @@ useCustom({
 | Description                             | Type                                                                                                                |
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | Result of the TanStack Query's useQuery | [`QueryObserverResult<CustomResponse<TData>, TError>`](https://tanstack.com/query/v4/docs/react/reference/useQuery) |
+
+```
+
+```


### PR DESCRIPTION
Added FAQ section to `useCustom` hook about how to invalidate a custom query.