### PR TITLE
fix(live-previews): missing icons in live previews

### DIFF
--- a/documentation/docs/api-reference/chakra-ui/components/basic-views/create.md
+++ b/documentation/docs/api-reference/chakra-ui/components/basic-views/create.md
@@ -302,36 +302,17 @@ setInitialRoutes(["/posts/create"]);
 import { Refine } from "@refinedev/core";
 import { CreateButton } from "@refinedev/chakra-ui";
 
-const IconMoodSmile = (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="icon icon-tabler icon-tabler-mood-smile"
-        width={24}
-        height={24}
-        viewBox="0 0 24 24"
-        strokeWidth="2"
-        stroke="currentColor"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-    >
-        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-        <circle cx={12} cy={12} r={9}></circle>
-        <line x1={9} y1={10} x2="9.01" y2={10}></line>
-        <line x1={15} y1={10} x2="15.01" y2={10}></line>
-        <path d="M9.5 15a3.5 3.5 0 0 0 5 0"></path>
-    </svg>
-);
-
 // visible-block-start
 import { Create } from "@refinedev/chakra-ui";
 /* highlight-next-line */
 import { IconMoodSmile } from "@tabler/icons";
 
+console.log("IconMoodSmile", IconMoodSmile);
+
 const PostCreate: React.FC = () => {
     return (
         /* highlight-next-line */
-        <Create goBack={IconMoodSmile}>
+        <Create goBack={<IconMoodSmile />}>
             <p>Rest of your page here 2</p>
         </Create>
     );

--- a/documentation/docs/api-reference/chakra-ui/components/basic-views/edit.md
+++ b/documentation/docs/api-reference/chakra-ui/components/basic-views/edit.md
@@ -624,27 +624,6 @@ import { EditButton } from "@refinedev/chakra-ui";
 import routerProvider from "@refinedev/react-router-v6/legacy";
 import dataProvider from "@refinedev/simple-rest";
 
-const IconMoodSmile = (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="icon icon-tabler icon-tabler-mood-smile"
-        width={24}
-        height={24}
-        viewBox="0 0 24 24"
-        strokeWidth="2"
-        stroke="currentColor"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-    >
-        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-        <circle cx={12} cy={12} r={9}></circle>
-        <line x1={9} y1={10} x2="9.01" y2={10}></line>
-        <line x1={15} y1={10} x2="15.01" y2={10}></line>
-        <path d="M9.5 15a3.5 3.5 0 0 0 5 0"></path>
-    </svg>
-);
-
 // visible-block-start
 import { Edit } from "@refinedev/chakra-ui";
 /* highlight-next-line */
@@ -653,7 +632,7 @@ import { IconMoodSmile } from "@tabler/icons";
 const PostEdit: React.FC = () => {
     return (
         /* highlight-next-line */
-        <Edit goBack={IconMoodSmile}>
+        <Edit goBack={<IconMoodSmile />}>
             <p>Rest of your page here 2</p>
         </Edit>
     );

--- a/documentation/docs/api-reference/chakra-ui/components/basic-views/show.md
+++ b/documentation/docs/api-reference/chakra-ui/components/basic-views/show.md
@@ -460,27 +460,6 @@ import { Refine } from "@refinedev/core";
 import { ShowButton } from "@refinedev/chakra-ui";
 import dataProvider from "@refinedev/simple-rest";
 
-const IconMoodSmile = (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="icon icon-tabler icon-tabler-mood-smile"
-        width={24}
-        height={24}
-        viewBox="0 0 24 24"
-        strokeWidth="2"
-        stroke="currentColor"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-    >
-        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-        <circle cx={12} cy={12} r={9}></circle>
-        <line x1={9} y1={10} x2="9.01" y2={10}></line>
-        <line x1={15} y1={10} x2="15.01" y2={10}></line>
-        <path d="M9.5 15a3.5 3.5 0 0 0 5 0"></path>
-    </svg>
-);
-
 // visible-block-start
 import { Show } from "@refinedev/chakra-ui";
 /* highlight-next-line */
@@ -489,7 +468,7 @@ import { IconMoodSmile } from "@tabler/icons";
 const PostShow: React.FC = () => {
     return (
         /* highlight-next-line */
-        <Show goBack={IconMoodSmile}>
+        <Show goBack={<IconMoodSmile />}>
             <p>Rest of your page here</p>
         </Show>
     );

--- a/documentation/docs/api-reference/chakra-ui/components/fields/boolean.md
+++ b/documentation/docs/api-reference/chakra-ui/components/fields/boolean.md
@@ -21,43 +21,6 @@ const Wrapper = ({ children }) => {
         </ChakraUI.ChakraProvider>
     );
 };
-
-const IconX = (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="icon icon-tabler icon-tabler-x"
-        width={18}
-        height={18}
-        viewBox="0 0 24 24"
-        strokeWidth="2"
-        stroke="currentColor"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-    >
-        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-        <line x1={18} y1={6} x2={6} y2={18}></line>
-        <line x1={6} y1={6} x2={18} y2={18}></line>
-    </svg>
-);
-
-const IconCheck = (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="icon icon-tabler icon-tabler-check"
-        width={18}
-        height={18}
-        viewBox="0 0 24 24"
-        strokeWidth="2"
-        stroke="currentColor"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-    >
-        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-        <path d="M5 12l5 5l10 -10"></path>
-    </svg>
-);
 ```
 
 This field is used to display boolean values. It uses the [`<Tooltip>`](https://chakra-ui.com/docs/components/tooltip/usage) values from Chakra UI.
@@ -93,6 +56,7 @@ import {
 } from "@chakra-ui/react";
 import { useTable } from "@refinedev/react-table";
 import { ColumnDef, flexRender } from "@tanstack/react-table";
+import { IconX, IconCheck } from "@tabler/icons";
 
 const PostList: React.FC = () => {
     const columns = React.useMemo<ColumnDef<IPost>[]>(
@@ -116,8 +80,8 @@ const PostList: React.FC = () => {
                         // highlight-start
                         <BooleanField
                             value={getValue() === "published"}
-                            trueIcon={IconCheck}
-                            falseIcon={IconX}
+                            trueIcon={<IconCheck />}
+                            falseIcon={<IconX />}
                             valueLabelTrue="published"
                             valueLabelFalse="unpublished"
                         />

--- a/documentation/docs/api-reference/chakra-ui/theming.md
+++ b/documentation/docs/api-reference/chakra-ui/theming.md
@@ -261,45 +261,6 @@ Chakra stores the color mode in `localStorage` and appends a className to the bo
 ```tsx live url=http://localhost:3000 previewHeight=500px
 setInitialRoutes(["/posts"]);
 
-const IconSun = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="icon icon-tabler icon-tabler-sun"
-        width={18}
-        height={18}
-        viewBox="0 0 24 24"
-        strokeWidth="2"
-        stroke="currentColor"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-    >
-        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-        <circle cx={12} cy={12} r={4}></circle>
-        <path d="M3 12h1m8 -9v1m8 8h1m-9 8v1m-6.4 -15.4l.7 .7m12.1 -.7l-.7 .7m0 11.4l.7 .7m-12.1 -.7l-.7 .7"></path>
-    </svg>
-);
-
-const IconMoonStars = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="icon icon-tabler icon-tabler-moon-stars"
-        width={18}
-        height={18}
-        viewBox="0 0 24 24"
-        stroke-width={2}
-        stroke="currentColor"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-    >
-        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-        <path d="M12 3c.132 0 .263 0 .393 0a7.5 7.5 0 0 0 7.92 12.446a9 9 0 1 1 -8.313 -12.454z"></path>
-        <path d="M17 4a2 2 0 0 0 2 2a2 2 0 0 0 -2 2a2 2 0 0 0 -2 -2a2 2 0 0 0 2 -2"></path>
-        <path d="M19 11h2m-1 -1v2"></path>
-    </svg>
-);
-
 // visible-block-start
 import { Refine } from "@refinedev/core";
 import routerProvider from "@refinedev/react-router-v6";

