### PR TITLE
feat(cli): add install required packages after swizzling

### DIFF
--- a/.changeset/nice-bobcats-breathe.md
+++ b/.changeset/nice-bobcats-breathe.md
@@ -1,0 +1,6 @@
+---
+"@refinedev/cli": minor
+---
+
+feat: added required packages to install after swizzling.
+Now with this feature, users can automatically install the required packages after swizzling.

--- a/packages/cli/src/commands/swizzle/index.tsx
+++ b/packages/cli/src/commands/swizzle/index.tsx
@@ -22,6 +22,7 @@ import { reorderImports } from "@utils/swizzle/import";
 import { SWIZZLE_CODES } from "@utils/swizzle/codes";
 import boxen from "boxen";
 import { getPathPrefix } from "@utils/swizzle/getPathPrefix";
+import { installRequiredPackages } from "./install-required-packages";
 
 const swizzle = (program: Command) => {
     return program
@@ -263,13 +264,18 @@ const action = async (_options: OptionValues) => {
     );
 
     if (createdFiles.length > 0) {
-        render(
+        const { unmount } = render(
             <SwizzleMessage
                 label={selectedComponent.label}
                 files={createdFiles}
                 message={selectedComponent.message}
             />,
         );
+        unmount();
+
+        if (selectedComponent?.requiredPackages?.length) {
+            await installRequiredPackages(selectedComponent.requiredPackages);
+        }
     }
 };
 

--- a/packages/cli/src/commands/swizzle/install-required-packages/index.spec.ts
+++ b/packages/cli/src/commands/swizzle/install-required-packages/index.spec.ts
@@ -1,0 +1,110 @@
+import inquirer from "inquirer";
+import { installPackages, getPreferedPM } from "@utils/package";
+
+jest.mock("inquirer");
+jest.mock("@utils/package");
+
+const getPreferedPMMock = getPreferedPM as jest.MockedFunction<
+    typeof getPreferedPM
+>;
+const inquirerMock = inquirer as jest.Mocked<typeof inquirer>;
+const installPackagesMock = installPackages as jest.MockedFunction<
+    typeof installPackages
+>;
+
+import * as installRequiredPackages from "./index";
+
+describe("should prompt for package installation and install packages if confirmed", () => {
+    afterEach(() => {
+        jest.resetAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    it("should install required packages", async () => {
+        inquirerMock.prompt.mockResolvedValueOnce({
+            installRequiredPackages: true,
+        });
+
+        const requiredPackages = ["react", "react-dom"];
+
+        const installRequiredPackagesSpy = jest.spyOn(
+            installRequiredPackages,
+            "installRequiredPackages",
+        );
+        const promptForPackageInstallationSpy = jest.spyOn(
+            installRequiredPackages,
+            "promptForPackageInstallation",
+        );
+        const displayManualInstallationCommandSpy = jest.spyOn(
+            installRequiredPackages,
+            "displayManualInstallationCommand",
+        );
+
+        await installRequiredPackages.installRequiredPackages(requiredPackages);
+
+        expect(installRequiredPackagesSpy).toHaveBeenCalledTimes(1);
+        expect(installRequiredPackagesSpy).toHaveBeenCalledWith(
+            requiredPackages,
+        );
+
+        expect(promptForPackageInstallationSpy).toHaveBeenCalledTimes(1);
+        expect(promptForPackageInstallationSpy).toHaveBeenCalledWith(
+            requiredPackages,
+        );
+
+        expect(displayManualInstallationCommandSpy).toHaveBeenCalledTimes(0);
+
+        expect(installPackagesMock).toHaveBeenCalledTimes(1);
+        expect(installPackagesMock).toHaveBeenCalledWith(requiredPackages);
+    });
+
+    it("should display manual installation command if not confirmed", async () => {
+        inquirerMock.prompt.mockResolvedValueOnce({
+            installRequiredPackages: false,
+        });
+        getPreferedPMMock.mockResolvedValueOnce({
+            name: "npm",
+            version: "1",
+        });
+
+        const requiredPackages = ["react", "react-dom"];
+
+        const installRequiredPackagesSpy = jest.spyOn(
+            installRequiredPackages,
+            "installRequiredPackages",
+        );
+        const promptForPackageInstallationSpy = jest.spyOn(
+            installRequiredPackages,
+            "promptForPackageInstallation",
+        );
+        const displayManualInstallationCommandSpy = jest.spyOn(
+            installRequiredPackages,
+            "displayManualInstallationCommand",
+        );
+        const consoleSpy = jest.spyOn(console, "log").mockImplementation();
+
+        await installRequiredPackages.installRequiredPackages(requiredPackages);
+
+        expect(installRequiredPackagesSpy).toHaveBeenCalledTimes(1);
+        expect(installRequiredPackagesSpy).toHaveBeenCalledWith(
+            requiredPackages,
+        );
+
+        expect(promptForPackageInstallationSpy).toHaveBeenCalledTimes(1);
+        expect(promptForPackageInstallationSpy).toHaveBeenCalledWith(
+            requiredPackages,
+        );
+
+        expect(displayManualInstallationCommandSpy).toHaveBeenCalledTimes(1);
+        expect(displayManualInstallationCommandSpy).toHaveBeenCalledWith(
+            requiredPackages,
+        );
+        expect(getPreferedPM).toHaveBeenCalledTimes(1);
+
+        expect(installPackagesMock).toHaveBeenCalledTimes(0);
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+            `\nYou can install them manually by running this command:`,
+        );
+    });
+});

--- a/packages/cli/src/commands/swizzle/install-required-packages/index.ts
+++ b/packages/cli/src/commands/swizzle/install-required-packages/index.ts
@@ -1,0 +1,49 @@
+import inquirer from "inquirer";
+import chalk from "chalk";
+import { getPreferedPM, installPackages, pmCommands } from "@utils/package";
+
+export const installRequiredPackages = async (requiredPackages: string[]) => {
+    const installRequiredPackages = await promptForPackageInstallation(
+        requiredPackages,
+    );
+
+    if (!installRequiredPackages) {
+        await displayManualInstallationCommand(requiredPackages);
+    } else {
+        await installPackages(requiredPackages);
+    }
+};
+
+export const promptForPackageInstallation = async (
+    requiredPackages: string[],
+) => {
+    const message =
+        `This component requires following packages to be installed:\n`
+            .concat(requiredPackages.map((pkg) => ` - ${pkg}`).join("\n"))
+            .concat("\nDo you want to install them?");
+
+    const { installRequiredPackages } = await inquirer.prompt<{
+        installRequiredPackages: boolean;
+    }>([
+        {
+            type: "confirm",
+            name: "installRequiredPackages",
+            default: true,
+            message,
+        },
+    ]);
+
+    return installRequiredPackages;
+};
+
+export const displayManualInstallationCommand = async (
+    requiredPackages: string[],
+) => {
+    const pm = await getPreferedPM();
+    const pmCommand = pmCommands[pm.name].install.join(" ");
+    const packages = requiredPackages.join(" ");
+    const command = `${pm.name} ${pmCommand} ${packages}`;
+
+    console.log(`\nYou can install them manually by running this command:`);
+    console.log(chalk.bold.blueBright(command));
+};

--- a/packages/cli/src/definitions/refineConfig.ts
+++ b/packages/cli/src/definitions/refineConfig.ts
@@ -19,6 +19,10 @@ export type SwizzleFile = {
      * Success message shown after swizzle is complete. Supports markdown features.
      */
     message?: string;
+    /**
+     * Array of packages to install after swizzling
+     */
+    requiredPackages?: string[];
 };
 
 export type SwizzleConfig = {


### PR DESCRIPTION
feat: added required packages to install after swizzling.
Now with this feature, users can automatically install the required packages after sizzling.

CLI output image:

<img width="300" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/23058882/231407614-2a1c110a-f2de-46fb-9776-bbe26db20ec5.png">

Usage:

Add the required packages to the `swizzle.items[idex].requiredPackages` array in the `refinedev.config.js` file.

```ts
requiredPackages: [
    "@refinedev/mui@4.5.7",
    "@refinedev/ui-tests@1.3.1",
    "@refinedev/react-hook-form@latest",
],
```


### Test plan (required)
All tests passed. new tests added.

```bash
 PASS   refine-cli  src/commands/swizzle/install-required-packages/index.spec.ts
  should prompt for package installation and install packages if confirmed
    ✓ should install required packages (1 ms)
    ✓ should display manual installation command if not confirmed (1 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        1.388 s, estimated 3 s
Ran all test suites matching /\/src\/commands\/swizzle\/install-required-packages\/index.spec.ts/i.
```



