### PR TITLE
feat(live-previews): add mock google auth

### DIFF
--- a/packages/live-previews/pages/preview.tsx
+++ b/packages/live-previews/pages/preview.tsx
@@ -121,6 +121,12 @@ const Preview: NextPage = () => {
                         : {},
             ];
 
+            if (code.includes("React.createElement(GoogleButton,")) {
+                callbacks.push(
+                    async () => (await import("../src/scope/google")).default,
+                );
+            }
+
             let scopesToUse: Record<string, any> = {};
 
             const resolvedScopes = await Promise.all(

--- a/packages/live-previews/src/scope/google.tsx
+++ b/packages/live-previews/src/scope/google.tsx
@@ -1,0 +1,78 @@
+import { useLogin } from "@refinedev/core";
+
+const dummyCredentials =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+const MockGoogleButton = () => {
+    const { mutate } = useLogin();
+
+    return (
+        <button
+            type="button"
+            onClick={() => mutate({ credential: dummyCredentials })}
+            style={{
+                border: "none",
+                background: "#3871E0",
+                borderRadius: "4px",
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                padding: "2px",
+                paddingRight: "12px",
+                color: "white",
+                fontWeight: 500,
+                gap: "12px",
+                cursor: "pointer",
+                fontSize: "14px",
+            }}
+        >
+            <div
+                style={{
+                    width: "28px",
+                    height: "28px",
+                    display: "flex",
+                    justifyContent: "center",
+                    alignItems: "center",
+                    background: "white",
+                    borderTopLeftRadius: "3px",
+                    borderBottomLeftRadius: "3px",
+                }}
+            >
+                <svg
+                    version="1.1"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 48 48"
+                    width="14px"
+                    height="14px"
+                >
+                    <g>
+                        <path
+                            fill="#EA4335"
+                            d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+                        ></path>
+                        <path
+                            fill="#4285F4"
+                            d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+                        ></path>
+                        <path
+                            fill="#FBBC05"
+                            d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+                        ></path>
+                        <path
+                            fill="#34A853"
+                            d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+                        ></path>
+                        <path fill="none" d="M0 0h48v48H0z"></path>
+                    </g>
+                </svg>
+            </div>
+            <div>Sign in with Google</div>
+        </button>
+    );
+};
+
+const GoogleScope = {
+    MockGoogleButton,
+};
+
+export default GoogleScope;

--- a/packages/live-previews/src/utils/replace-imports.ts
+++ b/packages/live-previews/src/utils/replace-imports.ts
@@ -42,9 +42,16 @@ export const replaceImports = (content: string): string => {
         }
     }
 
+    console.log("includes google", "React.crateElement(GoogleButton,");
     const pretty = prettySpaces(`
     ${Array.from(imports).join("\n")}
-    ${content.replace(packageRegex, "").replace(sideEffectRegex, "")}
+    ${content
+        .replace(packageRegex, "")
+        .replace(sideEffectRegex, "")
+        .replace(
+            "React.createElement(GoogleButton,",
+            "React.createElement(MockGoogleButton,",
+        )}
     `);
 
     if (isDevelopmentModeByCookie()) {


### PR DESCRIPTION
Added a simple mock for google auth in live previews.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