--- a/documentation/docs/api-reference/mantine/components/fields/boolean.md
+++ b/documentation/docs/api-reference/mantine/components/fields/boolean.md
@@ -31,43 +31,6 @@ const Wrapper = ({ children }) => {
         </MantineCore.MantineProvider>
     );
 };
-
-const IconX = (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="icon icon-tabler icon-tabler-x"
-        width={18}
-        height={18}
-        viewBox="0 0 24 24"
-        strokeWidth="2"
-        stroke="currentColor"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-    >
-        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-        <line x1={18} y1={6} x2={6} y2={18}></line>
-        <line x1={6} y1={6} x2={18} y2={18}></line>
-    </svg>
-);
-
-const IconCheck = (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="icon icon-tabler icon-tabler-check"
-        width={18}
-        height={18}
-        viewBox="0 0 24 24"
-        strokeWidth="2"
-        stroke="currentColor"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-    >
-        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-        <path d="M5 12l5 5l10 -10"></path>
-    </svg>
-);
 ```
 
 This field is used to display boolean values. It uses the [`<Tooltip>`](https://mantine.dev/core/tooltip/) values from Mantine.
@@ -113,8 +76,8 @@ const PostList: React.FC = () => {
                         // highlight-start
                         <BooleanField
                             value={getValue() === "published"}
-                            trueIcon={IconCheck}
-                            falseIcon={IconX}
+                            trueIcon={<IconCheck />}
+                            falseIcon={<IconX />}
                             valueLabelTrue="published"
                             valueLabelFalse="unpublished"
                         />

--- a/documentation/docs/api-reference/mantine/theming.md
+++ b/documentation/docs/api-reference/mantine/theming.md
@@ -335,45 +335,6 @@ You can switch between themes as Mantine mentioned in its documentation. You can
 ```tsx live url=http://localhost:3000 previewHeight=420px
 setInitialRoutes(["/posts"]);
 
