### PR TITLE
fix(core): missing resource `meta` in route creation

### DIFF
--- a/.changeset/smart-waves-remember.md
+++ b/.changeset/smart-waves-remember.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+fixed: missing resource meta in route compositions
+
+Added missing resource meta values when composing routes. This fixes the bug where the resource meta values does not included in the route composition.

--- a/packages/core/src/definitions/helpers/router/__tests__/compose-route.ts
+++ b/packages/core/src/definitions/helpers/router/__tests__/compose-route.ts
@@ -20,12 +20,15 @@ describe("composeRoute", () => {
     });
 
     it("should return the route with multiple params replaced", () => {
-        const result = composeRoute("/users/:id/:name", {
-            id: 1,
-            params: {
+        const result = composeRoute(
+            "/users/:id/:name",
+            { name: "Jane" },
+            { id: 5 },
+            {
+                id: 1,
                 name: "John",
             },
-        });
+        );
 
         expect(result).toEqual("/users/1/John");
     });
@@ -33,7 +36,8 @@ describe("composeRoute", () => {
     it("should return the route with multiple params by prioritizing meta params", () => {
         const result = composeRoute(
             "/users/:id/:name",
-            { params: { id: 1, name: "John" } },
+            {},
+            { id: 1 },
             { name: "Doe" },
         );
 

--- a/packages/core/src/definitions/helpers/router/__tests__/prepare-route-params.ts
+++ b/packages/core/src/definitions/helpers/router/__tests__/prepare-route-params.ts
@@ -10,14 +10,17 @@ describe("prepareRouteParams", () => {
     });
 
     it("should prioritize meta over params", () => {
-        expect(prepareRouteParams(["id"], { id: "1" }, { id: "2" })).toEqual({
+        expect(prepareRouteParams(["id"], { id: "2" })).toEqual({
             id: "2",
         });
     });
 
     it("should combine params and meta", () => {
         expect(
-            prepareRouteParams(["id", "action"], { id: "1" }, { action: "2" }),
+            prepareRouteParams(["id", "action"], {
+                ...{ id: "1" },
+                ...{ action: "2" },
+            }),
         ).toEqual({ id: "1", action: "2" });
     });
 });

--- a/packages/core/src/definitions/helpers/router/compose-route.ts
+++ b/packages/core/src/definitions/helpers/router/compose-route.ts
@@ -1,5 +1,4 @@
-import { MetaDataQuery, ParseResponse } from "../../../interfaces";
-
+import { MetaQuery, ParseResponse } from "src/interfaces";
 import { pickRouteParams } from "./pick-route-params";
 import { prepareRouteParams } from "./prepare-route-params";
 
@@ -12,13 +11,25 @@ import { prepareRouteParams } from "./prepare-route-params";
  */
 export const composeRoute = (
     designatedRoute: string,
-    params: ParseResponse = {},
-    meta: MetaDataQuery = {},
+    resourceMeta: MetaQuery = {},
+    parsed: ParseResponse = {},
+    meta: Record<string, unknown> = {},
 ): string => {
     // pickRouteParams (from the route)
     const routeParams = pickRouteParams(designatedRoute);
     // prepareRouteParams (from route params, params and meta)
-    const preparedRouteParams = prepareRouteParams(routeParams, params, meta);
+    const preparedRouteParams = prepareRouteParams(routeParams, {
+        ...resourceMeta,
+        ...(typeof parsed?.id !== "undefined" ? { id: parsed?.id } : {}),
+        ...(typeof parsed?.action !== "undefined"
+            ? { action: parsed?.action }
+            : {}),
+        ...(typeof parsed?.resource !== "undefined"
+            ? { resource: parsed?.resource }
+            : {}),
+        ...parsed?.params,
+        ...meta,
+    });
     // replace route params with prepared route params
     return designatedRoute.replace(/:([^\/]+)/g, (match, key) => {
         const fromParams = preparedRouteParams[key];

--- a/packages/core/src/definitions/helpers/router/compose-route.ts
+++ b/packages/core/src/definitions/helpers/router/compose-route.ts
@@ -20,12 +20,12 @@ export const composeRoute = (
     // prepareRouteParams (from route params, params and meta)
     const preparedRouteParams = prepareRouteParams(routeParams, {
         ...resourceMeta,
-        ...(typeof parsed?.id !== "undefined" ? { id: parsed?.id } : {}),
+        ...(typeof parsed?.id !== "undefined" ? { id: parsed.id } : {}),
         ...(typeof parsed?.action !== "undefined"
-            ? { action: parsed?.action }
+            ? { action: parsed.action }
             : {}),
         ...(typeof parsed?.resource !== "undefined"
-            ? { resource: parsed?.resource }
+            ? { resource: parsed.resource }
             : {}),
         ...parsed?.params,
         ...meta,

--- a/packages/core/src/definitions/helpers/router/prepare-route-params.ts
+++ b/packages/core/src/definitions/helpers/router/prepare-route-params.ts
@@ -1,5 +1,3 @@
-import { MetaDataQuery, ParseResponse } from "../../../interfaces";
-
 /**
  * Prepares the route params by checking the existing params and meta data.
  * Meta data is prioritized over params.
@@ -7,25 +5,15 @@ import { MetaDataQuery, ParseResponse } from "../../../interfaces";
  * This means, we can use `meta` for user supplied params (both manually or from the query string)
  */
 export const prepareRouteParams = <
-    TRouteParams extends Record<
-        string,
-        string | number | undefined | Symbol
-    > = Record<string, string | number | undefined | Symbol>,
+    TRouteParams extends Record<string, unknown> = Record<string, unknown>,
 >(
     routeParams: (keyof TRouteParams)[],
-    params: ParseResponse = {},
-    meta: MetaDataQuery = {},
+    meta: Record<string, unknown> = {},
 ): Partial<TRouteParams> => {
-    // meta is prioritized over params
     return routeParams.reduce((acc, key) => {
-        const value =
-            meta[key as string] ||
-            params.params?.[key as string] ||
-            (key === "id" ? params.id : undefined) ||
-            (key === "action" ? params.action : undefined) ||
-            (key === "resource" ? params.resource : undefined);
+        const value = meta[key as string];
         if (typeof value !== "undefined") {
-            acc[key] = value;
+            acc[key] = value as TRouteParams[keyof TRouteParams];
         }
         return acc;
     }, {} as Partial<TRouteParams>);

--- a/packages/core/src/hooks/breadcrumb/index.ts
+++ b/packages/core/src/hooks/breadcrumb/index.ts
@@ -77,7 +77,15 @@ export const useBreadcrumb = ({
             const href = hrefRaw
                 ? routerType === "legacy"
                     ? hrefRaw
-                    : composeRoute(hrefRaw, parsed, metaFromProps)
+                    : composeRoute(
+                          hrefRaw,
+                          {},
+                          {
+                              ...parentResource?.meta,
+                              ...parsed,
+                              ...metaFromProps,
+                          },
+                      )
                 : undefined;
 
             breadcrumbs.push({

--- a/packages/core/src/hooks/breadcrumb/index.ts
+++ b/packages/core/src/hooks/breadcrumb/index.ts
@@ -79,12 +79,9 @@ export const useBreadcrumb = ({
                     ? hrefRaw
                     : composeRoute(
                           hrefRaw,
-                          {},
-                          {
-                              ...parentResource?.meta,
-                              ...parsed,
-                              ...metaFromProps,
-                          },
+                          parentResource?.meta,
+                          parsed,
+                          metaFromProps,
                       )
                 : undefined;
 

--- a/packages/core/src/hooks/navigation/index.ts
+++ b/packages/core/src/hooks/navigation/index.ts
@@ -61,12 +61,9 @@ export const useNavigation = () => {
 
             return composeRoute(
                 createActionRoute.route,
-                {},
-                {
-                    ...resourceItem?.meta,
-                    ...parsed,
-                    ...meta,
-                },
+                resourceItem?.meta,
+                parsed,
+                meta,
             );
         } else {
             const resourceItem =
@@ -86,12 +83,9 @@ export const useNavigation = () => {
             return go({
                 to: composeRoute(
                     createActionRoute,
-                    {},
-                    {
-                        ...resourceItem?.meta,
-                        ...parsed,
-                        ...meta,
-                    },
+                    resourceItem?.meta,
+                    parsed,
+                    meta,
                 ),
                 type: "path",
             }) as string;
@@ -125,10 +119,9 @@ export const useNavigation = () => {
 
             return composeRoute(
                 editActionRoute.route,
-                {},
+                resourceItem?.meta,
+                parsed,
                 {
-                    ...resourceItem?.meta,
-                    ...parsed,
                     ...meta,
                     id: encodedId,
                 },
@@ -149,16 +142,10 @@ export const useNavigation = () => {
             }
 
             return go({
-                to: composeRoute(
-                    editActionRoute,
-                    {},
-                    {
-                        ...resourceItem?.meta,
-                        ...parsed,
-                        ...meta,
-                        id: encodedId,
-                    },
-                ),
+                to: composeRoute(editActionRoute, resourceItem?.meta, parsed, {
+                    ...meta,
+                    id: encodedId,
+                }),
                 type: "path",
             }) as string;
         }
@@ -192,10 +179,9 @@ export const useNavigation = () => {
 
             return composeRoute(
                 cloneActionRoute.route,
-                {},
+                resourceItem?.meta,
+                parsed,
                 {
-                    ...resourceItem?.meta,
-                    ...parsed,
                     ...meta,
                     id: encodedId,
                 },
@@ -216,16 +202,10 @@ export const useNavigation = () => {
             }
 
             return go({
-                to: composeRoute(
-                    cloneActionRoute,
-                    {},
-                    {
-                        ...resourceItem?.meta,
-                        ...parsed,
-                        ...meta,
-                        id: encodedId,
-                    },
-                ),
+                to: composeRoute(cloneActionRoute, resourceItem?.meta, parsed, {
+                    ...meta,
+                    id: encodedId,
+                }),
                 type: "path",
             }) as string;
         }
@@ -258,10 +238,9 @@ export const useNavigation = () => {
 
             return composeRoute(
                 showActionRoute.route,
-                {},
+                resourceItem?.meta,
+                parsed,
                 {
-                    ...resourceItem?.meta,
-                    ...parsed,
                     ...meta,
                     id: encodedId,
                 },
@@ -282,16 +261,10 @@ export const useNavigation = () => {
             }
 
             return go({
-                to: composeRoute(
-                    showActionRoute,
-                    {},
-                    {
-                        ...resourceItem?.meta,
-                        ...parsed,
-                        ...meta,
-                        id: encodedId,
-                    },
-                ),
+                to: composeRoute(showActionRoute, resourceItem?.meta, parsed, {
+                    ...meta,
+                    id: encodedId,
+                }),
                 type: "path",
             }) as string;
         }
@@ -322,12 +295,9 @@ export const useNavigation = () => {
 
             return composeRoute(
                 listActionRoute.route,
-                {},
-                {
-                    ...resourceItem?.meta,
-                    ...parsed,
-                    ...meta,
-                },
+                resourceItem?.meta,
+                parsed,
+                meta,
             );
         } else {
             const resourceItem =
@@ -347,12 +317,9 @@ export const useNavigation = () => {
             return go({
                 to: composeRoute(
                     listActionRoute,
-                    {},
-                    {
-                        ...resourceItem?.meta,
-                        ...parsed,
-                        ...meta,
-                    },
+                    resourceItem?.meta,
+                    parsed,
+                    meta,
                 ),
                 type: "path",
             }) as string;

--- a/packages/core/src/hooks/navigation/index.ts
+++ b/packages/core/src/hooks/navigation/index.ts
@@ -59,7 +59,15 @@ export const useNavigation = () => {
                 return "";
             }
 
-            return composeRoute(createActionRoute.route, parsed, meta);
+            return composeRoute(
+                createActionRoute.route,
+                {},
+                {
+                    ...resourceItem?.meta,
+                    ...parsed,
+                    ...meta,
+                },
+            );
         } else {
             const resourceItem =
                 typeof resource === "string"
@@ -76,7 +84,15 @@ export const useNavigation = () => {
             }
 
             return go({
-                to: composeRoute(createActionRoute, parsed, meta),
+                to: composeRoute(
+                    createActionRoute,
+                    {},
+                    {
+                        ...resourceItem?.meta,
+                        ...parsed,
+                        ...meta,
+                    },
+                ),
                 type: "path",
             }) as string;
         }
@@ -107,10 +123,16 @@ export const useNavigation = () => {
                 return "";
             }
 
-            return composeRoute(editActionRoute.route, parsed, {
-                ...meta,
-                id: encodedId,
-            });
+            return composeRoute(
+                editActionRoute.route,
+                {},
+                {
+                    ...resourceItem?.meta,
+                    ...parsed,
+                    ...meta,
+                    id: encodedId,
+                },
+            );
         } else {
             const resourceItem =
                 typeof resource === "string"
@@ -127,10 +149,16 @@ export const useNavigation = () => {
             }
 
             return go({
-                to: composeRoute(editActionRoute, parsed, {
-                    ...meta,
-                    id: encodedId,
-                }),
+                to: composeRoute(
+                    editActionRoute,
+                    {},
+                    {
+                        ...resourceItem?.meta,
+                        ...parsed,
+                        ...meta,
+                        id: encodedId,
+                    },
+                ),
                 type: "path",
             }) as string;
         }
@@ -162,10 +190,16 @@ export const useNavigation = () => {
                 return "";
             }
 
-            return composeRoute(cloneActionRoute.route, parsed, {
-                ...meta,
-                id: encodedId,
-            });
+            return composeRoute(
+                cloneActionRoute.route,
+                {},
+                {
+                    ...resourceItem?.meta,
+                    ...parsed,
+                    ...meta,
+                    id: encodedId,
+                },
+            );
         } else {
             const resourceItem =
                 typeof resource === "string"
@@ -182,10 +216,16 @@ export const useNavigation = () => {
             }
 
             return go({
-                to: composeRoute(cloneActionRoute, parsed, {
-                    ...meta,
-                    id: encodedId,
-                }),
+                to: composeRoute(
+                    cloneActionRoute,
+                    {},
+                    {
+                        ...resourceItem?.meta,
+                        ...parsed,
+                        ...meta,
+                        id: encodedId,
+                    },
+                ),
                 type: "path",
             }) as string;
         }
@@ -216,10 +256,16 @@ export const useNavigation = () => {
                 return "";
             }
 
-            return composeRoute(showActionRoute.route, parsed, {
-                ...meta,
-                id: encodedId,
-            });
+            return composeRoute(
+                showActionRoute.route,
+                {},
+                {
+                    ...resourceItem?.meta,
+                    ...parsed,
+                    ...meta,
+                    id: encodedId,
+                },
+            );
         } else {
             const resourceItem =
                 typeof resource === "string"
@@ -236,10 +282,16 @@ export const useNavigation = () => {
             }
 
             return go({
-                to: composeRoute(showActionRoute, parsed, {
-                    ...meta,
-                    id: encodedId,
-                }),
+                to: composeRoute(
+                    showActionRoute,
+                    {},
+                    {
+                        ...resourceItem?.meta,
+                        ...parsed,
+                        ...meta,
+                        id: encodedId,
+                    },
+                ),
                 type: "path",
             }) as string;
         }
@@ -268,7 +320,15 @@ export const useNavigation = () => {
                 return "";
             }
 
-            return composeRoute(listActionRoute.route, parsed, meta);
+            return composeRoute(
+                listActionRoute.route,
+                {},
+                {
+                    ...resourceItem?.meta,
+                    ...parsed,
+                    ...meta,
+                },
+            );
         } else {
             const resourceItem =
                 typeof resource === "string"
@@ -285,7 +345,15 @@ export const useNavigation = () => {
             }
 
             return go({
-                to: composeRoute(listActionRoute, parsed, meta),
+                to: composeRoute(
+                    listActionRoute,
+                    {},
+                    {
+                        ...resourceItem?.meta,
+                        ...parsed,
+                        ...meta,
+                    },
+                ),
                 type: "path",
             }) as string;
         }

--- a/packages/core/src/hooks/router/use-get-to-path/index.ts
+++ b/packages/core/src/hooks/router/use-get-to-path/index.ts
@@ -49,7 +49,15 @@ export const useGetToPath = (): GetToPathFn => {
                 return undefined;
             }
 
-            const composed = composeRoute(actionRoute, parsed, meta);
+            const composed = composeRoute(
+                actionRoute,
+                {},
+                {
+                    ...selectedResource?.meta,
+                    ...parsed?.params,
+                    ...meta,
+                },
+            );
 
             return composed;
         },

--- a/packages/core/src/hooks/router/use-get-to-path/index.ts
+++ b/packages/core/src/hooks/router/use-get-to-path/index.ts
@@ -51,12 +51,9 @@ export const useGetToPath = (): GetToPathFn => {
 
             const composed = composeRoute(
                 actionRoute,
-                {},
-                {
-                    ...selectedResource?.meta,
-                    ...parsed?.params,
-                    ...meta,
-                },
+                selectedResource?.meta,
+                parsed,
+                meta,
             );
 
             return composed;

--- a/packages/core/src/hooks/useSelect/index.spec.ts
+++ b/packages/core/src/hooks/useSelect/index.spec.ts
@@ -30,7 +30,8 @@ describe("useSelect Hook", () => {
 
         const { options } = result.current;
 
-        expect(options).toHaveLength(2);
+        await waitFor(() => expect(options).toHaveLength(2));
+
         expect(options).toEqual([
             {
                 label: "Necessitatibus necessitatibus id et cupiditate provident est qui amet.",


### PR DESCRIPTION
When creating the routes with parameters internally, we were missing the `resource.meta` values which causes missing parameters when user defines a default parameter value in `resource.meta` and doesn't have any values in current `meta` or `params`.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
