### PR TITLE
feat(mui-themed-title): add default flex gap

### DIFF
--- a/.changeset/honest-balloons-call.md
+++ b/.changeset/honest-balloons-call.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/chakra-ui": patch
+---
+
+-   Added: `wrapperStyles` prop to `<ThemedTitle>` component to allow for custom styles to be passed in.
+
+-   Added: `textDecoration: none` to `<ThemedTitle>` component.

--- a/.changeset/seven-numbers-divide.md
+++ b/.changeset/seven-numbers-divide.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mui": patch
+---
+
+-   Added: default `gap: 8px` to `<ThemedTitle>` component.

--- a/.changeset/wild-humans-float.md
+++ b/.changeset/wild-humans-float.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/antd": patch
+---
+
+-   Added: `wrapperStyles` prop to `<ThemedTitle>` component to allow for custom styles to be passed in.
+
+-   Added: `textDecoration: none` to `<ThemedTitle>` component.

--- a/packages/antd/src/components/themedLayout/title/index.tsx
+++ b/packages/antd/src/components/themedLayout/title/index.tsx
@@ -33,6 +33,7 @@ export const ThemedTitle: React.FC<RefineLayoutThemedTitleProps> = ({
     collapsed,
     icon = defaultIcon,
     text = defaultText,
+    wrapperStyles,
 }) => {
     const { token } = useToken();
     const routerType = useRouterType();
@@ -46,6 +47,7 @@ export const ThemedTitle: React.FC<RefineLayoutThemedTitleProps> = ({
             to="/"
             style={{
                 display: "inline-block",
+                textDecoration: "none",
             }}
         >
             <Space
@@ -53,6 +55,7 @@ export const ThemedTitle: React.FC<RefineLayoutThemedTitleProps> = ({
                     display: "flex",
                     alignItems: "center",
                     fontSize: "inherit",
+                    ...wrapperStyles,
                 }}
             >
                 <div

--- a/packages/chakra-ui/src/components/themedLayout/title/index.tsx
+++ b/packages/chakra-ui/src/components/themedLayout/title/index.tsx
@@ -31,6 +31,7 @@ export const ThemedTitle: React.FC<RefineLayoutThemedTitleProps> = ({
     collapsed,
     icon = defaultIcon,
     text = defaultText,
+    wrapperStyles,
 }) => {
     const routerType = useRouterType();
     const Link = useLink();
@@ -39,12 +40,23 @@ export const ThemedTitle: React.FC<RefineLayoutThemedTitleProps> = ({
     const ActiveLink = routerType === "legacy" ? LegacyLink : Link;
 
     return (
-        <ChakraLink as={ActiveLink} to="/" fontSize="inherit">
+        <ChakraLink
+            as={ActiveLink}
+            to="/"
+            fontSize="inherit"
+            textDecoration="none"
+            _hover={{
+                textDecoration: "none",
+            }}
+        >
             <HStack
                 spacing="8px"
                 justifyContent="center"
                 alignItems="center"
                 fontSize="inherit"
+                style={{
+                    ...wrapperStyles,
+                }}
             >
                 <Icon height="24px" width="24px" color="brand.500">
                     {icon}

--- a/packages/mui/src/components/themedLayout/sider/index.tsx
+++ b/packages/mui/src/components/themedLayout/sider/index.tsx
@@ -49,7 +49,6 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
     onToggleSiderClick,
 }) => {
     const theme = useTheme();
-    console.log("theme", theme);
     const [opened, setOpened] = useState(false);
 
     const drawerWidth = () => {

--- a/packages/mui/src/components/themedLayout/title/index.tsx
+++ b/packages/mui/src/components/themedLayout/title/index.tsx
@@ -47,6 +47,7 @@ export const ThemedTitle: React.FC<RefineLayoutThemedTitleProps> = ({
             sx={{
                 display: "flex",
                 alignItems: "center",
+                gap: "8px",
                 ...wrapperStyles,
             }}
         >

--- a/packages/mui/src/theme/palette/index.tsx
+++ b/packages/mui/src/theme/palette/index.tsx
@@ -1,3 +1,3 @@
 export { darkPalette } from "./darkPalette";
 export { lightPalette } from "./lightPalette";
-export { RefinePalettes, refineCustomColors } from "./refinePalette";
+export { RefinePalettes } from "./refinePalette";


### PR DESCRIPTION
chakra-ui
-   Added: `wrapperStyles` prop to `<ThemedTitle>` component to allow for custom styles to be passed in.
-   Added: `textDecoration: none` to `<ThemedTitle>` component.

antd
-   Added: `wrapperStyles` prop to `<ThemedTitle>` component to allow for custom styles to be passed in.

-   Added: `textDecoration: none` to `<ThemedTitle>` component.

mui
- Added: default `gap: 8px` to `<ThemedTitle>` component.