### PR TITLE
feat: allow custom input types for graphql data provider

### DIFF
--- a/packages/graphql/src/dataProvider/index.ts
+++ b/packages/graphql/src/dataProvider/index.ts
@@ -73,13 +73,14 @@ const dataProvider = (client: GraphQLClient): Required<DataProvider> => {
             const camelCreateName = camelCase(`create-${singularResource}`);
 
             const operation = meta?.operation ?? camelCreateName;
+            const inputType = meta?.inputType ?? `${camelCreateName}Input`;
 
             const { query, variables: gqlVariables } = gql.mutation({
                 operation,
                 variables: {
                     input: {
                         value: { data: variables },
-                        type: `${camelCreateName}Input`,
+                        type: inputType,
                     },
                 },
                 fields: meta?.fields ?? [
@@ -105,6 +106,7 @@ const dataProvider = (client: GraphQLClient): Required<DataProvider> => {
             const camelCreateName = camelCase(`create-${singularResource}`);
 
             const operation = meta?.operation ?? camelCreateName;
+            const inputType = meta?.operation ?? `${camelCreateName}Input`;
 
             const response = await Promise.all(
                 variables.map(async (param) => {
@@ -113,7 +115,7 @@ const dataProvider = (client: GraphQLClient): Required<DataProvider> => {
                         variables: {
                             input: {
                                 value: { data: param },
-                                type: `${camelCreateName}Input`,
+                                type: inputType,
                             },
                         },
                         fields: meta?.fields ?? [
@@ -142,13 +144,14 @@ const dataProvider = (client: GraphQLClient): Required<DataProvider> => {
             const camelUpdateName = camelCase(`update-${singularResource}`);
 
             const operation = meta?.operation ?? camelUpdateName;
+            const inputType = meta?.operation ?? `${camelUpdateName}Input`;
 
             const { query, variables: gqlVariables } = gql.mutation({
                 operation,
                 variables: {
                     input: {
                         value: { where: { id }, data: variables },
-                        type: `${camelUpdateName}Input`,
+                        type: inputType,
                     },
                 },
                 fields: meta?.fields ?? [
@@ -174,6 +177,7 @@ const dataProvider = (client: GraphQLClient): Required<DataProvider> => {
             const camelUpdateName = camelCase(`update-${singularResource}`);
 
             const operation = meta?.operation ?? camelUpdateName;
+            const inputType = meta?.operation ?? `${camelUpdateName}Input`;
 
             const response = await Promise.all(
                 ids.map(async (id) => {
@@ -182,7 +186,7 @@ const dataProvider = (client: GraphQLClient): Required<DataProvider> => {
                         variables: {
                             input: {
                                 value: { where: { id }, data: variables },
-                                type: `${camelUpdateName}Input`,
+                                type: inputType,
                             },
                         },
                         fields: meta?.fields ?? [
@@ -232,13 +236,14 @@ const dataProvider = (client: GraphQLClient): Required<DataProvider> => {
             const camelDeleteName = camelCase(`delete-${singularResource}`);
 
             const operation = meta?.operation ?? camelDeleteName;
+            const inputType = meta?.operation ?? `${camelDeleteName}Input`;
 
             const { query, variables } = gql.mutation({
                 operation,
                 variables: {
                     input: {
                         value: { where: { id } },
-                        type: `${camelDeleteName}Input`,
+                        type: inputType,
                     },
                 },
                 fields: meta?.fields ?? [
@@ -262,6 +267,7 @@ const dataProvider = (client: GraphQLClient): Required<DataProvider> => {
             const camelDeleteName = camelCase(`delete-${singularResource}`);
 
             const operation = meta?.operation ?? camelDeleteName;
+            const inputType = meta?.operation ?? `${camelDeleteName}Input`;
 
             const response = await Promise.all(
                 ids.map(async (id) => {
@@ -270,7 +276,7 @@ const dataProvider = (client: GraphQLClient): Required<DataProvider> => {
                         variables: {
                             input: {
                                 value: { where: { id } },
-                                type: `${camelDeleteName}Input`,
+                                type: inputType,
                             },
                         },
                         fields: meta?.fields ?? [


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

The custom GraphQL data provider hard codes input types. 

This PR adds a way for the user to put their own type via the `meta` field when instantiating the data provider.

Example:

```
const { data } = await dataProvider(client).create({
    resource: "posts",
    variables: {
        title: "foo",
        content: "bar",
        category: "2",
    },
    meta: {
        inputType: <input type here>
        fields: [
            {
                operation: "post",
                fields: [
                    "id",
                    "title",
                    "content",
                    { category: ["id"] },
                ],
                variables: {},
            },
        ],
    },
});

```

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

### Test plan (required)

I didn't include tests initially because this is an optional parameter for a custom GraphQL database. That means the field could really be anything. Of course, I am open to any requested changes and will add any needed coverage.

<!-- Make sure tests pass. -->

### Closing issues

closes #3409

### Self Check before Merge

Please check all items below before review.

-   [ ] Corresponding issues are created/updated or not needed
-   [ ] Docs are updated/provided or not needed
-   [ ] Examples are updated/provided or not needed
-   [ ] TypeScript definitions are updated/provided or not needed
-   [ ] Tests are updated/provided or not needed
-   [ ] Changesets are provided or not needed
