### PR TITLE
fix(mantine): custom themed title styles

### DIFF
--- a/.changeset/hot-bobcats-bow.md
+++ b/.changeset/hot-bobcats-bow.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mantine": patch
+---
+
+-   The `wrapperStyles` properties of `<ThemedSider>`'s `<ThemedTitle>` have been moved to the parent component. As a result, it is now possible to pass a custom `<Title>` component to `<ThemedLayout>` that will be styled correctly.

--- a/packages/mantine/src/components/themedLayout/sider/index.tsx
+++ b/packages/mantine/src/components/themedLayout/sider/index.tsx
@@ -29,6 +29,7 @@ import {
     TooltipProps,
     Styles,
     useMantineTheme,
+    Flex,
 } from "@mantine/core";
 import {
     IconList,
@@ -300,16 +301,17 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
                         zIndex: 199,
                     }}
                 >
-                    <Box>
-                        <RenderToTitle
-                            collapsed={collapsed}
-                            wrapperStyles={{
-                                height: "64px",
-                                paddingLeft: collapsed ? 0 : "16px",
-                                borderBottom: `1px solid ${borderColor}`,
-                            }}
-                        />
-                    </Box>
+                    <Flex
+                        h="64px"
+                        pl={collapsed ? 0 : "16px"}
+                        align="center"
+                        justify={collapsed ? "center" : "flex-start"}
+                        sx={{
+                            borderBottom: `1px solid ${borderColor}`,
+                        }}
+                    >
+                        <RenderToTitle collapsed={collapsed} />
+                    </Flex>
                     <Navbar.Section
                         grow
                         component={ScrollArea}


### PR DESCRIPTION
The `wrapperStyles` properties of `<ThemedSider>`'s `<ThemedTitle>` have been moved to the parent component. As a result, it is now possible to pass a custom `<Title>` component to `<ThemedLayout>` that will be styled correctly.