### PR TITLE
fix(mui): sider toggle button color

### DIFF
--- a/.changeset/unlucky-jeans-know.md
+++ b/.changeset/unlucky-jeans-know.md
@@ -1,0 +1,6 @@
+---
+"@refinedev/mui": patch
+---
+
+-   Fixed: Sider toggle button color
+    -   The color of the toggle button in the `<ThemedSider>` and `<ThemedHeader>` does not meet the contrast ratio. This is now fixed.

--- a/packages/mui/src/components/themedLayout/header/index.tsx
+++ b/packages/mui/src/components/themedLayout/header/index.tsx
@@ -29,6 +29,7 @@ export const ThemedHeader: React.FC<RefineThemedLayoutHeaderProps> = ({
             <Toolbar>
                 {hasSidebarToggle && (
                     <IconButton
+                        color="inherit"
                         aria-label="open drawer"
                         onClick={() => onToggleSiderClick?.()}
                         edge="start"

--- a/packages/mui/src/components/themedLayout/sider/index.tsx
+++ b/packages/mui/src/components/themedLayout/sider/index.tsx
@@ -500,16 +500,26 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
                     </Box>
                 </Drawer>
                 <IconButton
-                    sx={{
-                        display: { xs: "flex", md: "none" },
-                        justifyContent: "center",
-                        alignItems: "center",
-                        position: "fixed",
-                        top: "12px",
-                        left: "16px",
-                        zIndex: 1199,
-                        height: "36px",
-                        width: "36px",
+                    sx={(theme) => {
+                        const { palette } = theme;
+                        const { mode, getContrastText, primary, background } =
+                            palette;
+
+                        return {
+                            color:
+                                mode === "light"
+                                    ? getContrastText(primary.main)
+                                    : getContrastText(background.paper),
+                            display: { xs: "flex", md: "none" },
+                            justifyContent: "center",
+                            alignItems: "center",
+                            position: "fixed",
+                            top: "12px",
+                            left: "16px",
+                            zIndex: 1199,
+                            height: "36px",
+                            width: "36px",
+                        };
                     }}
                     onClick={() => setOpened((prev) => !prev)}
                 >


### PR DESCRIPTION
The color of the toggle button in the `<ThemedSider>` and `<ThemedHeader>` does not meet the contrast ratio. This is now fixed.