### PR TITLE
fix(docs): added RefineThemes to generate-crud-pages antd tutorial

### DIFF
--- a/documentation/docs/tutorial/1-getting-started/antd/3-generate-crud-pages.md
+++ b/documentation/docs/tutorial/1-getting-started/antd/3-generate-crud-pages.md
@@ -162,7 +162,6 @@ import {
     ErrorComponent,
     RefineThemes,
 } from "@refinedev/antd";
-import { ConfigProvider } from "antd";
 import routerBindings, {
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
@@ -254,7 +253,6 @@ import {
     ErrorComponent,
     RefineThemes,
 } from "@refinedev/antd";
-import { ConfigProvider } from "antd";
 import routerBindings, {
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
@@ -346,7 +344,6 @@ import {
     ErrorComponent,
     RefineThemes,
 } from "@refinedev/antd";
-import { ConfigProvider } from "antd";
 import routerBindings, {
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
@@ -438,7 +435,6 @@ import {
     ErrorComponent,
     RefineThemes,
 } from "@refinedev/antd";
-import { ConfigProvider } from "antd";
 import routerBindings, {
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";


### PR DESCRIPTION
Added the missing RefineThemes import to the antd generate-crud-pages part of the tutorial

<img width="595" alt="Screenshot 2023-04-17 at 10 40 48" src="https://user-images.githubusercontent.com/76914028/232417787-fc3794d2-2f65-42e1-b2c6-4509881e506b.png">

<img width="595" alt="Screenshot 2023-04-17 at 10 40 21" src="https://user-images.githubusercontent.com/76914028/232417683-45684b59-b2ed-49be-942c-3eee76c3ea6f.png">

-   [ ] Corresponding issues are created/updated or not needed
-   [ ] Docs are updated/provided or not needed
-   [ ] Examples are updated/provided or not needed
-   [ ] TypeScript definitions are updated/provided or not needed
-   [ ] Tests are updated/provided or not needed
-   [ ] Changesets are provided or not needed
