### PR TITLE
fix(mantine): changed themed title cursor to pointer

### DIFF
--- a/.changeset/perfect-flies-tease.md
+++ b/.changeset/perfect-flies-tease.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mantine": patch
+---
+
+-   `ThemedTitle` cursor is now a pointer when hovering over the logo.

--- a/packages/mantine/src/components/themedLayout/title/index.tsx
+++ b/packages/mantine/src/components/themedLayout/title/index.tsx
@@ -44,6 +44,7 @@ export const ThemedTitle: React.FC<RefineLayoutThemedTitleProps> = ({
         <ActiveLink to="/" style={{ all: "unset" }}>
             <Center
                 style={{
+                    cursor: "pointer",
                     display: "flex",
                     alignItems: "center",
                     justifyContent: collapsed ? "center" : "flex-start",


### PR DESCRIPTION
- `ThemedTitle` cursor is now a pointer when hovering over the logo.