### PR TITLE
feat(docs): update use-on-error documentation

### DIFF
--- a/documentation/docs/api-reference/core/hooks/auth/useOnError.md
+++ b/documentation/docs/api-reference/core/hooks/auth/useOnError.md
@@ -36,7 +36,7 @@ According to the `onError` method's returned values, the following process will 
 
 [Refer to Data Provider documentation for more information about data hooks. → ](/docs/api-reference/core/providers/data-provider/#supported-hooks)
 
-When an error is thrown by any data hook, the `useOnError` function is triggered with the error object. Afterward, the error object is passed to the [`onError`][on-error] method of the [`authProvider`][auth-provider]. This error object can be utilized to redirect the user to the login page or to log them out.
+When an error is thrown by any data hook, the `useOnError` function is triggered with the error object. Afterward, the error object is passed to the [`onError`][on-error] method of the [`authProvider`][auth-provider]. This error object can be utilized to redirect the user or to log them out.
 
 ```tsx
 import type { AuthBindings } from "@refinedev/core";

--- a/documentation/docs/api-reference/core/hooks/auth/useOnError.md
+++ b/documentation/docs/api-reference/core/hooks/auth/useOnError.md
@@ -12,7 +12,7 @@ This hook can only be used if the [`authProvider`][auth-provider] is provided.
 
 `useOnError` calls the [`onError`][on-error] method from the [`authProvider`][auth-provider] under the hood.
 
-It returns the result of `react-query`'s [useMutation](https://react-query.tanstack.com/reference/useMutation) which includes many properties, some of which being `isSuccess` and `isError`.
+It returns the result of `react-query`'s [useMutation](https://react-query.tanstack.com/reference/useMutation), which includes many properties like `isSuccess` and `isError`.
 
 Data that is resolved from the [`onError`][on-error] will be returned as the `data` in the query result with the following type:
 

--- a/documentation/docs/api-reference/core/hooks/auth/useOnError.md
+++ b/documentation/docs/api-reference/core/hooks/auth/useOnError.md
@@ -36,7 +36,7 @@ According to the `onError` method's returned values, the following process will 
 
 [Refer to Data Provider documentation for more information about data hooks. → ](/docs/api-reference/core/providers/data-provider/#supported-hooks)
 
-When an error is thrown by any data hook, the `useOnError` function is triggered with the error object. Afterward, the error object is passed to the [`onError`][on-error] method of the [`authProvider`][auth-provider]. This error object can be utilized to redirect the user or to log them out.
+When an error is thrown by any data hook, the `useOnError` function is triggered with the error object. Afterward, the error object is passed to the [`onError`][on-error] method of the [`authProvider`][auth-provider], which can be utilized to redirect the user or to log them out.
 
 ```tsx
 import type { AuthBindings } from "@refinedev/core";

--- a/documentation/docs/api-reference/core/hooks/auth/useOnError.md
+++ b/documentation/docs/api-reference/core/hooks/auth/useOnError.md
@@ -12,7 +12,7 @@ This hook can only be used if the [`authProvider`][auth-provider] is provided.
 
 `useOnError` calls the [`onError`][on-error] method from the [`authProvider`][auth-provider] under the hood.
 
-It returns the result of `react-query`'s [useMutation](https://react-query.tanstack.com/reference/useMutation), which includes many properties like `isSuccess` and `isError`.
+It returns the result of `react-query`'s [useMutation](https://tanstack.com/query/v4/docs/react/reference/useMutation), which includes many properties like `isSuccess` and `isError`.
 
 Data that is resolved from the [`onError`][on-error] will be returned as the `data` in the query result with the following type:
 

--- a/documentation/docs/api-reference/core/hooks/auth/useOnError.md
+++ b/documentation/docs/api-reference/core/hooks/auth/useOnError.md
@@ -7,14 +7,14 @@ source: /packages/core/src/hooks/auth/useOnError/index.ts
 ---
 
 :::caution
-This hook can only be used if the `authProvider` is provided.
+This hook can only be used if the [`authProvider`][auth-provider] is provided.
 :::
 
-`useOnError` calls the `onError` method from the [`authProvider`](/api-reference/core/providers/auth-provider.md) under the hood.
+`useOnError` calls the [`onError`][on-error] method from the [`authProvider`][auth-provider] under the hood.
 
-It returns the result of `react-query`'s [useMutation](https://react-query.tanstack.com/reference/useMutation) which includes many properties, some of which being isSuccess and isError.
+It returns the result of `react-query`'s [useMutation](https://react-query.tanstack.com/reference/useMutation) which includes many properties, some of which being `isSuccess` and `isError`.
 
-Data that is resolved from the `onError` will be returned as the `data` in the query result with the following type:
+Data that is resolved from the [`onError`][on-error] will be returned as the `data` in the query result with the following type:
 
 ```ts
 type OnErrorResponse = {
@@ -24,9 +24,48 @@ type OnErrorResponse = {
 };
 ```
 
+According to the `onError` method's returned values, the following process will be executed:
+
 -   `redirectTo`: If has a value, the app will be redirected to the given URL.
 -   `logout`: If is `true`, `useOnError` calls the `logout` method.
 -   `error`: An Error object representing any errors that may have occurred during the operation.
+
+## Internal Usage
+
+**refine** uses `useOnError` internally in the data hooks to handle errors in a unified way.
+
+[Refer to Data Provider documentation for more information about data hooks. → ](/docs/api-reference/core/providers/data-provider/#supported-hooks)
+
+When an error is thrown by any data hook, the `useOnError` function is triggered with the error object. Afterward, the error object is passed to the [`onError`][on-error] method of the [`authProvider`][auth-provider]. This error object can be utilized to redirect the user to the login page or to log them out.
+
+```tsx
+import type { AuthBindings } from "@refinedev/core";
+
+const authProvider: AuthBindings = {
+    // ---
+    logout: () => {
+        // ---
+        return {
+            success: true,
+            redirectTo: "/login",
+        };
+    },
+    // highlight-start
+    onError: (error) => {
+        const status = error.status;
+        if (status === 418) {
+            return {
+                logout: true,
+                redirectTo: "/login",
+                error: new Error(error),
+            };
+        }
+        return {};
+    },
+    // highlight-end
+    // ---
+};
+```
 
 ## Usage
 
@@ -78,3 +117,6 @@ const authProvider: AuthBindings = {
     // ---
 };
 ```
+
+[on-error]: /docs/api-reference/core/providers/auth-provider/#onerror-
+[auth-provider]: /docs/api-reference/core/providers/auth-provider/


### PR DESCRIPTION
added: An explanation of how **refine** internally uses `useOnError`.