### PR TITLE
fix: use `menu` instead of the deprecated `overlay` to remove warn

### DIFF
--- a/examples/blog-invoice-generator/src/components/client/item.tsx
+++ b/examples/blog-invoice-generator/src/components/client/item.tsx
@@ -2,7 +2,7 @@ import { useDelete } from "@refinedev/core";
 import { TagField } from "@refinedev/antd";
 
 import { FormOutlined, DeleteOutlined, MoreOutlined } from "@ant-design/icons";
-import { Card, Typography, Dropdown, Menu } from "antd";
+import { Card, Typography, Dropdown, MenuProps } from "antd";
 
 import { IClient } from "interfaces";
 
@@ -16,55 +16,33 @@ type ClientItemProps = {
 export const ClientItem: React.FC<ClientItemProps> = ({ item, editShow }) => {
     const { mutate } = useDelete();
 
+    const menuItems: MenuProps["items"] = [
+        {
+            key: "1",
+            style: { fontWeight: 500 },
+            icon: <FormOutlined style={{ color: "green" }} />,
+            onClick: () => editShow(item.id),
+            label: "Edit Client",
+        },
+        {
+            key: "2",
+            style: { fontWeight: 500 },
+            icon: <DeleteOutlined style={{ color: "red" }} />,
+            onClick: () =>
+                mutate({
+                    resource: "clients",
+                    id: item.id,
+                    mutationMode: "undoable",
+                    undoableTimeout: 5000,
+                }),
+            label: "Delete Client",
+        },
+    ];
+
     return (
         <Card style={{ width: 300, height: 300, borderColor: "black" }}>
             <div style={{ position: "absolute", top: "10px", right: "5px" }}>
-                <Dropdown
-                    overlay={
-                        <Menu mode="vertical">
-                            <Menu.Item
-                                key="1"
-                                style={{
-                                    fontWeight: 500,
-                                }}
-                                icon={
-                                    <FormOutlined
-                                        style={{
-                                            color: "green",
-                                        }}
-                                    />
-                                }
-                                onClick={() => editShow(item.id)}
-                            >
-                                Edit Client
-                            </Menu.Item>
-                            <Menu.Item
-                                key="2"
-                                style={{
-                                    fontWeight: 500,
-                                }}
-                                icon={
-                                    <DeleteOutlined
-                                        style={{
-                                            color: "red",
-                                        }}
-                                    />
-                                }
-                                onClick={() =>
-                                    mutate({
-                                        resource: "clients",
-                                        id: item.id,
-                                        mutationMode: "undoable",
-                                        undoableTimeout: 5000,
-                                    })
-                                }
-                            >
-                                Delete Client
-                            </Menu.Item>
-                        </Menu>
-                    }
-                    trigger={["click"]}
-                >
+                <Dropdown menu={{ items: menuItems }} trigger={["click"]}>
                     <MoreOutlined
                         style={{
                             fontSize: 24,

--- a/examples/finefoods-antd/src/components/header/index.tsx
+++ b/examples/finefoods-antd/src/components/header/index.tsx
@@ -10,7 +10,6 @@ import { Link } from "react-router-dom";
 import { SearchOutlined, DownOutlined } from "@ant-design/icons";
 
 import {
-    Menu,
     Dropdown,
     Input,
     Avatar,
@@ -23,6 +22,7 @@ import {
     Layout as AntdLayout,
     Button,
     theme,
+    MenuProps,
 } from "antd";
 
 import { useTranslation } from "react-i18next";
@@ -171,26 +171,18 @@ export const Header: React.FC = () => {
         refetchStores();
     }, [value]);
 
-    const menu = (
-        <Menu selectedKeys={currentLocale ? [currentLocale] : []}>
-            {[...(i18n.languages ?? [])].sort().map((lang: string) => (
-                <Menu.Item
-                    key={lang}
-                    onClick={() => changeLanguage(lang)}
-                    icon={
-                        <span style={{ marginRight: 8 }}>
-                            <Avatar
-                                size={16}
-                                src={`/images/flags/${lang}.svg`}
-                            />
-                        </span>
-                    }
-                >
-                    {lang === "en" ? "English" : "German"}
-                </Menu.Item>
-            ))}
-        </Menu>
-    );
+    const menuItems: MenuProps["items"] = [...(i18n.languages || [])]
+        .sort()
+        .map((lang: string) => ({
+            key: lang,
+            onClick: () => changeLanguage(lang),
+            icon: (
+                <span style={{ marginRight: 8 }}>
+                    <Avatar size={16} src={`/images/flags/${lang}.svg`} />
+                </span>
+            ),
+            label: lang === "en" ? "English" : "German",
+        }));
 
     return (
         <AntdHeader
@@ -239,7 +231,14 @@ export const Header: React.FC = () => {
                                 setMode(mode === "light" ? "dark" : "light");
                             }}
                         />
-                        <Dropdown overlay={menu}>
+                        <Dropdown
+                            menu={{
+                                items: menuItems,
+                                selectedKeys: currentLocale
+                                    ? [currentLocale]
+                                    : [],
+                            }}
+                        >
                             <a
                                 style={{ color: "inherit" }}
                                 onClick={(e) => e.preventDefault()}

--- a/examples/i18n-nextjs/src/components/header/index.tsx
+++ b/examples/i18n-nextjs/src/components/header/index.tsx
@@ -3,10 +3,10 @@ import { DownOutlined } from "@ant-design/icons";
 import {
     Layout as AntdLayout,
     Space,
-    Menu,
     Button,
     Dropdown,
     Avatar,
+    MenuProps,
 } from "antd";
 import { useRouter } from "next/router";
 import Link from "next/link";
@@ -17,27 +17,21 @@ export const Header: React.FC = () => {
 
     const currentLocale = locale();
 
-    const menu = (
-        <Menu selectedKeys={currentLocale ? [currentLocale] : []}>
-            {[...(locales || [])].sort().map((lang: string) => (
-                <Menu.Item
-                    key={lang}
-                    icon={
-                        <span style={{ marginRight: 8 }}>
-                            <Avatar
-                                size={16}
-                                src={`/images/flags/${lang}.svg`}
-                            />
-                        </span>
-                    }
-                >
-                    <Link href="/" locale={lang}>
-                        {lang === "en" ? "English" : "German"}
-                    </Link>
-                </Menu.Item>
-            ))}
-        </Menu>
-    );
+    const menuItems: MenuProps["items"] = [...(locales || [])]
+        .sort()
+        .map((lang: string) => ({
+            key: lang,
+            icon: (
+                <span style={{ marginRight: 8 }}>
+                    <Avatar size={16} src={`/images/flags/${lang}.svg`} />
+                </span>
+            ),
+            label: (
+                <Link href="/" locale={lang}>
+                    {lang === "en" ? "English" : "German"}
+                </Link>
+            ),
+        }));
 
     return (
         <AntdLayout.Header
@@ -50,8 +44,13 @@ export const Header: React.FC = () => {
                 backgroundColor: "#FFF",
             }}
         >
-            <Dropdown overlay={menu}>
-                <Button type="link">
+            <Dropdown
+                menu={{
+                    items: menuItems,
+                    selectedKeys: currentLocale ? [currentLocale] : [],
+                }}
+            >
+                <Button type="text">
                     <Space>
                         <Avatar
                             size={16}

--- a/examples/i18n-react/src/components/header/index.tsx
+++ b/examples/i18n-react/src/components/header/index.tsx
@@ -3,10 +3,10 @@ import { DownOutlined } from "@ant-design/icons";
 import {
     Layout as AntdLayout,
     Space,
-    Menu,
     Button,
     Dropdown,
     Avatar,
+    MenuProps,
 } from "antd";
 import { useTranslation } from "react-i18next";
 
@@ -17,26 +17,18 @@ export const Header: React.FC = () => {
 
     const currentLocale = locale();
 
-    const menu = (
-        <Menu selectedKeys={currentLocale ? [currentLocale] : []}>
-            {[...(i18n.languages || [])].sort().map((lang: string) => (
-                <Menu.Item
-                    key={lang}
-                    onClick={() => changeLanguage(lang)}
-                    icon={
-                        <span style={{ marginRight: 8 }}>
-                            <Avatar
-                                size={16}
-                                src={`/images/flags/${lang}.svg`}
-                            />
-                        </span>
-                    }
-                >
-                    {lang === "en" ? "English" : "German"}
-                </Menu.Item>
-            ))}
-        </Menu>
-    );
+    const menuItems: MenuProps["items"] = [...(i18n.languages || [])]
+        .sort()
+        .map((lang: string) => ({
+            key: lang,
+            onClick: () => changeLanguage(lang),
+            icon: (
+                <span style={{ marginRight: 8 }}>
+                    <Avatar size={16} src={`/images/flags/${lang}.svg`} />
+                </span>
+            ),
+            label: lang === "en" ? "English" : "German",
+        }));
 
     return (
         <AntdLayout.Header
@@ -49,8 +41,13 @@ export const Header: React.FC = () => {
                 backgroundColor: "#FFF",
             }}
         >
-            <Dropdown overlay={menu}>
-                <Button type="link">
+            <Dropdown
+                menu={{
+                    items: menuItems,
+                    selectedKeys: currentLocale ? [currentLocale] : [],
+                }}
+            >
+                <Button type="text">
                     <Space>
                         <Avatar
                             size={16}


### PR DESCRIPTION
Fixed deprecated `<Dropdown>` prop. To solve it, used `menu` instead of the deprecated `overlay`.