### PR TITLE
feat(core): hide `<GithubBanner/>` on mobile

### DIFF
--- a/.changeset/slow-glasses-smell.md
+++ b/.changeset/slow-glasses-smell.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": minor
+---
+
+Added: Hide `<GithubBanner />` on mobile.

--- a/examples/base-mui/src/App.tsx
+++ b/examples/base-mui/src/App.tsx
@@ -20,6 +20,7 @@ import { PostList, PostCreate, PostEdit } from "pages/posts";
 const App: React.FC = () => {
     return (
         <BrowserRouter>
+            <GitHubBanner />
             <ThemeProvider theme={RefineThemes.Blue}>
                 <CssBaseline />
                 <GlobalStyles

--- a/packages/core/src/components/gh-banner/index.tsx
+++ b/packages/core/src/components/gh-banner/index.tsx
@@ -14,7 +14,6 @@ export const GitHubBanner = () => {
         <div
             className="banner"
             style={{
-                display: "flex",
                 flexDirection: "row",
                 justifyContent: "center",
                 alignItems: "center",
@@ -24,6 +23,12 @@ export const GitHubBanner = () => {
                 borderBottom: "1px solid rgba(255, 255, 255, 0.15)",
             }}
         >
+            {/* sider offset for center alignment */}
+            <div
+                style={{
+                    width: "200px",
+                }}
+            />
             <a
                 className="gh-link"
                 href="https://s.refine.dev/github-support"
@@ -34,7 +39,6 @@ export const GitHubBanner = () => {
                     className="content"
                     style={{
                         position: "relative",
-                        zIndex: 2,
                         color: "#fff",
                         display: "flex",
                         flexDirection: "row",

--- a/packages/core/src/components/gh-banner/styles.ts
+++ b/packages/core/src/components/gh-banner/styles.ts
@@ -1,5 +1,12 @@
 export const CSSRules = [
     `
+    .banner {
+        display: flex;
+        @media (max-width: 1000px) {
+            display: none;
+        }
+    }`,
+    `
     .banner::before,
     .banner::after {
         content: '';
@@ -53,7 +60,6 @@ export const CSSRules = [
     `
     .gh-link, .gh-link:hover, .gh-link:active, .gh-link:visited, .gh-link:focus {
         text-decoration: none;
-        z-index: 9;
     }
     `,
 ];


### PR DESCRIPTION
added: `display: none` to `<GithubBanner/>` when screen width below `1000px`. `1000px` was chosen because Mantine close sider below `990px`


new alignment:
![image](https://user-images.githubusercontent.com/23058882/230911057-977739c7-68c0-4235-ad9d-e30717fe5443.png)

old alignment:
![image](https://user-images.githubusercontent.com/23058882/230911380-73c693d8-cc33-4bfe-92c1-b281e4668617.png)

