### PR TITLE
fix(useAutocomplete): reset the search value when the option is selected

### DIFF
--- a/.changeset/silent-countries-jump.md
+++ b/.changeset/silent-countries-jump.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mui": patch
+---
+
+fix: `useAutocomplete` now resets the search value when the option is selected

--- a/packages/mui/src/hooks/useAutocomplete/index.ts
+++ b/packages/mui/src/hooks/useAutocomplete/index.ts
@@ -71,6 +71,8 @@ export const useAutocomplete = <
             onInputChange: (event, value) => {
                 if (event?.type === "change") {
                     onSearch(value);
+                } else if (event?.type === "click") {
+                    onSearch("");
                 }
             },
             filterOptions: (x) => x,


### PR DESCRIPTION
`useAutocomplete` now resets the search value when the option is selected.

fixed #4164 