### PR TITLE
fix: use steps form dirty state

### DIFF
--- a/.changeset/clever-bananas-refuse.md
+++ b/.changeset/clever-bananas-refuse.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/react-hook-form": patch
+---
+
+fixed: The values of the registered fields were set using the `reset()` function. This has been changed to use `getValues()` instead. This fixes an issue where the values of the registered fields' dirty state were not being set correctly.

--- a/examples/finefoods-mui/src/pages/couriers/edit.tsx
+++ b/examples/finefoods-mui/src/pages/couriers/edit.tsx
@@ -590,7 +590,7 @@ export const CourierEdit: React.FC<IResourceComponentsProps> = () => {
     return (
         <Edit
             isLoading={formLoading}
-            headerButtons={
+            footerButtons={
                 <>
                     {currentStep > 0 && (
                         <Button

--- a/packages/react-hook-form/src/useForm/index.ts
+++ b/packages/react-hook-form/src/useForm/index.ts
@@ -5,6 +5,7 @@ import {
     UseFormReturn,
     FieldValues,
     UseFormHandleSubmit,
+    Path,
 } from "react-hook-form";
 import {
     BaseRecord,
@@ -95,26 +96,24 @@ export const useForm = <
 
     const {
         watch,
-        reset,
+        setValue,
         getValues,
         handleSubmit: handleSubmitReactHookForm,
     } = useHookFormResult;
 
     useEffect(() => {
-        if (typeof queryResult?.data !== "undefined") {
-            const fields: any = {};
-            const registeredFields = Object.keys(getValues());
-            Object.entries(queryResult?.data?.data || {}).forEach(
-                ([key, value]) => {
-                    if (registeredFields.includes(key)) {
-                        fields[key] = value;
-                    }
-                },
-            );
+        const data = queryResult?.data?.data;
+        if (!data) return;
 
-            reset(fields as any);
-        }
-    }, [queryResult?.data]);
+        const registeredFields = Object.keys(getValues());
+        Object.entries(data).forEach(([key, value]) => {
+            const name = key as Path<TVariables>;
+
+            if (registeredFields.includes(name)) {
+                setValue(name, value);
+            }
+        });
+    }, [queryResult?.data, setValue, getValues]);
 
     useEffect(() => {
         const subscription = watch((values: any, { type }: { type?: any }) => {

--- a/packages/react-hook-form/src/useStepsForm/index.ts
+++ b/packages/react-hook-form/src/useStepsForm/index.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { FieldValues } from "react-hook-form";
+import { FieldValues, Path } from "react-hook-form";
 import { BaseRecord, HttpError } from "@refinedev/core";
 
 import { useForm, UseFormProps, UseFormReturnType } from "../useForm";
@@ -79,31 +79,26 @@ export const useStepsForm = <
     const {
         trigger,
         getValues,
-        reset,
+        setValue,
         formState: { dirtyFields },
         refineCore: { queryResult },
     } = useHookFormResult;
 
     useEffect(() => {
-        if (queryResult?.data) {
-            const fields: any = {};
-            const registeredFields = Object.keys(getValues());
-            Object.entries(queryResult?.data?.data).forEach(([key, value]) => {
-                if (registeredFields.includes(key)) {
-                    if (dirtyFields[key]) {
-                        fields[key] = getValues(key as any);
-                    } else {
-                        fields[key] = value;
-                    }
-                }
-            });
+        const data = queryResult?.data?.data;
+        if (!data) return;
 
-            reset(fields as any, {
-                keepDirty: true,
-                keepDirtyValues: true,
-            });
-        }
-    }, [queryResult?.data, current]);
+        const registeredFields = Object.keys(getValues());
+        Object.entries(data).forEach(([key, value]) => {
+            const name = key as Path<TVariables>;
+
+            if (registeredFields.includes(name)) {
+                if (!dirtyFields[name]) {
+                    setValue(name, value);
+                }
+            }
+        });
+    }, [queryResult?.data, current, setValue, getValues]);
 
     const go = (step: number) => {
         let targetStep = step;


### PR DESCRIPTION
fixed: The values of the registered fields were set using the `reset()` function. This has been changed to use `getValues()` instead. This fixes an issue where the values of the registered fields' dirty state were not being set correctly.

you can use this edit form component to test:
https://pastebin.mozilla.org/vUOT6sUX#L4

closes #4126


