### PR TITLE
fix: rename the header prop of `isSticky` to `sticky`

### DIFF
--- a/.changeset/proud-rivers-rule.md
+++ b/.changeset/proud-rivers-rule.md
@@ -1,0 +1,31 @@
+---
+"@refinedev/antd": patch
+"@refinedev/chakra-ui": patch
+"@refinedev/mantine": patch
+"@refinedev/mui": patch
+---
+
+fix: renamed the `<ThemedHeaderV2/>` prop `isSticky` to `sticky`
+
+To provide backwards compatibility, the old prop name is still supported, but it is deprecated and will be removed in the next major version.
+
+Example:
+
+```tsx
+import { Refine } from "@refinedev/core";
+import { ThemedLayoutV2, ThemedHeaderV2 } from "@refinedev/antd"; // or @refinedev/chakra-ui, @refinedev/mui, @refinedev/mantine
+
+const App: React.FC = () => {
+    return (
+        <Refine
+            ...
+        >
+            <ThemedLayoutV2
+                Header={() => <ThemedHeaderV2 sticky />}
+            >
+                {/* ... */}
+            </ThemedLayoutV2>
+        </Refine>
+    );
+};
+```

--- a/documentation/docs/api-reference/antd/components/themed-layout.md
+++ b/documentation/docs/api-reference/antd/components/themed-layout.md
@@ -257,14 +257,14 @@ const App: React.FC = () => {
 };
 ```
 
-You can also make it sticky using the `isSticky` property, which is optional and defaults to `false`. An example of its usage is shown below.
+You can also make it sticky using the `sticky` property, which is optional and defaults to `false`. An example of its usage is shown below:
 
 ```tsx
 import { Refine } from "@refinedev/core";
