### PR TITLE
fix: change enum from lowercase to UPPERCASE in api request for hasura graphql default naming convention 

### DIFF
--- a/.changeset/clean-actors-arrive.md
+++ b/.changeset/clean-actors-arrive.md
@@ -4,7 +4,7 @@
 
 fix: change enum from lowercase to UPPERCASE in api request for hasura camelCase naming convention
 
-From the hasura documentation ![here](https://hasura.io/docs/latest/schema/postgres/naming-convention/), for the graphql-default naming convension, the naming convension for enums is upper-cased. Currently the request are being made with the lowercase enum and not uppercase. 
+From the hasura documentation [here](https://hasura.io/docs/latest/schema/postgres/naming-convention/), for the graphql-default naming convention, the naming convention for enums is upper-cased. Currently the request are being made with the lowercase enum and not uppercase. 
 
 The change mainly 
 affects `sort`, desc gets changed to DESC and asc gets changed to ASC. the request from the refine client interface maintains the underscore and convertion to uppercase is only done at the API request layer. 

--- a/.changeset/clean-actors-arrive.md
+++ b/.changeset/clean-actors-arrive.md
@@ -1,0 +1,10 @@
+---
+"@refinedev/hasura": major
+---
+
+fix: change enum from lowercase to UPPERCASE in api request for hasura camelCase naming convention
+
+From the hasura documentation ![here](https://hasura.io/docs/latest/schema/postgres/naming-convention/), for the graphql-default naming convension, the naming convension for enums is upper-cased. Currently the request are being made with the lowercase enum and not uppercase. 
+
+The change mainly 
+affects `sort`, desc gets changed to DESC and asc gets changed to ASC. the request from the refine client interface maintains the underscore and convertion to uppercase is only done at the API request layer. 

--- a/.changeset/clean-actors-arrive.md
+++ b/.changeset/clean-actors-arrive.md
@@ -1,10 +1,10 @@
 ---
-"@refinedev/hasura": major
+"@refinedev/hasura": patch
 ---
 
 fix: change enum from lowercase to UPPERCASE in api request for hasura camelCase naming convention
 
-From the hasura documentation [here](https://hasura.io/docs/latest/schema/postgres/naming-convention/), for the graphql-default naming convention, the naming convention for enums is upper-cased. Currently the request are being made with the lowercase enum and not uppercase. 
+From the hasura documentation [here](https://hasura.io/docs/latest/schema/postgres/naming-convention/), for the graphql-default naming convention, the naming convention for enums is upper-cased. Currently the request are being made with the lowercase enum and not uppercase.
 
-The change mainly 
-affects `sort`, desc gets changed to DESC and asc gets changed to ASC. the request from the refine client interface maintains the underscore and convertion to uppercase is only done at the API request layer. 
+The change mainly
+affects `sort`, desc gets changed to DESC and asc gets changed to ASC. the request from the refine client interface maintains the underscore and convertion to uppercase is only done at the API request layer.

--- a/packages/hasura/src/dataProvider/index.ts
+++ b/packages/hasura/src/dataProvider/index.ts
@@ -12,6 +12,7 @@ import setWith from "lodash/setWith";
 import set from "lodash/set";
 import mapKeys from "lodash/mapKeys";
 import camelCase from "camelcase";
+import { mapValues } from "lodash";
 
 export type HasuraSortingType = Record<string, "asc" | "desc">;
 
@@ -159,6 +160,11 @@ const camelizeKeys = (obj: any): any => {
     return mapKeys(obj, (_v, k) => camelCase(k));
 };
 
+const uperCaseValues = (obj: any): any => {
+    if (!obj) return undefined;
+    return mapValues(obj, (v: string) => v.toUpperCase());
+};
+
 type IDType = "uuid" | "Int" | "String" | "Numeric";
 
 type NamingConvention = "hasura-default" | "graphql-default";
@@ -248,7 +254,7 @@ const dataProvider = (
             } = pagination ?? {};
             const hasuraSorting = defaultNamingConvention
                 ? generateSorting(sorters)
-                : camelizeKeys(generateSorting(sorters));
+                : uperCaseValues(camelizeKeys(generateSorting(sorters)));
 
             const hasuraFilters = generateFilters(filters);
 

--- a/packages/hasura/src/dataProvider/index.ts
+++ b/packages/hasura/src/dataProvider/index.ts
@@ -160,7 +160,7 @@ const camelizeKeys = (obj: any): any => {
     return mapKeys(obj, (_v, k) => camelCase(k));
 };
 
-const uperCaseValues = (obj: any): any => {
+const upperCaseValues = (obj: any): any => {
     if (!obj) return undefined;
     return mapValues(obj, (v: string) => v.toUpperCase());
 };
@@ -254,7 +254,7 @@ const dataProvider = (
             } = pagination ?? {};
             const hasuraSorting = defaultNamingConvention
                 ? generateSorting(sorters)
-                : uperCaseValues(camelizeKeys(generateSorting(sorters)));
+                : upperCaseValues(camelizeKeys(generateSorting(sorters)));
 
             const hasuraFilters = generateFilters(filters);
 

--- a/packages/hasura/test/getList/index.mock.ts
+++ b/packages/hasura/test/getList/index.mock.ts
@@ -1,5 +1,9 @@
 import nock from "nock";
 
+/**
+ * Hasura default 'snake_case' naming convension
+ */
+
 nock("https://flowing-mammal-24.hasura.app:443", { encodedQueryParams: true })
     .post("/v1/graphql", {
         query: "query ($limit: Int, $offset: Int, $where: posts_bool_exp) { posts (limit: $limit, offset: $offset) { id, title } posts_aggregate (where: $where) { aggregate { count } } }",
@@ -227,6 +231,10 @@ nock("https://flowing-mammal-24.hasura.app:443", { encodedQueryParams: true })
         ],
     );
 
+/**
+ * Graphql  default 'camelCase' naming convension
+ */
+
 nock("https://flowing-mammal-24.hasura.app:443", { encodedQueryParams: true })
     .post("/v1/graphql", {
         query: "query ($limit: Int, $offset: Int, $where: PostsBoolExp) { posts (limit: $limit, offset: $offset) { id, title } postsAggregate (where: $where) { aggregate { count } } }",
@@ -266,7 +274,7 @@ nock("https://flowing-mammal-24.hasura.app:443", { encodedQueryParams: true })
 nock("https://flowing-mammal-24.hasura.app:443", { encodedQueryParams: true })
     .post("/v1/graphql", {
         query: "query ($limit: Int, $offset: Int, $orderBy: [PostsOrderBy!], $where: PostsBoolExp) { posts (limit: $limit, offset: $offset, orderBy: $orderBy) { id, title } postsAggregate (where: $where) { aggregate { count } } }",
-        variables: { limit: 10, offset: 0, orderBy: { id: "asc" } },
+        variables: { limit: 10, offset: 0, orderBy: { id: "ASC" } },
     })
     .reply(
         200,
@@ -353,7 +361,7 @@ nock("https://flowing-mammal-24.hasura.app:443", { encodedQueryParams: true })
         variables: {
             limit: 10,
             offset: 0,
-            orderBy: { title: "asc" },
+            orderBy: { title: "ASC" },
             where: {
                 _and: [
                     {


### PR DESCRIPTION

### Description 
From the hasura documentation [here](https://hasura.io/docs/latest/schema/postgres/naming-convention/), for the graphql-default naming convention, the naming convention for enums is upper-cased. Currently the request are being made with the lowercase enum and not uppercase. 

### Change Details 
The change mainly affects `sort`, desc gets changed to DESC and asc gets changed to ASC. the request from the refine client interface maintains the underscore and convertion to uppercase is only done at the API request layer. 
Explain the **details** for making this change. What existing problem does the pull request solve?

### Test plan (required)
Current test have been updated to use UPPERCASE and not lowercase for graphql-default naming convention tests. 

### Closing issues
closes #3482 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
