### PR TITLE
feat: add `initialSiderCollapsed` prop to themed layout

### DIFF
--- a/.changeset/beige-toys-change.md
+++ b/.changeset/beige-toys-change.md
@@ -6,12 +6,12 @@
 "@refinedev/ui-types": minor
 ---
 
-feat: `isSiderCollapsedByDefault` added to `RefineThemedLayoutV2Props` to control initial state of `<ThemedSiderV2>`.
-From now on, you can control the initial collapsed state of `<ThemedSiderV2>` by passing the `isSiderCollapsedByDefault` prop to `<ThemedLayoutV2>`.
+feat: `initialSiderCollapsed` added to `RefineThemedLayoutV2Props` to control initial state of `<ThemedSiderV2>`.
+From now on, you can control the initial collapsed state of `<ThemedSiderV2>` by passing the `initialSiderCollapsed` prop to `<ThemedLayoutV2>`.
 
 ```tsx
 <ThemedLayoutV2
-    isSiderCollapsedByDefault={true} // This will make the sider collapsed by default
+    initialSiderCollapsed={true} // This will make the sider collapsed by default
 >
     {/* .. */}
 </ThemedLayoutV2>

--- a/.changeset/beige-toys-change.md
+++ b/.changeset/beige-toys-change.md
@@ -1,0 +1,18 @@
+---
+"@refinedev/antd": minor
+"@refinedev/chakra-ui": minor
+"@refinedev/mantine": minor
+"@refinedev/mui": minor
+"@refinedev/ui-types": minor
+---
+
+feat: `isSiderCollapsedByDefault` added to `RefineThemedLayoutV2Props` to control initial state of `<ThemedSiderV2>`.
+From now on, you can control the initial collapsed state of `<ThemedSiderV2>` by passing the `isSiderCollapsedByDefault` prop to `<ThemedLayoutV2>`.
+
+```tsx
+<ThemedLayoutV2
+    isSiderCollapsedByDefault={true} // This will make the sider collapsed by default
+>
+    {/* .. */}
+</ThemedLayoutV2>
+```

--- a/documentation/docs/api-reference/antd/components/themed-layout.md
+++ b/documentation/docs/api-reference/antd/components/themed-layout.md
@@ -212,6 +212,22 @@ type SiderRenderFunction = (props: {
 }) => React.ReactNode;
 ```
 
+### `isSiderCollapsedByDefault`
+
+This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+
+-   `true`: The [`<ThemedSiderV2>`][themed-sider] component will be collapsed by default.
+-   `false`: The [`<ThemedSiderV2>`][themed-sider] component will be expanded by default.
+
+```tsx
+<ThemedLayoutV2
+    // highlight-next-line
+    isSiderCollapsedByDefault={true}
+>
+    {/* ... */}
+</ThemedLayoutV2>
+```
+
 ### `Header`
 
 In `<ThemedLayoutV2>`, the header section is rendered using the [`<ThemedHeader>`][themed-header] component by default. It uses [`useGetIdentity`](/docs/api-reference/core/hooks/auth/useGetIdentity/) hook to display the user's name and avatar on the right side of the header. However, if desired, it's possible to replace the default [`<ThemedHeader>`][themed-header] component by passing a custom component to the `Header` prop.
@@ -634,6 +650,7 @@ If there is already a file with the same name in the directory, the swizzle comm
 :::
 
 ## Migrate ThemedLayout to ThemedLayoutV2
+
 Fixed some UI problems with `ThemedLayoutV2`. If you are still using `ThemedLayout` you can update it by following these step.
 
 ```diff title="src/App.tsx"
@@ -649,6 +666,7 @@ Fixed some UI problems with `ThemedLayoutV2`. If you are still using `ThemedLayo
 ```
 
 ## collapse/uncollapse `Sider` component with `useSiderVisible` hook
+
 The `useSiderVisible` hook is that is used to collapse/uncollapse the `Sider` component. You can do this anywhere you want using the `useSiderVisible` hook. Below you can see an example put on the dashboard page.
 
 ```tsx live previewHeight=300px hideCode url=http://localhost:3000/
@@ -682,15 +700,18 @@ const DashboardPage = () => {
 
     return (
         <Space style={{ paddingTop: 30 }}>
-            <Button type="primary" onClick={() => setSiderVisible?.(!siderVisible)}>
+            <Button
+                type="primary"
+                onClick={() => setSiderVisible?.(!siderVisible)}
+            >
                 toggle visible for mobile
             </Button>
-            <Button type="primary"
+            <Button
+                type="primary"
                 onClick={() => setDrawerSiderVisible?.(!drawerSiderVisible)}
             >
                 toggle drawer
             </Button>
-            
         </Space>
     );
 };
