### PR TITLE
refactor: updated the generic type name of hooks that use `useQuery`

### DIFF
--- a/.changeset/wet-otters-bake.md
+++ b/.changeset/wet-otters-bake.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/antd": patch
+"@refinedev/core": patch
+"@refinedev/mantine": patch
+"@refinedev/mui": patch
+"@refinedev/react-table": patch
+---
+
+Updated the generic type name of hooks that use `useQuery` to synchronize generic type names with `tanstack-query`.

--- a/documentation/docs/api-reference/antd/hooks/field/useCheckboxGroup.md
+++ b/documentation/docs/api-reference/antd/hooks/field/useCheckboxGroup.md
@@ -221,11 +221,11 @@ Use `sorters` instead.
 
 ### Type Parameters
 
-| Property    | Desription                                                                                                                                                   | Type                       | Default                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData       | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError      | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSelectData | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property     | Desription                                                                                                                                                          | Type                       | Default                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ## Example
 

--- a/documentation/docs/api-reference/antd/hooks/field/useRadioGroup.md
+++ b/documentation/docs/api-reference/antd/hooks/field/useRadioGroup.md
@@ -221,11 +221,11 @@ Use `sorters` instead.
 
 ### Type Parameters
 
-| Property    | Desription                                                                                                                                                   | Type                       | Default                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData       | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError      | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSelectData | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property     | Desription                                                                                                                                                          | Type                       | Default                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return values
 

--- a/documentation/docs/api-reference/antd/hooks/field/useSelect/index.md
+++ b/documentation/docs/api-reference/antd/hooks/field/useSelect/index.md
@@ -436,11 +436,11 @@ return <Select options={options} />;
 
 ### Type Parameters
 
-| Property    | Desription                                                                                                                                                   | Type                       | Default                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData       | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError      | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSelectData | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property     | Desription                                                                                                                                                          | Type                       | Default                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return values
 

--- a/documentation/docs/api-reference/antd/hooks/list/useSimpleList.md
+++ b/documentation/docs/api-reference/antd/hooks/list/useSimpleList.md
@@ -792,12 +792,12 @@ A function to set current [sorters state][crudsorting].
 
 ### Type Parameters
 
-| Property         | Desription                                                                                                                                                   | Type                       | Default                    |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData            | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError           | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSearchVariables | Antd form values                                                                                                                                             | `{}`                       | `{}`                       |
-| TSelectData      | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property         | Desription                                                                                                                                                          | Type                       | Default                    |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData     | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError           | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TSearchVariables | Antd form values                                                                                                                                                    | `{}`                       | `{}`                       |
+| TData            | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return values
 

--- a/documentation/docs/api-reference/antd/hooks/table/useEditableTable.md
+++ b/documentation/docs/api-reference/antd/hooks/table/useEditableTable.md
@@ -349,13 +349,13 @@ Takes a `id` as a parameter and returns `true` if the given `BaseKey` is equal t
 
 ### Type Parameters
 
-| Property         | Desription                                                                                                                                                   | Type                       | Default                    |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData            | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError           | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TVariables       | Values for params                                                                                                                                            |                            | `{}`                       |
-| TSearchVariables | Values for search params                                                                                                                                     |                            | `{}`                       |
-| TSelectData      | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property         | Desription                                                                                                                                                          | Type                       | Default                    |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData     | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError           | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TVariables       | Values for params                                                                                                                                                   |                            | `{}`                       |
+| TSearchVariables | Values for search params                                                                                                                                            |                            | `{}`                       |
+| TData            | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return values
 

--- a/documentation/docs/api-reference/antd/hooks/table/useTable.md
+++ b/documentation/docs/api-reference/antd/hooks/table/useTable.md
@@ -844,12 +844,12 @@ You can use [`useMany`](/docs/api-reference/core/hooks/data/useMany/) hook to fe
 
 ### Type Parameters
 
-| Property         | Desription                                                                                                                                                   | Type                       | Default                    |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData            | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError           | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSearchVariables | Values for search params                                                                                                                                     |                            | `{}`                       |
-| TSelectData      | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property         | Desription                                                                                                                                                          | Type                       | Default                    |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData     | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError           | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TSearchVariables | Values for search params                                                                                                                                            |                            | `{}`                       |
+| TData            | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return values
 

