### PR TITLE
feat(docs): added markdown feature to tutorial tracker

### DIFF
--- a/documentation/docs/tutorial/2-understanding-dataprovider/1-swizzle.md
+++ b/documentation/docs/tutorial/2-understanding-dataprovider/1-swizzle.md
@@ -1,12 +1,13 @@
 ---
 id: swizzle
-title: 2. Create Data Provider with Swizzle
 tutorial:
     prev: tutorial/understanding-dataprovider/index
     next: tutorial/understanding-dataprovider/create-dataprovider
 ---
 
-## What is Swizzle?
+# 2. Create Data Provider with `swizzle`
+
+## What is `swizzle`?
 
 The [`swizzle`](../../packages/documentation/cli.md#swizzle) is a command in [`refine-cli`](../../packages/documentation/cli.md) that allows you to customize the refine's supported components and data providers. It allows you to eject selected files from the **refine** packages and modify depending on your needs.
 

--- a/documentation/package-lock.json
+++ b/documentation/package-lock.json
@@ -34,6 +34,7 @@
                 "react-share": "^4.4.0",
                 "react-twitter-widgets": "^1.11.0",
                 "react-use-cookie": "^1.4.0",
+                "snarkdown": "^2.0.0",
                 "swiper": "^8.4.5",
                 "tailwindcss": "^3.1.8"
             },
@@ -13221,6 +13222,11 @@
                 "node": ">=8"
             }
         },
+        "node_modules/snarkdown": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/snarkdown/-/snarkdown-2.0.0.tgz",
+            "integrity": "sha512-MgL/7k/AZdXCTJiNgrO7chgDqaB9FGM/1Tvlcenenb7div6obaDATzs16JhFyHHBGodHT3B7RzRc5qk8pFhg3A=="
+        },
         "node_modules/sockjs": {
             "version": "0.3.24",
             "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -24893,6 +24899,11 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+        },
+        "snarkdown": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/snarkdown/-/snarkdown-2.0.0.tgz",
+            "integrity": "sha512-MgL/7k/AZdXCTJiNgrO7chgDqaB9FGM/1Tvlcenenb7div6obaDATzs16JhFyHHBGodHT3B7RzRc5qk8pFhg3A=="
         },
         "sockjs": {
             "version": "0.3.24",

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -39,6 +39,7 @@
         "react-share": "^4.4.0",
         "react-twitter-widgets": "^1.11.0",
         "react-use-cookie": "^1.4.0",
+        "snarkdown": "^2.0.0",
         "swiper": "^8.4.5",
         "tailwindcss": "^3.1.8"
     },

--- a/documentation/src/components/tutorial-toc/index.tsx
+++ b/documentation/src/components/tutorial-toc/index.tsx
@@ -58,7 +58,7 @@ const LinkWithId = ({
 };
 
 const markdownConverter = (text) => {
-    const numericStartRegexp = /^\d+.\s?/g;
+    const numericStartRegexp = /^\d+\.\s?/g;
     const numericStart = text.match(numericStartRegexp)?.[0] || "";
     const numericStartIgnore = text.replace(numericStartRegexp, "");
 

--- a/documentation/src/components/tutorial-toc/index.tsx
+++ b/documentation/src/components/tutorial-toc/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Link from "@docusaurus/Link";
+import snarkdown from "snarkdown";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import { useWindowSize } from "@docusaurus/theme-common";
 // @ts-expect-error no types
@@ -56,19 +56,15 @@ const LinkWithId = ({
         />
     );
 };
-const markdownConverter = (text) => {
-    text = text.replace(
-        /(?<!`)\*\*\*(?!\*)(.*?)(?<!\*)\*\*\*(?!`)/g,
-        "<strong><em>$1</em></strong>",
-    );
-    text = text.replace(
-        /(?<!`)\*\*(?!\*)(.*?)(?<!\*)\*\*(?!`)/g,
-        "<strong>$1</strong>",
-    );
-    text = text.replace(/(?<!`)\*(?!\*)(.*?)(?<!\*)\*(?!`)/g, "<em>$1</em>");
 
-    text = text.replace(/`(\w+)`/g, "<code>$1</code>");
-    return text;
+const markdownConverter = (text) => {
+    const numericStartRegexp = /^\d+.\s?/g;
+    const numericStart = text.match(numericStartRegexp)?.[0] || "";
+    const numericStartIgnore = text.replace(numericStartRegexp, "");
+
+    const marked = snarkdown(numericStartIgnore);
+
+    return `${numericStart}${marked}`;
 };
 
 const TutorialUIStatus = () => {
@@ -153,7 +149,7 @@ export const TutorialTOC = ({ isMobile }: { isMobile?: boolean }) => {
         >["units"][number]["docs"][number],
     ) => {
         const formattedTitle = markdownConverter(doc.title);
-        console.log(formattedTitle);
+
         return (
             <li key={doc.id} className="flex flex-row items-start gap-2 pb-2">
                 <div className="mt-0.5 h-5 w-5 flex-shrink-0">


### PR DESCRIPTION
Made it possible to have markdown on the tutorial tracker 
from:
<img width="1011" alt="Screenshot 2023-04-17 at 14 48 23" src="https://user-images.githubusercontent.com/76914028/232475580-90cb41b6-f465-43a0-ad78-43fff70fda4d.png">
to:
<img width="1011" alt="Screenshot 2023-04-17 at 14 43 09" src="https://user-images.githubusercontent.com/76914028/232474466-3ff3514c-9d2a-47fc-aa6f-f82d0456305d.png">

It works for *cursive*, **bold**, ***cursive+bold*** and `code`. Additional markdowns can be added to the  `markdownConverter` function if needed
For the main titles(Create Data Provider with `swizzle` in this case) to work and convert properly, they need to be brought down from the front matter and placed below it with a # below. I am planning to go through all titles in tutorial soon anyways, so i can do those changes myself when i do that. 
If there is a way to keep them in the front matter yet use markdown, that can be implemented too but the Docusaurus discord said that it is not possible  
<img width="594" alt="Screenshot 2023-04-17 at 14 49 15" src="https://user-images.githubusercontent.com/76914028/232475754-d71fd7dd-ea4f-4c4e-b35e-cce7330356d7.png">
