### PR TITLE
feat(examples): add multi select usage examples

### DIFF
--- a/examples/base-mantine/src/interfaces/index.d.ts
+++ b/examples/base-mantine/src/interfaces/index.d.ts
@@ -1,5 +1,10 @@
 import { Column } from "@tanstack/react-table";
 
+export interface ITag {
+    id: number;
+    title: string;
+}
+
 export interface ICategory {
     id: number;
     title: string;
@@ -11,6 +16,7 @@ export interface IPost {
     content: string;
     status: "published" | "draft" | "rejected";
     category: { id: number };
+    tags: number[];
 }
 
 export interface ColumnButtonProps {

--- a/examples/base-mantine/src/pages/posts/create.tsx
+++ b/examples/base-mantine/src/pages/posts/create.tsx
@@ -1,6 +1,7 @@
 import { Create, useForm, useSelect } from "@refinedev/mantine";
-import { Select, TextInput, Text } from "@mantine/core";
+import { Select, TextInput, Text, MultiSelect } from "@mantine/core";
 import MDEditor from "@uiw/react-md-editor";
+import { ITag } from "../../interfaces";
 
 export const PostCreate: React.FC = () => {
     const { saveButtonProps, getInputProps, errors } = useForm({
@@ -29,6 +30,10 @@ export const PostCreate: React.FC = () => {
         resource: "categories",
     });
 
+    const { selectProps: tagSelectProps } = useSelect<ITag>({
+        resource: "tags",
+    });
+
     return (
         <Create saveButtonProps={saveButtonProps}>
             <form>
@@ -55,6 +60,17 @@ export const PostCreate: React.FC = () => {
                     placeholder="Pick one"
                     {...getInputProps("category.id")}
                     {...selectProps}
+                />
+                <MultiSelect
+                    {...getInputProps("tags")}
+                    {...tagSelectProps}
+                    mt={8}
+                    label="Tags"
+                    placeholder="Pick multiple"
+                    defaultValue={[]}
+                    filter={(value, _selected, item) => {
+                        return !!item.label?.toLowerCase().includes(value);
+                    }}
                 />
                 <Text mt={8} weight={500} size="sm" color="#212529">
                     Content

--- a/examples/base-mantine/src/pages/posts/edit.tsx
+++ b/examples/base-mantine/src/pages/posts/edit.tsx
@@ -1,8 +1,8 @@
 import { Edit, useForm, useSelect } from "@refinedev/mantine";
-import { Select, TextInput, Text } from "@mantine/core";
+import { Select, TextInput, Text, MultiSelect } from "@mantine/core";
 import MDEditor from "@uiw/react-md-editor";
 
-import { ICategory } from "../../interfaces";
+import { ICategory, ITag } from "../../interfaces";
 
 export const PostEdit: React.FC = () => {
     const {
@@ -18,6 +18,7 @@ export const PostEdit: React.FC = () => {
                 id: "",
             },
             content: "",
+            tags: [],
         },
         validate: {
             title: (value) => (value.length < 2 ? "Too short title" : null),
@@ -32,9 +33,16 @@ export const PostEdit: React.FC = () => {
         },
     });
 
+    const defaultTags = queryResult?.data?.data?.tags || [];
+
     const { selectProps } = useSelect<ICategory>({
         resource: "categories",
         defaultValue: queryResult?.data?.data.category.id,
+    });
+
+    const { selectProps: tagSelectProps } = useSelect<ITag>({
+        resource: "tags",
+        defaultValue: defaultTags,
     });
 
     return (
@@ -63,6 +71,17 @@ export const PostEdit: React.FC = () => {
                     placeholder="Pick one"
                     {...getInputProps("category.id")}
                     {...selectProps}
+                />
+                <MultiSelect
+                    {...getInputProps("tags")}
+                    {...tagSelectProps}
+                    mt={8}
+                    label="Tags"
+                    placeholder="Pick multiple"
+                    defaultValue={defaultTags}
+                    filter={(value, _selected, item) => {
+                        return !!item.label?.toLowerCase().includes(value);
+                    }}
                 />
                 <Text mt={8} weight={500} size="sm" color="#212529">
                     Content

--- a/examples/base-mantine/src/pages/posts/show.tsx
+++ b/examples/base-mantine/src/pages/posts/show.tsx
@@ -1,9 +1,9 @@
-import { useShow, useOne } from "@refinedev/core";
+import { useShow, useOne, useMany } from "@refinedev/core";
 import { Show, MarkdownField } from "@refinedev/mantine";
 
-import { Title, Text } from "@mantine/core";
+import { Title, Text, Badge, Flex } from "@mantine/core";
 
-import { ICategory, IPost } from "../../interfaces";
+import { ICategory, IPost, ITag } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
     const { queryResult } = useShow<IPost>();
@@ -15,6 +15,14 @@ export const PostShow: React.FC = () => {
         id: record?.category.id || "",
         queryOptions: {
             enabled: !!record?.category.id,
+        },
+    });
+
+    const { data: tagsData } = useMany<ITag>({
+        resource: "tags",
+        ids: record?.tags || [],
+        queryOptions: {
+            enabled: !!record?.tags.length,
         },
     });
 
@@ -37,6 +45,23 @@ export const PostShow: React.FC = () => {
                 Category
             </Title>
             <Text mt="xs">{categoryData?.data?.title}</Text>
+
+            <Title mt="xs" order={5}>
+                Tags
+            </Title>
+            <Flex
+                gap="xs"
+                justify="flex-start"
+                align="center"
+                direction="row"
+                wrap="wrap"
+            >
+                {tagsData?.data?.map((tag) => (
+                    <Badge key={tag.id} mt="xs">
+                        {tag.title}
+                    </Badge>
+                ))}
+            </Flex>
 
             <Title mt="xs" order={5}>
                 Content

--- a/examples/field-antd-use-select-basic/src/interfaces/index.d.ts
+++ b/examples/field-antd-use-select-basic/src/interfaces/index.d.ts
@@ -1,3 +1,8 @@
+export interface ITag {
+    id: number;
+    title: string;
+}
+
 export interface ICategory {
     id: number;
     title: string;
@@ -9,4 +14,5 @@ export interface IPost {
     content: string;
     status: "published" | "draft" | "rejected";
     category: { id: number };
+    tags: number[];
 }

--- a/examples/field-antd-use-select-basic/src/pages/posts/create.tsx
+++ b/examples/field-antd-use-select-basic/src/pages/posts/create.tsx
@@ -31,13 +31,6 @@ export const PostCreate: React.FC<IResourceComponentsProps> = () => {
 
     const { selectProps: tagSelectProps } = useSelect<ICategory>({
         resource: "tags",
-        onSearch: (value) => [
-            {
-                field: "title",
-                operator: "contains",
-                value,
-            },
-        ],
     });
 
     return (

--- a/examples/field-antd-use-select-basic/src/pages/posts/create.tsx
+++ b/examples/field-antd-use-select-basic/src/pages/posts/create.tsx
@@ -29,6 +29,17 @@ export const PostCreate: React.FC<IResourceComponentsProps> = () => {
         ],
     });
 
+    const { selectProps: tagSelectProps } = useSelect<ICategory>({
+        resource: "tags",
+        onSearch: (value) => [
+            {
+                field: "title",
+                operator: "contains",
+                value,
+            },
+        ],
+    });
+
     return (
         <Create saveButtonProps={saveButtonProps}>
             <Form {...formProps} layout="vertical">
@@ -53,6 +64,21 @@ export const PostCreate: React.FC<IResourceComponentsProps> = () => {
                     ]}
                 >
                     <Select {...categorySelectProps} />
+                </Form.Item>
+                <Form.Item
+                    label="Tags"
+                    name={["tags"]}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                >
+                    <Select
+                        {...tagSelectProps}
+                        onBlur={() => tagSelectProps?.onSearch?.("")}
+                        mode="multiple"
+                    />
                 </Form.Item>
                 <Form.Item
                     label="Status"

--- a/examples/field-antd-use-select-basic/src/pages/posts/edit.tsx
+++ b/examples/field-antd-use-select-basic/src/pages/posts/edit.tsx
@@ -7,15 +7,27 @@ import { Form, Input, Select } from "antd";
 
 import MDEditor from "@uiw/react-md-editor";
 
-import { IPost, ICategory } from "interfaces";
+import { IPost, ICategory, ITag } from "interfaces";
 
 export const PostEdit: React.FC<IResourceComponentsProps> = () => {
     const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
-
     const postData = queryResult?.data?.data;
+
     const { selectProps: categorySelectProps } = useSelect<ICategory>({
         resource: "categories",
         defaultValue: postData?.category.id,
+        onSearch: (value) => [
+            {
+                field: "title",
+                operator: "contains",
+                value,
+            },
+        ],
+    });
+
+    const { selectProps: tagSelectProps } = useSelect<ITag>({
+        resource: "tags",
+        defaultValue: postData?.tags || [],
         onSearch: (value) => [
             {
                 field: "title",
@@ -49,6 +61,21 @@ export const PostEdit: React.FC<IResourceComponentsProps> = () => {
                     ]}
                 >
                     <Select {...categorySelectProps} />
+                </Form.Item>
+                <Form.Item
+                    label="Tags"
+                    name={["tags"]}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                >
+                    <Select
+                        {...tagSelectProps}
+                        onBlur={() => tagSelectProps?.onSearch?.("")}
+                        mode="multiple"
+                    />
                 </Form.Item>
                 <Form.Item
                     label="Status"

--- a/examples/field-antd-use-select-basic/src/pages/posts/edit.tsx
+++ b/examples/field-antd-use-select-basic/src/pages/posts/edit.tsx
@@ -28,13 +28,6 @@ export const PostEdit: React.FC<IResourceComponentsProps> = () => {
     const { selectProps: tagSelectProps } = useSelect<ITag>({
         resource: "tags",
         defaultValue: postData?.tags || [],
-        onSearch: (value) => [
-            {
-                field: "title",
-                operator: "contains",
-                value,
-            },
-        ],
     });
 
     return (

--- a/examples/field-antd-use-select-basic/src/pages/posts/show.tsx
+++ b/examples/field-antd-use-select-basic/src/pages/posts/show.tsx
@@ -1,10 +1,15 @@
-import { useShow, IResourceComponentsProps, useOne } from "@refinedev/core";
+import {
+    useShow,
+    IResourceComponentsProps,
+    useOne,
+    useMany,
+} from "@refinedev/core";
 
 import { Show, MarkdownField } from "@refinedev/antd";
 
-import { Typography } from "antd";
+import { Space, Tag, Typography } from "antd";
 
-import { IPost, ICategory } from "interfaces";
+import { IPost, ICategory, ITag } from "interfaces";
 
 const { Title, Text } = Typography;
 
@@ -22,6 +27,14 @@ export const PostShow: React.FC<IResourceComponentsProps> = () => {
             },
         });
 
+    const { data: tagsData } = useMany<ITag>({
+        resource: "tags",
+        ids: record?.tags || [],
+        queryOptions: {
+            enabled: !!record?.tags.length,
+        },
+    });
+
     return (
         <Show isLoading={isLoading}>
             <Title level={5}>Id</Title>
@@ -37,6 +50,13 @@ export const PostShow: React.FC<IResourceComponentsProps> = () => {
 
             <Title level={5}>Content</Title>
             <MarkdownField value={record?.content} />
+
+            <Title level={5}>Tags</Title>
+            <Space size={[0, 8]} wrap>
+                {tagsData?.data?.map((tag) => (
+                    <Tag key={tag.id}>{tag.title}</Tag>
+                ))}
+            </Space>
         </Show>
     );
 };

--- a/examples/field-mui-use-autocomplete/src/interfaces/index.d.ts
+++ b/examples/field-mui-use-autocomplete/src/interfaces/index.d.ts
@@ -9,4 +9,10 @@ export interface IPost {
     content: string;
     status: "published" | "draft" | "rejected";
     category: { id: number };
+    tags: number[];
+}
+
+export interface ITag {
+    id: number;
+    title: string;
 }

--- a/examples/field-mui-use-autocomplete/src/pages/posts/create.tsx
+++ b/examples/field-mui-use-autocomplete/src/pages/posts/create.tsx
@@ -5,7 +5,7 @@ import { useForm } from "@refinedev/react-hook-form";
 
 import { Controller } from "react-hook-form";
 
-import { ICategory, IPost } from "interfaces";
+import { ICategory, IPost, ITag } from "interfaces";
 
 export const PostCreate: React.FC = () => {
     const {
@@ -24,6 +24,11 @@ export const PostCreate: React.FC = () => {
 
     const { autocompleteProps } = useAutocomplete<ICategory>({
         resource: "categories",
+    });
+
+    const { autocompleteProps: tagsAutocompleteProps } = useAutocomplete<ITag>({
+        resource: "tags",
+        defaultValue: [],
     });
 
     return (
@@ -110,6 +115,63 @@ export const PostCreate: React.FC = () => {
                             )}
                         />
                     )}
+                />
+                <Controller
+                    control={control}
+                    name="tags"
+                    defaultValue={[]}
+                    render={({ field }) => {
+                        const newValue = tagsAutocompleteProps.options.filter(
+                            (p) =>
+                                field.value?.find((v) => v === p?.id) !==
+                                undefined,
+                        );
+
+                        return (
+                            <Autocomplete
+                                {...tagsAutocompleteProps}
+                                {...field}
+                                value={newValue}
+                                multiple
+                                clearOnBlur={false}
+                                onChange={(_, value) => {
+                                    const newValue = value.map((p) => p?.id);
+                                    field.onChange(newValue);
+                                }}
+                                getOptionLabel={(item) => {
+                                    return (
+                                        tagsAutocompleteProps?.options?.find(
+                                            (p) =>
+                                                p?.id?.toString() ===
+                                                item?.id.toString(),
+                                        )?.title ?? ""
+                                    );
+                                }}
+                                isOptionEqualToValue={(option, value) => {
+                                    return (
+                                        value === undefined ||
+                                        option?.id?.toString() ===
+                                            value?.id?.toString()
+                                    );
+                                }}
+                                renderInput={(params) => {
+                                    return (
+                                        <TextField
+                                            {...params}
+                                            label="Tags"
+                                            name="tags"
+                                            id="tags"
+                                            margin="normal"
+                                            variant="outlined"
+                                            error={!!errors.tags}
+                                            helperText={errors.tags?.message}
+                                            required
+                                        />
+                                    );
+                                }}
+                            />
+                        );
+                    }}
                 />
             </Box>
         </Create>

--- a/examples/field-mui-use-autocomplete/src/pages/posts/create.tsx
+++ b/examples/field-mui-use-autocomplete/src/pages/posts/create.tsx
@@ -14,6 +14,7 @@ export const PostCreate: React.FC = () => {
         register,
         control,
         formState: { errors },
+        getValues,
     } = useForm<
         IPost,
         HttpError,
@@ -28,7 +29,7 @@ export const PostCreate: React.FC = () => {
 
     const { autocompleteProps: tagsAutocompleteProps } = useAutocomplete<ITag>({
         resource: "tags",
-        defaultValue: [],
+        defaultValue: getValues("tags") || [],
     });
 
     return (

--- a/examples/field-mui-use-autocomplete/src/pages/posts/edit.tsx
+++ b/examples/field-mui-use-autocomplete/src/pages/posts/edit.tsx
@@ -4,7 +4,7 @@ import { Edit, useAutocomplete } from "@refinedev/mui";
 
 import { Box, TextField, Autocomplete } from "@mui/material";
 
-import { ICategory, IPost } from "interfaces";
+import { ICategory, IPost, ITag } from "interfaces";
 import { HttpError } from "@refinedev/core";
 
 export const PostEdit: React.FC = () => {
@@ -14,6 +14,7 @@ export const PostEdit: React.FC = () => {
         register,
         control,
         formState: { errors },
+        getValues,
     } = useForm<
         IPost,
         HttpError,
@@ -25,6 +26,11 @@ export const PostEdit: React.FC = () => {
     const { autocompleteProps } = useAutocomplete<ICategory>({
         resource: "categories",
         defaultValue: queryResult?.data?.data.category.id,
+    });
+
+    const { autocompleteProps: tagsAutocompleteProps } = useAutocomplete<ITag>({
+        resource: "tags",
+        defaultValue: getValues("tags") || [],
     });
 
     return (
@@ -115,6 +121,63 @@ export const PostEdit: React.FC = () => {
                             )}
                         />
                     )}
+                />
+                <Controller
+                    control={control}
+                    name="tags"
+                    defaultValue={[]}
+                    render={({ field }) => {
+                        const newValue = tagsAutocompleteProps.options.filter(
+                            (p) =>
+                                field.value?.find((v) => v === p?.id) !==
+                                undefined,
+                        );
+
+                        return (
+                            <Autocomplete
+                                {...tagsAutocompleteProps}
+                                {...field}
+                                value={newValue}
+                                multiple
+                                clearOnBlur={false}
+                                onChange={(_, value) => {
+                                    const newValue = value.map((p) => p?.id);
+                                    field.onChange(newValue);
+                                }}
+                                getOptionLabel={(item) => {
+                                    return (
+                                        tagsAutocompleteProps?.options?.find(
+                                            (p) =>
+                                                p?.id?.toString() ===
+                                                item?.id.toString(),
+                                        )?.title ?? ""
+                                    );
+                                }}
+                                isOptionEqualToValue={(option, value) => {
+                                    return (
+                                        value === undefined ||
+                                        option?.id?.toString() ===
+                                            value?.id?.toString()
+                                    );
+                                }}
+                                renderInput={(params) => {
+                                    return (
+                                        <TextField
+                                            {...params}
+                                            label="Tags"
+                                            name="tags"
+                                            id="tags"
+                                            margin="normal"
+                                            variant="outlined"
+                                            error={!!errors.tags}
+                                            helperText={errors.tags?.message}
+                                            required
+                                        />
+                                    );
+                                }}
+                            />
+                        );
+                    }}
                 />
             </Box>
         </Edit>


### PR DESCRIPTION
added: Material UI, Mantine, Ant Design multi-select usage examples to
- base-mantine
- field-antd-use-select
- field-mui-use-autocomplete