--- a/documentation/docs/api-reference/core/hooks/audit-log/useLogList.md
+++ b/documentation/docs/api-reference/core/hooks/audit-log/useLogList.md
@@ -32,15 +32,15 @@ const postAuditLogResults = useLogList({
 | author                                                                                              | `Record<string, any>`                                              |                                 |
 | meta                                                                                                | `Record<string, any>`                                              |                                 |
 | metaData                                                                                            | [`MetaDataQuery`](/api-reference/core/interfaces.md#metadataquery) |                                 |
-| queryOptions                                                                                        | `UseQueryOptions<TData, TError>`                                   |                                 |
+| queryOptions                                                                                        | `UseQueryOptions<TQueryFnData, TError, TData>`                     |                                 |
 
 ### Type Parameters
 
-| Property    | Desription                                                                                                                                                   | Type                       | Default                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData       | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError      | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSelectData | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property     | Desription                                                                                                                                                          | Type                       | Default                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return values
 

--- a/documentation/docs/api-reference/core/hooks/data/useCustom/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCustom/index.md
@@ -291,13 +291,13 @@ By default, the query key is generated based on the properties passed to `useCus
 
 ### Type Parameters
 
-| Property    | Desription                                                                                                                                                   | Type                       | Default                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData       | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError      | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TQuery      | Values for query params.                                                                                                                                     | `TQuery`                   | unknown                    |
-| TPayload    | Values for params.                                                                                                                                           | `TPayload`                 | unknown                    |
-| TSelectData | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property     | Desription                                                                                                                                                          | Type                       | Default                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TQuery       | Values for query params.                                                                                                                                            | `TQuery`                   | unknown                    |
+| TPayload     | Values for params.                                                                                                                                                  | `TPayload`                 | unknown                    |
+| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`                    |
 
 ### Return value
 

--- a/documentation/docs/api-reference/core/hooks/data/useInfiniteList/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useInfiniteList/index.md
@@ -406,11 +406,11 @@ errorNotification-default='"Error (status code: `statusCode`)"'
 
 ### Type Parameters
 
-| Property    | Desription                                                                                                                                                   | Type                       | Default                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData       | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError      | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSelectData | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property     | Desription                                                                                                                                                          | Type                       | Default                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return Values
 

--- a/documentation/docs/api-reference/core/hooks/data/useList/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useList/index.md
@@ -318,11 +318,11 @@ errorNotification-default='"Error (status code: `statusCode`)"'
 
 ### Type Parameters
 
-| Property    | Desription                                                                                                                                                   | Type                       | Default                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData       | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError      | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSelectData | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property     | Desription                                                                                                                                                          | Type                       | Default                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return Values
 

--- a/documentation/docs/api-reference/core/hooks/data/useMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useMany/index.md
@@ -213,11 +213,11 @@ errorNotification-default='"Error (status code: `statusCode`)"'
 
 ### Type Parameters
 
-| Property    | Desription                                                                                                                                                   | Type                       | Default                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData       | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError      | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSelectData | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property     | Desription                                                                                                                                                          | Type                       | Default                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return values
 

--- a/documentation/docs/api-reference/core/hooks/data/useOne/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useOne/index.md
@@ -207,11 +207,11 @@ errorNotification-default='"Error (status code: `statusCode`)"'
 
 ### Type Parameters
 
-| Property    | Desription                                                                                                                                                   | Type                       | Default                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData       | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError      | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSelectData | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property     | Desription                                                                                                                                                          | Type                       | Default                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return values
 

--- a/documentation/docs/api-reference/core/hooks/show/useShow.md
+++ b/documentation/docs/api-reference/core/hooks/show/useShow.md
@@ -252,11 +252,11 @@ It will trigger new request to fetch the data when the `showId` value is changed
 
 ### Type Parameters
 
-| Property    | Desription                                                                                                                                                   | Type                       | Default                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData       | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError      | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSelectData | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property     | Desription                                                                                                                                                          | Type                       | Default                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return values
 

--- a/documentation/docs/api-reference/core/hooks/useSelect/index.md
+++ b/documentation/docs/api-reference/core/hooks/useSelect/index.md
@@ -432,11 +432,11 @@ return (
 
 ### Type Parameters
 
-| Property    | Desription                                                                                                                                                   | Type                       | Default                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData       | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError      | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSelectData | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property     | Desription                                                                                                                                                          | Type                       | Default                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return values
 

--- a/documentation/docs/api-reference/core/hooks/useTable/index.md
+++ b/documentation/docs/api-reference/core/hooks/useTable/index.md
@@ -652,12 +652,12 @@ errorNotification-default='"There was an error creating resource (status code: `
 
 ### Type Parameters
 
-| Property         | Desription                                                                                                                                                   | Type                       | Default                    |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData            | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError           | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSearchVariables | Values for search params                                                                                                                                     |                            | `{}`                       |
-| TSelectData      | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property         | Desription                                                                                                                                                          | Type                       | Default                    |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData     | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError           | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TSearchVariables | Values for search params                                                                                                                                            |                            | `{}`                       |
+| TData            | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return values
 

--- a/documentation/docs/api-reference/mantine/hooks/useSelect/index.md
+++ b/documentation/docs/api-reference/mantine/hooks/useSelect/index.md
@@ -437,11 +437,11 @@ return <Select options={options} />;
 
 ### Type Parameters
 
-| Property    | Desription                                                                                                                                                   | Type                       | Default                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData       | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError      | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSelectData | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property     | Desription                                                                                                                                                          | Type                       | Default                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return values
 

--- a/documentation/docs/api-reference/mui/hooks/useAutocomplete/index.md
+++ b/documentation/docs/api-reference/mui/hooks/useAutocomplete/index.md
@@ -418,11 +418,11 @@ By default, refine does the search using the [`useList`](/docs/api-reference/cor
 
 ### Type Parameters
 
-| Property    | Desription                                                                                                                                                   | Type                       | Default                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData       | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError      | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSelectData | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property     | Desription                                                                                                                                                          | Type                       | Default                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return values
 

--- a/documentation/docs/api-reference/mui/hooks/useDataGrid/index.md
+++ b/documentation/docs/api-reference/mui/hooks/useDataGrid/index.md
@@ -923,12 +923,12 @@ You can use [`useSelect`](http://localhost:3000/docs/api-reference/core/hooks/us
 
 ### Type Parameters
 
-| Property         | Desription                                                                                                                                                   | Type                       | Default                    |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData            | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError           | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSearchVariables | Values for search params                                                                                                                                     |                            | `{}`                       |
-| TSelectData      | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property         | Desription                                                                                                                                                          | Type                       | Default                    |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData     | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError           | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TSearchVariables | Values for search params                                                                                                                                            |                            | `{}`                       |
+| TData            | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return values
 

--- a/documentation/docs/packages/documentation/react-table/index.md
+++ b/documentation/docs/packages/documentation/react-table/index.md
@@ -736,11 +736,11 @@ You can use [`useMany`](/docs/api-reference/core/hooks/data/useMany/) hook to fe
 
 ### Type Parameters
 
-| Property    | Desription                                                                                                                                                   | Type                       | Default                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- |
-| TData       | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError      | Custom error object that extends [`HttpError`][httperror]                                                                                                    | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TSelectData | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TData` will be used as the default value. | [`BaseRecord`][baserecord] | `TData`                    |
+| Property     | Desription                                                                                                                                                 | Type                       | Default                    |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data of the query. Extends [`BaseRecord`][baserecord]                                                                                               | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                  | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TData        | Result data of the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
 
 ### Return values
 

--- a/packages/antd/src/hooks/fields/useCheckboxGroup/index.ts
+++ b/packages/antd/src/hooks/fields/useCheckboxGroup/index.ts
@@ -11,23 +11,15 @@ import {
     pickNotDeprecated,
 } from "@refinedev/core";
 
-export type UseCheckboxGroupReturnType<TData extends BaseRecord = BaseRecord> =
-    {
-        checkboxGroupProps: CheckboxGroupProps;
-        queryResult: QueryObserverResult<GetListResponse<TData>>;
-    };
+export type UseCheckboxGroupReturnType<
+    TQueryFnData extends BaseRecord = BaseRecord,
+> = {
+    checkboxGroupProps: CheckboxGroupProps;
+    queryResult: QueryObserverResult<GetListResponse<TQueryFnData>>;
+};
 
-/**
- * `useCheckboxGroup` hook allows you to manage an Ant Design {@link https://ant.design/components/checkbox/#components-checkbox-demo-group Checkbox.Group} component when records in a resource needs to be used as checkbox options.
- *
- * @see {@link https://refine.dev/docs/ui-framewors/antd/hooks/field/useCheckboxGroup} for more details.
- *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-references/interfaceReferences#baserecord `BaseRecord`}
- *
- */
-
-type UseCheckboxGroupProps<TData, TError, TSelectData> = Omit<
-    UseSelectProps<TData, TError, TSelectData>,
+type UseCheckboxGroupProps<TQueryFnData, TError, TData> = Omit<
+    UseSelectProps<TQueryFnData, TError, TData>,
     "defaultValue"
 > & {
     /**
@@ -36,10 +28,21 @@ type UseCheckboxGroupProps<TData, TError, TSelectData> = Omit<
     defaultValue?: BaseKey[];
 };
 
+/**
+ * `useCheckboxGroup` hook allows you to manage an Ant Design {@link https://ant.design/components/checkbox/#components-checkbox-demo-group Checkbox.Group} component when records in a resource needs to be used as checkbox options.
+ *
+ * @see {@link https://refine.dev/docs/ui-framewors/antd/hooks/field/useCheckboxGroup} for more details
+ *
+ * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
+ *
+ */
+
 export const useCheckboxGroup = <
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 >({
     resource,
     sort,
@@ -58,10 +61,10 @@ export const useCheckboxGroup = <
     metaData,
     dataProviderName,
 }: UseCheckboxGroupProps<
-    TData,
+    TQueryFnData,
     TError,
-    TSelectData
->): UseCheckboxGroupReturnType<TSelectData> => {
+    TData
+>): UseCheckboxGroupReturnType<TData> => {
     const { queryResult, options } = useSelect({
         resource,
         sort,

--- a/packages/antd/src/hooks/fields/useCheckboxGroup/index.ts
+++ b/packages/antd/src/hooks/fields/useCheckboxGroup/index.ts
@@ -31,7 +31,7 @@ type UseCheckboxGroupProps<TQueryFnData, TError, TData> = Omit<
 /**
  * `useCheckboxGroup` hook allows you to manage an Ant Design {@link https://ant.design/components/checkbox/#components-checkbox-demo-group Checkbox.Group} component when records in a resource needs to be used as checkbox options.
  *
- * @see {@link https://refine.dev/docs/ui-framewors/antd/hooks/field/useCheckboxGroup} for more details
+ * @see {@link https://refine.dev/docs/api-reference/antd/hooks/field/useCheckboxGroup/} for more details
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/antd/src/hooks/fields/useRadioGroup/index.ts
+++ b/packages/antd/src/hooks/fields/useRadioGroup/index.ts
@@ -11,22 +11,15 @@ import {
     UseSelectProps,
 } from "@refinedev/core";
 
-export type UseRadioGroupReturnType<TData extends BaseRecord = BaseRecord> = {
+export type UseRadioGroupReturnType<
+    TQueryFnData extends BaseRecord = BaseRecord,
+> = {
     radioGroupProps: RadioGroupProps;
-    queryResult: QueryObserverResult<GetListResponse<TData>>;
+    queryResult: QueryObserverResult<GetListResponse<TQueryFnData>>;
 };
 
-/**
- * `useRadioGroup` hook allows you to manage an Ant Design {@link https://ant.design/components/radio/#components-radio-demo-radiogroup-with-name Radio.Group} component when records in a resource needs to be used as radio options.
- *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/hooks/field/useRadioGroup} for more details.
- *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/core/interfaceReferences#baserecord `BaseRecord`}
- *
- */
-
-type UseRadioGroupProps<TData, TError, TSelectData> = Omit<
-    UseSelectProps<TData, TError, TSelectData>,
+type UseRadioGroupProps<TQueryFnData, TError, TData> = Omit<
+    UseSelectProps<TQueryFnData, TError, TData>,
     "defaultValue"
 > & {
     /**
@@ -35,10 +28,21 @@ type UseRadioGroupProps<TData, TError, TSelectData> = Omit<
     defaultValue?: BaseKey;
 };
 
+/**
+ * `useRadioGroup` hook allows you to manage an Ant Design {@link https://ant.design/components/radio/#components-radio-demo-radiogroup-with-name Radio.Group} component when records in a resource needs to be used as radio options.
+ *
+ * @see {@link https://refine.dev/docs/ui-frameworks/antd/hooks/field/useRadioGroup} for more details.
+ *
+ * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
+ *
+ */
+
 export const useRadioGroup = <
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 >({
     resource,
     sort,
@@ -57,10 +61,10 @@ export const useRadioGroup = <
     metaData,
     dataProviderName,
 }: UseRadioGroupProps<
-    TData,
+    TQueryFnData,
     TError,
-    TSelectData
->): UseRadioGroupReturnType<TSelectData> => {
+    TData
+>): UseRadioGroupReturnType<TData> => {
     const { queryResult, options } = useSelect({
         resource,
         sort,

--- a/packages/antd/src/hooks/fields/useRadioGroup/index.ts
+++ b/packages/antd/src/hooks/fields/useRadioGroup/index.ts
@@ -31,7 +31,7 @@ type UseRadioGroupProps<TQueryFnData, TError, TData> = Omit<
 /**
  * `useRadioGroup` hook allows you to manage an Ant Design {@link https://ant.design/components/radio/#components-radio-demo-radiogroup-with-name Radio.Group} component when records in a resource needs to be used as radio options.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/hooks/field/useRadioGroup} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/hooks/field/useRadioGroup/} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/antd/src/hooks/fields/useSelect/index.ts
+++ b/packages/antd/src/hooks/fields/useSelect/index.ts
@@ -10,27 +10,33 @@ import {
     UseSelectProps,
 } from "@refinedev/core";
 
-export type UseSelectReturnType<TData extends BaseRecord = BaseRecord> = {
-    selectProps: SelectProps<{ value: string; label: string }>;
-    queryResult: QueryObserverResult<GetListResponse<TData>>;
-    defaultValueQueryResult: QueryObserverResult<GetManyResponse<TData>>;
-};
+export type UseSelectReturnType<TQueryFnData extends BaseRecord = BaseRecord> =
+    {
+        selectProps: SelectProps<{ value: string; label: string }>;
+        queryResult: QueryObserverResult<GetListResponse<TQueryFnData>>;
+        defaultValueQueryResult: QueryObserverResult<
+            GetManyResponse<TQueryFnData>
+        >;
+    };
 
 /**
  * `useSelect` hook allows you to manage an Ant Design {@link https://ant.design/components/select/ Select} component when records in a resource needs to be used as select options.
  *
  * @see {@link https://refine.dev/docs/api-references/hooks/field/useSelect} for more details.
  *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-references/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
  *
  */
+
 export const useSelect = <
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 >(
-    props: UseSelectProps<TData, TError, TSelectData>,
-): UseSelectReturnType<TSelectData> => {
+    props: UseSelectProps<TQueryFnData, TError, TData>,
+): UseSelectReturnType<TData> => {
     const { queryResult, defaultValueQueryResult, onSearch, options } =
         useSelectCore(props);
 

--- a/packages/antd/src/hooks/fields/useSelect/index.ts
+++ b/packages/antd/src/hooks/fields/useSelect/index.ts
@@ -22,7 +22,7 @@ export type UseSelectReturnType<TQueryFnData extends BaseRecord = BaseRecord> =
 /**
  * `useSelect` hook allows you to manage an Ant Design {@link https://ant.design/components/select/ Select} component when records in a resource needs to be used as select options.
  *
- * @see {@link https://refine.dev/docs/api-references/hooks/field/useSelect} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/hooks/field/useSelect/} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/antd/src/hooks/list/useSimpleList/useSimpleList.ts
+++ b/packages/antd/src/hooks/list/useSimpleList/useSimpleList.ts
@@ -14,19 +14,19 @@ import { useLiveMode } from "@refinedev/core";
 import { PaginationLink } from "@hooks/table/useTable/paginationLink";
 import { PaginationConfig } from "antd/lib/pagination";
 
-export type useSimpleListProps<TData, TError, TSearchVariables, TSelectData> =
-    useTablePropsCore<TData, TError, TSelectData> & {
+export type useSimpleListProps<TQueryFnData, TError, TSearchVariables, TData> =
+    useTablePropsCore<TQueryFnData, TError, TData> & {
         onSearch?: (
             data: TSearchVariables,
         ) => CrudFilters | Promise<CrudFilters>;
     };
 
 export type useSimpleListReturnType<
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TSearchVariables = unknown,
-    TSelectData extends BaseRecord = TData,
-> = Omit<useTableReturnType<TSelectData>, "tableQueryResult"> & {
-    listProps: ListProps<TSelectData>;
+    TData extends BaseRecord = TQueryFnData,
+> = Omit<useTableReturnType<TData>, "tableQueryResult"> & {
+    listProps: ListProps<TData>;
     queryResult: useTableReturnType["tableQueryResult"];
     searchFormProps: FormProps<TSearchVariables>;
 };
@@ -37,17 +37,18 @@ export type useSimpleListReturnType<
  *
  * @see {@link https://refine.dev/docs/ui-frameworks/antd/hooks/list/useSimpleList} for more details.
  *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-references/interfaceReferences#baserecord `BaseRecord`}
- * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-references/interfaceReferences#httperror `HttpError`}
+ * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
  * @typeParam TSearchVariables - Antd form values
+ * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
  *
  */
 
 export const useSimpleList = <
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TSearchVariables = unknown,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 >({
     resource,
     initialCurrent,
@@ -73,11 +74,11 @@ export const useSimpleList = <
     metaData,
     dataProviderName,
 }: useSimpleListProps<
-    TData,
+    TQueryFnData,
     TError,
     TSearchVariables,
-    TSelectData
-> = {}): useSimpleListReturnType<TSelectData, TSearchVariables> => {
+    TData
+> = {}): useSimpleListReturnType<TData, TSearchVariables> => {
     const {
         sorters,
         sorter,

--- a/packages/antd/src/hooks/table/useEditableTable/useEditableTable.ts
+++ b/packages/antd/src/hooks/table/useEditableTable/useEditableTable.ts
@@ -6,13 +6,13 @@ import { useTableProps, useTableReturnType } from "../useTable";
 import { UseFormReturnType, useForm } from "../../form/useForm";
 
 export type useEditableTableReturnType<
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TVariables = {},
     TSearchVariables = unknown,
-    TSelectData extends BaseRecord = TData,
-> = useTableReturnType<TData, TError, TSearchVariables, TSelectData> &
-    UseFormReturnType<TData, TError, TVariables> & {
+    TData extends BaseRecord = TQueryFnData,
+> = useTableReturnType<TQueryFnData, TError, TSearchVariables, TData> &
+    UseFormReturnType<TQueryFnData, TError, TVariables> & {
         saveButtonProps: ButtonProps & {
             onClick: () => void;
         };
@@ -26,16 +26,16 @@ export type useEditableTableReturnType<
     };
 
 type useEditableTableProps<
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TVariables = {},
     TSearchVariables = unknown,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 > = Omit<
-    useTableProps<TData, TError, TSearchVariables, TSelectData>,
+    useTableProps<TQueryFnData, TError, TSearchVariables, TData>,
     "successNotification" | "errorNotification"
 > &
-    UseFormProps<TData, TError, TVariables>;
+    UseFormProps<TQueryFnData, TError, TVariables>;
 
 /**
  * `useEditeableTable` allows you to implement edit feature on the table with ease,
@@ -44,26 +44,41 @@ type useEditableTableProps<
  * and {@link https://ant.design/components/form/ `<Form>`} components.
  *
  * @see {@link https://refine.dev/docs/ui-frameworks/antd/hooks/table/useEditableTable} for more details.
+ *
+ * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TVariables - Values for params
+ * @typeParam TSearchVariables - Values for search params
+ * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
+ *
  */
 export const useEditableTable = <
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TVariables = {},
     TSearchVariables = unknown,
+    TData extends BaseRecord = TQueryFnData,
 >(
     props: useEditableTableProps<
-        TData,
+        TQueryFnData,
         TError,
         TVariables,
-        TSearchVariables
+        TSearchVariables,
+        TData
     > = {},
-): useEditableTableReturnType<TData, TError, TVariables, TSearchVariables> => {
-    const table = useTable<TData, TError, TSearchVariables>({
+): useEditableTableReturnType<
+    TQueryFnData,
+    TError,
+    TVariables,
+    TSearchVariables,
+    TData
+> => {
+    const table = useTable<TQueryFnData, TError, TSearchVariables, TData>({
         ...props,
         successNotification: undefined,
         errorNotification: undefined,
     });
-    const edit = useForm<TData, TError, TVariables>({
+    const edit = useForm<TQueryFnData, TError, TVariables>({
         ...props,
         action: "edit",
         redirect: false,

--- a/packages/antd/src/hooks/table/useEditableTable/useEditableTable.ts
+++ b/packages/antd/src/hooks/table/useEditableTable/useEditableTable.ts
@@ -39,11 +39,11 @@ type useEditableTableProps<
 
 /**
  * `useEditeableTable` allows you to implement edit feature on the table with ease,
- * on top of all the features that {@link https://refine.dev/docs/api-references/hooks/table/useTable `useTable`} provides.
+ * on top of all the features that {@link https://refine.dev/docs/api-reference/core/hooks/useTable/ `useTable`} provides.
  * `useEditableTable` return properties that can be used on Ant Design's {@link https://ant.design/components/table/ `<Table>`}
  * and {@link https://ant.design/components/form/ `<Form>`} components.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/hooks/table/useEditableTable} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/hooks/table/useTable/} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/antd/src/hooks/table/useTable/useTable.ts
+++ b/packages/antd/src/hooks/table/useTable/useTable.ts
@@ -21,21 +21,21 @@ import {
 } from "@definitions/table";
 import { PaginationLink } from "./paginationLink";
 
-export type useTableProps<TData, TError, TSearchVariables, TSelectData> =
-    useTablePropsCore<TData, TError, TSelectData> & {
+export type useTableProps<TQueryFnData, TError, TSearchVariables, TData> =
+    useTablePropsCore<TQueryFnData, TError, TData> & {
         onSearch?: (
             data: TSearchVariables,
         ) => CrudFilters | Promise<CrudFilters>;
     };
 
 export type useTableReturnType<
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TSearchVariables = unknown,
-    TSelectData extends BaseRecord = TData,
-> = useTableCoreReturnType<TData, TError, TSelectData> & {
+    TData extends BaseRecord = TQueryFnData,
+> = useTableCoreReturnType<TQueryFnData, TError, TData> & {
     searchFormProps: FormProps<TSearchVariables>;
-    tableProps: TableProps<TSelectData>;
+    tableProps: TableProps<TData>;
 };
 
 /**
@@ -44,13 +44,19 @@ export type useTableReturnType<
  * All features such as sorting, filtering and pagination comes as out of box.
  *
  * @see {@link https://refine.dev/docs/api-references/hooks/table/useTable} for more details.
+ *
+ * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TSearchVariables - Values for search params
+ * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
+ *
  */
 
 export const useTable = <
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TSearchVariables = unknown,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 >({
     onSearch,
     initialCurrent,
@@ -76,11 +82,11 @@ export const useTable = <
     metaData,
     dataProviderName,
 }: useTableProps<
-    TData,
+    TQueryFnData,
     TError,
     TSearchVariables,
-    TSelectData
-> = {}): useTableReturnType<TData, TError, TSearchVariables, TSelectData> => {
+    TData
+> = {}): useTableReturnType<TQueryFnData, TError, TSearchVariables, TData> => {
     const {
         tableQueryResult,
         current,
@@ -95,7 +101,7 @@ export const useTable = <
         setSorter,
         createLinkForSyncWithLocation,
         pageCount,
-    } = useTableCore<TData, TError, TSelectData>({
+    } = useTableCore<TQueryFnData, TError, TData>({
         permanentSorter,
         permanentFilter,
         initialCurrent,

--- a/packages/antd/src/hooks/table/useTable/useTable.ts
+++ b/packages/antd/src/hooks/table/useTable/useTable.ts
@@ -43,7 +43,7 @@ export type useTableReturnType<
  * Ant Design {@link https://ant.design/components/table/ `<Table>`} component.
  * All features such as sorting, filtering and pagination comes as out of box.
  *
- * @see {@link https://refine.dev/docs/api-references/hooks/table/useTable} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/hooks/table/useTable/} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/core/src/hooks/auditLog/useLogList/index.ts
+++ b/packages/core/src/hooks/auditLog/useLogList/index.ts
@@ -9,23 +9,29 @@ import { AuditLogContext } from "@contexts/auditLog";
 import { queryKeys } from "@definitions/helpers";
 import { HttpError, MetaQuery } from "../../../interfaces";
 
-export type UseLogProps<TData, TError, TSelectData> = {
+export type UseLogProps<TQueryFnData, TError, TData> = {
     resource: string;
     action?: string;
     meta?: Record<number | string, any>;
     author?: Record<number | string, any>;
-    queryOptions?: UseQueryOptions<TData, TError, TSelectData>;
+    queryOptions?: UseQueryOptions<TQueryFnData, TError, TData>;
     metaData?: MetaQuery;
 };
 
 /**
  * useLogList is used to get and filter audit logs.
+ *
  * @see {@link https://refine.dev/docs/core/hooks/audit-log/useLogList} for more details.
+ *
+ * @typeParam TQueryFnData - Result data returned by the query function.
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data returned by the `select` function. Defaults to `TQueryFnData`
+ *
  */
 export const useLogList = <
-    TData = any,
+    TQueryFnData = any,
     TError extends HttpError = HttpError,
-    TSelectData = TData,
+    TData = TQueryFnData,
 >({
     resource,
     action,
@@ -33,12 +39,12 @@ export const useLogList = <
     author,
     metaData,
     queryOptions,
-}: UseLogProps<TData, TError, TSelectData>): UseQueryResult<TSelectData> => {
+}: UseLogProps<TQueryFnData, TError, TData>): UseQueryResult<TData> => {
     const { get } = useContext(AuditLogContext);
 
     const queryKey = queryKeys(resource, undefined, metaData);
 
-    const queryResponse = useQuery<TData, TError, TSelectData>(
+    const queryResponse = useQuery<TQueryFnData, TError, TData>(
         queryKey.logList(meta),
         () =>
             get?.({

--- a/packages/core/src/hooks/data/useInfiniteList.ts
+++ b/packages/core/src/hooks/data/useInfiniteList.ts
@@ -80,7 +80,7 @@ type BaseInfiniteListProps = {
     dataProviderName?: string;
 };
 
-export type UseInfiniteListProps<TData, TError, TSelectData> = {
+export type UseInfiniteListProps<TQueryFnData, TError, TData> = {
     /**
      * Resource name for API data interactions
      */
@@ -89,13 +89,13 @@ export type UseInfiniteListProps<TData, TError, TSelectData> = {
      * Tanstack Query's [useInfiniteQuery](https://tanstack.com/query/v4/docs/react/reference/useInfiniteQuery) options
      */
     queryOptions?: UseInfiniteQueryOptions<
-        GetListResponse<TData>,
+        GetListResponse<TQueryFnData>,
         TError,
-        GetListResponse<TSelectData>
+        GetListResponse<TData>
     >;
 } & BaseInfiniteListProps &
     SuccessErrorNotification<
-        InfiniteData<GetListResponse<TSelectData>>,
+        InfiniteData<GetListResponse<TData>>,
         TError,
         Prettify<BaseInfiniteListProps>
     > &
@@ -108,14 +108,16 @@ export type UseInfiniteListProps<TData, TError, TSelectData> = {
  *
  * @see {@link https://refine.dev/docs/core/hooks/data/useInfiniteList} for more details.
  *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/core/interfaceReferences#baserecord `BaseRecord`}
- * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
  *
  */
+
 export const useInfiniteList = <
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 >({
     resource,
     config,
@@ -133,10 +135,10 @@ export const useInfiniteList = <
     liveParams,
     dataProviderName,
 }: UseInfiniteListProps<
-    TData,
+    TQueryFnData,
     TError,
-    TSelectData
->): InfiniteQueryObserverResult<GetListResponse<TSelectData>, TError> => {
+    TData
+>): InfiniteQueryObserverResult<GetListResponse<TData>, TError> => {
     const { resources } = useResource();
     const dataProvider = useDataProvider();
     const translate = useTranslate();
@@ -210,9 +212,9 @@ export const useInfiniteList = <
     });
 
     const queryResponse = useInfiniteQuery<
-        GetListResponse<TData>,
+        GetListResponse<TQueryFnData>,
         TError,
-        GetListResponse<TSelectData>
+        GetListResponse<TData>
     >(
         queryKey.list({
             filters: prefferedFilters,
@@ -233,7 +235,7 @@ export const useInfiniteList = <
                 current: pageParam,
             };
 
-            return getList<TData>({
+            return getList<TQueryFnData>({
                 resource,
                 pagination: paginationProperties,
                 hasPagination: isServerPagination,

--- a/packages/core/src/hooks/data/useMany.ts
+++ b/packages/core/src/hooks/data/useMany.ts
@@ -29,7 +29,7 @@ import {
     useActiveAuthProvider,
 } from "@definitions/helpers";
 
-export type UseManyProps<TData, TError, TSelectData> = {
+export type UseManyProps<TQueryFnData, TError, TData> = {
     /**
      * Resource name for API data interactions
      */
@@ -43,9 +43,9 @@ export type UseManyProps<TData, TError, TSelectData> = {
      * react-query's [useQuery](https://tanstack.com/query/v4/docs/reference/useQuery) options
      */
     queryOptions?: UseQueryOptions<
-        GetManyResponse<TData>,
+        GetManyResponse<TQueryFnData>,
         TError,
-        GetManyResponse<TSelectData>
+        GetManyResponse<TData>
     >;
     /**
      * Metadata query for `dataProvider`,
@@ -61,7 +61,7 @@ export type UseManyProps<TData, TError, TSelectData> = {
      * @default "default"
      */
     dataProviderName?: string;
-} & SuccessErrorNotification<GetManyResponse<TSelectData>, TError, BaseKey[]> &
+} & SuccessErrorNotification<GetManyResponse<TData>, TError, BaseKey[]> &
     LiveModeProps;
 
 /**
@@ -71,14 +71,16 @@ export type UseManyProps<TData, TError, TSelectData> = {
  *
  * @see {@link https://refine.dev/docs/core/hooks/data/useMany} for more details.
  *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/core/interfaceReferences#baserecord `BaseRecord`}
- * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
  *
  */
+
 export const useMany = <
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 >({
     resource,
     ids,
@@ -91,8 +93,8 @@ export const useMany = <
     onLiveEvent,
     liveParams,
     dataProviderName,
-}: UseManyProps<TData, TError, TSelectData>): QueryObserverResult<
-    GetManyResponse<TSelectData>
+}: UseManyProps<TQueryFnData, TError, TData>): QueryObserverResult<
+    GetManyResponse<TData>
 > => {
     const { resources } = useResource();
     const dataProvider = useDataProvider();
@@ -134,9 +136,9 @@ export const useMany = <
     });
 
     const queryResponse = useQuery<
-        GetManyResponse<TData>,
+        GetManyResponse<TQueryFnData>,
         TError,
-        GetManyResponse<TSelectData>
+        GetManyResponse<TData>
     >(
         queryKey.many(ids),
         ({ queryKey, pageParam, signal }) => {
@@ -156,7 +158,7 @@ export const useMany = <
             } else {
                 return handleMultiple(
                     ids.map((id) =>
-                        getOne<TData>({
+                        getOne<TQueryFnData>({
                             resource,
                             id,
                             metaData: {

--- a/packages/core/src/hooks/data/useOne.ts
+++ b/packages/core/src/hooks/data/useOne.ts
@@ -29,7 +29,7 @@ import {
     useActiveAuthProvider,
 } from "@definitions";
 
-export type UseOneProps<TData, TError, TSelectData> = {
+export type UseOneProps<TQueryFnData, TError, TData> = {
     /**
      * Resource name for API data interactions
      */
@@ -43,9 +43,9 @@ export type UseOneProps<TData, TError, TSelectData> = {
      * react-query's [useQuery](https://tanstack.com/query/v4/docs/reference/useQuery) options
      */
     queryOptions?: UseQueryOptions<
-        GetOneResponse<TData>,
+        GetOneResponse<TQueryFnData>,
         TError,
-        GetOneResponse<TSelectData>
+        GetOneResponse<TData>
     >;
     /**
      * Metadata query for `dataProvider`,
@@ -62,7 +62,7 @@ export type UseOneProps<TData, TError, TSelectData> = {
      */
     dataProviderName?: string;
 } & SuccessErrorNotification<
-    GetOneResponse<TSelectData>,
+    GetOneResponse<TData>,
     TError,
     Prettify<{ id?: BaseKey } & MetaQuery>
 > &
@@ -75,14 +75,16 @@ export type UseOneProps<TData, TError, TSelectData> = {
  *
  * @see {@link https://refine.dev/docs/core/hooks/data/useOne} for more details.
  *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-references/interfaceReferences#baserecord `BaseRecord`}
- * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-references/interfaceReferences#httperror `HttpError`}
+ * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
  *
  */
+
 export const useOne = <
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 >({
     resource,
     id,
@@ -95,8 +97,8 @@ export const useOne = <
     onLiveEvent,
     liveParams,
     dataProviderName,
-}: UseOneProps<TData, TError, TSelectData>): QueryObserverResult<
-    GetOneResponse<TSelectData>
+}: UseOneProps<TQueryFnData, TError, TData>): QueryObserverResult<
+    GetOneResponse<TData>
 > => {
     const { resources } = useResource();
     const dataProvider = useDataProvider();
@@ -138,13 +140,13 @@ export const useOne = <
     });
 
     const queryResponse = useQuery<
-        GetOneResponse<TData>,
+        GetOneResponse<TQueryFnData>,
         TError,
-        GetOneResponse<TSelectData>
+        GetOneResponse<TData>
     >(
         queryKey.detail(id),
         ({ queryKey, pageParam, signal }) =>
-            getOne<TData>({
+            getOne<TQueryFnData>({
                 resource: resource!,
                 id: id!,
                 meta: {

--- a/packages/core/src/hooks/show/useShow.ts
+++ b/packages/core/src/hooks/show/useShow.ts
@@ -22,16 +22,16 @@ import { pickResource } from "@definitions/helpers/pick-resource";
 import { useResource } from "../resource/useResource";
 import { pickNotDeprecated } from "@definitions/helpers";
 
-export type useShowReturnType<TData extends BaseRecord = BaseRecord> = {
-    queryResult: QueryObserverResult<GetOneResponse<TData>>;
+export type useShowReturnType<TQueryFnData extends BaseRecord = BaseRecord> = {
+    queryResult: QueryObserverResult<GetOneResponse<TQueryFnData>>;
     showId?: BaseKey;
     setShowId: React.Dispatch<React.SetStateAction<BaseKey | undefined>>;
 };
 
 export type useShowProps<
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 > = {
     /**
      * Resource name for API data interactions
@@ -47,9 +47,9 @@ export type useShowProps<
      * react-query's [useQuery](https://tanstack.com/query/v4/docs/reference/useQuery) options
      */
     queryOptions?: UseQueryOptions<
-        GetOneResponse<TData>,
+        GetOneResponse<TQueryFnData>,
         TError,
-        GetOneResponse<TSelectData>
+        GetOneResponse<TData>
     >;
     /**
      * Additional meta data to pass to the data provider's `getOne`
@@ -67,7 +67,7 @@ export type useShowProps<
     dataProviderName?: string;
 } & LiveModeProps &
     SuccessErrorNotification<
-        GetOneResponse<TSelectData>,
+        GetOneResponse<TData>,
         TError,
         Prettify<{ id?: BaseKey } & MetaQuery>
     >;
@@ -78,11 +78,17 @@ export type useShowProps<
  * passed to {@link https://refine.dev/docs/api-references/components/refine-config `<Refine>`}.
  *
  * @see {@link https://refine.dev/docs/core/hooks/show/useShow} for more details.
+ *
+ * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
+ *
  */
+
 export const useShow = <
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 >({
     resource: resourceFromProp,
     id,
@@ -95,10 +101,10 @@ export const useShow = <
     dataProviderName,
     queryOptions,
 }: useShowProps<
-    TData,
+    TQueryFnData,
     TError,
-    TSelectData
-> = {}): useShowReturnType<TSelectData> => {
+    TData
+> = {}): useShowReturnType<TData> => {
     const routerType = useRouterType();
     const { resources } = useResource();
     const { useParams } = useRouterContext();
@@ -180,7 +186,7 @@ export const useShow = <
             `See https://refine.dev/docs/api-reference/core/hooks/show/useShow/#resource`,
     );
 
-    const queryResult = useOne<TData, TError, TSelectData>({
+    const queryResult = useOne<TQueryFnData, TError, TData>({
         resource: resource?.name,
         id: showId ?? "",
         queryOptions: {

--- a/packages/core/src/hooks/show/useShow.ts
+++ b/packages/core/src/hooks/show/useShow.ts
@@ -75,7 +75,7 @@ export type useShowProps<
 /**
  * `useShow` hook allows you to fetch the desired record.
  * It uses `getOne` method as query function from the dataProvider that is
- * passed to {@link https://refine.dev/docs/api-references/components/refine-config `<Refine>`}.
+ * passed to {@link https://refine.dev/docs/api-reference/core/components/refine-config/ `<Refine>`}.
  *
  * @see {@link https://refine.dev/docs/core/hooks/show/useShow} for more details.
  *

--- a/packages/core/src/hooks/useSelect/index.ts
+++ b/packages/core/src/hooks/useSelect/index.ts
@@ -148,7 +148,7 @@ export type UseSelectReturnType<TQueryFnData extends BaseRecord = BaseRecord> =
  * `useSelect` hook is used to fetch data from the dataProvider and return the options for the select box.
  *
  * It uses `getList` method as query function from the dataProvider that is
- * passed to {@link https://refine.dev/docs/api-references/components/refine-config `<Refine>`}.
+ * passed to {@link https://refine.dev/docs/api-reference/core/components/refine-config/ `<Refine>`}.
  *
  * @see {@link https://refine.dev/docs/core/hooks/useSelect} for more details.
  *

--- a/packages/core/src/hooks/useSelect/index.ts
+++ b/packages/core/src/hooks/useSelect/index.ts
@@ -25,7 +25,7 @@ import { pickResource } from "@definitions/helpers/pick-resource";
 import { useResource } from "../resource/useResource/index";
 import { BaseListProps } from "../data/useList";
 
-export type UseSelectProps<TData, TError, TSelectData> = {
+export type UseSelectProps<TQueryFnData, TError, TData> = {
     /**
      * Resource name for API data interactions
      */
@@ -34,12 +34,16 @@ export type UseSelectProps<TData, TError, TSelectData> = {
      * Set the option's value
      * @default `"title"`
      */
-    optionLabel?: keyof TData extends string ? keyof TData : never;
+    optionLabel?: keyof TQueryFnData extends string
+        ? keyof TQueryFnData
+        : never;
     /**
      * Set the option's label value
      * @default `"id"`
      */
-    optionValue?: keyof TData extends string ? keyof TData : never;
+    optionValue?: keyof TQueryFnData extends string
+        ? keyof TQueryFnData
+        : never;
     /**
      * Allow us to sort the options
      * @deprecated Use `sorters` instead
@@ -66,9 +70,9 @@ export type UseSelectProps<TData, TError, TSelectData> = {
      * react-query [useQuery](https://react-query.tanstack.com/reference/useQuery) options
      */
     queryOptions?: UseQueryOptions<
-        GetListResponse<TData>,
+        GetListResponse<TQueryFnData>,
         TError,
-        GetListResponse<TSelectData>
+        GetListResponse<TData>
     >;
     /**
      * Pagination option from [`useList()`](/docs/api-reference/core/hooks/data/useList/)
@@ -94,7 +98,10 @@ export type UseSelectProps<TData, TError, TSelectData> = {
     /**
      * react-query [useQuery](https://react-query.tanstack.com/reference/useQuery) options
      */
-    defaultValueQueryOptions?: UseQueryOptions<GetManyResponse<TData>, TError>;
+    defaultValueQueryOptions?: UseQueryOptions<
+        GetManyResponse<TQueryFnData>,
+        TError
+    >;
     /**
      * If defined, this callback allows us to override all filters for every search request.
      * @default `undefined`
@@ -121,26 +128,43 @@ export type UseSelectProps<TData, TError, TSelectData> = {
      */
     fetchSize?: number;
 } & SuccessErrorNotification<
-    GetListResponse<TSelectData>,
+    GetListResponse<TData>,
     TError,
     Prettify<BaseListProps>
 > &
     LiveModeProps;
 
-export type UseSelectReturnType<TData extends BaseRecord = BaseRecord> = {
-    queryResult: QueryObserverResult<GetListResponse<TData>>;
-    defaultValueQueryResult: QueryObserverResult<GetManyResponse<TData>>;
-    onSearch: (value: string) => void;
-    options: Option[];
-};
+export type UseSelectReturnType<TQueryFnData extends BaseRecord = BaseRecord> =
+    {
+        queryResult: QueryObserverResult<GetListResponse<TQueryFnData>>;
+        defaultValueQueryResult: QueryObserverResult<
+            GetManyResponse<TQueryFnData>
+        >;
+        onSearch: (value: string) => void;
+        options: Option[];
+    };
+
+/**
+ * `useSelect` hook is used to fetch data from the dataProvider and return the options for the select box.
+ *
+ * It uses `getList` method as query function from the dataProvider that is
+ * passed to {@link https://refine.dev/docs/api-references/components/refine-config `<Refine>`}.
+ *
+ * @see {@link https://refine.dev/docs/core/hooks/useSelect} for more details.
+ *
+ * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
+ *
+ */
 
 export const useSelect = <
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 >(
-    props: UseSelectProps<TData, TError, TSelectData>,
-): UseSelectReturnType<TSelectData> => {
+    props: UseSelectProps<TQueryFnData, TError, TData>,
+): UseSelectReturnType<TData> => {
     const [search, setSearch] = useState<CrudFilters>([]);
     const [options, setOptions] = useState<Option[]>([]);
     const [selectedOptions, setSelectedOptions] = useState<Option[]>([]);
@@ -184,7 +208,7 @@ export const useSelect = <
         : [defaultValue];
 
     const defaultValueQueryOnSuccess = useCallback(
-        (data: GetManyResponse<TSelectData>) => {
+        (data: GetManyResponse<TData>) => {
             setSelectedOptions(
                 data.data.map((item) => ({
                     label: get(item, optionLabel) as string,
@@ -198,7 +222,7 @@ export const useSelect = <
     const defaultValueQueryOptions =
         defaultValueQueryOptionsFromProps ?? (queryOptions as any);
 
-    const defaultValueQueryResult = useMany<TData, TError, TSelectData>({
+    const defaultValueQueryResult = useMany<TQueryFnData, TError, TData>({
         resource,
         ids: defaultValues,
         queryOptions: {
@@ -218,7 +242,7 @@ export const useSelect = <
     });
 
     const defaultQueryOnSuccess = useCallback(
-        (data: GetListResponse<TSelectData>) => {
+        (data: GetListResponse<TData>) => {
             {
                 setOptions(
                     data.data.map((item) => ({
@@ -231,7 +255,7 @@ export const useSelect = <
         [optionLabel, optionValue],
     );
 
-    const queryResult = useList<TData, TError, TSelectData>({
+    const queryResult = useList<TQueryFnData, TError, TData>({
         resource,
         sorters: pickNotDeprecated(sorters, sort),
         filters: filters.concat(search),

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -42,7 +42,7 @@ import { BaseListProps } from "../data/useList";
 
 type SetFilterBehavior = "merge" | "replace";
 
-export type useTableProps<TData, TError, TSelectData> = {
+export type useTableProps<TQueryFnData, TError, TData> = {
     /**
      * Resource name for API data interactions
      * @default Resource name that it reads from route
@@ -140,9 +140,9 @@ export type useTableProps<TData, TError, TSelectData> = {
      * react-query's [useQuery](https://tanstack.com/query/v4/docs/reference/useQuery) options
      */
     queryOptions?: UseQueryOptions<
-        GetListResponse<TData>,
+        GetListResponse<TQueryFnData>,
         TError,
-        GetListResponse<TSelectData>
+        GetListResponse<TData>
     >;
     /**
      * Metadata query for dataProvider
@@ -158,7 +158,7 @@ export type useTableProps<TData, TError, TSelectData> = {
      */
     dataProviderName?: string;
 } & SuccessErrorNotification<
-    GetListResponse<TSelectData>,
+    GetListResponse<TData>,
     TError,
     Prettify<BaseListProps>
 > &
@@ -177,11 +177,11 @@ type SyncWithLocationParams = {
 };
 
 export type useTableReturnType<
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 > = {
-    tableQueryResult: QueryObserverResult<GetListResponse<TSelectData>, TError>;
+    tableQueryResult: QueryObserverResult<GetListResponse<TData>, TError>;
     /**
      * @deprecated `sorter` is deprecated. Use `sorters` instead.
      */
@@ -209,15 +209,20 @@ export type useTableReturnType<
  * All features such as sorting, filtering and pagination comes as out of box.
  *
  * @see {@link https://refine.dev/docs/api-references/hooks/table/useTable} for more details.
+ *
+ * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
+ *
  */
 
 const defaultPermanentFilter: CrudFilters = [];
 const defaultPermanentSorter: CrudSorting = [];
 
 export function useTable<
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 >({
     initialCurrent,
     initialPageSize,
@@ -241,10 +246,10 @@ export function useTable<
     meta,
     metaData,
     dataProviderName,
-}: useTableProps<TData, TError, TSelectData> = {}): useTableReturnType<
-    TData,
+}: useTableProps<TQueryFnData, TError, TData> = {}): useTableReturnType<
+    TQueryFnData,
     TError,
-    TSelectData
+    TData
 > {
     const { syncWithLocation: syncWithLocationContext } = useSyncWithLocation();
 
@@ -485,7 +490,7 @@ export function useTable<
         }
     }, [syncWithLocation, current, pageSize, sorters, filters]);
 
-    const queryResult = useList<TData, TError, TSelectData>({
+    const queryResult = useList<TQueryFnData, TError, TData>({
         resource: resourceInUse,
         hasPagination,
         pagination: { current, pageSize, mode: pagination?.mode },
@@ -520,7 +525,7 @@ export function useTable<
         );
     };
 
-    const setFiltersFn: useTableReturnType<TData>["setFilters"] = (
+    const setFiltersFn: useTableReturnType<TQueryFnData>["setFilters"] = (
         setterOrFilters,
         behavior: SetFilterBehavior = prefferedFilterBehavior,
     ) => {

--- a/packages/mantine/src/hooks/useSelect/index.ts
+++ b/packages/mantine/src/hooks/useSelect/index.ts
@@ -10,21 +10,38 @@ import {
     UseSelectProps,
 } from "@refinedev/core";
 
-export type UseSelectReturnType<TData extends BaseRecord = BaseRecord> = {
-    selectProps: SelectProps;
-    queryResult: QueryObserverResult<GetListResponse<TData>>;
-    defaultValueQueryResult: QueryObserverResult<GetManyResponse<TData>>;
-};
+export type UseSelectReturnType<TQueryFnData extends BaseRecord = BaseRecord> =
+    {
+        selectProps: SelectProps;
+        queryResult: QueryObserverResult<GetListResponse<TQueryFnData>>;
+        defaultValueQueryResult: QueryObserverResult<
+            GetManyResponse<TQueryFnData>
+        >;
+    };
+
+/**
+ * `useSelect` hook is used to fetch data from the dataProvider and return the options for the select box.
+ *
+ * It uses `getList` method as query function from the dataProvider that is
+ * passed to {@link https://refine.dev/docs/api-references/components/refine-config `<Refine>`}.
+ *
+ * @see {@link https://refine.dev/docs/mantine/hooks/useSelect} for more details.
+ *
+ * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
+ *
+ */
 
 export const useSelect = <
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 >(
-    props: UseSelectProps<TData, TError, TSelectData>,
-): UseSelectReturnType<TSelectData> => {
+    props: UseSelectProps<TQueryFnData, TError, TData>,
+): UseSelectReturnType<TData> => {
     const { queryResult, defaultValueQueryResult, onSearch, options } =
-        useSelectCore<TData, TError, TSelectData>(props);
+        useSelectCore<TQueryFnData, TError, TData>(props);
 
     return {
         selectProps: {

--- a/packages/mui/src/hooks/useAutocomplete/index.ts
+++ b/packages/mui/src/hooks/useAutocomplete/index.ts
@@ -9,40 +9,54 @@ import { AutocompleteProps } from "@mui/material/Autocomplete";
 import isEqual from "lodash/isEqual";
 import unionWith from "lodash/unionWith";
 
-export type UseAutocompleteProps<TData, TError, TSelectData> = Pick<
-    UseSelectProps<TData, TError, TSelectData>,
+export type UseAutocompleteProps<TQueryFnData, TError, TData> = Pick<
+    UseSelectProps<TQueryFnData, TError, TData>,
     "resource"
 > &
     Omit<
-        UseSelectProps<TData, TError, TSelectData>,
+        UseSelectProps<TQueryFnData, TError, TData>,
         "optionLabel" | "optionValue"
     >;
 
-type AutocompletePropsType<TData> = Required<
+type AutocompletePropsType<TQueryFnData> = Required<
     Pick<
-        AutocompleteProps<TData, boolean, boolean, boolean>,
+        AutocompleteProps<TQueryFnData, boolean, boolean, boolean>,
         "options" | "loading" | "onInputChange" | "filterOptions"
     >
 >;
 
-export type UseAutocompleteReturnType<TData extends BaseRecord> = Omit<
-    UseSelectReturnType<TData>,
+export type UseAutocompleteReturnType<TQueryFnData extends BaseRecord> = Omit<
+    UseSelectReturnType<TQueryFnData>,
     "options"
 > & {
-    autocompleteProps: AutocompletePropsType<TData>;
+    autocompleteProps: AutocompletePropsType<TQueryFnData>;
 };
 
+/**
+ * `useAutocomplete` hook is used to fetch data from the dataProvider and return the options for the select box.
+ *
+ * It uses `getList` method as query function from the dataProvider that is
+ * passed to {@link https://refine.dev/docs/api-references/components/refine-config `<Refine>`}.
+ *
+ * @see {@link https://refine.dev/docs/api-reference/mui/hooks/useAutocomplete/} for more details.
+ *
+ * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
+ *
+ */
+
 export const useAutocomplete = <
-    TData extends BaseRecord = any,
+    TQueryFnData extends BaseRecord = any,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 >(
-    props: UseAutocompleteProps<TData, TError, TSelectData>,
-): UseAutocompleteReturnType<TSelectData> => {
+    props: UseAutocompleteProps<TQueryFnData, TError, TData>,
+): UseAutocompleteReturnType<TData> => {
     const { queryResult, defaultValueQueryResult, onSearch } = useSelectCore<
-        TData,
+        TQueryFnData,
         TError,
-        TSelectData
+        TData
     >(props);
 
     return {

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -53,9 +53,9 @@ type DataGridPropsType = Required<
         | "filterModel"
     >;
 
-export type UseDataGridProps<TData, TError, TSearchVariables, TSelectData> =
+export type UseDataGridProps<TQueryFnData, TError, TSearchVariables, TData> =
     Omit<
-        useTablePropsCore<TData, TError, TSelectData>,
+        useTablePropsCore<TQueryFnData, TError, TData>,
         "pagination" | "filters"
     > & {
         onSearch?: (
@@ -73,7 +73,7 @@ export type UseDataGridProps<TData, TError, TSearchVariables, TSelectData> =
         filters?: Prettify<
             Omit<
                 NonNullable<
-                    useTablePropsCore<TData, TError, TSelectData>["filters"]
+                    useTablePropsCore<TQueryFnData, TError, TData>["filters"]
                 >,
                 "defaultBehavior"
             > & {
@@ -87,20 +87,34 @@ export type UseDataGridProps<TData, TError, TSearchVariables, TSelectData> =
     };
 
 export type UseDataGridReturnType<
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TSearchVariables = unknown,
-    TSelectData extends BaseRecord = TData,
-> = useTableReturnTypeCore<TData, TError, TSelectData> & {
+    TData extends BaseRecord = TQueryFnData,
+> = useTableReturnTypeCore<TQueryFnData, TError, TData> & {
     dataGridProps: DataGridPropsType;
     search: (value: TSearchVariables) => Promise<void>;
 };
 
+/**
+ * By using useDataGrid, you are able to get properties that are compatible with
+ * Material UI {@link https://mui.com/x/react-data-grid/ `<DataGrid>`} component.
+ * All features such as sorting, filtering and pagination comes as out of box.
+ *
+ * @see {@link https://refine.dev/docs/api-reference/mui/hooks/useDataGrid/} for more details.
+ *
+ * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}
+ * @typeParam TSearchVariables - Values for search params
+ * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
+ *
+ */
+
 export function useDataGrid<
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TSearchVariables = unknown,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 >({
     onSearch: onSearchProp,
     initialCurrent,
@@ -126,11 +140,11 @@ export function useDataGrid<
     metaData,
     dataProviderName,
 }: UseDataGridProps<
-    TData,
+    TQueryFnData,
     TError,
     TSearchVariables,
-    TSelectData
-> = {}): UseDataGridReturnType<TData, TError, TSearchVariables, TSelectData> {
+    TData
+> = {}): UseDataGridReturnType<TQueryFnData, TError, TSearchVariables, TData> {
     const theme = useTheme();
     const liveMode = useLiveMode(liveModeFromProp);
 
@@ -150,7 +164,7 @@ export function useDataGrid<
         setSorter,
         pageCount,
         createLinkForSyncWithLocation,
-    } = useTableCore<TData, TError, TSelectData>({
+    } = useTableCore<TQueryFnData, TError, TData>({
         permanentSorter,
         permanentFilter,
         initialCurrent,

--- a/packages/react-table/src/useTable/index.ts
+++ b/packages/react-table/src/useTable/index.ts
@@ -19,42 +19,42 @@ import {
 import { useIsFirstRender } from "../utils";
 
 export type UseTableReturnType<
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
-> = Table<TSelectData> & {
-    refineCore: useTableReturnTypeCore<TData, TError, TSelectData>;
+    TData extends BaseRecord = TQueryFnData,
+> = Table<TData> & {
+    refineCore: useTableReturnTypeCore<TQueryFnData, TError, TData>;
 };
 
 export type UseTableProps<
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 > = {
     /**
      * Configuration object for the core of the [useTable](/docs/api-reference/core/hooks/useTable/)
-     * @type [`useTablePropsCore<TData, TError>`](/docs/api-reference/core/hooks/useTable/#properties)
+     * @type [`useTablePropsCore<TQueryFnData, TError>`](/docs/api-reference/core/hooks/useTable/#properties)
      */
-    refineCoreProps?: useTablePropsCore<TData, TError, TSelectData>;
-} & Pick<TableOptions<TSelectData>, "columns"> &
-    Partial<Omit<TableOptions<TSelectData>, "columns">>;
+    refineCoreProps?: useTablePropsCore<TQueryFnData, TError, TData>;
+} & Pick<TableOptions<TData>, "columns"> &
+    Partial<Omit<TableOptions<TData>, "columns">>;
 
 export function useTable<
-    TData extends BaseRecord = BaseRecord,
+    TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
-    TSelectData extends BaseRecord = TData,
+    TData extends BaseRecord = TQueryFnData,
 >({
     refineCoreProps: { hasPagination = true, ...refineCoreProps } = {},
     initialState: reactTableInitialState = {},
     ...rest
-}: UseTableProps<TData, TError, TSelectData>): UseTableReturnType<
-    TData,
+}: UseTableProps<TQueryFnData, TError, TData>): UseTableReturnType<
+    TQueryFnData,
     TError,
-    TSelectData
+    TData
 > {
     const isFirstRender = useIsFirstRender();
 
-    const useTableResult = useTableCore<TData, TError, TSelectData>({
+    const useTableResult = useTableCore<TQueryFnData, TError, TData>({
         ...refineCoreProps,
         hasPagination,
     });
@@ -87,7 +87,7 @@ export function useTable<
         }
     });
 
-    const reactTableResult = useReactTable<TSelectData>({
+    const reactTableResult = useReactTable<TData>({
         getCoreRowModel: getCoreRowModel(),
         data: data?.data ?? [],
         initialState: {


### PR DESCRIPTION
Updated the generic type name of hooks that use `useQuery` to synchronize generic type names with `tanstack-query`.

`TData` => `TQueryFnData`
`TSelectData` => `TData`