-import { 
+import {
     ThemedLayoutV2,
     // highlight-next-line
-    ThemedHeaderV2
+    ThemedHeaderV2,
 } from "@refinedev/antd";
 
 const App: React.FC = () => {
@@ -274,9 +274,7 @@ const App: React.FC = () => {
         >
             <ThemedLayoutV2
                 // highlight-start
-                Header={() => (
-                    <ThemedHeaderV2 isSticky={true} />
-                )}
+                Header={() => <ThemedHeaderV2 sticky />}
                 // highlight-end
             >
                 {/* ... */}

--- a/documentation/docs/api-reference/chakra-ui/components/themed-layout.md
+++ b/documentation/docs/api-reference/chakra-ui/components/themed-layout.md
@@ -258,14 +258,14 @@ const App: React.FC = () => {
 };
 ```
 
-You can also make it sticky using the `isSticky` property, which is optional and defaults to `false`. An example of its usage is shown below.
+You can also make it sticky using the `sticky` property, which is optional and defaults to `false`. An example of its usage is shown below:
 
 ```tsx
 import { Refine } from "@refinedev/core";
-import { 
+import {
     ThemedLayoutV2,
     // highlight-next-line
-    ThemedHeaderV2
+    ThemedHeaderV2,
 } from "@refinedev/chakra-ui";
 
 const App: React.FC = () => {
@@ -275,9 +275,7 @@ const App: React.FC = () => {
         >
             <ThemedLayoutV2
                 // highlight-start
-                Header={() => (
-                    <ThemedHeaderV2 isSticky={true} />
-                )}
+                Header={() => <ThemedHeaderV2 sticky />}
                 // highlight-end
             >
                 {/* ... */}
@@ -286,7 +284,6 @@ const App: React.FC = () => {
     );
 };
 ```
-
 
 ### `Title`
 

--- a/documentation/docs/api-reference/mantine/components/themed-layout.md
+++ b/documentation/docs/api-reference/mantine/components/themed-layout.md
@@ -262,14 +262,14 @@ const App: React.FC = () => {
 };
 ```
 
-You can also make it sticky using the `isSticky` property, which is optional and defaults to `false`. An example of its usage is shown below.
+You can also make it sticky using the `sticky` property, which is optional and defaults to `false`. An example of its usage is shown below.
 
 ```tsx
 import { Refine } from "@refinedev/core";
-import { 
+import {
     ThemedLayoutV2,
     // highlight-next-line
-    ThemedHeaderV2
+    ThemedHeaderV2,
 } from "@refinedev/mantine";
 
 const App: React.FC = () => {
@@ -279,9 +279,7 @@ const App: React.FC = () => {
         >
             <ThemedLayoutV2
                 // highlight-start
-                Header={() => (
-                    <ThemedHeaderV2 isSticky={true} />
-                )}
+                Header={() => <ThemedHeaderV2 sticky />}
                 // highlight-end
             >
                 {/* ... */}
@@ -290,7 +288,6 @@ const App: React.FC = () => {
     );
 };
 ```
-
 
 ### `Title`
 

--- a/documentation/docs/api-reference/mui/components/themed-layout.md
+++ b/documentation/docs/api-reference/mui/components/themed-layout.md
@@ -266,15 +266,15 @@ const App: React.FC = () => {
 };
 ```
 
-You can also make it sticky using the `isSticky` property, which is optional and defaults to `true`. An example of its usage is shown below.
+You can also change the default sticky behavior of the [`<ThemedHeaderV2>`][themed-header] component using the `sticky` prop, which is optional and defaults to `true`. An example of its usage is shown below:
 
 ```tsx
 import { Refine } from "@refinedev/core";
-import { 
+import {
     ThemedLayoutV2,
     // highlight-next-line
-    ThemedHeaderV2
-} from "@refinedev/antd";
+    ThemedHeaderV2,
+} from "@refinedev/mui";
 
 const App: React.FC = () => {
     return (
@@ -283,9 +283,7 @@ const App: React.FC = () => {
         >
             <ThemedLayoutV2
                 // highlight-start
-                Header={() => (
-                    <ThemedHeaderV2 isSticky={false} />
-                )}
+                Header={() => <ThemedHeaderV2 sticky={false} />}
                 // highlight-end
             >
                 {/* ... */}
@@ -294,7 +292,6 @@ const App: React.FC = () => {
     );
 };
 ```
-
 
 ### `Title`
 

--- a/packages/antd/src/components/themedLayoutV2/header/index.tsx
+++ b/packages/antd/src/components/themedLayoutV2/header/index.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { Layout as AntdLayout, Typography, Avatar, Space, theme } from "antd";
-import { useActiveAuthProvider, useGetIdentity } from "@refinedev/core";
+import {
+    pickNotDeprecated,
+    useActiveAuthProvider,
+    useGetIdentity,
+} from "@refinedev/core";
 import { RefineThemedLayoutV2HeaderProps } from "../types";
 
 const { Text } = Typography;
@@ -8,6 +12,7 @@ const { useToken } = theme;
 
 export const ThemedHeaderV2: React.FC<RefineThemedLayoutV2HeaderProps> = ({
     isSticky,
+    sticky,
 }) => {
     const { token } = useToken();
 
@@ -31,7 +36,7 @@ export const ThemedHeaderV2: React.FC<RefineThemedLayoutV2HeaderProps> = ({
         height: "64px",
     };
 
-    if (isSticky) {
+    if (pickNotDeprecated(sticky, isSticky)) {
         headerStyles.position = "sticky";
         headerStyles.top = 0;
         headerStyles.zIndex = 1;

--- a/packages/chakra-ui/src/components/themedLayoutV2/header/index.tsx
+++ b/packages/chakra-ui/src/components/themedLayoutV2/header/index.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { useGetIdentity, useActiveAuthProvider } from "@refinedev/core";
+import {
+    useGetIdentity,
+    useActiveAuthProvider,
+    pickNotDeprecated,
+} from "@refinedev/core";
 import {
     Box,
     Avatar,
@@ -13,6 +17,7 @@ import { HamburgerMenu } from "../hamburgerMenu";
 
 export const ThemedHeaderV2: React.FC<RefineThemedLayoutV2HeaderProps> = ({
     isSticky,
+    sticky,
 }) => {
     const authProvider = useActiveAuthProvider();
     const { data: user } = useGetIdentity({
@@ -25,7 +30,7 @@ export const ThemedHeaderV2: React.FC<RefineThemedLayoutV2HeaderProps> = ({
     );
 
     let stickyProps: BoxProps = {};
-    if (isSticky) {
+    if (pickNotDeprecated(sticky, isSticky)) {
         stickyProps = {
             position: "sticky",
             top: 0,

--- a/packages/mantine/src/components/themedLayoutV2/header/index.tsx
+++ b/packages/mantine/src/components/themedLayoutV2/header/index.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { useGetIdentity, useActiveAuthProvider } from "@refinedev/core";
+import {
+    useGetIdentity,
+    useActiveAuthProvider,
+    pickNotDeprecated,
+} from "@refinedev/core";
 import {
     Avatar,
     Flex,
@@ -14,6 +18,7 @@ import { HamburgerMenu } from "../hamburgerMenu";
 
 export const ThemedHeaderV2: React.FC<RefineThemedLayoutV2HeaderProps> = ({
     isSticky,
+    sticky,
 }) => {
     const theme = useMantineTheme();
 
@@ -28,7 +33,7 @@ export const ThemedHeaderV2: React.FC<RefineThemedLayoutV2HeaderProps> = ({
             : theme.colors.gray[2];
 
     let stickyStyles: Sx = {};
-    if (isSticky) {
+    if (pickNotDeprecated(sticky, isSticky)) {
         stickyStyles = {
             position: `sticky`,
             top: 0,

--- a/packages/mui/src/components/themedLayoutV2/header/index.tsx
+++ b/packages/mui/src/components/themedLayoutV2/header/index.tsx
@@ -1,20 +1,27 @@
 import React from "react";
-import { useGetIdentity, useActiveAuthProvider } from "@refinedev/core";
+import {
+    useGetIdentity,
+    useActiveAuthProvider,
+    pickNotDeprecated,
+} from "@refinedev/core";
 import { AppBar, Stack, Toolbar, Typography, Avatar } from "@mui/material";
 
 import { RefineThemedLayoutV2HeaderProps } from "../types";
 import { HamburgerMenu } from "../hamburgerMenu";
 
 export const ThemedHeaderV2: React.FC<RefineThemedLayoutV2HeaderProps> = ({
-    isSticky = true,
+    isSticky,
+    sticky,
 }) => {
     const authProvider = useActiveAuthProvider();
     const { data: user } = useGetIdentity({
         v3LegacyAuthProviderCompatible: Boolean(authProvider?.isLegacy),
     });
 
+    const prefferedSticky = pickNotDeprecated(sticky, isSticky) ?? true;
+
     return (
-        <AppBar position={isSticky ? "sticky" : "relative"}>
+        <AppBar position={prefferedSticky ? "sticky" : "relative"}>
             <Toolbar>
                 <HamburgerMenu />
                 <Stack

--- a/packages/ui-types/src/types/layout.tsx
+++ b/packages/ui-types/src/types/layout.tsx
@@ -70,5 +70,10 @@ export type RefineThemedLayoutV2Props = {
 } & RefineLayoutLayoutProps;
 export type RefineThemedLayoutV2SiderProps = RefineLayoutSiderProps & {};
 export type RefineThemedLayoutV2HeaderProps = RefineLayoutHeaderProps & {
+    /**
+     * Whether the header is sticky or not.
+     * @deprecated `isSticky` is deprecated. Please use `sticky` instead.
+     */
     isSticky?: boolean;
+    sticky?: boolean;
 };


### PR DESCRIPTION
Rename the header prop of `isSticky` to `sticky`. To provide backward compatibility `isSticky` has been deprecated.