### PR TITLE
fix(cli): add file system check to find installed packages

### DIFF
--- a/.changeset/brown-cameras-flow.md
+++ b/.changeset/brown-cameras-flow.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/cli": patch
+---
+
+fix(cli): add file system check to find installed packages
+
+Updated the package find logic and added file system check for double checking if the package is installed or not.

--- a/packages/cli/src/commands/swizzle/index.tsx
+++ b/packages/cli/src/commands/swizzle/index.tsx
@@ -108,9 +108,10 @@ const action = async (_options: OptionValues) => {
 
     const packageConfigs = await Promise.all(
         packagesWithConfig.map(async (pkg) => {
-            const config = (await getRefineConfig(pkg.path, true)) ?? {
-                swizzle: { items: [] },
-            };
+            const config = (await getRefineConfig(pkg.path, true)) ??
+                (await getRefineConfig(pkg.path, false)) ?? {
+                    swizzle: { items: [] },
+                };
             return {
                 ...pkg,
                 config,


### PR DESCRIPTION
Updated the package find logic and added file system check for double checking if the package is installed or not. This only takes effect in `swizzle` command.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