-const IconSun = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="icon icon-tabler icon-tabler-sun"
-        width={18}
-        height={18}
-        viewBox="0 0 24 24"
-        strokeWidth="2"
-        stroke="currentColor"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-    >
-        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-        <circle cx={12} cy={12} r={4}></circle>
-        <path d="M3 12h1m8 -9v1m8 8h1m-9 8v1m-6.4 -15.4l.7 .7m12.1 -.7l-.7 .7m0 11.4l.7 .7m-12.1 -.7l-.7 .7"></path>
-    </svg>
-);
-
-const IconMoonStars = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="icon icon-tabler icon-tabler-moon-stars"
-        width={18}
-        height={18}
-        viewBox="0 0 24 24"
-        stroke-width={2}
-        stroke="currentColor"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-    >
-        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-        <path d="M12 3c.132 0 .263 0 .393 0a7.5 7.5 0 0 0 7.92 12.446a9 9 0 1 1 -8.313 -12.454z"></path>
-        <path d="M17 4a2 2 0 0 0 2 2a2 2 0 0 0 -2 2a2 2 0 0 0 -2 -2a2 2 0 0 0 2 -2"></path>
-        <path d="M19 11h2m-1 -1v2"></path>
-    </svg>
-);
-
 // visible-block-start
 import { Refine } from "@refinedev/core";
 import routerProvider from "@refinedev/react-router-v6";

