### PR TITLE
refactor(cli): add monorepo support

### DIFF
--- a/.changeset/curly-pandas-jump.md
+++ b/.changeset/curly-pandas-jump.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/cli": minor
+---
+
+refactor: use `require.resolve` to find script executables.
+
+Updated the runner command to use `require.resolve` to find the script executable. This allows the script to be run from anywhere in the project and allow mono-repos with workspaces to work.

--- a/.changeset/swift-worms-pump.md
+++ b/.changeset/swift-worms-pump.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/cli": minor
+---
+
+refactor: use `require.resolve` to find refine package paths.
+
+Updated the refine package search to use `require.resolve` to find the package path. This allows the package to be run from anywhere in the project and allow mono-repos with workspaces to work.

--- a/packages/cli/src/commands/runner/projectScripts.ts
+++ b/packages/cli/src/commands/runner/projectScripts.ts
@@ -1,7 +1,5 @@
 import { ProjectTypes } from "@definitions/projectTypes";
 
-const binPath = `${process.cwd()}/node_modules/.bin`;
-
 /**
  * Map `refine` cli commands to project script
  */
@@ -10,19 +8,19 @@ export const projectScripts = {
         dev: ["start"],
         start: ["start"],
         build: ["build"],
-        getBin: () => `${binPath}/react-scripts`,
+        getBin: () => require.resolve(".bin/react-scripts"),
     },
     [ProjectTypes.VITE]: {
         dev: ["dev"],
         start: ["preview"],
         build: ["build"],
-        getBin: () => `${binPath}/vite`,
+        getBin: () => require.resolve(".bin/vite"),
     },
     [ProjectTypes.NEXTJS]: {
         dev: ["dev"],
         start: ["start"],
         build: ["build"],
-        getBin: () => `${binPath}/next`,
+        getBin: () => require.resolve(".bin/next"),
     },
     [ProjectTypes.REMIX]: {
         dev: ["dev"],
@@ -30,20 +28,20 @@ export const projectScripts = {
         build: ["build"],
         getBin: (type: "dev" | "start" | "build") => {
             const binName = type === "start" ? "remix-serve" : "remix";
-            return `${binPath}/${binName}`;
+            return require.resolve(`.bin/${binName}`);
         },
     },
     [ProjectTypes.CRACO]: {
         dev: ["start"],
         start: ["start"],
         build: ["build"],
-        getBin: () => `${binPath}/craco`,
+        getBin: () => require.resolve(".bin/craco"),
     },
     [ProjectTypes.PARCEL]: {
         dev: ["start"],
         start: ["start"],
         build: ["build"],
-        getBin: () => `${binPath}/parcel`,
+        getBin: () => require.resolve(".bin/parcel"),
     },
     [ProjectTypes.UNKNOWN]: {
         dev: [],

--- a/packages/cli/src/commands/swizzle/index.tsx
+++ b/packages/cli/src/commands/swizzle/index.tsx
@@ -108,7 +108,7 @@ const action = async (_options: OptionValues) => {
 
     const packageConfigs = await Promise.all(
         packagesWithConfig.map(async (pkg) => {
-            const config = (await getRefineConfig(pkg.path)) ?? {
+            const config = (await getRefineConfig(pkg.path, true)) ?? {
                 swizzle: { items: [] },
             };
             return {

--- a/packages/cli/src/utils/package/index.ts
+++ b/packages/cli/src/utils/package/index.ts
@@ -1,6 +1,6 @@
 import { readFileSync, existsSync, readJSON, pathExists } from "fs-extra";
-import globby from "globby";
 import execa from "execa";
+import path from "path";
 import preferredPM from "preferred-pm";
 import spinner from "@utils/spinner";
 
@@ -64,13 +64,20 @@ export const getInstalledRefinePackages = async () => {
 };
 
 export const getInstalledRefinePackagesFromNodeModules = async () => {
+    const REFINE_PACKAGES = ["core"];
+
     try {
-        const packageDirsFromModules = await globby(
-            "node_modules/@refinedev/*",
-            {
-                onlyDirectories: true,
-            },
-        );
+        const packageDirsFromModules = REFINE_PACKAGES.flatMap((pkg) => {
+            try {
+                const pkgPath = require.resolve(
+                    path.join("@refinedev", pkg, "package.json"),
+                );
+
+                return [path.dirname(pkgPath)];
+            } catch (err) {
+                return [];
+            }
+        });
 
         const refinePackages: Array<{ name: string; path: string }> = [];
 

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -18,6 +18,15 @@ export default defineConfig({
     dts: false,
     clean: false,
     platform: "node",
+    external: [
+        ".bin/next",
+        ".bin/craco",
+        ".bin/react-scripts",
+        ".bin/parcel",
+        ".bin/remix-serve",
+        ".bin/remix",
+        ".bin/vite",
+    ],
     esbuildPlugins: [
         {
             name: "textReplace",

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -5,10 +5,29 @@ import path from "path";
 
 const JS_EXTENSIONS = new Set(["js", "cjs", "mjs"]);
 
-const getRefineCLIVersion = async () => {
-    const packages = await fs.promises.readFile("./package.json", "utf8");
-    const { version } = JSON.parse(packages);
-    return version;
+const getRefinePackageNames = async () => {
+    try {
+        const ignored = [
+            "live-previews",
+            "cli",
+            "antd-audit-log",
+            "demo-sidebar",
+            "create-refine-app",
+            "ui-types",
+            "ui-tests",
+        ];
+
+        const dirs = await fs.promises.readdir("../");
+
+        const packages = dirs.filter(
+            (el) =>
+                !el.startsWith(".") && el !== "cli" && !ignored.includes(el),
+        );
+
+        return packages;
+    } catch (error) {
+        return [];
+    }
 };
 
 export default defineConfig({
@@ -42,23 +61,26 @@ export default defineConfig({
                         ? "jsx"
                         : (extension as any);
 
-                    const versionRegex =
-                        /const REFINE_CLI_VERSION = "\d.\d.\d";/gm;
-                    const hasVersion = contents.match(versionRegex);
+                    const packageListRegex =
+                        /const REFINE_PACKAGES = \[(.|\s)*?\];/gm;
+                    const hasPackageList = contents.match(packageListRegex);
 
-                    if (!hasVersion) {
+                    if (!hasPackageList) {
                         return {
                             loader,
                             contents,
                         };
                     }
 
-                    const version = await getRefineCLIVersion();
+                    const packageList = await getRefinePackageNames();
+
                     return {
                         loader,
                         contents: contents.replace(
-                            versionRegex,
-                            `const REFINE_CLI_VERSION = "${version}";`,
+                            packageListRegex,
+                            `const REFINE_PACKAGES = [${packageList
+                                .map((el) => `"${el}"`)
+                                .join(", ")}];`,
                         ),
                     };
                 });


### PR DESCRIPTION
- Updated the runner commands to look for all available `node_modules` to resolve the `.bin` instead of hard coded `./node_modules`. 
- Updated the swizzle command to look for all available `node_modules` to resolve refine package paths instead of hard coded `./node_modules`.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
