### PR TITLE
fix(core): add missing `meta` in `useMany`

### DIFF
--- a/.changeset/plenty-cows-love.md
+++ b/.changeset/plenty-cows-love.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": patch
+---
+
+Added the missing connection between the data provider's and the `useMany` hook's `meta` property.

--- a/packages/core/src/hooks/data/useMany.ts
+++ b/packages/core/src/hooks/data/useMany.ts
@@ -135,6 +135,14 @@ export const useMany = <
                 return getMany({
                     resource,
                     ids,
+                    meta: {
+                        ...(pickNotDeprecated(meta, metaData) || {}),
+                        queryContext: {
+                            queryKey,
+                            pageParam,
+                            signal,
+                        },
+                    },
                     metaData: {
                         ...(pickNotDeprecated(meta, metaData) || {}),
                         queryContext: {
@@ -150,6 +158,14 @@ export const useMany = <
                         getOne<TData>({
                             resource,
                             id,
+                            meta: {
+                                ...(pickNotDeprecated(meta, metaData) || {}),
+                                queryContext: {
+                                    queryKey,
+                                    pageParam,
+                                    signal,
+                                },
+                            },
                             metaData: {
                                 ...(pickNotDeprecated(meta, metaData) || {}),
                                 queryContext: {


### PR DESCRIPTION
With the `@refinedev/core`'s new version, we've replaced the `metaData` property with `meta`. This change was missed in the `useMany` hook, causing a break in the functionality of passing `meta` to data provider's `getMany`.
 
### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
