### PR TITLE
fix(docs): added config provider to antd edit page

### DIFF
--- a/documentation/docs/tutorial/4-adding-crud-pages/antd/add-edit-page.md
+++ b/documentation/docs/tutorial/4-adding-crud-pages/antd/add-edit-page.md
@@ -183,6 +183,7 @@ import {
     RefineThemes,
     notificationProvider,
 } from "@refinedev/antd";
+import { ConfigProvider } from "antd";
 import { Refine } from "@refinedev/core";
 import { AntdInferencer } from "@refinedev/inferencer/antd";
 import routerBindings, {

--- a/documentation/docs/tutorial/4-adding-crud-pages/antd/add-edit-page.md
+++ b/documentation/docs/tutorial/4-adding-crud-pages/antd/add-edit-page.md
@@ -36,6 +36,7 @@ import {
     RefineThemes,
     notificationProvider,
 } from "@refinedev/antd";
+import { ConfigProvider } from "antd";
 import { Refine } from "@refinedev/core";
 import { AntdInferencer } from "@refinedev/inferencer/antd";
 import routerBindings, {


### PR DESCRIPTION
fix(docs): `configProvider` was missing from the antd edit page example, so i added it. 
<img width="588" alt="Screenshot 2023-04-12 at 12 03 07" src="https://user-images.githubusercontent.com/76914028/231408443-e2ade906-46cd-4d37-ae71-b8b73564fb3e.png">

<img width="588" alt="Screenshot 2023-04-12 at 12 02 55" src="https://user-images.githubusercontent.com/76914028/231408388-26de1426-8aa1-497c-99f9-f404a1fdad2a.png">
