### PR TITLE
fix: `<Sider />` icon and list item spacing for MUI

### DIFF
--- a/packages/mui/src/components/themedLayout/sider/index.tsx
+++ b/packages/mui/src/components/themedLayout/sider/index.tsx
@@ -159,7 +159,7 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
                                             minWidth: "24px",
                                             transition: "margin-right 0.3s",
                                             marginRight: isSiderOpen
-                                                ? "32px"
+                                                ? "12px"
                                                 : "0px",
                                             color: "currentColor",
                                         }}
@@ -237,7 +237,7 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
                                 sx={{
                                     justifyContent: "center",
                                     transition: "margin-right 0.3s",
-                                    marginRight: isSiderOpen ? "32px" : "0px",
+                                    marginRight: isSiderOpen ? "12px" : "0px",
                                     minWidth: "24px",
                                     color: "currentColor",
                                 }}
@@ -284,7 +284,7 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
                             justifyContent: "center",
                             minWidth: "24px",
                             transition: "margin-right 0.3s",
-                            marginRight: isSiderOpen ? "32px" : "0px",
+                            marginRight: isSiderOpen ? "12px" : "0px",
                             fontSize: "14px",
                         }}
                     >
@@ -331,7 +331,6 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
                 onClick={() => handleLogout()}
                 sx={{
                     justifyContent: "center",
-                    marginTop: "8px",
                 }}
             >
                 <ListItemIcon
@@ -339,7 +338,7 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
                         justifyContent: "center",
                         minWidth: "24px",
                         transition: "margin-right 0.3s",
-                        marginRight: isSiderOpen ? "32px" : "0px",
+                        marginRight: isSiderOpen ? "12px" : "0px",
                         marginLeft: "2px",
                     }}
                 >


### PR DESCRIPTION
Fix `<Sider />` icon and list item spacing for MUI.

<img width="298" alt="Screenshot 2023-04-06 at 17 00 14" src="https://user-images.githubusercontent.com/3484713/230401163-ebbcdf55-44c5-4181-ab91-7496b91743ea.png">
