### PR TITLE
feat(live-previews): add code reveal cookie

### DIFF
--- a/packages/live-previews/src/utils/development-cookie.ts
+++ b/packages/live-previews/src/utils/development-cookie.ts
@@ -1,0 +1,12 @@
+const DEVELOPMENT_MODE_COOKIE = "refine-live-preview-development-mode";
+
+export const isDevelopmentModeByCookie = (): boolean => {
+    if (typeof document === "undefined") return false;
+
+    const cookie = document.cookie;
+    const parts = cookie.split(";");
+    const dev = parts.find((part) => part.includes(DEVELOPMENT_MODE_COOKIE));
+    if (!dev) return false;
+    const [, value] = dev.split("=");
+    return value === "true";
+};

--- a/packages/live-previews/src/utils/replace-imports.ts
+++ b/packages/live-previews/src/utils/replace-imports.ts
@@ -1,4 +1,5 @@
 import { packageMap } from "@/src/scope/map";
+import { isDevelopmentModeByCookie } from "./development-cookie";
 import { prettySpaces } from "./pretty-spaces";
 
 const packageRegex =
@@ -41,8 +42,19 @@ export const replaceImports = (content: string): string => {
         }
     }
 
-    return prettySpaces(`
+    const pretty = prettySpaces(`
     ${Array.from(imports).join("\n")}
     ${content.replace(packageRegex, "").replace(sideEffectRegex, "")}
     `);
+
+    if (isDevelopmentModeByCookie()) {
+        console.log("== Incoming Code ==");
+        console.log(content);
+        console.log("== ==");
+        console.log("== Transformed Code ==");
+        console.log(pretty);
+        console.log("== ==");
+    }
+
+    return pretty;
 };


### PR DESCRIPTION
Added a simple method to reveal the incoming and used code blocks in live previews. 

Enabled by setting the `refine-live-preview-development-mode` cookie to `true`

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
