### PR TITLE
It Solves "react-i18next:: You will need to pass in an i18next instan…

### DIFF
--- a/examples/i18n-nextjs/next-i18next.config.js
+++ b/examples/i18n-nextjs/next-i18next.config.js
@@ -1,6 +1,9 @@
+const path = require('path')
+
 module.exports = {
     i18n: {
         defaultLocale: "en",
         locales: ["en", "de"],
+        localePath: path.resolve('./public/locales')
     },
 };


### PR DESCRIPTION
This pull request fixes the error below

```
react-i18next:: You will need to pass in an i18next instance by using initReactI18next
Error: ENOENT: no such file or directory, scandir '/var/task/public/locales/en'
at Object.readdirSync (node:fs:1452:3)
at getLocaleNamespaces (/var/task/node_modules/next-i18next/dist/commonjs/config/createConfig.js:175:23)
at /var/task/node_modules/next-i18next/dist/commonjs/config/createConfig.js:181:20
at Array.map ()
at getNamespaces (/var/task/node_modules/next-i18next/dist/commonjs/config/createConfig.js:180:44)
at createConfig (/var/task/node_modules/next-i18next/dist/commonjs/config/createConfig.js:221:29)
at _callee$ (/var/task/node_modules/next-i18next/dist/commonjs/serverSideTranslations.js:199:53)
at tryCatch (/var/task/node_modules/@babel/runtime/helpers/regeneratorRuntime.js:44:17)
at Generator. (/var/task/node_modules/@babel/runtime/helpers/regeneratorRuntime.js:125:22)
at Generator.next (/var/task/node_modules/@babel/runtime/helpers/regeneratorRuntime.js:69:21) {
errno: -2,
syscall: 'scandir',
path: '/var/task/public/locales/en',
page: '/en/images/flags/undefined.svg'
}
RequestId: f3c59618-5d5d-43e0-8fd3-7287369c82bd Error: Runtime exited with error: exit status 1
Runtime.ExitError
```

### Closing issues

closes #4226 

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
