### PR TITLE
fix: `useModalForm` and `useDrawerForm` use `onFinish` prop

### DIFF
--- a/.changeset/loud-hats-reply.md
+++ b/.changeset/loud-hats-reply.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/antd": patch
+---
+
+fix: `onFinish` prop override on `useDrawerForm` and `useModalForm` hook 
+
+When override `onFinish` prop using the `useDrawerForm` and `useModalForm` hooks, the modal not close after submit the form.

--- a/documentation/docs/advanced-tutorials/multi-tenancy/appwrite.md
+++ b/documentation/docs/advanced-tutorials/multi-tenancy/appwrite.md
@@ -562,17 +562,7 @@ export const CreateProduct: React.FC<CreateProductProps> = ({
     // highlight-next-line
     const { params } = useParsed<{ tenant?: string }>();
     return (
-        <Modal
-            {...modalProps}
-            // highlight-start
-            okButtonProps={{
-                ...modalProps.okButtonProps,
-                onClick: () => {
-                    formProps.form?.submit();
-                },
-            }}
-            // highlight-end
-        >
+        <Modal {...modalProps}>
             <Form
                 {...formProps}
                 layout="vertical"

--- a/documentation/docs/advanced-tutorials/multi-tenancy/strapi.md
+++ b/documentation/docs/advanced-tutorials/multi-tenancy/strapi.md
@@ -688,17 +688,7 @@ export const CreateProduct: React.FC<CreateProductProps> = ({
     const { params } = useParsed<{ tenant: string }>();
 
     return (
-        <Modal
-            {...modalProps}
-            // highlight-start
-            okButtonProps={{
-                ...modalProps.okButtonProps,
-                onClick: () => {
-                    formProps.form?.submit();
-                },
-            }}
-            // highlight-end
-        >
+        <Modal {...modalProps}>
             <Form
                 {...formProps}
                 layout="vertical"

--- a/documentation/docs/api-reference/antd/hooks/form/useDrawerForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useDrawerForm.md
@@ -372,39 +372,44 @@ It renders `<Drawer>` instead of lazy rendering it.
 
 You may need to modify the form data before it is sent to the API.
 
-For example, Let's send the values we received from the user in two separate inputs, name and surname, to the API as fullName.
+For example, Let's send the values we received from the user in two separate inputs, `name` and `surname`, to the API as `fullName`.
 
-```tsx
-import { useDrawerForm, Drawer, Create, Form } from "@refinedev/antd";
+```tsx title="pages/user/create.tsx"
+import React from "react";
+import { Drawer, Create, useDrawerForm } from "@refinedev/antd";
+import { Form, Input } from "antd";
 
-const { formProps, drawerProps, saveButtonProps } = useDrawerForm<IPost>({
-    action: "create",
-});
+export const UserCreate: React.FC = () => {
+    // highlight-start
+    const { formProps, drawerProps, saveButtonProps, onFinish } = useDrawerForm({
+        action: "create",
+    });
+    // highlight-end
 
-//...
+    // highlight-start
+    const handleOnFinish = (values) => {
+        onFinish({
+            fullName: `${values.name} ${values.surname}`,
+        });
+    };
+    // highlight-end
 
-return (
-    //...
-    <Drawer {...drawerProps}>
-        <Create saveButtonProps={saveButtonProps} goBack={false}>
-            <Form 
-                {...formProps}
-                layout="vertical"
-                // highlight-start
-                onFinish={(values) => {
-                    const fullName = `${values.name} ${values.surname}`;
-                    formProps.onFinish?.({
-                        ...values,
-                        fullName,
-                    });
-                }}
-                // highlight-end
-            >
-            //...
-            </Form>
-        </Create>
-    </Drawer>
-);
+    return (
+        <Drawer {...drawerProps}>
+            <Create saveButtonProps={saveButtonProps}>
+                // highlight-next-line
+                <Form {...formProps} onFinish={handleOnFinish} layout="vertical">
+                    <Form.Item label="Name" name="name">
+                        <Input />
+                    </Form.Item>
+                    <Form.Item label="Surname" name="surname">
+                        <Input />
+                    </Form.Item>
+                </Form>
+            </Create>
+        </Drawer>
+    );
+};
 ```
 
 ## API Parameters

--- a/documentation/docs/api-reference/antd/hooks/form/useDrawerForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useDrawerForm.md
@@ -366,6 +366,47 @@ Current visible state of `<Drawer>`.
 
 It renders `<Drawer>` instead of lazy rendering it.
 
+## FAQ
+
+### How can I change the form data before submitting it to the API?
+
+You may need to modify the form data before it is sent to the API.
+
+For example, Let's send the values we received from the user in two separate inputs, name and surname, to the API as fullName.
+
+```tsx
+import { useDrawerForm, Drawer, Create, Form } from "@refinedev/antd";
+
+const { formProps, drawerProps, saveButtonProps } = useDrawerForm<IPost>({
+    action: "create",
+});
+
+//...
+
+return (
+    //...
+    <Drawer {...drawerProps}>
+        <Create saveButtonProps={saveButtonProps} goBack={false}>
+            <Form 
+                {...formProps}
+                layout="vertical"
+                // highlight-start
+                onFinish={(values) => {
+                    const fullName = `${values.name} ${values.surname}`;
+                    formProps.onFinish?.({
+                        ...values,
+                        fullName,
+                    });
+                }}
+                // highlight-end
+            >
+            //...
+            </Form>
+        </Create>
+    </Drawer>
+);
+```
+
 ## API Parameters
 
 ### Properties

--- a/documentation/docs/api-reference/antd/hooks/form/useDrawerForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useDrawerForm.md
@@ -381,14 +381,14 @@ import { Form, Input } from "antd";
 
 export const UserCreate: React.FC = () => {
     // highlight-start
-    const { formProps, drawerProps, saveButtonProps, onFinish } = useDrawerForm({
+    const { formProps, drawerProps, saveButtonProps } = useDrawerForm({
         action: "create",
     });
     // highlight-end
 
     // highlight-start
     const handleOnFinish = (values) => {
-        onFinish({
+        formProps.onFinish?.({
             fullName: `${values.name} ${values.surname}`,
         });
     };

--- a/documentation/docs/api-reference/antd/hooks/form/useModalForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useModalForm.md
@@ -694,14 +694,14 @@ import { Form, Input } from "antd";
 
 export const UserCreate: React.FC = () => {
     // highlight-start
-    const { formProps, modalProps, onFinish } = useModalForm({
+    const { formProps, modalProps } = useModalForm({
         action: "create",
     });
     // highlight-end
 
     // highlight-start
     const handleOnFinish = (values) => {
-        onFinish({
+        formProps.onFinish?.({
             fullName: `${values.name} ${values.surname}`,
         });
     };

--- a/documentation/docs/api-reference/antd/hooks/form/useModalForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useModalForm.md
@@ -679,6 +679,45 @@ return (
 );
 ```
 
+## FAQ
+
+### How can I change the form data before submitting it to the API?
+
+You may need to modify the form data before it is sent to the API.
+
+For example, Let's send the values we received from the user in two separate inputs, name and surname, to the API as fullName.
+
+```tsx
+import { useModalForm, Modal, Form } from "@refinedev/antd";
+
+const { formProps, modalProps } = useModalForm<IPost>({
+    action: "create",
+});
+
+//...
+
+return (
+    //...
+    <Modal {...modalProps}>
+        <Form 
+            {...formProps}
+            layout="vertical"
+            // highlight-start
+            onFinish={(values) => {
+                const fullName = `${values.name} ${values.surname}`;
+                formProps.onFinish?.({
+                    ...values,
+                    fullName,
+                });
+            }}
+            // highlight-end
+        >
+        //...
+        </Form>
+    </Modal>
+);
+```
+
 ## API Reference
 
 ### Properties

--- a/documentation/docs/api-reference/antd/hooks/form/useModalForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useModalForm.md
@@ -685,6 +685,48 @@ return (
 
 You may need to modify the form data before it is sent to the API.
 
+For example, Let's send the values we received from the user in two separate inputs, `name` and `surname`, to the API as `fullName`.
+
+```tsx title="pages/user/create.tsx"
+import React from "react";
+import { Modal, useModalForm } from "@refinedev/antd";
+import { Form, Input } from "antd";
+
+export const UserCreate: React.FC = () => {
+    // highlight-start
+    const { formProps, modalProps, onFinish } = useModalForm({
+        action: "create",
+    });
+    // highlight-end
+
+    // highlight-start
+    const handleOnFinish = (values) => {
+        onFinish({
+            fullName: `${values.name} ${values.surname}`,
+        });
+    };
+    // highlight-end
+
+    return (
+        <Modal {...modalProps}>
+            // highlight-next-line
+            <Form {...formProps} onFinish={handleOnFinish} layout="vertical">
+                <Form.Item label="Name" name="name">
+                    <Input />
+                </Form.Item>
+                <Form.Item label="Surname" name="surname">
+                    <Input />
+                </Form.Item>
+            </Form>
+        </Modal>
+    );
+};
+```
+
+### How can I change the form data before submitting it to the API?
+
+You may need to modify the form data before it is sent to the API.
+
 For example, Let's send the values we received from the user in two separate inputs, name and surname, to the API as fullName.
 
 ```tsx

--- a/documentation/docs/api-reference/antd/hooks/form/useModalForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useModalForm.md
@@ -723,43 +723,6 @@ export const UserCreate: React.FC = () => {
 };
 ```
 
-### How can I change the form data before submitting it to the API?
-
-You may need to modify the form data before it is sent to the API.
-
-For example, Let's send the values we received from the user in two separate inputs, name and surname, to the API as fullName.
-
-```tsx
-import { useModalForm, Modal, Form } from "@refinedev/antd";
-
-const { formProps, modalProps } = useModalForm<IPost>({
-    action: "create",
-});
-
-//...
-
-return (
-    //...
-    <Modal {...modalProps}>
-        <Form 
-            {...formProps}
-            layout="vertical"
-            // highlight-start
-            onFinish={(values) => {
-                const fullName = `${values.name} ${values.surname}`;
-                formProps.onFinish?.({
-                    ...values,
-                    fullName,
-                });
-            }}
-            // highlight-end
-        >
-        //...
-        </Form>
-    </Modal>
-);
-```
-
 ## API Reference
 
 ### Properties

--- a/documentation/docs/api-reference/antd/hooks/form/useStepsForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useStepsForm.md
@@ -1098,9 +1098,17 @@ You may need to modify the form data before it is sent to the API.
 For example, Let's send the values we received from the user in two separate inputs, `name` and `surname`, to the API as `fullName`. We can do this by overriding the `submit` function.
 
 ```tsx title="pages/user/create.tsx"
-// --
-useStepsForm({
-    submit: (formValues) => {
+import { useStepsForm } from "@refinedev/antd";
+// ...
+const {
+    current,
+    gotoStep,
+    stepsProps,
+    formProps,
+    saveButtonProps,
+    onFinish,
+} = useStepsForm<IPost>({
+    submit: (values) => {
         // highlight-start
         const data = {
             fullName: `${formValues.name} ${formValues.surname}`,
@@ -1108,10 +1116,10 @@ useStepsForm({
             city: formValues.city,
         };
         onFinish(data as any);
-        // highlight-end
+    // highlight-end
     },
 });
-// --
+// ...
 ```
 
 <br/>

--- a/documentation/docs/api-reference/mantine/hooks/form/useDrawerForm.md
+++ b/documentation/docs/api-reference/mantine/hooks/form/useDrawerForm.md
@@ -765,6 +765,64 @@ return (
 );
 ```
 
+## FAQ
+### How can I change the form data before submitting it to the API?
+
+You may need to modify the form data before it is sent to the API.
+
+For example, Let's send the values we received from the user in two separate inputs, `name` and `surname`, to the API as `fullName`.
+
+```tsx title="pages/user/create.tsx"
+import React from "react";
+import { useDrawerForm } from "@refinedev/mantine";
+import { TextInput, Drawer } from "@mantine/core";
+
+const UserCreate: React.FC = () => {
+    const {
+        getInputProps,
+        saveButtonProps,
+        modal: { show, close, title, visible },
+    } = useDrawerForm({
+        refineCoreProps: { action: "create" },
+        initialValues: {
+            name: "",
+            surname: "",
+        },
+        // highlight-start
+        transformValues: (values) => ({
+            fullName: `${values.name} ${values.surname}`,
+        }),
+        // highlight-end
+    });
+    
+    return (
+        <Drawer opened={visible} onClose={close} title={title}>
+            <TextInput
+                mt={8}
+                label="Name"
+                placeholder="Name"
+                {...getInputProps("name")}
+            />
+            <TextInput
+                mt={8}
+                label="Surname"
+                placeholder="Surname"
+                {...getInputProps("surname")}
+            />
+            <Box mt={8} sx={{ display: "flex", justifyContent: "flex-end" }}>
+                <Button
+                    {...saveButtonProps}
+                    onClick={(e) => {
+                        // -- your custom logic
+                        saveButtonProps.onClick(e);
+                    }}
+                />
+            </Box>
+        </Drawer>
+    );
+};
+```
+
 ## API Reference
 
 ### Properties

--- a/documentation/docs/api-reference/mantine/hooks/form/useModalForm.md
+++ b/documentation/docs/api-reference/mantine/hooks/form/useModalForm.md
@@ -1012,6 +1012,64 @@ return (
 );
 ```
 
+## FAQ
+### How can I change the form data before submitting it to the API?
+
+You may need to modify the form data before it is sent to the API.
+
+For example, Let's send the values we received from the user in two separate inputs, `name` and `surname`, to the API as `fullName`.
+
+```tsx title="pages/user/create.tsx"
+import React from "react";
+import { useModalForm } from "@refinedev/mantine";
+import { TextInput, Modal } from "@mantine/core";
+
+const UserCreate: React.FC = () => {
+    const {
+        getInputProps,
+        saveButtonProps,
+        modal: { show, close, title, visible },
+    } = useModalForm({
+        refineCoreProps: { action: "create" },
+        initialValues: {
+            name: "",
+            surname: "",
+        },
+        // highlight-start
+        transformValues: (values) => ({
+            fullName: `${values.name} ${values.surname}`,
+        }),
+        // highlight-end
+    });
+    
+    return (
+        <Modal opened={visible} onClose={close} title={title}>
+            <TextInput
+                mt={8}
+                label="Name"
+                placeholder="Name"
+                {...getInputProps("name")}
+            />
+            <TextInput
+                mt={8}
+                label="Surname"
+                placeholder="Surname"
+                {...getInputProps("surname")}
+            />
+            <Box mt={8} sx={{ display: "flex", justifyContent: "flex-end" }}>
+                <Button
+                    {...saveButtonProps}
+                    onClick={(e) => {
+                        // -- your custom logic
+                        saveButtonProps.onClick(e);
+                    }}
+                />
+            </Box>
+        </Drawer>
+    );
+};
+```
+
 ## API Reference
 
 ### Properties

--- a/documentation/docs/api-reference/mantine/hooks/form/useStepsForm.md
+++ b/documentation/docs/api-reference/mantine/hooks/form/useStepsForm.md
@@ -1047,6 +1047,40 @@ Current step, counting from `0`.
 Is a function that allows you to programmatically change the current step of a form.
 It takes in one argument, step, which is a number representing the index of the step you want to navigate to.
 
+## FAQ
+### How can I change the form data before submitting it to the API?
+
+You may need to modify the form data before it is sent to the API.
+
+For example, Let's send the values we received from the user in two separate inputs, `name` and `surname`, to the API as `fullName`.
+
+```tsx title="pages/user/create.tsx"
+import React from "react";
+import { useStepsForm } from "@refinedev/mantine";
+
+const UserCreate: React.FC = () => {
+    const {
+        saveButtonProps,
+        getInputProps,
+        values,
+        steps: { currentStep, gotoStep },
+    } = useStepsForm({
+        refineCoreProps: { action: "create" },
+        initialValues: {
+            name: "",
+            surname: "",
+        },
+        // highlight-start
+        transformValues: (values) => ({
+            fullName: `${values.name} ${values.surname}`,
+        }),
+        // highlight-end
+    });
+    
+    // ...
+};
+```
+
 ## API Reference
 
 ### Properties

--- a/examples/blog-invoice-generator/src/components/company/create.tsx
+++ b/examples/blog-invoice-generator/src/components/company/create.tsx
@@ -14,16 +14,7 @@ export const CreateCompany: React.FC<CreateCompanyProps> = ({
     formProps,
 }) => {
     return (
-        <Modal
-            {...modalProps}
-            title="Create Company"
-            okButtonProps={{
-                ...modalProps.okButtonProps,
-                onClick: () => {
-                    formProps.form?.submit();
-                },
-            }}
-        >
+        <Modal {...modalProps} title="Create Company">
             <Form
                 {...formProps}
                 layout="vertical"

--- a/examples/blog-invoice-generator/src/components/company/edit.tsx
+++ b/examples/blog-invoice-generator/src/components/company/edit.tsx
@@ -13,15 +13,7 @@ export const EditCompany: React.FC<EditCompanyProps> = ({
     formProps,
 }) => {
     return (
-        <Modal
-            {...modalProps}
-            okButtonProps={{
-                ...modalProps.okButtonProps,
-                onClick: () => {
-                    formProps.form?.submit();
-                },
-            }}
-        >
+        <Modal {...modalProps}>
             <Form
                 {...formProps}
                 wrapperCol={{ span: 12 }}

--- a/examples/multi-tenancy-appwrite/src/components/product/create.tsx
+++ b/examples/multi-tenancy-appwrite/src/components/product/create.tsx
@@ -16,15 +16,7 @@ export const CreateProduct: React.FC<CreateProductProps> = ({
 }) => {
     const { params } = useParsed<{ tenant?: string }>();
     return (
-        <Modal
-            {...modalProps}
-            okButtonProps={{
-                ...modalProps.okButtonProps,
-                onClick: () => {
-                    formProps.form?.submit();
-                },
-            }}
-        >
+        <Modal {...modalProps}>
             <Form
                 {...formProps}
                 layout="vertical"

--- a/examples/multi-tenancy-appwrite/src/components/product/edit.tsx
+++ b/examples/multi-tenancy-appwrite/src/components/product/edit.tsx
@@ -15,15 +15,7 @@ export const EditProduct: React.FC<EditProductProps> = ({
 }) => {
     const { params } = useParsed<{ tenant?: string }>();
     return (
-        <Modal
-            {...modalProps}
-            okButtonProps={{
-                ...modalProps.okButtonProps,
-                onClick: () => {
-                    formProps.form?.submit();
-                },
-            }}
-        >
+        <Modal {...modalProps}>
             <Form
                 {...formProps}
                 wrapperCol={{ span: 12 }}

--- a/examples/multi-tenancy-strapi/src/components/product/create.tsx
+++ b/examples/multi-tenancy-strapi/src/components/product/create.tsx
@@ -16,15 +16,7 @@ export const CreateProduct: React.FC<CreateProductProps> = ({
     const { params } = useParsed<{ tenant: string }>();
 
     return (
-        <Modal
-            {...modalProps}
-            okButtonProps={{
-                ...modalProps.okButtonProps,
-                onClick: () => {
-                    formProps.form?.submit();
-                },
-            }}
-        >
+        <Modal {...modalProps}>
             <Form
                 {...formProps}
                 layout="vertical"

--- a/examples/multi-tenancy-strapi/src/components/product/edit.tsx
+++ b/examples/multi-tenancy-strapi/src/components/product/edit.tsx
@@ -13,15 +13,7 @@ export const EditProduct: React.FC<EditProductProps> = ({
     formProps,
 }) => {
     return (
-        <Modal
-            {...modalProps}
-            okButtonProps={{
-                ...modalProps.okButtonProps,
-                onClick: () => {
-                    formProps.form?.submit();
-                },
-            }}
-        >
+        <Modal {...modalProps}>
             <Form
                 {...formProps}
                 wrapperCol={{ span: 12 }}

--- a/examples/refine-week-invoice-generator/src/components/company/create.tsx
+++ b/examples/refine-week-invoice-generator/src/components/company/create.tsx
@@ -20,12 +20,6 @@ export const CreateCompany: React.FC<CreateCompanyProps> = ({
     return (
         <Modal
             {...modalProps}
-            okButtonProps={{
-                ...modalProps.okButtonProps,
-                onClick: () => {
-                    formProps.form?.submit();
-                },
-            }}
             title="Create Company"
             width={breakpoint.sm ? "600px" : "80%"}
         >

--- a/examples/refine-week-invoice-generator/src/components/company/edit.tsx
+++ b/examples/refine-week-invoice-generator/src/components/company/edit.tsx
@@ -17,12 +17,6 @@ export const EditCompany: React.FC<EditCompanyProps> = ({
     return (
         <Modal
             {...modalProps}
-            okButtonProps={{
-                ...modalProps.okButtonProps,
-                onClick: () => {
-                    formProps.form?.submit();
-                },
-            }}
             title="Edit Company"
             width={breakpoint.sm ? "600px" : "80%"}
         >

--- a/packages/antd/src/hooks/form/useDrawerForm/index.spec.tsx
+++ b/packages/antd/src/hooks/form/useDrawerForm/index.spec.tsx
@@ -132,7 +132,7 @@ describe("useDrawerForm Hook", () => {
 
         await act(async () => {
             result.current.show();
-            result.current.saveButtonProps.onClick?.({} as any);
+            result.current.formProps.onFinish?.({});
         });
 
         expect(result.current.drawerProps.open).toBe(false);
@@ -218,7 +218,7 @@ describe("useDrawerForm Hook", () => {
 
         await act(async () => {
             result.current.show();
-            result.current.saveButtonProps.onClick?.({} as any);
+            result.current.formProps.onFinish?.({});
             jest.runAllTimers();
         });
 
@@ -231,4 +231,40 @@ describe("useDrawerForm Hook", () => {
         expect(updateMock).toBeCalledTimes(1);
         expect(result.current.drawerProps.open).toBe(false);
     });
+
+    it.each(["optimistic", "undoable"] as const)(
+        "when mutationMode is '%s', the form should be closed when the mutation is successful",
+        async (mutationMode) => {
+            jest.useFakeTimers();
+            const updateMock = jest.fn(
+                () => new Promise((resolve) => setTimeout(resolve, 1000)),
+            );
+
+            const { result } = renderHook(
+                () =>
+                    useDrawerForm({
+                        action: "edit",
+                        resource: "posts",
+                        id: 1,
+                        mutationMode,
+                    }),
+                {
+                    wrapper: TestWrapper({
+                        dataProvider: {
+                            ...MockJSONServer,
+                            update: updateMock,
+                        },
+                    }),
+                },
+            );
+
+            await act(async () => {
+                result.current.show();
+                result.current.formProps.onFinish?.({});
+                jest.runAllTimers();
+            });
+
+            expect(result.current.drawerProps.open).toBe(false);
+        },
+    );
 });

--- a/packages/antd/src/hooks/form/useDrawerForm/useDrawerForm.ts
+++ b/packages/antd/src/hooks/form/useDrawerForm/useDrawerForm.ts
@@ -208,21 +208,11 @@ export const useDrawerForm = <
 
     const { warnWhen, setWarnWhen } = useWarnAboutChange();
 
-    const submit = async () => {
-        await onFinish(form.getFieldsValue());
-
-        if (autoSubmitClose) {
-            close();
-        }
-
-        if (autoResetForm) {
-            form.resetFields();
-        }
-    };
-
     const saveButtonProps = {
         disabled: formLoading,
-        onClick: submit,
+        onClick: () => {
+            form.submit();
+        },
         loading: formLoading,
     };
 
@@ -278,7 +268,17 @@ export const useDrawerForm = <
             ...useFormProps.formProps,
             onValuesChange: formProps?.onValuesChange,
             onKeyUp: formProps?.onKeyUp,
-            onFinish: formProps.onFinish,
+            onFinish: async (values) => {
+                await onFinish(values);
+
+                if (autoSubmitClose) {
+                    close();
+                }
+
+                if (autoResetForm) {
+                    form.resetFields();
+                }
+            },
         },
         drawerProps: {
             width: "500px",

--- a/packages/antd/src/hooks/form/useModalForm/index.spec.tsx
+++ b/packages/antd/src/hooks/form/useModalForm/index.spec.tsx
@@ -131,7 +131,7 @@ describe("useModalForm Hook", () => {
         });
 
         await act(async () => {
-            result.current.modalProps.onOk?.({} as any);
+            result.current.formProps.onFinish?.({});
         });
 
         await waitFor(() => result.current.mutationResult.isSuccess);
@@ -157,7 +157,7 @@ describe("useModalForm Hook", () => {
 
         await act(async () => {
             result.current.show();
-            result.current.modalProps.onOk?.({} as any);
+            result.current.formProps.onFinish?.({});
         });
 
         expect(result.current.modalProps.open).toBe(true);
@@ -218,7 +218,7 @@ describe("useModalForm Hook", () => {
 
         await act(async () => {
             result.current.show();
-            result.current.modalProps.onOk?.({} as any);
+            result.current.formProps.onFinish?.({});
             jest.runAllTimers();
         });
 
@@ -229,4 +229,40 @@ describe("useModalForm Hook", () => {
         expect(updateMock).toBeCalledTimes(1);
         expect(result.current.modalProps.open).toBe(false);
     });
+
+    it.each(["optimistic", "undoable"] as const)(
+        "when mutationMode is '%s', the form should be closed when the mutation is successful",
+        async (mutationMode) => {
+            jest.useFakeTimers();
+            const updateMock = jest.fn(
+                () => new Promise((resolve) => setTimeout(resolve, 1000)),
+            );
+
+            const { result } = renderHook(
+                () =>
+                    useModalForm({
+                        action: "edit",
+                        resource: "posts",
+                        id: 1,
+                        mutationMode,
+                    }),
+                {
+                    wrapper: TestWrapper({
+                        dataProvider: {
+                            ...MockJSONServer,
+                            update: updateMock,
+                        },
+                    }),
+                },
+            );
+
+            await act(async () => {
+                result.current.show();
+                result.current.formProps.onFinish?.({});
+                jest.runAllTimers();
+            });
+
+            expect(result.current.modalProps.open).toBe(false);
+        },
+    );
 });

--- a/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
+++ b/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
@@ -85,6 +85,7 @@ export type UseModalFormProps<
     useModalFormConfig &
     LiveModeProps &
     FormWithSyncWithLocationParams & {
+        defaultVisible?: boolean;
         autoSubmitClose?: boolean;
         autoResetForm?: boolean;
     };
@@ -108,6 +109,7 @@ export const useModalForm = <
     TResponseError extends HttpError = TError,
 >({
     syncWithLocation,
+    defaultVisible = false,
     autoSubmitClose = true,
     autoResetForm = true,
     ...rest
@@ -162,7 +164,11 @@ export const useModalForm = <
 
     const { warnWhen, setWarnWhen } = useWarnAboutChange();
 
-    const { show, close, modalProps } = useModal();
+    const { show, close, modalProps } = useModal({
+        modalProps: {
+            open: defaultVisible,
+        },
+    });
 
     const visible = modalProps.open || false;
     const sunflowerUseModal: useModalFormFromSFReturnType<

--- a/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
+++ b/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
@@ -163,25 +163,26 @@ export const useModalForm = <
     const { warnWhen, setWarnWhen } = useWarnAboutChange();
 
     const { show, close, modalProps } = useModal();
+
+    const visible = modalProps.open || false;
     const sunflowerUseModal: useModalFormFromSFReturnType<
         TResponse,
         TVariables
     > = {
-        close,
-        defaultFormValuesLoading: false,
+        modalProps,
         form,
         formLoading,
         formProps,
         formResult: undefined,
         formValues: form.getFieldsValue,
+        defaultFormValuesLoading: false,
         initialValues: {},
-        modalProps,
-        open: modalProps.open || false,
-        visible: modalProps.visible || false,
-        show,
         submit: onFinish as any,
+        close,
+        open: modalProps.open || false,
+        show,
+        visible,
     };
-    const visible = modalProps.open || false;
 
     React.useEffect(() => {
         if (initiallySynced.current === false && syncWithLocationKey) {

--- a/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
+++ b/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
@@ -82,7 +82,6 @@ export type UseModalFormProps<
         TResponse,
         TResponseError
     > &
-    // UseModalFormConfigSF &
     useModalFormConfig &
     LiveModeProps &
     FormWithSyncWithLocationParams & {


### PR DESCRIPTION
Form submit problem when `onFinish` is overridden in `useModalForm` and `useDrawerForm`