### PR TITLE
fix(docs): with-remix-auth wrong example link

### DIFF
--- a/documentation/docs/examples/remix/oauth.md
+++ b/documentation/docs/examples/remix/oauth.md
@@ -1,9 +1,9 @@
 ---
 id: remix-auth
 title: Authentication with remix-auth
-example-tags: [remix, oauth, google, auth0, keycloak]
+example-tags: [remix, oauth, auth, google, auth0, keycloak]
 ---
 
 **refine** allows you to build your **SSR** supported web applications using [Remix](https://remix.run/). With this example, you can see how to authorize with Google, Auth0 and Keycloak using [remix-auth](https://github.com/sergiodxa/remix-auth).
 
-<CodeSandboxExample path="with-remix-oauth" />
+<CodeSandboxExample path="with-remix-auth" />


### PR DESCRIPTION
closes #4225