### PR TITLE
docs:  add note on adding URLs to OAuth app settings in example

### DIFF
--- a/documentation/docs/examples/auth-provider/google-auth.md
+++ b/documentation/docs/examples/auth-provider/google-auth.md
@@ -1,9 +1,17 @@
 ---
 id: google-auth
 title: Google Auth
-example-tags: [antd,auth-provider,google-sign-in]
+example-tags: [antd, auth-provider, google-sign-in]
 ---
 
 You can use Google Login to control access and provide identity for your app. This example will guide you through how to connect Google Login into your project using **refine**.
+
+:::note
+
+If you are developing your own OAuth application, it's important to add the URLs of both your deployed application and your local development to the list of allowed origins in the OAuth app settings. Failure to do so can cause the app to fail.
+
+For more detailed guidance, you may find this helpful [video tutorial](https://www.youtube.com/watch?v=HtJKUQXmtok).
+
+:::
 
 <CodeSandboxExample path="auth-google-login" />


### PR DESCRIPTION
Add a note on adding URLs to OAuth app settings in Google Auth example.

**Doc View**
<img width="811" alt="image" src="https://user-images.githubusercontent.com/41580619/228531844-1c026c9d-ec5a-4fa7-b686-909efb29173a.png">
