### PR TITLE
fix(form): `useModalForm` and `useDrawerForm` with `create` action

### DIFF
--- a/.changeset/cool-vans-raise.md
+++ b/.changeset/cool-vans-raise.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/antd": patch
+---
+
+Fix broken `useModalForm` and `useDrawerForm` with `create` actions.

--- a/.changeset/olive-rabbits-wave.md
+++ b/.changeset/olive-rabbits-wave.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/react-hook-form": patch
+---
+
+Fix broken `useModalForm` with `create` actions.

--- a/.changeset/thin-ravens-smoke.md
+++ b/.changeset/thin-ravens-smoke.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mantine": patch
+---
+
+Fix broken `useModalForm` with `create` actions.

--- a/packages/antd/src/hooks/form/useDrawerForm/useDrawerForm.ts
+++ b/packages/antd/src/hooks/form/useDrawerForm/useDrawerForm.ts
@@ -212,7 +212,10 @@ export const useDrawerForm = <
             if (typeof showId !== "undefined") {
                 setId?.(showId);
             }
-            if (typeof showId !== "undefined" || typeof id !== "undefined") {
+            const needsIdToOpen = action === "edit" || action === "clone";
+            const hasId =
+                typeof showId !== "undefined" || typeof id !== "undefined";
+            if (needsIdToOpen ? hasId : true) {
                 show();
             }
         },

--- a/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
+++ b/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
@@ -207,7 +207,10 @@ export const useModalForm = <
             if (typeof showId !== "undefined") {
                 setId?.(showId);
             }
-            if (typeof showId !== "undefined" || typeof id !== "undefined") {
+            const needsIdToOpen = action === "edit" || action === "clone";
+            const hasId =
+                typeof showId !== "undefined" || typeof id !== "undefined";
+            if (needsIdToOpen ? hasId : true) {
                 sunflowerUseModal.show();
             }
         },

--- a/packages/mantine/src/hooks/form/useModalForm/index.ts
+++ b/packages/mantine/src/hooks/form/useModalForm/index.ts
@@ -217,7 +217,10 @@ export const useModalForm = <
             if (typeof showId !== "undefined") {
                 setId?.(showId);
             }
-            if (typeof showId !== "undefined" || typeof id !== "undefined") {
+            const needsIdToOpen = action === "edit" || action === "clone";
+            const hasId =
+                typeof showId !== "undefined" || typeof id !== "undefined";
+            if (needsIdToOpen ? hasId : true) {
                 show();
             }
         },

--- a/packages/react-hook-form/src/useModalForm/index.spec.ts
+++ b/packages/react-hook-form/src/useModalForm/index.spec.ts
@@ -79,6 +79,9 @@ describe("useModalForm Hook", () => {
         const { result } = renderHook(
             () =>
                 useModalForm({
+                    refineCoreProps: {
+                        action: "edit",
+                    },
                     modalProps: {
                         defaultVisible: false,
                     },

--- a/packages/react-hook-form/src/useModalForm/index.ts
+++ b/packages/react-hook-form/src/useModalForm/index.ts
@@ -209,7 +209,10 @@ export const useModalForm = <
             if (typeof showId !== "undefined") {
                 setId?.(showId);
             }
-            if (typeof showId !== "undefined" || typeof id !== "undefined") {
+            const needsIdToOpen = action === "edit" || action === "clone";
+            const hasId =
+                typeof showId !== "undefined" || typeof id !== "undefined";
+            if (needsIdToOpen ? hasId : true) {
                 show();
             }
         },


### PR DESCRIPTION
Fixed `create` action not working issue with `useModalForm` and `useDrawerForm`.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
