### PR TITLE
feat(simple-rest): install required packages after swizzle

### DIFF
--- a/.changeset/brown-birds-stare.md
+++ b/.changeset/brown-birds-stare.md
@@ -4,5 +4,3 @@
 
 feat: `requiredPackages` added to refine.config.js
 Now with that, CLI automatically installs the required packages for the project.
-
-chore: deprecated warning added to `stringify` export. Users should use from `query-string` package instead.

--- a/.changeset/brown-birds-stare.md
+++ b/.changeset/brown-birds-stare.md
@@ -2,5 +2,4 @@
 "@refinedev/simple-rest": minor
 ---
 
-feat: `requiredPackages` added to refine.config.js
-Now with that, CLI automatically installs the required packages for the project.
+feat: `requiredPackages` added to refine.config.js for CLI to automatically install required packages for the project.

--- a/.changeset/brown-birds-stare.md
+++ b/.changeset/brown-birds-stare.md
@@ -1,0 +1,8 @@
+---
+"@refinedev/simple-rest": minor
+---
+
+feat: `requiredPackages` added to refine.config.js
+Now with that, CLI automatically installs the required packages for the project.
+
+chore: deprecated warning added to `stringify` export. Users should use from `query-string` package instead.

--- a/packages/simple-rest/refine.config.js
+++ b/packages/simple-rest/refine.config.js
@@ -1,5 +1,3 @@
-const { getImports } = require("@refinedev/cli");
-
 /** @type {import('@refinedev/cli').RefineConfig} */
 module.exports = {
     group: "Data Provider",
@@ -7,6 +5,7 @@ module.exports = {
         items: [
             {
                 label: "Data Provider",
+                requiredPackages: ["query-string@7.1.1", "axios@0.26.1"],
                 files: [
                     {
                         src: "./src/provider.ts",
@@ -34,9 +33,6 @@ module.exports = {
                     },
                 ],
                 message: `
-                **\`Warning:\`**
-                You will also need to add \`axios\` to your project dependencies.
-
                 **\`Usage\`**
 
                 \`\`\`
@@ -55,47 +51,5 @@ module.exports = {
                 `,
             },
         ],
-        transform: (content) => {
-            let newContent = content;
-            const imports = getImports(content);
-
-            imports?.map((importItem) => {
-                if (
-                    importItem?.importPath === "axios" &&
-                    importItem?.defaultImport === "axios"
-                ) {
-                    // add comment for axios import
-                    newContent = newContent.replace(
-                        importItem.statement,
-                        `// "axios" package should be installed to customize the http client
-            ${importItem.statement}`,
-                    );
-                }
-                if (importItem?.importPath === "query-string") {
-                    // update query-string import
-                    newContent = newContent.replace(
-                        importItem?.statement,
-                        `// "stringify" function is re-exported from "query-string" package by "@refinedev/simple-rest"
-            ${importItem.statement.replace(
-                "query-string",
-                "@refinedev/simple-rest",
-            )}`,
-                    );
-                }
-                if (
-                    importItem?.importPath === "axios" &&
-                    importItem?.namedImports
-                ) {
-                    // update axios type import
-                    newContent = newContent.replace(
-                        importItem.statement,
-                        `// "axios" package needs to be installed
-            ${importItem.statement}`,
-                    );
-                }
-            });
-
-            return newContent;
-        },
     },
 };

--- a/packages/simple-rest/src/index.ts
+++ b/packages/simple-rest/src/index.ts
@@ -1,13 +1,8 @@
-import { stringify as queryStringStringify } from "query-string";
+import { stringify } from "query-string";
 import { dataProvider } from "./provider";
 
 export default dataProvider;
 
 export * from "./utils";
-
-/**
- * @deprecated Use `stringify` from `query-string` instead. This function will be removed in the next major version. To install `query-string` run `npm install query-string`
- **/
-const stringify = queryStringStringify;
 
 export { stringify };

--- a/packages/simple-rest/src/index.ts
+++ b/packages/simple-rest/src/index.ts
@@ -1,8 +1,13 @@
-import { stringify } from "query-string";
+import { stringify as queryStringStringify } from "query-string";
 import { dataProvider } from "./provider";
 
 export default dataProvider;
 
 export * from "./utils";
+
+/**
+ * @deprecated Use `stringify` from `query-string` instead. This function will be removed in the next major version. To install `query-string` run `npm install query-string`
+ **/
+const stringify = queryStringStringify;
 
 export { stringify };

--- a/packages/simple-rest/test/utils/generateFilter.spec.ts
+++ b/packages/simple-rest/test/utils/generateFilter.spec.ts
@@ -13,7 +13,6 @@ describe("generateFilter", () => {
             { field: "age", operator: "gte", value: 25 },
         ];
         const result = generateFilter(filters);
-        console.log(result);
         expect(result).toEqual({
             name: "John",
             age_gte: 25,
@@ -36,8 +35,6 @@ describe("generateFilter", () => {
             { field: "name", operator: "eq", value: "John" },
         ];
         const result = generateFilter(filters);
-        console.log(result);
-
         expect(result).toEqual({
             q: "searchValue",
             name: "John",

--- a/packages/simple-rest/test/utils/generateFilter.spec.ts
+++ b/packages/simple-rest/test/utils/generateFilter.spec.ts
@@ -1,0 +1,46 @@
+import { CrudFilters } from "@refinedev/core";
+import { generateFilter } from "../../src/utils/generateFilter";
+
+describe("generateFilter", () => {
+    it("returns an empty object when no filters are provided", () => {
+        const result = generateFilter();
+        expect(result).toEqual({});
+    });
+
+    it("creates a filter object based on the provided filters", () => {
+        const filters: CrudFilters = [
+            { field: "name", operator: "eq", value: "John" },
+            { field: "age", operator: "gte", value: 25 },
+        ];
+        const result = generateFilter(filters);
+        console.log(result);
+        expect(result).toEqual({
+            name: "John",
+            age_gte: 25,
+        });
+    });
+
+    it.each(["or", "and"])(
+        "throws an error for unsupported '%s' operator",
+        (operator) => {
+            const filters: CrudFilters = [
+                { operator: operator as "or" | "and", value: [] },
+            ];
+            expect(() => generateFilter(filters)).toThrow();
+        },
+    );
+
+    it("creates a filter object with the 'q' field", () => {
+        const filters: CrudFilters = [
+            { field: "q", operator: "eq", value: "searchValue" },
+            { field: "name", operator: "eq", value: "John" },
+        ];
+        const result = generateFilter(filters);
+        console.log(result);
+
+        expect(result).toEqual({
+            q: "searchValue",
+            name: "John",
+        });
+    });
+});

--- a/packages/simple-rest/test/utils/generateSort.spec.ts
+++ b/packages/simple-rest/test/utils/generateSort.spec.ts
@@ -1,0 +1,34 @@
+import { CrudSorting } from "@refinedev/core";
+import { generateSort } from "../../src/utils";
+
+describe("generateSort", () => {
+    it("should return undefined when sorters are not provided", () => {
+        const result = generateSort();
+        expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when sorters are empty", () => {
+        const result = generateSort([]);
+        expect(result).toBeUndefined();
+    });
+
+    it("should generate correct _sort and _order arrays for given sorters", () => {
+        const sorters: CrudSorting = [
+            {
+                field: "field1",
+                order: "asc",
+            },
+            {
+                field: "field2",
+                order: "desc",
+            },
+        ];
+
+        const result = generateSort(sorters);
+
+        expect(result).toEqual({
+            _sort: ["field1", "field2"],
+            _order: ["asc", "desc"],
+        });
+    });
+});

--- a/packages/simple-rest/test/utils/mapOperator.spec.ts
+++ b/packages/simple-rest/test/utils/mapOperator.spec.ts
@@ -1,0 +1,49 @@
+import { CrudOperators } from "@refinedev/core";
+import { mapOperator } from "../../src/utils";
+
+describe("mapOperator", () => {
+    it("should return correct mapping for given operator", () => {
+        const operatorMappings: Record<CrudOperators, string> = {
+            ne: "_ne",
+            gte: "_gte",
+            lte: "_lte",
+            contains: "_like",
+            eq: "",
+            and: "",
+            between: "",
+            containss: "",
+            endswith: "",
+            endswiths: "",
+            gt: "",
+            in: "",
+            lt: "",
+            ncontains: "",
+            ncontainss: "",
+            nendswith: "",
+            nendswiths: "",
+            nnull: "",
+            nin: "",
+            nbetween: "",
+            nstartswith: "",
+            nstartswiths: "",
+            null: "",
+            or: "",
+            startswith: "",
+            startswiths: "",
+        };
+
+        for (const operator in operatorMappings) {
+            const expectedResult = operatorMappings[operator as CrudOperators];
+            expect(mapOperator(operator as CrudOperators)).toEqual(
+                expectedResult,
+            );
+        }
+    });
+
+    it.each(["unsupported", "", undefined, null])(
+        "should return empty string for %s operator ",
+        (operator) => {
+            expect(mapOperator(operator as CrudOperators)).toEqual("");
+        },
+    );
+});


### PR DESCRIPTION
feat: `requiredPackages` added to refine.config.js
Now with that, CLI automatically installs the required packages for the project.

chore: deprecated warning added to `stringify` export. Users should use from `query-string` package instead.