@@ -727,7 +748,10 @@ const App: React.FC = () => {
                         >
                             {/* highlight-next-line */}
                             <Route path="/" element={<DashboardPage />} />
-                            <Route path="/samples" element={<AntdInferencer />} />
+                            <Route
+                                path="/samples"
+                                element={<AntdInferencer />}
+                            />
                         </Route>
                     </Routes>
                 </Refine>
@@ -739,6 +763,139 @@ const App: React.FC = () => {
 // visible-block-end
 
 render(<App />);
+```
+
+## FAQ
+
+### How can I persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component?
+
+You can use [`isSiderCollapsedByDefault`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+
+For example, you can get `isSiderCollapsedByDefault`'s value from `localStorage` or `cookie` for persistence between sessions.
+
+<Tabs
+defaultValue="react-router"
+values={[
+{label: 'React Router', value: 'react-router'},
+{label: 'Next.js', value: 'next.js'},
+{label: 'Remix', value: 'remix'},
+]}>
+
+<TabItem value="react-router">
+
+```tsx title="src/App.tsx"
+import { useState } from "react";
+import { Refine } from "@refinedev/core";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
+import { ThemedLayoutV2 } from "@refinedev/antd";
+
+const App: React.FC = () => {
+    // you can get this value from `localStorage` or `cookie`
+    // for persistence between sessions
+    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
+        useState(true);
+
+    return (
+        <BrowserRouter>
+            <Refine
+            // ...
+            >
+                {/* ... */}
+                <Routes>
+                    <Route
+                        element={
+                            <ThemedLayoutV2
+                                isSiderCollapsedByDefault={
+                                    isSiderCollapsedByDefault
+                                }
+                            >
+                                <Outlet />
+                            </ThemedLayoutV2>
+                        }
+                    >
+                        {/* ... */}
+                    </Route>
+                </Routes>
+            </Refine>
+        </BrowserRouter>
+    );
+};
+
+export default App;
+```
+
+</TabItem>
+
+<TabItem value="next.js">
+
+```tsx title="pages/_app.tsx"
+import { useState } from "react";
+
+import { Refine } from "@refinedev/core";
+import { ThemedLayoutV2 } from "@refinedev/antd";
+
+import type { AppProps } from "next/app";
+import type { NextPage } from "next";
+
+function MyApp({ Component, pageProps }: AppProps): JSX.Element {
+    // you can get this value from `localStorage` or `cookie`
+    // for persistence between sessions
+    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
+        useState(true);
+
+    const renderComponent = () => {
+        if (Component.noLayout) {
+            return <Component {...pageProps} />;
+        }
+
+        return (
+            <ThemedLayoutV2
+                isSiderCollapsedByDefault={isSiderCollapsedByDefault}
+            >
+                <Component {...pageProps} />
+            </ThemedLayoutV2>
+        );
+    };
+
+    return (
+        <Refine
+        // ...
+        >
+            {/* ... */}
+            {renderComponent()}
+        </Refine>
+    );
+}
+
+export default MyApp;
+```
+
+</TabItem>
+
+<TabItem value="remix">
+
+```tsx title="app/routes/_layout.tsx"
+import { useState } from "react";
+import { Outlet } from "@remix-run/react";
+import { ThemedLayoutV2 } from "@refinedev/antd";
+
+export default function BaseLayout() {
+    // you can get this value from `localStorage` or `cookie`
+    // for persistence between sessions
+    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
+        useState(true);
+
+    return (
+        <ThemedLayoutV2 isSiderCollapsedByDefault={isSiderCollapsedByDefault}>
+            <Outlet />
+        </ThemedLayoutV2>
+    );
+}
+```
+
+</TabItem>
+
+</Tabs>
 ```
 
 [themed-sider]: https://github.com/refinedev/refine/blob/next/packages/antd/src/components/themedLayoutV2/sider/index.tsx

--- a/documentation/docs/api-reference/antd/components/themed-layout.md
+++ b/documentation/docs/api-reference/antd/components/themed-layout.md
@@ -769,7 +769,7 @@ render(<App />);
 
 ### How can I persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component?
 
-You can use [`initialSiderCollapsed`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+You can use [`initialSiderCollapsed`](#initialsidercollapsed) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
 
 For example, you can get `initialSiderCollapsed`'s value from `localStorage` or `cookie` for persistence between sessions.
 

--- a/documentation/docs/api-reference/antd/components/themed-layout.md
+++ b/documentation/docs/api-reference/antd/components/themed-layout.md
@@ -212,7 +212,7 @@ type SiderRenderFunction = (props: {
 }) => React.ReactNode;
 ```
 
-### `isSiderCollapsedByDefault`
+### `initialSiderCollapsed`
 
 This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
 
@@ -222,7 +222,7 @@ This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][
 ```tsx
 <ThemedLayoutV2
     // highlight-next-line
-    isSiderCollapsedByDefault={true}
+    initialSiderCollapsed={true}
 >
     {/* ... */}
 </ThemedLayoutV2>
@@ -769,9 +769,9 @@ render(<App />);
 
 ### How can I persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component?
 
-You can use [`isSiderCollapsedByDefault`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+You can use [`initialSiderCollapsed`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
 
-For example, you can get `isSiderCollapsedByDefault`'s value from `localStorage` or `cookie` for persistence between sessions.
+For example, you can get `initialSiderCollapsed`'s value from `localStorage` or `cookie` for persistence between sessions.
 
 <Tabs
 defaultValue="react-router"
@@ -792,8 +792,7 @@ import { ThemedLayoutV2 } from "@refinedev/antd";
 const App: React.FC = () => {
     // you can get this value from `localStorage` or `cookie`
     // for persistence between sessions
-    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
-        useState(true);
+    const [initialSiderCollapsed, setInitialSiderCollapsed] = useState(true);
 
     return (
         <BrowserRouter>
@@ -805,9 +804,7 @@ const App: React.FC = () => {
                     <Route
                         element={
                             <ThemedLayoutV2
-                                isSiderCollapsedByDefault={
-                                    isSiderCollapsedByDefault
-                                }
+                                initialSiderCollapsed={initialSiderCollapsed}
                             >
                                 <Outlet />
                             </ThemedLayoutV2>
@@ -840,8 +837,7 @@ import type { NextPage } from "next";
 function MyApp({ Component, pageProps }: AppProps): JSX.Element {
     // you can get this value from `localStorage` or `cookie`
     // for persistence between sessions
-    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
-        useState(true);
+    const [initialSiderCollapsed, setInitialSiderCollapsed] = useState(true);
 
     const renderComponent = () => {
         if (Component.noLayout) {
@@ -849,9 +845,7 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
         }
 
         return (
-            <ThemedLayoutV2
-                isSiderCollapsedByDefault={isSiderCollapsedByDefault}
-            >
+            <ThemedLayoutV2 initialSiderCollapsed={initialSiderCollapsed}>
                 <Component {...pageProps} />
             </ThemedLayoutV2>
         );
@@ -882,11 +876,10 @@ import { ThemedLayoutV2 } from "@refinedev/antd";
 export default function BaseLayout() {
     // you can get this value from `localStorage` or `cookie`
     // for persistence between sessions
-    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
-        useState(true);
+    const [initialSiderCollapsed, setInitialSiderCollapsed] = useState(true);
 
     return (
-        <ThemedLayoutV2 isSiderCollapsedByDefault={isSiderCollapsedByDefault}>
+        <ThemedLayoutV2 initialSiderCollapsed={initialSiderCollapsed}>
             <Outlet />
         </ThemedLayoutV2>
     );

--- a/documentation/docs/api-reference/chakra-ui/components/themed-layout.md
+++ b/documentation/docs/api-reference/chakra-ui/components/themed-layout.md
@@ -834,7 +834,7 @@ render(<App />);
 
 ### How can I persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component?
 
-You can use [`initialSiderCollapsed`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+You can use [`initialSiderCollapsed`](#initialsidercollapsed) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
 
 For example, you can get `initialSiderCollapsed`'s value from `localStorage` or `cookie` for persistence between sessions.
 

--- a/documentation/docs/api-reference/chakra-ui/components/themed-layout.md
+++ b/documentation/docs/api-reference/chakra-ui/components/themed-layout.md
@@ -213,6 +213,22 @@ type SiderRenderFunction = (props: {
 }) => React.ReactNode;
 ```
 
+### `isSiderCollapsedByDefault`
+
+This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+
+-   `true`: The [`<ThemedSiderV2>`][themed-sider] component will be collapsed by default.
+-   `false`: The [`<ThemedSiderV2>`][themed-sider] component will be expanded by default.
+
+```tsx
+<ThemedLayoutV2
+    // highlight-next-line
+    isSiderCollapsedByDefault={true}
+>
+    {/* ... */}
+</ThemedLayoutV2>
+```
+
 ### `Header`
 
 In `<ThemedLayoutV2>`, the header section is rendered using the [`<ThemedHeader>`][themed-header] component by default. It uses [`useGetIdentity`](/docs/api-reference/core/hooks/auth/useGetIdentity/) hook to display the user's name and avatar on the right side of the header. However, if desired, it's possible to replace the default [`<ThemedHeader>`][themed-header] component by passing a custom component to the `Header` prop.
@@ -578,7 +594,7 @@ You should pass layout related components to the <ThemedLayoutV2/> component's p
     │               /* ... */                                                                        │
     │           >                                                                                    │
     │               <ThemedLayoutV2                                                                  │
-    │                   Header={ThemedHeaderV2}                                                      │ 
+    │                   Header={ThemedHeaderV2}                                                      │
     │                    Sider={ThemedSiderV2}                                                       │
     │                    Title={ThemedTitleV2}                                                       │
     │                />                                                                              │
@@ -736,11 +752,11 @@ setInitialRoutes(["/"]);
 // visible-block-start
 
 import { Refine } from "@refinedev/core";
-import { 
-    ThemedLayoutV2, 
-    RefineThemes, 
+import {
+    ThemedLayoutV2,
+    RefineThemes,
     // highlight-next-line
-    HamburgerMenu 
+    HamburgerMenu,
 } from "@refinedev/chakra-ui";
 import { ChakraProvider, Box } from "@chakra-ui/react";
 import { ChakraUIInferencer } from "@refinedev/inferencer/chakra-ui";
@@ -814,6 +830,138 @@ const App = () => {
 render(<App />);
 ```
 
+## FAQ
+
+### How can I persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component?
+
+You can use [`isSiderCollapsedByDefault`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+
+For example, you can get `isSiderCollapsedByDefault`'s value from `localStorage` or `cookie` for persistence between sessions.
+
+<Tabs
+defaultValue="react-router"
+values={[
+{label: 'React Router', value: 'react-router'},
+{label: 'Next.js', value: 'next.js'},
+{label: 'Remix', value: 'remix'},
+]}>
+
+<TabItem value="react-router">
+
+```tsx title="src/App.tsx"
+import { useState } from "react";
+import { Refine } from "@refinedev/core";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
+import { ThemedLayoutV2 } from "@refinedev/chakra-ui";
+
+const App: React.FC = () => {
+    // you can get this value from `localStorage` or `cookie`
+    // for persistence between sessions
+    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
+        useState(true);
+
+    return (
+        <BrowserRouter>
+            <Refine
+            // ...
+            >
+                {/* ... */}
+                <Routes>
+                    <Route
+                        element={
+                            <ThemedLayoutV2
+                                isSiderCollapsedByDefault={
+                                    isSiderCollapsedByDefault
+                                }
+                            >
+                                <Outlet />
+                            </ThemedLayoutV2>
+                        }
+                    >
+                        {/* ... */}
+                    </Route>
+                </Routes>
+            </Refine>
+        </BrowserRouter>
+    );
+};
+
+export default App;
+```
+
+</TabItem>
+
+<TabItem value="next.js">
+
+```tsx title="pages/_app.tsx"
+import { useState } from "react";
+
+import { Refine } from "@refinedev/core";
+import { ThemedLayoutV2 } from "@refinedev/chakra-ui";
+
+import type { AppProps } from "next/app";
+import type { NextPage } from "next";
+
+function MyApp({ Component, pageProps }: AppProps): JSX.Element {
+    // you can get this value from `localStorage` or `cookie`
+    // for persistence between sessions
+    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
+        useState(true);
+
+    const renderComponent = () => {
+        if (Component.noLayout) {
+            return <Component {...pageProps} />;
+        }
+
+        return (
+            <ThemedLayoutV2
+                isSiderCollapsedByDefault={isSiderCollapsedByDefault}
+            >
+                <Component {...pageProps} />
+            </ThemedLayoutV2>
+        );
+    };
+
+    return (
+        <Refine
+        // ...
+        >
+            {/* ... */}
+            {renderComponent()}
+        </Refine>
+    );
+}
+
+export default MyApp;
+```
+
+</TabItem>
+
+<TabItem value="remix">
+
+```tsx title="app/routes/_layout.tsx"
+import { useState } from "react";
+import { Outlet } from "@remix-run/react";
+import { ThemedLayoutV2 } from "@refinedev/chakra-ui";
+
+export default function BaseLayout() {
+    // you can get this value from `localStorage` or `cookie`
+    // for persistence between sessions
+    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
+        useState(true);
+
+    return (
+        <ThemedLayoutV2 isSiderCollapsedByDefault={isSiderCollapsedByDefault}>
+            <Outlet />
+        </ThemedLayoutV2>
+    );
+}
+```
+
+</TabItem>
+
+</Tabs>
+```
 
 [themed-sider]: https://github.com/refinedev/refine/blob/next/packages/chakra-ui/src/components/themedLayoutV2/sider/index.tsx
 [themed-header]: https://github.com/refinedev/refine/blob/next/packages/chakra-ui/src/components/themedLayoutV2/header/index.tsx

--- a/documentation/docs/api-reference/chakra-ui/components/themed-layout.md
+++ b/documentation/docs/api-reference/chakra-ui/components/themed-layout.md
@@ -213,7 +213,7 @@ type SiderRenderFunction = (props: {
 }) => React.ReactNode;
 ```
 
-### `isSiderCollapsedByDefault`
+### `initialSiderCollapsed`
 
 This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
 
@@ -223,7 +223,7 @@ This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][
 ```tsx
 <ThemedLayoutV2
     // highlight-next-line
-    isSiderCollapsedByDefault={true}
+    initialSiderCollapsed={true}
 >
     {/* ... */}
 </ThemedLayoutV2>
@@ -834,9 +834,9 @@ render(<App />);
 
 ### How can I persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component?
 
-You can use [`isSiderCollapsedByDefault`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+You can use [`initialSiderCollapsed`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
 
-For example, you can get `isSiderCollapsedByDefault`'s value from `localStorage` or `cookie` for persistence between sessions.
+For example, you can get `initialSiderCollapsed`'s value from `localStorage` or `cookie` for persistence between sessions.
 
 <Tabs
 defaultValue="react-router"
@@ -857,8 +857,7 @@ import { ThemedLayoutV2 } from "@refinedev/chakra-ui";
 const App: React.FC = () => {
     // you can get this value from `localStorage` or `cookie`
     // for persistence between sessions
-    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
-        useState(true);
+    const [initialSiderCollapsed, setInitialSiderCollapsed] = useState(true);
 
     return (
         <BrowserRouter>
@@ -870,9 +869,7 @@ const App: React.FC = () => {
                     <Route
                         element={
                             <ThemedLayoutV2
-                                isSiderCollapsedByDefault={
-                                    isSiderCollapsedByDefault
-                                }
+                                initialSiderCollapsed={initialSiderCollapsed}
                             >
                                 <Outlet />
                             </ThemedLayoutV2>
@@ -905,8 +902,7 @@ import type { NextPage } from "next";
 function MyApp({ Component, pageProps }: AppProps): JSX.Element {
     // you can get this value from `localStorage` or `cookie`
     // for persistence between sessions
-    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
-        useState(true);
+    const [initialSiderCollapsed, setInitialSiderCollapsed] = useState(true);
 
     const renderComponent = () => {
         if (Component.noLayout) {
@@ -914,9 +910,7 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
         }
 
         return (
-            <ThemedLayoutV2
-                isSiderCollapsedByDefault={isSiderCollapsedByDefault}
-            >
+            <ThemedLayoutV2 initialSiderCollapsed={initialSiderCollapsed}>
                 <Component {...pageProps} />
             </ThemedLayoutV2>
         );
@@ -947,11 +941,10 @@ import { ThemedLayoutV2 } from "@refinedev/chakra-ui";
 export default function BaseLayout() {
     // you can get this value from `localStorage` or `cookie`
     // for persistence between sessions
-    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
-        useState(true);
+    const [initialSiderCollapsed, setInitialSiderCollapsed] = useState(true);
 
     return (
-        <ThemedLayoutV2 isSiderCollapsedByDefault={isSiderCollapsedByDefault}>
+        <ThemedLayoutV2 initialSiderCollapsed={initialSiderCollapsed}>
             <Outlet />
         </ThemedLayoutV2>
     );

--- a/documentation/docs/api-reference/mantine/components/themed-layout.md
+++ b/documentation/docs/api-reference/mantine/components/themed-layout.md
@@ -217,6 +217,22 @@ type SiderRenderFunction = (props: {
 }) => React.ReactNode;
 ```
 
+### `isSiderCollapsedByDefault`
+
+This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+
+-   `true`: The [`<ThemedSiderV2>`][themed-sider] component will be collapsed by default.
+-   `false`: The [`<ThemedSiderV2>`][themed-sider] component will be expanded by default.
+
+```tsx
+<ThemedLayoutV2
+    // highlight-next-line
+    isSiderCollapsedByDefault={true}
+>
+    {/* ... */}
+</ThemedLayoutV2>
+```
+
 ### `Header`
 
 In `<ThemedLayoutV2>`, the header section is rendered using the [`<ThemedHeaderV2>`][themed-header] component by default. It uses [`useGetIdentity`](/docs/api-reference/core/hooks/auth/useGetIdentity/) hook to display the user's name and avatar on the right side of the header. However, if desired, it's possible to replace the default [`<ThemedHeaderV2>`][themed-header] component by passing a custom component to the `Header` prop.
@@ -648,6 +664,7 @@ If there is already a file with the same name in the directory, the swizzle comm
 :::
 
 ## Migrate ThemedLayout to ThemedLayoutV2
+
 Fixed some UI problems with `ThemedLayoutV2`. If you are still using `ThemedLayout` you can update it by following these steps.
 Only if you are using `ThemedLayout`. If you are not customizing the `Header` component, an update like the one below will suffice.
 
@@ -719,7 +736,9 @@ But mostly we customize the `Header` component. For this, an update like the one
     );
 };
 ```
+
 ## Hamburger Menu
+
 The `HamburgerMenu` component is a component that is used to collapse/uncollapse the `Sider` component. It is used by default in the `Header` component. However, you can do this anywhere you want using the `<HamburgerMenu />` component. Below you can see an example put on the dashboard page.
 
 ```tsx live previewHeight=600px hideCode url=http://localhost:3000/samples
@@ -729,11 +748,11 @@ setInitialRoutes(["/"]);
 import { Refine } from "@refinedev/core";
 
 import { MantineInferencer } from "@refinedev/inferencer/mantine";
-import { 
-    ThemedLayoutV2, 
+import {
+    ThemedLayoutV2,
     RefineThemes,
     // highlight-next-line
-    HamburgerMenu 
+    HamburgerMenu,
 } from "@refinedev/mantine";
 import { MantineProvider, Global, Box } from "@mantine/core";
 
@@ -808,6 +827,139 @@ const App: React.FC = () => {
 // visible-block-end
 
 render(<App />);
+```
+
+## FAQ
+
+### How can I persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component?
+
+You can use [`isSiderCollapsedByDefault`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+
+For example, you can get `isSiderCollapsedByDefault`'s value from `localStorage` or `cookie` for persistence between sessions.
+
+<Tabs
+defaultValue="react-router"
+values={[
+{label: 'React Router', value: 'react-router'},
+{label: 'Next.js', value: 'next.js'},
+{label: 'Remix', value: 'remix'},
+]}>
+
+<TabItem value="react-router">
+
+```tsx title="src/App.tsx"
+import { useState } from "react";
+import { Refine } from "@refinedev/core";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
+import { ThemedLayoutV2 } from "@refinedev/mantine";
+
+const App: React.FC = () => {
+    // you can get this value from `localStorage` or `cookie`
+    // for persistence between sessions
+    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
+        useState(true);
+
+    return (
+        <BrowserRouter>
+            <Refine
+            // ...
+            >
+                {/* ... */}
+                <Routes>
+                    <Route
+                        element={
+                            <ThemedLayoutV2
+                                isSiderCollapsedByDefault={
+                                    isSiderCollapsedByDefault
+                                }
+                            >
+                                <Outlet />
+                            </ThemedLayoutV2>
+                        }
+                    >
+                        {/* ... */}
+                    </Route>
+                </Routes>
+            </Refine>
+        </BrowserRouter>
+    );
+};
+
+export default App;
+```
+
+</TabItem>
+
+<TabItem value="next.js">
+
+```tsx title="pages/_app.tsx"
+import { useState } from "react";
+
+import { Refine } from "@refinedev/core";
+import { ThemedLayoutV2 } from "@refinedev/mantine";
+
+import type { AppProps } from "next/app";
+import type { NextPage } from "next";
+
+function MyApp({ Component, pageProps }: AppProps): JSX.Element {
+    // you can get this value from `localStorage` or `cookie`
+    // for persistence between sessions
+    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
+        useState(true);
+
+    const renderComponent = () => {
+        if (Component.noLayout) {
+            return <Component {...pageProps} />;
+        }
+
+        return (
+            <ThemedLayoutV2
+                isSiderCollapsedByDefault={isSiderCollapsedByDefault}
+            >
+                <Component {...pageProps} />
+            </ThemedLayoutV2>
+        );
+    };
+
+    return (
+        <Refine
+        // ...
+        >
+            {/* ... */}
+            {renderComponent()}
+        </Refine>
+    );
+}
+
+export default MyApp;
+```
+
+</TabItem>
+
+<TabItem value="remix">
+
+```tsx title="app/routes/_layout.tsx"
+import { useState } from "react";
+import { Outlet } from "@remix-run/react";
+import { ThemedLayoutV2 } from "@refinedev/mantine";
+
+export default function BaseLayout() {
+    // you can get this value from `localStorage` or `cookie`
+    // for persistence between sessions
+    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
+        useState(true);
+
+    return (
+        <ThemedLayoutV2 isSiderCollapsedByDefault={isSiderCollapsedByDefault}>
+            <Outlet />
+        </ThemedLayoutV2>
+    );
+}
+```
+
+</TabItem>
+
+</Tabs>
 ```
 
 [themed-sider]: https://github.com/refinedev/refine/blob/next/packages/mantine/src/components/themedLayoutV2/sider/index.tsx

--- a/documentation/docs/api-reference/mantine/components/themed-layout.md
+++ b/documentation/docs/api-reference/mantine/components/themed-layout.md
@@ -217,7 +217,7 @@ type SiderRenderFunction = (props: {
 }) => React.ReactNode;
 ```
 
-### `isSiderCollapsedByDefault`
+### `initialSiderCollapsed`
 
 This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
 
@@ -227,7 +227,7 @@ This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][
 ```tsx
 <ThemedLayoutV2
     // highlight-next-line
-    isSiderCollapsedByDefault={true}
+    initialSiderCollapsed={true}
 >
     {/* ... */}
 </ThemedLayoutV2>
@@ -833,9 +833,9 @@ render(<App />);
 
 ### How can I persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component?
 
-You can use [`isSiderCollapsedByDefault`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+You can use [`initialSiderCollapsed`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
 
-For example, you can get `isSiderCollapsedByDefault`'s value from `localStorage` or `cookie` for persistence between sessions.
+For example, you can get `initialSiderCollapsed`'s value from `localStorage` or `cookie` for persistence between sessions.
 
 <Tabs
 defaultValue="react-router"
@@ -856,8 +856,7 @@ import { ThemedLayoutV2 } from "@refinedev/mantine";
 const App: React.FC = () => {
     // you can get this value from `localStorage` or `cookie`
     // for persistence between sessions
-    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
-        useState(true);
+    const [initialSiderCollapsed, setInitialSiderCollapsed] = useState(true);
 
     return (
         <BrowserRouter>
@@ -869,9 +868,7 @@ const App: React.FC = () => {
                     <Route
                         element={
                             <ThemedLayoutV2
-                                isSiderCollapsedByDefault={
-                                    isSiderCollapsedByDefault
-                                }
+                                initialSiderCollapsed={initialSiderCollapsed}
                             >
                                 <Outlet />
                             </ThemedLayoutV2>
@@ -904,8 +901,7 @@ import type { NextPage } from "next";
 function MyApp({ Component, pageProps }: AppProps): JSX.Element {
     // you can get this value from `localStorage` or `cookie`
     // for persistence between sessions
-    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
-        useState(true);
+    const [initialSiderCollapsed, setInitialSiderCollapsed] = useState(true);
 
     const renderComponent = () => {
         if (Component.noLayout) {
@@ -913,9 +909,7 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
         }
 
         return (
-            <ThemedLayoutV2
-                isSiderCollapsedByDefault={isSiderCollapsedByDefault}
-            >
+            <ThemedLayoutV2 initialSiderCollapsed={initialSiderCollapsed}>
                 <Component {...pageProps} />
             </ThemedLayoutV2>
         );
@@ -946,11 +940,10 @@ import { ThemedLayoutV2 } from "@refinedev/mantine";
 export default function BaseLayout() {
     // you can get this value from `localStorage` or `cookie`
     // for persistence between sessions
-    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
-        useState(true);
+    const [initialSiderCollapsed, setInitialSiderCollapsed] = useState(true);
 
     return (
-        <ThemedLayoutV2 isSiderCollapsedByDefault={isSiderCollapsedByDefault}>
+        <ThemedLayoutV2 initialSiderCollapsed={initialSiderCollapsed}>
             <Outlet />
         </ThemedLayoutV2>
     );

--- a/documentation/docs/api-reference/mantine/components/themed-layout.md
+++ b/documentation/docs/api-reference/mantine/components/themed-layout.md
@@ -833,7 +833,7 @@ render(<App />);
 
 ### How can I persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component?
 
-You can use [`initialSiderCollapsed`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+You can use [`initialSiderCollapsed`](#initialsidercollapsed) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
 
 For example, you can get `initialSiderCollapsed`'s value from `localStorage` or `cookie` for persistence between sessions.
 

--- a/documentation/docs/api-reference/mui/components/themed-layout.md
+++ b/documentation/docs/api-reference/mui/components/themed-layout.md
@@ -221,7 +221,7 @@ type SiderRenderFunction = (props: {
 }) => React.ReactNode;
 ```
 
-### `isSiderCollapsedByDefault`
+### `initialSiderCollapsed`
 
 This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
 
@@ -231,7 +231,7 @@ This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][
 ```tsx
 <ThemedLayoutV2
     // highlight-next-line
-    isSiderCollapsedByDefault={true}
+    initialSiderCollapsed={true}
 >
     {/* ... */}
 </ThemedLayoutV2>
@@ -857,9 +857,9 @@ render(<App />);
 
 ### How can I persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component?
 
-You can use [`isSiderCollapsedByDefault`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+You can use [`initialSiderCollapsed`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
 
-For example, you can get `isSiderCollapsedByDefault`'s value from `localStorage` or `cookie` for persistence between sessions.
+For example, you can get `initialSiderCollapsed`'s value from `localStorage` or `cookie` for persistence between sessions.
 
 <Tabs
 defaultValue="react-router"
@@ -880,8 +880,7 @@ import { ThemedLayoutV2 } from "@refinedev/mui";
 const App: React.FC = () => {
     // you can get this value from `localStorage` or `cookie`
     // for persistence between sessions
-    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
-        useState(true);
+    const [initialSiderCollapsed, setInitialSiderCollapsed] = useState(true);
 
     return (
         <BrowserRouter>
@@ -893,9 +892,7 @@ const App: React.FC = () => {
                     <Route
                         element={
                             <ThemedLayoutV2
-                                isSiderCollapsedByDefault={
-                                    isSiderCollapsedByDefault
-                                }
+                                initialSiderCollapsed={initialSiderCollapsed}
                             >
                                 <Outlet />
                             </ThemedLayoutV2>
@@ -928,8 +925,7 @@ import type { NextPage } from "next";
 function MyApp({ Component, pageProps }: AppProps): JSX.Element {
     // you can get this value from `localStorage` or `cookie`
     // for persistence between sessions
-    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
-        useState(true);
+    const [initialSiderCollapsed, setInitialSiderCollapsed] = useState(true);
 
     const renderComponent = () => {
         if (Component.noLayout) {
@@ -937,9 +933,7 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
         }
 
         return (
-            <ThemedLayoutV2
-                isSiderCollapsedByDefault={isSiderCollapsedByDefault}
-            >
+            <ThemedLayoutV2 initialSiderCollapsed={initialSiderCollapsed}>
                 <Component {...pageProps} />
             </ThemedLayoutV2>
         );
@@ -970,11 +964,10 @@ import { ThemedLayoutV2 } from "@refinedev/mui";
 export default function BaseLayout() {
     // you can get this value from `localStorage` or `cookie`
     // for persistence between sessions
-    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
-        useState(true);
+    const [initialSiderCollapsed, setInitialSiderCollapsed] = useState(true);
 
     return (
-        <ThemedLayoutV2 isSiderCollapsedByDefault={isSiderCollapsedByDefault}>
+        <ThemedLayoutV2 initialSiderCollapsed={initialSiderCollapsed}>
             <Outlet />
         </ThemedLayoutV2>
     );

--- a/documentation/docs/api-reference/mui/components/themed-layout.md
+++ b/documentation/docs/api-reference/mui/components/themed-layout.md
@@ -857,7 +857,7 @@ render(<App />);
 
 ### How can I persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component?
 
-You can use [`initialSiderCollapsed`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+You can use [`initialSiderCollapsed`](#initialsidercollapsed) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
 
 For example, you can get `initialSiderCollapsed`'s value from `localStorage` or `cookie` for persistence between sessions.
 

--- a/documentation/docs/api-reference/mui/components/themed-layout.md
+++ b/documentation/docs/api-reference/mui/components/themed-layout.md
@@ -221,6 +221,22 @@ type SiderRenderFunction = (props: {
 }) => React.ReactNode;
 ```
 
+### `isSiderCollapsedByDefault`
+
+This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+
+-   `true`: The [`<ThemedSiderV2>`][themed-sider] component will be collapsed by default.
+-   `false`: The [`<ThemedSiderV2>`][themed-sider] component will be expanded by default.
+
+```tsx
+<ThemedLayoutV2
+    // highlight-next-line
+    isSiderCollapsedByDefault={true}
+>
+    {/* ... */}
+</ThemedLayoutV2>
+```
+
 ### `Header`
 
 In `<ThemedLayoutV2>`, the header section is rendered using the [`<ThemedHeaderV2>`][themed-header] component by default. It uses [`useGetIdentity`](/docs/api-reference/core/hooks/auth/useGetIdentity/) hook to display the user's name and avatar on the right side of the header. However, if desired, it's possible to replace the default [`<ThemedHeaderV2>`][themed-header] component by passing a custom component to the `Header` prop.
@@ -607,7 +623,7 @@ You should pass layout related components to the <ThemedLayoutV2/> component's p
     │               <ThemedLayoutV2                                                                  │
     │                    Header={ThemedHeaderV2}                                                     │
     │                    Sider={ThemedSiderV2}                                                       │
-    │                    Title={ThemedTitleV2}                                                       │ 
+    │                    Title={ThemedTitleV2}                                                       │
     │                />                                                                              │
     │                    /* ... */                                                                   │
     │               </ThemedLayoutV2>                                                                │
@@ -752,11 +768,11 @@ setInitialRoutes(["/"]);
 
 import { Refine } from "@refinedev/core";
 
-import { 
-    ThemedLayoutV2, 
-    RefineThemes, 
+import {
+    ThemedLayoutV2,
+    RefineThemes,
     // highlight-next-line
-    HamburgerMenu 
+    HamburgerMenu,
 } from "@refinedev/mui";
 import { CssBaseline, GlobalStyles, Box } from "@mui/material";
 import { ThemeProvider } from "@mui/material/styles";
@@ -835,6 +851,139 @@ const App: React.FC = () => {
 // visible-block-end
 
 render(<App />);
+```
+
+## FAQ
+
+### How can I persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component?
+
+You can use [`isSiderCollapsedByDefault`](#issidercollapsedbydefault) prop to persist the collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
+
+For example, you can get `isSiderCollapsedByDefault`'s value from `localStorage` or `cookie` for persistence between sessions.
+
+<Tabs
+defaultValue="react-router"
+values={[
+{label: 'React Router', value: 'react-router'},
+{label: 'Next.js', value: 'next.js'},
+{label: 'Remix', value: 'remix'},
+]}>
+
+<TabItem value="react-router">
+
+```tsx title="src/App.tsx"
+import { useState } from "react";
+import { Refine } from "@refinedev/core";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
+import { ThemedLayoutV2 } from "@refinedev/mui";
+
+const App: React.FC = () => {
+    // you can get this value from `localStorage` or `cookie`
+    // for persistence between sessions
+    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
+        useState(true);
+
+    return (
+        <BrowserRouter>
+            <Refine
+            // ...
+            >
+                {/* ... */}
+                <Routes>
+                    <Route
+                        element={
+                            <ThemedLayoutV2
+                                isSiderCollapsedByDefault={
+                                    isSiderCollapsedByDefault
+                                }
+                            >
+                                <Outlet />
+                            </ThemedLayoutV2>
+                        }
+                    >
+                        {/* ... */}
+                    </Route>
+                </Routes>
+            </Refine>
+        </BrowserRouter>
+    );
+};
+
+export default App;
+```
+
+</TabItem>
+
+<TabItem value="next.js">
+
+```tsx title="pages/_app.tsx"
+import { useState } from "react";
+
+import { Refine } from "@refinedev/core";
+import { ThemedLayoutV2 } from "@refinedev/mui";
+
+import type { AppProps } from "next/app";
+import type { NextPage } from "next";
+
+function MyApp({ Component, pageProps }: AppProps): JSX.Element {
+    // you can get this value from `localStorage` or `cookie`
+    // for persistence between sessions
+    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
+        useState(true);
+
+    const renderComponent = () => {
+        if (Component.noLayout) {
+            return <Component {...pageProps} />;
+        }
+
+        return (
+            <ThemedLayoutV2
+                isSiderCollapsedByDefault={isSiderCollapsedByDefault}
+            >
+                <Component {...pageProps} />
+            </ThemedLayoutV2>
+        );
+    };
+
+    return (
+        <Refine
+        // ...
+        >
+            {/* ... */}
+            {renderComponent()}
+        </Refine>
+    );
+}
+
+export default MyApp;
+```
+
+</TabItem>
+
+<TabItem value="remix">
+
+```tsx title="app/routes/_layout.tsx"
+import { useState } from "react";
+import { Outlet } from "@remix-run/react";
+import { ThemedLayoutV2 } from "@refinedev/mui";
+
+export default function BaseLayout() {
+    // you can get this value from `localStorage` or `cookie`
+    // for persistence between sessions
+    const [isSiderCollapsedByDefault, setIsSiderCollapsedByDefault] =
+        useState(true);
+
+    return (
+        <ThemedLayoutV2 isSiderCollapsedByDefault={isSiderCollapsedByDefault}>
+            <Outlet />
+        </ThemedLayoutV2>
+    );
+}
+```
+
+</TabItem>
+
+</Tabs>
 ```
 
 [themed-sider]: https://github.com/refinedev/refine/blob/next/packages/mui/src/components/themedLayoutV2/sider/index.tsx

--- a/packages/antd/src/components/themedLayoutV2/index.tsx
+++ b/packages/antd/src/components/themedLayoutV2/index.tsx
@@ -13,6 +13,7 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
     Title,
     Footer,
     OffLayoutArea,
+    isSiderCollapsedByDefault,
 }) => {
     const breakpoint = Grid.useBreakpoint();
     const SiderToRender = Sider ?? DefaultSider;
@@ -20,7 +21,9 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
     const isSmall = typeof breakpoint.sm === "undefined" ? true : breakpoint.sm;
 
     return (
-        <ThemedLayoutContextProvider>
+        <ThemedLayoutContextProvider
+            isSiderCollapsedByDefault={isSiderCollapsedByDefault}
+        >
             <AntdLayout style={{ minHeight: "100vh" }}>
                 <SiderToRender Title={Title} />
                 <AntdLayout>

--- a/packages/antd/src/components/themedLayoutV2/index.tsx
+++ b/packages/antd/src/components/themedLayoutV2/index.tsx
@@ -13,7 +13,7 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
     Title,
     Footer,
     OffLayoutArea,
-    isSiderCollapsedByDefault,
+    initialSiderCollapsed,
 }) => {
     const breakpoint = Grid.useBreakpoint();
     const SiderToRender = Sider ?? DefaultSider;
@@ -22,7 +22,7 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
 
     return (
         <ThemedLayoutContextProvider
-            isSiderCollapsedByDefault={isSiderCollapsedByDefault}
+            initialSiderCollapsed={initialSiderCollapsed}
         >
             <AntdLayout style={{ minHeight: "100vh" }}>
                 <SiderToRender Title={Title} />

--- a/packages/antd/src/components/themedLayoutV2/sider/index.tsx
+++ b/packages/antd/src/components/themedLayoutV2/sider/index.tsx
@@ -273,7 +273,11 @@ export const ThemedSiderV2: React.FC<RefineThemedLayoutV2SiderProps> = ({
             }}
             collapsible
             collapsed={drawerSiderVisible}
-            onCollapse={(collapsed) => setDrawerSiderVisible?.(collapsed)}
+            onCollapse={(collapsed, type) => {
+                if (type === "clickTrigger") {
+                    setDrawerSiderVisible?.(collapsed);
+                }
+            }}
             collapsedWidth={80}
             breakpoint="lg"
             trigger={

--- a/packages/antd/src/contexts/themedLayoutContext/index.tsx
+++ b/packages/antd/src/contexts/themedLayoutContext/index.tsx
@@ -9,11 +9,11 @@ export const ThemedLayoutContext = React.createContext<IThemedLayoutContext>({
 
 export const ThemedLayoutContextProvider: React.FC<{
     children: ReactNode;
-    isSiderCollapsedByDefault?: boolean;
-}> = ({ children, isSiderCollapsedByDefault }) => {
+    initialSiderCollapsed?: boolean;
+}> = ({ children, initialSiderCollapsed }) => {
     const [siderVisible, setSiderVisible] = useState(false);
     const [drawerSiderVisible, setDrawerSiderVisible] = useState(
-        isSiderCollapsedByDefault ?? true,
+        initialSiderCollapsed ?? true,
     );
 
     return (

--- a/packages/antd/src/contexts/themedLayoutContext/index.tsx
+++ b/packages/antd/src/contexts/themedLayoutContext/index.tsx
@@ -7,11 +7,14 @@ export const ThemedLayoutContext = React.createContext<IThemedLayoutContext>({
     drawerSiderVisible: true,
 });
 
-export const ThemedLayoutContextProvider: React.FC<{ children: ReactNode }> = ({
-    children,
-}) => {
+export const ThemedLayoutContextProvider: React.FC<{
+    children: ReactNode;
+    isSiderCollapsedByDefault?: boolean;
+}> = ({ children, isSiderCollapsedByDefault }) => {
     const [siderVisible, setSiderVisible] = useState(false);
-    const [drawerSiderVisible, setDrawerSiderVisible] = useState(true);
+    const [drawerSiderVisible, setDrawerSiderVisible] = useState(
+        isSiderCollapsedByDefault ?? true,
+    );
 
     return (
         <ThemedLayoutContext.Provider

--- a/packages/chakra-ui/src/components/themedLayoutV2/index.tsx
+++ b/packages/chakra-ui/src/components/themedLayoutV2/index.tsx
@@ -13,14 +13,14 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
     Footer,
     OffLayoutArea,
     children,
-    isSiderCollapsedByDefault,
+    initialSiderCollapsed,
 }) => {
     const SiderToRender = Sider ?? DefaultSider;
     const HeaderToRender = Header ?? DefaultHeader;
 
     return (
         <ThemedLayoutContextProvider
-            isSiderCollapsedByDefault={isSiderCollapsedByDefault}
+            initialSiderCollapsed={initialSiderCollapsed}
         >
             <Box display="flex">
                 <SiderToRender Title={Title} />

--- a/packages/chakra-ui/src/components/themedLayoutV2/index.tsx
+++ b/packages/chakra-ui/src/components/themedLayoutV2/index.tsx
@@ -13,12 +13,15 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
     Footer,
     OffLayoutArea,
     children,
+    isSiderCollapsedByDefault,
 }) => {
     const SiderToRender = Sider ?? DefaultSider;
     const HeaderToRender = Header ?? DefaultHeader;
 
     return (
-        <ThemedLayoutContextProvider>
+        <ThemedLayoutContextProvider
+            isSiderCollapsedByDefault={isSiderCollapsedByDefault}
+        >
             <Box display="flex">
                 <SiderToRender Title={Title} />
                 <Box

--- a/packages/chakra-ui/src/contexts/themedLayoutContext/index.tsx
+++ b/packages/chakra-ui/src/contexts/themedLayoutContext/index.tsx
@@ -9,13 +9,13 @@ export const ThemedLayoutContext = React.createContext<IThemedLayoutContext>({
 
 export const ThemedLayoutContextProvider: React.FC<{
     children: ReactNode;
-    isSiderCollapsedByDefault?: boolean;
-}> = ({ children, isSiderCollapsedByDefault }) => {
+    initialSiderCollapsed?: boolean;
+}> = ({ children, initialSiderCollapsed }) => {
     const [siderVisible, setSiderVisible] = useState(false);
     const [drawerSiderVisible, setDrawerSiderVisible] = useState(
-        typeof isSiderCollapsedByDefault === "undefined"
+        typeof initialSiderCollapsed === "undefined"
             ? true
-            : !isSiderCollapsedByDefault,
+            : !initialSiderCollapsed,
     );
 
     return (

--- a/packages/chakra-ui/src/contexts/themedLayoutContext/index.tsx
+++ b/packages/chakra-ui/src/contexts/themedLayoutContext/index.tsx
@@ -7,11 +7,16 @@ export const ThemedLayoutContext = React.createContext<IThemedLayoutContext>({
     drawerSiderVisible: true,
 });
 
-export const ThemedLayoutContextProvider: React.FC<{ children: ReactNode }> = ({
-    children,
-}) => {
+export const ThemedLayoutContextProvider: React.FC<{
+    children: ReactNode;
+    isSiderCollapsedByDefault?: boolean;
+}> = ({ children, isSiderCollapsedByDefault }) => {
     const [siderVisible, setSiderVisible] = useState(false);
-    const [drawerSiderVisible, setDrawerSiderVisible] = useState(true);
+    const [drawerSiderVisible, setDrawerSiderVisible] = useState(
+        typeof isSiderCollapsedByDefault === "undefined"
+            ? true
+            : !isSiderCollapsedByDefault,
+    );
 
     return (
         <ThemedLayoutContext.Provider

--- a/packages/mantine/src/components/themedLayoutV2/index.tsx
+++ b/packages/mantine/src/components/themedLayoutV2/index.tsx
@@ -12,13 +12,16 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
     Title,
     Footer,
     OffLayoutArea,
+    isSiderCollapsedByDefault,
     children,
 }) => {
     const SiderToRender = Sider ?? DefaultSider;
     const HeaderToRender = Header ?? DefaultHeader;
 
     return (
-        <ThemedLayoutContextProvider>
+        <ThemedLayoutContextProvider
+            isSiderCollapsedByDefault={isSiderCollapsedByDefault}
+        >
             <Box sx={{ display: "flex" }}>
                 <SiderToRender Title={Title} />
                 <Box

--- a/packages/mantine/src/components/themedLayoutV2/index.tsx
+++ b/packages/mantine/src/components/themedLayoutV2/index.tsx
@@ -12,7 +12,7 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
     Title,
     Footer,
     OffLayoutArea,
-    isSiderCollapsedByDefault,
+    initialSiderCollapsed,
     children,
 }) => {
     const SiderToRender = Sider ?? DefaultSider;
@@ -20,7 +20,7 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
 
     return (
         <ThemedLayoutContextProvider
-            isSiderCollapsedByDefault={isSiderCollapsedByDefault}
+            initialSiderCollapsed={initialSiderCollapsed}
         >
             <Box sx={{ display: "flex" }}>
                 <SiderToRender Title={Title} />

--- a/packages/mantine/src/contexts/themedLayoutContext/index.tsx
+++ b/packages/mantine/src/contexts/themedLayoutContext/index.tsx
@@ -7,11 +7,14 @@ export const ThemedLayoutContext = React.createContext<IThemedLayoutContext>({
     drawerSiderVisible: false,
 });
 
-export const ThemedLayoutContextProvider: React.FC<{ children: ReactNode }> = ({
-    children,
-}) => {
+export const ThemedLayoutContextProvider: React.FC<{
+    children: ReactNode;
+    isSiderCollapsedByDefault?: boolean;
+}> = ({ children, isSiderCollapsedByDefault }) => {
     const [siderVisible, setSiderVisible] = useState(false);
-    const [drawerSiderVisible, setDrawerSiderVisible] = useState(false);
+    const [drawerSiderVisible, setDrawerSiderVisible] = useState(
+        isSiderCollapsedByDefault ?? false,
+    );
 
     return (
         <ThemedLayoutContext.Provider

--- a/packages/mantine/src/contexts/themedLayoutContext/index.tsx
+++ b/packages/mantine/src/contexts/themedLayoutContext/index.tsx
@@ -9,11 +9,11 @@ export const ThemedLayoutContext = React.createContext<IThemedLayoutContext>({
 
 export const ThemedLayoutContextProvider: React.FC<{
     children: ReactNode;
-    isSiderCollapsedByDefault?: boolean;
-}> = ({ children, isSiderCollapsedByDefault }) => {
+    initialSiderCollapsed?: boolean;
+}> = ({ children, initialSiderCollapsed }) => {
     const [siderVisible, setSiderVisible] = useState(false);
     const [drawerSiderVisible, setDrawerSiderVisible] = useState(
-        isSiderCollapsedByDefault ?? false,
+        initialSiderCollapsed ?? false,
     );
 
     return (

--- a/packages/mui/src/components/themedLayoutV2/index.tsx
+++ b/packages/mui/src/components/themedLayoutV2/index.tsx
@@ -13,12 +13,15 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
     Footer,
     OffLayoutArea,
     children,
+    isSiderCollapsedByDefault,
 }) => {
     const SiderToRender = Sider ?? DefaultSider;
     const HeaderToRender = Header ?? DefaultHeader;
 
     return (
-        <ThemedLayoutContextProvider>
+        <ThemedLayoutContextProvider
+            isSiderCollapsedByDefault={isSiderCollapsedByDefault}
+        >
             <Box display="flex" flexDirection="row">
                 <SiderToRender Title={Title} />
                 <Box

--- a/packages/mui/src/components/themedLayoutV2/index.tsx
+++ b/packages/mui/src/components/themedLayoutV2/index.tsx
@@ -13,14 +13,14 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
     Footer,
     OffLayoutArea,
     children,
-    isSiderCollapsedByDefault,
+    initialSiderCollapsed,
 }) => {
     const SiderToRender = Sider ?? DefaultSider;
     const HeaderToRender = Header ?? DefaultHeader;
 
     return (
         <ThemedLayoutContextProvider
-            isSiderCollapsedByDefault={isSiderCollapsedByDefault}
+            initialSiderCollapsed={initialSiderCollapsed}
         >
             <Box display="flex" flexDirection="row">
                 <SiderToRender Title={Title} />

--- a/packages/mui/src/contexts/themedLayoutContext/index.tsx
+++ b/packages/mui/src/contexts/themedLayoutContext/index.tsx
@@ -6,11 +6,16 @@ export const ThemedLayoutContext = React.createContext<IThemedLayoutContext>(
     {},
 );
 
-export const ThemedLayoutContextProvider: React.FC<{ children: ReactNode }> = ({
-    children,
-}) => {
+export const ThemedLayoutContextProvider: React.FC<{
+    children: ReactNode;
+    isSiderCollapsedByDefault?: boolean;
+}> = ({ children, isSiderCollapsedByDefault }) => {
     const [siderVisible, setSiderVisible] = useState(false);
-    const [drawerSiderVisible, setDrawerSiderVisible] = useState(true);
+    const [drawerSiderVisible, setDrawerSiderVisible] = useState(
+        typeof isSiderCollapsedByDefault === "undefined"
+            ? true
+            : !isSiderCollapsedByDefault,
+    );
 
     return (
         <ThemedLayoutContext.Provider

--- a/packages/mui/src/contexts/themedLayoutContext/index.tsx
+++ b/packages/mui/src/contexts/themedLayoutContext/index.tsx
@@ -8,13 +8,13 @@ export const ThemedLayoutContext = React.createContext<IThemedLayoutContext>(
 
 export const ThemedLayoutContextProvider: React.FC<{
     children: ReactNode;
-    isSiderCollapsedByDefault?: boolean;
-}> = ({ children, isSiderCollapsedByDefault }) => {
+    initialSiderCollapsed?: boolean;
+}> = ({ children, initialSiderCollapsed }) => {
     const [siderVisible, setSiderVisible] = useState(false);
     const [drawerSiderVisible, setDrawerSiderVisible] = useState(
-        typeof isSiderCollapsedByDefault === "undefined"
+        typeof initialSiderCollapsed === "undefined"
             ? true
-            : !isSiderCollapsedByDefault,
+            : !initialSiderCollapsed,
     );
 
     return (

--- a/packages/ui-types/src/types/layout.tsx
+++ b/packages/ui-types/src/types/layout.tsx
@@ -66,7 +66,7 @@ export type RefineThemedLayoutV2Props = {
     /**
      * Whether the sider is collapsed or not by default.
      */
-    isSiderCollapsedByDefault?: boolean;
+    initialSiderCollapsed?: boolean;
 } & RefineLayoutLayoutProps;
 export type RefineThemedLayoutV2SiderProps = RefineLayoutSiderProps & {};
 export type RefineThemedLayoutV2HeaderProps = RefineLayoutHeaderProps & {

--- a/packages/ui-types/src/types/layout.tsx
+++ b/packages/ui-types/src/types/layout.tsx
@@ -62,7 +62,12 @@ export type RefineLayoutThemedTitleProps = RefineLayoutTitleProps & {
     wrapperStyles?: React.CSSProperties;
 };
 
-export type RefineThemedLayoutV2Props = RefineLayoutLayoutProps;
+export type RefineThemedLayoutV2Props = {
+    /**
+     * Whether the sider is collapsed or not by default.
+     */
+    isSiderCollapsedByDefault?: boolean;
+} & RefineLayoutLayoutProps;
 export type RefineThemedLayoutV2SiderProps = RefineLayoutSiderProps & {};
 export type RefineThemedLayoutV2HeaderProps = RefineLayoutHeaderProps & {
     isSticky?: boolean;


### PR DESCRIPTION
feat: `initialSiderCollapsed` added to `RefineThemedLayoutV2Props` to control initial state of `<ThemedSiderV2>`.
From now on, you can control the initial collapsed state of `<ThemedSiderV2>` by passing the `initialSiderCollapsed` prop to `<ThemedLayoutV2>`.

```tsx
<ThemedLayoutV2
    initialSiderCollapsed={true} // This will make the sider collapsed by default
>
    {/* .. */}
</ThemedLayoutV2>
```