### PR TITLE
fix(mantine-chakra-ui): overflow issue in `ErrorComponent`

### DIFF
--- a/.changeset/flat-spiders-double.md
+++ b/.changeset/flat-spiders-double.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/chakra-ui": patch
+---
+
+Fixed the `ErrorComponent` height overflow issue which was causing header to be unresponsive.

--- a/.changeset/slimy-buses-brush.md
+++ b/.changeset/slimy-buses-brush.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mantine": patch
+---
+
+Fixed the `ErrorComponent` height overflow issue which was causing header to be unresponsive.

--- a/.github/workflows/build-example-chunks.js
+++ b/.github/workflows/build-example-chunks.js
@@ -4,10 +4,17 @@ const fs = require("fs");
 
 const EXAMPLES_DIR = "./examples";
 
+const ignoredRegexes = [
+    /^monorepo-/,
+    /^with-nx/,
+]
+
 const CHUNK_COUNT = Number(process.env.CHUNKS ? process.env.CHUNKS : 0);
 
 const examples = fs.readdirSync(EXAMPLES_DIR).filter((dir) => {
     return fs.statSync(EXAMPLES_DIR + "/" + dir).isDirectory();
+}).filter((dir) => {
+    return !ignoredRegexes.some((regex) => regex.test(dir));
 });
 
 const chunkSize = Math.ceil(examples.length / CHUNK_COUNT);

--- a/examples/monorepo-with-lerna-bootstrap/apps/my-refine-app/package.json
+++ b/examples/monorepo-with-lerna-bootstrap/apps/my-refine-app/package.json
@@ -29,11 +29,6 @@
     "eject": "react-scripts eject",
     "refine": "refine"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/examples/monorepo-with-lerna/apps/my-refine-app/package.json
+++ b/examples/monorepo-with-lerna/apps/my-refine-app/package.json
@@ -29,11 +29,6 @@
     "eject": "react-scripts eject",
     "refine": "refine"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/examples/monorepo-with-turbo/apps/my-refine-app/package.json
+++ b/examples/monorepo-with-turbo/apps/my-refine-app/package.json
@@ -29,11 +29,6 @@
     "eject": "react-scripts eject",
     "refine": "refine"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/packages/chakra-ui/src/components/pages/error/index.tsx
+++ b/packages/chakra-ui/src/components/pages/error/index.tsx
@@ -51,12 +51,7 @@ export const ErrorComponent: React.FC<RefineErrorPageProps> = () => {
             flexDirection="column"
             alignItems="center"
             justifyContent="center"
-            minH="100vh"
-            sx={{
-                "@media (min-height: 755px)": {
-                    marginTop: "-150px",
-                },
-            }}
+            minH="calc(100vh - 150px)"
         >
             <Heading fontWeight={900} fontSize={[120, 160, 220]} color={color}>
                 404

--- a/packages/mantine/src/components/pages/error/index.tsx
+++ b/packages/mantine/src/components/pages/error/index.tsx
@@ -45,17 +45,15 @@ export const ErrorComponent: React.FC<RefineErrorPageProps> = () => {
 
     return (
         <Box
-            sx={[
-                {
-                    display: "flex",
-                    flexDirection: "column",
-                    justifyContent: "center",
-                    alignItems: "center",
-                    textAlign: "center",
-                    boxSizing: "border-box",
-                    minHeight: "calc(100vh - 150px)",
-                },
-            ]}
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: "center",
+                alignItems: "center",
+                textAlign: "center",
+                boxSizing: "border-box",
+                minHeight: "calc(100vh - 150px)",
+            }}
         >
             <Title
                 sx={(theme) => ({

--- a/packages/mantine/src/components/pages/error/index.tsx
+++ b/packages/mantine/src/components/pages/error/index.tsx
@@ -45,17 +45,17 @@ export const ErrorComponent: React.FC<RefineErrorPageProps> = () => {
 
     return (
         <Box
-            sx={{
-                display: "flex",
-                flexDirection: "column",
-                justifyContent: "center",
-                alignItems: "center",
-                textAlign: "center",
-                minHeight: "100vh",
-                "@media (min-height: 755px)": {
-                    marginTop: "-150px",
+            sx={[
+                {
+                    display: "flex",
+                    flexDirection: "column",
+                    justifyContent: "center",
+                    alignItems: "center",
+                    textAlign: "center",
+                    boxSizing: "border-box",
+                    minHeight: "calc(100vh - 150px)",
                 },
-            }}
+            ]}
         >
             <Title
                 sx={(theme) => ({

--- a/packages/nextjs-router/src/pages/unsaved-changes-notifier.tsx
+++ b/packages/nextjs-router/src/pages/unsaved-changes-notifier.tsx
@@ -35,7 +35,9 @@ export const UnsavedChangesNotifier: React.FC<UnsavedChangesNotifierProps> = ({
             window.addEventListener("beforeunload", warnWhenListener);
         }
 
-        return () => window.removeEventListener("beforeunload", warnWhenListener);
+        return () => {
+            window.removeEventListener("beforeunload", warnWhenListener);
+        };
     }, [warnWhen, warnWhenListener]);
 
     React.useEffect(() => {


### PR DESCRIPTION
Fixed the `ErrorComponent` heights to not interfere with the header above when used inside `Layout` components.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