--- a/documentation/docs/api-reference/mui/components/fields/boolean.md
+++ b/documentation/docs/api-reference/mui/components/fields/boolean.md
@@ -15,41 +15,6 @@ You can swizzle this component to customize it with the [**refine CLI**](/docs/p
 Let's see how we can use `<BooleanField>` with the example in the post list.
 
 ```tsx live url=http://localhost:3000/posts previewHeight=340px
-const IconX = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="icon icon-tabler icon-tabler-x"
-        width={18}
-        height={18}
-        viewBox="0 0 24 24"
-        strokeWidth="2"
-        stroke="currentColor"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-    >
-        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-        <line x1={18} y1={6} x2={6} y2={18}></line>
-        <line x1={6} y1={6} x2={18} y2={18}></line>
-    </svg>
-);
-const IconCheck = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="icon icon-tabler icon-tabler-check"
-        width={18}
-        height={18}
-        viewBox="0 0 24 24"
-        strokeWidth="2"
-        stroke="currentColor"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-    >
-        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-        <path d="M5 12l5 5l10 -10"></path>
-    </svg>
-);
 // visible-block-start
 import {
     useDataGrid,
@@ -58,6 +23,7 @@ import {
     BooleanField,
 } from "@refinedev/mui";
 import { DataGrid, GridColumns } from "@mui/x-data-grid";
+import { Close, Check } from "@mui/icons-material"
 
 const columns: GridColumns = [
     { field: "id", headerName: "ID", type: "number" },
@@ -70,8 +36,8 @@ const columns: GridColumns = [
             return (
                 <BooleanField
                     value={row.status === "published"}
-                    trueIcon={<IconX />}
-                    falseIcon={<IconCheck />}
+                    trueIcon={<Check />}
+                    falseIcon={<Close />}
                     valueLabelTrue="published"
                     valueLabelFalse="unpublished"
                 />

--- a/documentation/docs/api-reference/mui/theming.md
+++ b/documentation/docs/api-reference/mui/theming.md
@@ -634,7 +634,7 @@ import routerProvider from "@refinedev/react-router-v6";
 
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
-import { LightModeOutlines, DarkModeOutlined } from "./icons";
+import { LightModeOutlined, DarkModeOutlined } from "@mui/icons-material";
 
 import {
     SampleList,
@@ -736,7 +736,7 @@ import routerProvider from "@refinedev/react-router-v6";
 
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
-import { LightModeOutlines, DarkModeOutlined } from "./icons";
+import { LightModeOutlined, DarkModeOutlined } from "@mui/icons-material";
 
 import {
     SampleList,
@@ -935,22 +935,6 @@ import { useForm } from "@refinedev/react-hook-form";
 import { Controller } from "react-hook-form";
 
 import { useMany, useShow, useOne } from "@refinedev/core";
-
-const LightModeOutlined = (props) => {
-    return (
-        <svg width={24} height={24} viewBox="0 0 24 24" fill="white" {...props}>
-            <path d="M12 9c1.65 0 3 1.35 3 3s-1.35 3-3 3-3-1.35-3-3 1.35-3 3-3m0-2c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58c-.39-.39-1.03-.39-1.41 0-.39.39-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37c-.39-.39-1.03-.39-1.41 0-.39.39-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0 .39-.39.39-1.03 0-1.41l-1.06-1.06zm1.06-10.96c.39-.39.39-1.03 0-1.41-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06zM7.05 18.36c.39-.39.39-1.03 0-1.41-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06z"></path>
-        </svg>
-    );
-};
-
-const DarkModeOutlined = (props) => {
-    return (
-        <svg width={24} height={24} viewBox="0 0 24 24" {...props}>
-            <path d="M9.37 5.51c-.18.64-.27 1.31-.27 1.99 0 4.08 3.32 7.4 7.4 7.4.68 0 1.35-.09 1.99-.27C17.45 17.19 14.93 19 12 19c-3.86 0-7-3.14-7-7 0-2.93 1.81-5.45 4.37-6.49zM12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1z"></path>
-        </svg>
-    );
-};
 
 type ColorModeContextType = {
     mode: string;

--- a/packages/live-previews/package.json
+++ b/packages/live-previews/package.json
@@ -11,6 +11,7 @@
         "test": "jest --passWithNoTests"
     },
     "dependencies": {
+        "@ant-design/icons": "^5.0.1",
         "@refinedev/antd": "^5.0.0",
         "@refinedev/core": "^4.0.0",
         "@refinedev/react-router-v6": "^4.0.0",

--- a/packages/live-previews/src/scope/antd.tsx
+++ b/packages/live-previews/src/scope/antd.tsx
@@ -3,7 +3,16 @@ import type { RefineProps } from "@refinedev/core";
 import { RefineCommonScope } from "./common";
 import * as RefineAntd from "@refinedev/antd";
 import * as AntdCore from "antd";
-import { DownOutlined } from "@ant-design/icons";
+import {
+    UnorderedListOutlined,
+    GoogleOutlined,
+    AppstoreAddOutlined,
+    LoginOutlined,
+    SearchOutlined,
+    default as Icon,
+    DownOutlined,
+    EditOutlined,
+} from "@ant-design/icons";
 
 const SIMPLE_REST_API_URL = "https://api.fake-rest.refine.dev";
 
@@ -45,7 +54,14 @@ const AntdScope = {
     RefineAntd,
     AntdCore,
     AntDesignIcons: {
+        UnorderedListOutlined,
+        GoogleOutlined,
+        AppstoreAddOutlined,
+        LoginOutlined,
+        SearchOutlined,
+        default: Icon,
         DownOutlined,
+        EditOutlined,
     },
     // RefineMuiDemo,
     // RefineMui,

--- a/packages/live-previews/src/scope/antd.tsx
+++ b/packages/live-previews/src/scope/antd.tsx
@@ -3,6 +3,7 @@ import type { RefineProps } from "@refinedev/core";
 import { RefineCommonScope } from "./common";
 import * as RefineAntd from "@refinedev/antd";
 import * as AntdCore from "antd";
+import { DownOutlined } from "@ant-design/icons";
 
 const SIMPLE_REST_API_URL = "https://api.fake-rest.refine.dev";
 
@@ -43,6 +44,9 @@ const AntdScope = {
     RefineAntdDemo,
     RefineAntd,
     AntdCore,
+    AntDesignIcons: {
+        DownOutlined,
+    },
     // RefineMuiDemo,
     // RefineMui,
     // RefineMantine,

--- a/packages/live-previews/src/scope/map.tsx
+++ b/packages/live-previews/src/scope/map.tsx
@@ -27,6 +27,7 @@ export const packageMap: Record<string, string> = {
     "@react-keycloak/web": "ReactKeycloakWebScope",
     "react-router-dom": "ReactRouterDom",
     antd: "AntdCore",
+    "@ant-design/icons": "AntDesignIcons",
     "@mantine/core": "MantineCore",
     "@mantine/hooks": "MantineHooks",
     "@mantine/form": "MantineForm",

--- a/packages/live-previews/src/scope/mui.tsx
+++ b/packages/live-previews/src/scope/mui.tsx
@@ -14,7 +14,22 @@ import * as ReactHookForm from "react-hook-form";
 import { ThemeProvider } from "@mui/material/styles";
 import { CssBaseline, GlobalStyles } from "@mui/material";
 
-import { LightModeOutlined, DarkModeOutlined } from "@mui/icons-material";
+import {
+    LightModeOutlined,
+    DarkModeOutlined,
+    ArrowRight,
+    Camera,
+    ListOutlined,
+    Logout,
+    ExpandLess,
+    ExpandMore,
+    ChevronLeft,
+    ChevronRight,
+    MenuRounded,
+    Dashboard,
+    Check,
+    Close,
+} from "@mui/icons-material";
 
 const SIMPLE_REST_API_URL = "https://api.fake-rest.refine.dev";
 
@@ -68,8 +83,20 @@ const MuiScope = {
     MuiMaterialStyles,
     ReactHookForm,
     MuiIconsMaterial: {
+        Close,
+        Check,
         LightModeOutlined,
         DarkModeOutlined,
+        ArrowRight,
+        Camera,
+        ListOutlined,
+        Logout,
+        ExpandLess,
+        ExpandMore,
+        ChevronLeft,
+        ChevronRight,
+        MenuRounded,
+        Dashboard,
     },
     // RefineMantine,
     // RefineMantineDemo,

--- a/packages/live-previews/src/scope/tabler-icons.tsx
+++ b/packages/live-previews/src/scope/tabler-icons.tsx
@@ -1,9 +1,10 @@
-import { IconSun, IconMoonStars } from "@tabler/icons";
+import { IconSun, IconMoonStars, IconLanguage } from "@tabler/icons";
 
 const TablerScope = {
     TablerIcons: {
         IconSun,
         IconMoonStars,
+        IconLanguage,
     },
 };
 

--- a/packages/live-previews/src/scope/tabler-icons.tsx
+++ b/packages/live-previews/src/scope/tabler-icons.tsx
@@ -1,10 +1,42 @@
-import { IconSun, IconMoonStars, IconLanguage } from "@tabler/icons";
+import {
+    IconSun,
+    IconMoonStars,
+    IconLanguage,
+    IconChevronRight,
+    IconChevronLeft,
+    IconSelector,
+    IconChevronDown,
+    IconFilter,
+    IconX,
+    IconCheck,
+    IconMoodSmile,
+    IconList,
+    IconCategory,
+    IconUsers,
+    IconDashboard,
+    IconLogout,
+    IconMenu2,
+} from "@tabler/icons";
 
 const TablerScope = {
     TablerIcons: {
         IconSun,
         IconMoonStars,
         IconLanguage,
+        IconChevronRight,
+        IconChevronLeft,
+        IconSelector,
+        IconChevronDown,
+        IconFilter,
+        IconX,
+        IconCheck,
+        IconMoodSmile,
+        IconList,
+        IconCategory,
+        IconUsers,
+        IconDashboard,
+        IconLogout,
+        IconMenu2,
     },
 };
 

--- a/packages/live-previews/src/utils/check-package.ts
+++ b/packages/live-previews/src/utils/check-package.ts
@@ -4,7 +4,8 @@ export const checkPackage = (code = "") => {
     const hasAntd =
         code.includes("@refinedev/antd") ||
         code.includes("RefineAntd") ||
-        code.includes(`from "antd"`);
+        code.includes(`from "antd"`) ||
+        code.includes("@ant-design/icons");
     const hasMui =
         code.includes("@refinedev/mui") ||
         code.includes("RefineMui") ||


### PR DESCRIPTION
Added missing icons from `@tabler/icons` and `@ant-design/icons`.

Only adding the ones that are used in `create-refine-app` templates.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
