### PR TITLE
fix(use-modal-form): add `id` check to `show` method

### DIFF
--- a/.changeset/dull-ducks-brake.md
+++ b/.changeset/dull-ducks-brake.md
@@ -1,5 +1,5 @@
 ---
-"@refinedev/react-hook-form": minor
+"@refinedev/react-hook-form": patch
 ---
 
 Updated `useModalForm` hook's `modal.show` method to check if there's an `id` present or provided. If there is, it will continue to show the modal. If not, the modal will not show. (Resolves #4062)

--- a/.changeset/dull-ducks-brake.md
+++ b/.changeset/dull-ducks-brake.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/react-hook-form": minor
+---
+
+Updated `useModalForm` hook's `modal.show` method to check if there's an `id` present or provided. If there is, it will continue to show the modal. If not, the modal will not show. (Resolves #4062)

--- a/.changeset/red-monkeys-beam.md
+++ b/.changeset/red-monkeys-beam.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/antd": minor
+---
+
+Updated `useModalForm` and `useDrawerForm` hook's `show` method to check if there's an `id` present or provided. If there is, it will continue to show the modal/drawer. If not, the modal/drawer will not show. (Resolves #4062)

--- a/.changeset/red-monkeys-beam.md
+++ b/.changeset/red-monkeys-beam.md
@@ -1,5 +1,5 @@
 ---
-"@refinedev/antd": minor
+"@refinedev/antd": patch
 ---
 
 Updated `useModalForm` and `useDrawerForm` hook's `show` method to check if there's an `id` present or provided. If there is, it will continue to show the modal/drawer. If not, the modal/drawer will not show. (Resolves #4062)

--- a/.changeset/unlucky-penguins-dance.md
+++ b/.changeset/unlucky-penguins-dance.md
@@ -1,5 +1,5 @@
 ---
-"@refinedev/mantine": minor
+"@refinedev/mantine": patch
 ---
 
 Updated `useModalForm` hook's `modal.show` method to check if there's an `id` present or provided. If there is, it will continue to show the modal. If not, the modal will not show. (Resolves #4062)

--- a/.changeset/unlucky-penguins-dance.md
+++ b/.changeset/unlucky-penguins-dance.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mantine": minor
+---
+
+Updated `useModalForm` hook's `modal.show` method to check if there's an `id` present or provided. If there is, it will continue to show the modal. If not, the modal will not show. (Resolves #4062)

--- a/packages/antd/src/hooks/form/useDrawerForm/index.spec.tsx
+++ b/packages/antd/src/hooks/form/useDrawerForm/index.spec.tsx
@@ -57,6 +57,7 @@ describe("useDrawerForm Hook", () => {
         const { result } = renderHook(
             () =>
                 useDrawerForm({
+                    id: 1,
                     action: "edit",
                     defaultVisible: false,
                 }),
@@ -69,7 +70,30 @@ describe("useDrawerForm Hook", () => {
             result.current.show();
         });
 
-        expect(result.current.drawerProps.open).toBe(true);
+        await act(async () =>
+            expect(result.current.drawerProps.open).toBe(true),
+        );
+    });
+
+    it("'open' value should be false when 'show' is called without id", async () => {
+        const { result } = renderHook(
+            () =>
+                useDrawerForm({
+                    action: "edit",
+                    defaultVisible: false,
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        await act(async () => {
+            result.current.show();
+        });
+
+        await act(async () =>
+            expect(result.current.drawerProps.open).toBe(false),
+        );
     });
 
     it("'id' should be updated when 'show' is called with 'id'", async () => {
@@ -118,6 +142,7 @@ describe("useDrawerForm Hook", () => {
         const { result } = renderHook(
             () =>
                 useDrawerForm({
+                    id: 1,
                     action: "edit",
                     resource: "posts",
                     autoSubmitClose: false,
@@ -129,10 +154,13 @@ describe("useDrawerForm Hook", () => {
 
         await act(async () => {
             result.current.show();
+        });
+        await act(async () => {
             result.current.saveButtonProps.onClick?.({} as any);
         });
 
-        expect(result.current.drawerProps.open).toBe(true);
+        await waitFor(() => result.current.mutationResult.isSuccess);
+        await waitFor(() => expect(result.current.drawerProps.open).toBe(true));
     });
 
     it("autoResetForm is true, 'reset' should be called when the form is submitted", async () => {

--- a/packages/antd/src/hooks/form/useDrawerForm/useDrawerForm.ts
+++ b/packages/antd/src/hooks/form/useDrawerForm/useDrawerForm.ts
@@ -207,11 +207,17 @@ export const useDrawerForm = <
         setId?.(undefined);
     }, [warnWhen]);
 
-    const handleShow = useCallback((id?: BaseKey) => {
-        setId?.(id);
-
-        show();
-    }, []);
+    const handleShow = useCallback(
+        (showId?: BaseKey) => {
+            if (typeof showId !== "undefined") {
+                setId?.(showId);
+            }
+            if (typeof showId !== "undefined" || typeof id !== "undefined") {
+                show();
+            }
+        },
+        [id],
+    );
 
     return {
         ...useFormProps,

--- a/packages/antd/src/hooks/form/useModalForm/index.spec.tsx
+++ b/packages/antd/src/hooks/form/useModalForm/index.spec.tsx
@@ -59,6 +59,7 @@ describe("useModalForm Hook", () => {
         const { result } = renderHook(
             () =>
                 useModalForm({
+                    id: 1,
                     action: "edit",
                     defaultVisible: false,
                 }),
@@ -73,7 +74,7 @@ describe("useModalForm Hook", () => {
             result.current.show();
         });
 
-        expect(result.current.modalProps.open).toBe(true);
+        await waitFor(() => expect(result.current.modalProps.open).toBe(true));
     });
 
     it("'id' should be updated when 'show' is called with 'id'", async () => {
@@ -127,8 +128,15 @@ describe("useModalForm Hook", () => {
 
         await act(async () => {
             result.current.show();
+        });
+
+        await act(async () => {
             result.current.modalProps.onOk?.({} as any);
         });
+
+        await waitFor(() => result.current.mutationResult.isSuccess);
+
+        await waitFor(() => expect(result.current.modalProps.open).toBe(false));
 
         expect(result.current.modalProps.open).toBe(false);
     });
@@ -137,6 +145,7 @@ describe("useModalForm Hook", () => {
         const { result } = renderHook(
             () =>
                 useModalForm({
+                    id: 1,
                     action: "edit",
                     resource: "posts",
                     autoSubmitClose: false,

--- a/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
+++ b/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
@@ -202,11 +202,17 @@ export const useModalForm = <
         sunflowerUseModal.close();
     }, [warnWhen]);
 
-    const handleShow = useCallback((id?: BaseKey) => {
-        setId?.(id);
-
-        sunflowerUseModal.show();
-    }, []);
+    const handleShow = useCallback(
+        (showId?: BaseKey) => {
+            if (typeof showId !== "undefined") {
+                setId?.(showId);
+            }
+            if (typeof showId !== "undefined" || typeof id !== "undefined") {
+                sunflowerUseModal.show();
+            }
+        },
+        [id],
+    );
 
     const { visible: _visible, ...otherModalProps } = modalProps;
     const newModalProps = { open: _visible, ...otherModalProps };

--- a/packages/mantine/src/hooks/form/useModalForm/index.ts
+++ b/packages/mantine/src/hooks/form/useModalForm/index.ts
@@ -212,10 +212,17 @@ export const useModalForm = <
         close();
     }, [warnWhen]);
 
-    const handleShow = useCallback((id?: BaseKey) => {
-        setId?.(id);
-        show();
-    }, []);
+    const handleShow = useCallback(
+        (showId?: BaseKey) => {
+            if (typeof showId !== "undefined") {
+                setId?.(showId);
+            }
+            if (typeof showId !== "undefined" || typeof id !== "undefined") {
+                show();
+            }
+        },
+        [id],
+    );
 
     const title = translate(
         `${resource?.name}.titles.${actionProp}`,

--- a/packages/react-hook-form/src/useModalForm/index.spec.ts
+++ b/packages/react-hook-form/src/useModalForm/index.spec.ts
@@ -56,6 +56,9 @@ describe("useModalForm Hook", () => {
         const { result } = renderHook(
             () =>
                 useModalForm({
+                    refineCoreProps: {
+                        id: "5",
+                    },
                     modalProps: {
                         defaultVisible: false,
                     },
@@ -69,7 +72,27 @@ describe("useModalForm Hook", () => {
             result.current.modal.show();
         });
 
-        expect(result.current.modal.visible).toBe(true);
+        await waitFor(() => expect(result.current.modal.visible).toBe(true));
+    });
+
+    it("'visible' value should be false when 'show' is called without id", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    modalProps: {
+                        defaultVisible: false,
+                    },
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        await act(async () => {
+            result.current.modal.show();
+        });
+
+        expect(result.current.modal.visible).toBe(false);
     });
 
     it("'id' should be updated when 'show' is called with 'id'", async () => {
@@ -132,6 +155,7 @@ describe("useModalForm Hook", () => {
             () =>
                 useModalForm({
                     refineCoreProps: {
+                        id: 5,
                         resource: "posts",
                     },
                     modalProps: {
@@ -145,10 +169,12 @@ describe("useModalForm Hook", () => {
 
         await act(async () => {
             result.current.modal.show();
+        });
+        await act(async () => {
             result.current.modal.submit({});
         });
 
-        expect(result.current.modal.visible).toBe(true);
+        await waitFor(() => expect(result.current.modal.visible).toBe(true));
     });
 
     it("autoResetForm is true, 'reset' should be called when 'submit' is called", async () => {

--- a/packages/react-hook-form/src/useModalForm/index.ts
+++ b/packages/react-hook-form/src/useModalForm/index.ts
@@ -204,11 +204,17 @@ export const useModalForm = <
         close();
     }, [warnWhen]);
 
-    const handleShow = useCallback((id?: BaseKey) => {
-        setId?.(id);
-
-        show();
-    }, []);
+    const handleShow = useCallback(
+        (showId?: BaseKey) => {
+            if (typeof showId !== "undefined") {
+                setId?.(showId);
+            }
+            if (typeof showId !== "undefined" || typeof id !== "undefined") {
+                show();
+            }
+        },
+        [id],
+    );
 
     const title = translate(
         `${resource?.name}.titles.${actionProp}`,


### PR DESCRIPTION
Updated `useModalForm` and `useDrawerForm` hook's `show` method to check if there's an `id` present or provided. If there is, it will continue to show the modal. If not, the modal will not show. 

Resolves #4062

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
