### PR TITLE
feat(docs): add Material UI and Chakra UI example to faq

### DIFF
--- a/documentation/docs/faq.md
+++ b/documentation/docs/faq.md
@@ -17,9 +17,13 @@ defaultValue="core"
 values={[
 {label: 'Core Form', value: 'core'},
 {label: 'Ant Design Form', value: 'antd'},
-{label: 'React Hook Form', value: 'react-hook-form'}
+{label: 'React Hook Form', value: 'react-hook-form'},
+{label: 'MUI + React Hook Form', value: 'mui-react-hook-form'},
+{label: 'Chakra UI + React Hook Form', value: 'chakra-ui-react-hook-form'}
 ]}>
 <TabItem value="core">
+
+[Refer to the `useForm` documentation for more information. &#8594][use-form-core]
 
 ```tsx
 import React, { useState } from "react";
@@ -53,6 +57,8 @@ export const UserCreate: React.FC = () => {
 
 </TabItem>
 <TabItem value="antd">
+
+[Refer to the `useForm` documentation for more information. &#8594][use-form-antd]
 
 ```tsx
 import React from "react";
@@ -92,6 +98,8 @@ export const UserCreate: React.FC = () => {
 </TabItem>
 <TabItem value="react-hook-form">
 
+[Refer to the `useForm` documentation for more information. &#8594][use-form-react-hook-form]
+
 ```tsx
 import React from "react";
 import { useForm } from "@refinedev/react-hook-form";
@@ -117,6 +125,266 @@ export const UserCreate: React.FC = () => {
             <input {...register("name")} />
             <input {...register("surname")} />
         </form>
+    );
+};
+```
+
+</TabItem>
+
+<TabItem value="mui-react-hook-form">
+
+[Refer to the `useForm` documentation for more information. &#8594][use-form-react-hook-form]
+
+```tsx
+import React from "react";
+import { HttpError } from "@refinedev/core";
+import { useForm } from "@refinedev/react-hook-form";
+import { Button, Box, TextField } from "@mui/material";
+
+type FormValues = {
+    name: string;
+    surname: string;
+};
+
+export const UserCreate: React.FC = () => {
+    const {
+        refineCore: { onFinish },
+        register,
+        handleSubmit,
+    } = useForm<FormValues, HttpError, FormValues>();
+
+    const handleSubmitPostCreate = (values: FormValues) => {
+        const { name, surname } = values;
+        const fullName = `${name} ${surname}`;
+        onFinish({
+            ...value,
+            fullName,
+        });
+    };
+
+    return (
+        <Box component="form" onSubmit={handleSubmit(handleSubmitPostCreate)}>
+            <TextField
+                {...register("name", {
+                    required: "This field is required",
+                })}
+                name="name"
+                label="Name"
+                error={!!errors.name}
+                helperText={errors.name?.message}
+            />
+            <TextField
+                {...register("surname", {
+                    required: "This field is required",
+                })}
+                name="surname"
+                label="Surname"
+                error={!!errors.surname}
+                helperText={errors.surname?.message}
+            />
+            <Button type="submit">Submit</Button>
+        </Box>
+    );
+};
+```
+
+If you use [`<Edit>`](/docs/api-reference/mui/components/basic-views/edit/#savebuttonprops) component, you can override the [`saveButtonProps`](/docs/packages/documentation/react-hook-form/useForm/#savebuttonprops) prop to modify the form data before submitting it to the API.
+
+```tsx
+import React from "react";
+import { HttpError } from "@refinedev/core";
+import { useForm } from "@refinedev/react-hook-form";
+import { Button, Box, TextField } from "@mui/material";
+
+type FormValues = {
+    name: string;
+    surname: string;
+};
+
+export const UserCreate: React.FC = () => {
+    const {
+        saveButtonProps,
+        refineCore: { onFinish },
+        handleSubmit,
+    } = useForm<FormValues, HttpError, FormValues>();
+
+    const handleSubmitPostCreate = (values: FormValues) => {
+        const { name, surname } = values;
+        const fullName = `${name} ${surname}`;
+        onFinish({
+            ...value,
+            fullName,
+        });
+    };
+
+    return (
+        <Edit
+            saveButtonProps={{
+                ...saveButtonProps,
+                onClick: handleSubmit(handleSubmitForm),
+            }}
+        >
+            <Box component="form">
+                <TextField
+                    {...register("name", {
+                        required: "This field is required",
+                    })}
+                    name="name"
+                    label="Name"
+                    error={!!errors.name}
+                    helperText={errors.name?.message}
+                />
+                <TextField
+                    {...register("surname", {
+                        required: "This field is required",
+                    })}
+                    name="surname"
+                    label="Surname"
+                    error={!!errors.surname}
+                    helperText={errors.surname?.message}
+                />
+            </Box>
+        </Edit>
+    );
+};
+```
+
+</TabItem>
+
+<TabItem value="chakra-ui-react-hook-form">
+
+[Refer to the `useForm` documentation for more information. &#8594][use-form-react-hook-form]
+
+```tsx
+import React from "react";
+import { HttpError } from "@refinedev/core";
+import { useForm } from "@refinedev/react-hook-form";
+import {
+    FormControl,
+    FormErrorMessage,
+    FormLabel,
+    Input,
+    Button,
+} from "@chakra-ui/react";
+
+type FormValues = {
+    name: string;
+    surname: string;
+};
+
+export const UserCreate: React.FC = () => {
+    const {
+        refineCore: { onFinish },
+        register,
+        handleSubmit,
+    } = useForm<FormValues, HttpError, FormValues>();
+
+    const handleSubmitPostCreate = (values: FormValues) => {
+        const { name, surname } = values;
+        const fullName = `${name} ${surname}`;
+        onFinish({
+            ...value,
+            fullName,
+        });
+    };
+
+    return (
+        <form onSubmit={handleSubmit(handleSubmitPostCreate)}>
+            <FormControl mb="3" isInvalid={!!errors?.name}>
+                <FormLabel>Name</FormLabel>
+                <Input
+                    id="name"
+                    type="text"
+                    {...register("name", { required: "Name is required" })}
+                />
+                <FormErrorMessage>{`${errors.name?.message}`}</FormErrorMessage>
+            </FormControl>
+            <FormControl mb="3" isInvalid={!!errors?.surname}>
+                <FormLabel>Surname</FormLabel>
+                <Input
+                    id="surname"
+                    type="text"
+                    {...register("surname", {
+                        required: "Surname is required",
+                    })}
+                />
+                <FormErrorMessage>
+                    {`${errors.title?.surname}`}
+                </FormErrorMessage>
+                <Button type="submit">Submit</Button>
+            </FormControl>
+        </form>
+    );
+};
+```
+
+If you use [`<Edit>`](/docs/api-reference/mui/components/basic-views/edit/#savebuttonprops) component, you can override the [`saveButtonProps`](/docs/packages/documentation/react-hook-form/useForm/#savebuttonprops) prop to modify the form data before submitting it to the API.
+
+```tsx
+import React from "react";
+import { HttpError } from "@refinedev/core";
+import { useForm } from "@refinedev/react-hook-form";
+import {
+    FormControl,
+    FormErrorMessage,
+    FormLabel,
+    Input,
+    Button,
+} from "@chakra-ui/react";
+
+type FormValues = {
+    name: string;
+    surname: string;
+};
+
+export const UserCreate: React.FC = () => {
+    const {
+        saveButtonProps,
+        refineCore: { onFinish },
+        handleSubmit,
+    } = useForm<FormValues, HttpError, FormValues>();
+
+    const handleSubmitPostCreate = (values: FormValues) => {
+        const { name, surname } = values;
+        const fullName = `${name} ${surname}`;
+        onFinish({
+            ...value,
+            fullName,
+        });
+    };
+
+    return (
+        <Edit
+            saveButtonProps={{
+                ...saveButtonProps,
+                onClick: handleSubmit(handleSubmitForm),
+            }}
+        >
+            <form>
+                <FormControl mb="3" isInvalid={!!errors?.name}>
+                    <FormLabel>Name</FormLabel>
+                    <Input
+                        id="name"
+                        type="text"
+                        {...register("name", { required: "Name is required" })}
+                    />
+                    <FormErrorMessage>{`${errors.name?.message}`}</FormErrorMessage>
+                </FormControl>
+                <FormControl mb="3" isInvalid={!!errors?.surname}>
+                    <FormLabel>Surname</FormLabel>
+                    <Input
+                        id="surname"
+                        type="text"
+                        {...register("surname", {
+                            required: "Surname is required",
+                        })}
+                    />
+                    <FormErrorMessage>
+                        {`${errors.title?.surname}`}
+                    </FormErrorMessage>
+                </FormControl>
+            </form>
+        </Edit>
     );
 };
 ```
@@ -467,3 +735,8 @@ The third way is to use the `swizzle` command.
 You can use the command to copy the default `Sider` component to your project. This will allow you to customize the sider as you want.
 
 [Refer to the swizzle documentation for more information. &#8594](/docs/packages/documentation/cli/#swizzle)
+
+[use-form-core]: /docs/api-reference/core/hooks/useForm/
+[use-form-react-hook-form]: /docs/packages/documentation/react-hook-form/useForm/
+[use-form-antd]: /docs/api-reference/antd/hooks/form/useForm/
+[edit-mui]: /docs/packages/documentation/mui/edit/

--- a/documentation/docs/faq.md
+++ b/documentation/docs/faq.md
@@ -188,11 +188,12 @@ export const UserCreate: React.FC = () => {
 };
 ```
 
-If you use [`<Edit>`](/docs/api-reference/mui/components/basic-views/edit/#savebuttonprops) component, you can override the [`saveButtonProps`](/docs/packages/documentation/react-hook-form/useForm/#savebuttonprops) prop to modify the form data before submitting it to the API.
+If you use [`<Create>`](/docs/api-reference/mui/components/basic-views/create/#savebuttonprops) component, you can override the [`saveButtonProps`](/docs/packages/documentation/react-hook-form/useForm/#savebuttonprops) prop to modify the form data before submitting it to the API.
 
 ```tsx
 import React from "react";
 import { HttpError } from "@refinedev/core";
+import { Create } from "@refinedev/mui";
 import { useForm } from "@refinedev/react-hook-form";
 import { Button, Box, TextField } from "@mui/material";
 
@@ -218,7 +219,7 @@ export const UserCreate: React.FC = () => {
     };
 
     return (
-        <Edit
+        <Create
             saveButtonProps={{
                 ...saveButtonProps,
                 onClick: handleSubmit(handleSubmitForm),
@@ -244,7 +245,7 @@ export const UserCreate: React.FC = () => {
                     helperText={errors.surname?.message}
                 />
             </Box>
-        </Edit>
+        </Create>
     );
 };
 ```
@@ -318,11 +319,12 @@ export const UserCreate: React.FC = () => {
 };
 ```
 
-If you use [`<Edit>`](/docs/api-reference/mui/components/basic-views/edit/#savebuttonprops) component, you can override the [`saveButtonProps`](/docs/packages/documentation/react-hook-form/useForm/#savebuttonprops) prop to modify the form data before submitting it to the API.
+If you use [`<Create>`](/docs/api-reference/chakra-ui/components/basic-views/create/#savebuttonprops) component, you can override the [`saveButtonProps`](/docs/packages/documentation/react-hook-form/useForm/#savebuttonprops) prop to modify the form data before submitting it to the API.
 
 ```tsx
 import React from "react";
 import { HttpError } from "@refinedev/core";
+import { Create } from "@refinedev/chakra-ui";
 import { useForm } from "@refinedev/react-hook-form";
 import {
     FormControl,
@@ -354,7 +356,7 @@ export const UserCreate: React.FC = () => {
     };
 
     return (
-        <Edit
+        <Create
             saveButtonProps={{
                 ...saveButtonProps,
                 onClick: handleSubmit(handleSubmitForm),
@@ -384,7 +386,7 @@ export const UserCreate: React.FC = () => {
                     </FormErrorMessage>
                 </FormControl>
             </form>
-        </Edit>
+        </Create>
     );
 };
 ```

--- a/documentation/docs/faq.md
+++ b/documentation/docs/faq.md
@@ -18,7 +18,7 @@ values={[
 {label: 'Core Form', value: 'core'},
 {label: 'Ant Design Form', value: 'antd'},
 {label: 'React Hook Form', value: 'react-hook-form'},
-{label: 'MUI + React Hook Form', value: 'mui-react-hook-form'},
+{label: 'Material UI + React Hook Form', value: 'mui-react-hook-form'},
 {label: 'Chakra UI + React Hook Form', value: 'chakra-ui-react-hook-form'}
 ]}>
 <TabItem value="core">

--- a/documentation/docs/packages/documentation/react-hook-form/useForm.md
+++ b/documentation/docs/packages/documentation/react-hook-form/useForm.md
@@ -965,6 +965,10 @@ You can override the default behavior by passing an `onFinish` function in the h
 
 For example you can [change values before sending to the API](/docs/packages/documentation/react-hook-form/useForm/#how-can-i-change-the-form-data-before-submitting-it-to-the-api).
 
+### `saveButtonProps`
+
+It contains all the props needed by the "submit" button within the form (disabled, onClick etc.). When `saveButtonProps.onClick` is called, it triggers `handleSubmit`function with `onFinish`. You can manually pass these props to your custom button.
+
 ### `formLoading`
 
 Loading state of a modal. It's `true` when `useForm` is currently being submitted or data is being fetched for the `"edit"` or `"clone"` mode.


### PR DESCRIPTION
added: MUI and Chakra UI example to `How can I change the form data before submitting it to the API?` section