### PR TITLE
docs(inferencer): add section for `hideCodeViewerInProduction`

### DIFF
--- a/documentation/docs/packages/documentation/inferencer.md
+++ b/documentation/docs/packages/documentation/inferencer.md
@@ -170,3 +170,9 @@ This structure is designed to let users provide `meta` values for multiple resou
 ### Modifying the inferred fields
 
 If you want to customize the output of the Inferencer such as setting a custom `accessor` property for `object` type fields or changing the `type` of a field, or changing the `resource` for a `relation` type, you can use`fieldTransformer` prop in Inferencer components. It is a function that takes the field as an argument and returns the modified field. If `undefined | false | null` is returned, the field will be removed from the output, both for the preview and the code.
+
+### Hiding the Code Viewer and Development Warning
+
+If you want to hide the code viewer and the warning components, you can use the `hideCodeViewerInProduction` prop. This will only work in production mode. In development mode, the code viewer and the information block will always be visible.
+
+Please note that the Inferencer components are not meant to be used in production. They are meant to be used in development mode to help you generate the code for your components.


### PR DESCRIPTION
Added a section to the inferencer docs for the `hideCodeViewerInProduction` prop.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
