### PR TITLE
fix: `Checkbox` import path in Mui inferencer

### DIFF
--- a/.changeset/five-kids-double.md
+++ b/.changeset/five-kids-double.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/inferencer": patch
+---
+
+Fix the wrong import path for Mui `Checkbox` component.

--- a/packages/inferencer/src/inferencers/mui/list.tsx
+++ b/packages/inferencer/src/inferencers/mui/list.tsx
@@ -392,7 +392,7 @@ export const renderer = ({
 
     const booleanFields = (field: InferField) => {
         if (field?.type) {
-            imports.push(["Checkbox", "@refinedev/mui"]);
+            imports.push(["Checkbox", "@mui/material"]);
 
             const fieldProperty = `field: "${field.key}"`;
 


### PR DESCRIPTION
Update the wrong import path.

close #4087 