### PR TITLE
fix(nextjs-router) unsaved changes notifier, not blocking browser refreshes with prompt

### DIFF
--- a/.changeset/nervous-seals-sit.md
+++ b/.changeset/nervous-seals-sit.md
@@ -2,4 +2,4 @@
 "@refinedev/nextjs-router": patch
 ---
 
-Fixed unsaved changes prompt not showing when the browser is refreshed.
+fix: unsaved changes prompt not showing when the browser is refreshed.

--- a/.changeset/nervous-seals-sit.md
+++ b/.changeset/nervous-seals-sit.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/nextjs-router": patch
+---
+
+Fixed unsaved changes prompt not showing when the browser is refreshed.

--- a/packages/nextjs-router/src/pages/unsaved-changes-notifier.tsx
+++ b/packages/nextjs-router/src/pages/unsaved-changes-notifier.tsx
@@ -35,7 +35,7 @@ export const UnsavedChangesNotifier: React.FC<UnsavedChangesNotifierProps> = ({
             window.addEventListener("beforeunload", warnWhenListener);
         }
 
-        return window.removeEventListener("beforeunload", warnWhenListener);
+        return () => window.removeEventListener("beforeunload", warnWhenListener);
     }, [warnWhen, warnWhenListener]);
 
     React.useEffect(() => {


### PR DESCRIPTION
When using the `UnsavedChangesNotifier` component from the nextjs-router package, it is currently failing to block browser refreshes with a prompt. Normal router changes is working fine.

Issue is the incorrect callback from the `UseEffect` handling this part. `window.removeEventListener` returns undefined.