### PR TITLE
feat(antd): add autoSubmitClose prop to useEditableTable

### DIFF
--- a/.changeset/nasty-starfishes-fix.md
+++ b/.changeset/nasty-starfishes-fix.md
@@ -1,0 +1,12 @@
+---
+"@refinedev/antd": minor
+---
+
+feat: added `autoSubmitClose` prop to `useEditableTable`.
+Now you can choose whether to close the table's row after submitting the form or not.
+
+```tsx
+const editableTable = useEditableTable({
+    autoSubmitClose: false,
+});
+```

--- a/documentation/docs/api-reference/antd/hooks/table/useEditableTable.md
+++ b/documentation/docs/api-reference/antd/hooks/table/useEditableTable.md
@@ -301,6 +301,19 @@ export const PostList: React.FC = () => {
 
 All `useForm` and [`useTable`][usetable] properties are available in `useEditableTable`. You can read the documentation of [`useForm`][useform] and [`useTable`][usetable] for more information.
 
+### `autoSubmitClose`
+
+> Default: `true`
+
+When `true`, table's row will be closed after successful submit.
+To do that, `useEditableTable` automatically calls `setId` function with `undefined` after successful submit.
+
+```tsx
+const editableTable = useEditableTable({
+    autoSubmitClose: false,
+});
+```
+
 :::
 
 ## Return Values

--- a/examples/table-antd-use-editable-table/src/pages/posts/list.tsx
+++ b/examples/table-antd-use-editable-table/src/pages/posts/list.tsx
@@ -21,7 +21,9 @@ export const PostList: React.FC<IResourceComponentsProps> = () => {
         saveButtonProps,
         cancelButtonProps,
         editButtonProps,
-    } = useEditableTable<IPost>();
+    } = useEditableTable<IPost>({
+        autoSubmitClose: false,
+    });
 
     return (
         <List>

--- a/examples/table-antd-use-editable-table/src/pages/posts/list.tsx
+++ b/examples/table-antd-use-editable-table/src/pages/posts/list.tsx
@@ -21,9 +21,7 @@ export const PostList: React.FC<IResourceComponentsProps> = () => {
         saveButtonProps,
         cancelButtonProps,
         editButtonProps,
-    } = useEditableTable<IPost>({
-        autoSubmitClose: false,
-    });
+    } = useEditableTable<IPost>();
 
     return (
         <List>

--- a/packages/antd/src/hooks/table/useEditableTable/useEditableTable.spec.tsx
+++ b/packages/antd/src/hooks/table/useEditableTable/useEditableTable.spec.tsx
@@ -51,4 +51,97 @@ describe("useEditableTable Hook", () => {
             examplePost.title,
         );
     });
+
+    it.each(["success", "fail"] as const)(
+        `should set ot not set ID to undefined after submit is %p`,
+        async (scenario) => {
+            const { result } = renderHook(() => useEditableTable(), {
+                wrapper: TestWrapper({
+                    routerProvider,
+                }),
+            });
+            if (scenario === "fail") {
+                jest.spyOn(
+                    result.current.formProps,
+                    "onFinish",
+                ).mockImplementation(() => new Error("Error"));
+            }
+
+            await waitFor(() => {
+                expect(!result.current.tableProps.loading).toBeTruthy();
+            });
+
+            const examplePost = posts[0];
+
+            act(() => {
+                result.current.editButtonProps(examplePost.id).onClick();
+            });
+
+            await waitFor(() => {
+                expect(!result.current.formLoading).toBeTruthy();
+            });
+
+            await waitFor(() => {
+                expect(result.current.id).toBe(examplePost.id);
+            });
+
+            act(() => {
+                result.current.formProps?.onFinish?.(examplePost);
+            });
+
+            await waitFor(() => {
+                expect(!result.current.formLoading).toBeTruthy();
+            });
+
+            await waitFor(() => {
+                expect(result.current.id).toBe(
+                    scenario === "success" ? undefined : examplePost.id,
+                );
+            });
+        },
+    );
+
+    it("should not set id to `undefined` when `autoSubmitClose` is false", async () => {
+        const { result } = renderHook(
+            () =>
+                useEditableTable({
+                    autoSubmitClose: false,
+                }),
+            {
+                wrapper: TestWrapper({
+                    routerProvider,
+                }),
+            },
+        );
+
+        await waitFor(() => {
+            expect(!result.current.tableProps.loading).toBeTruthy();
+        });
+
+        const examplePost = posts[0];
+
+        act(() => {
+            result.current.editButtonProps(examplePost.id).onClick();
+        });
+
+        await waitFor(() => {
+            expect(!result.current.formLoading).toBeTruthy();
+        });
+
+        await waitFor(() => {
+            expect(result.current.id).toBe(examplePost.id);
+        });
+
+        act(() => {
+            result.current.formProps?.onFinish?.(examplePost);
+        });
+
+        await waitFor(() => {
+            expect(!result.current.formLoading).toBeTruthy();
+        });
+
+        await waitFor(() => {
+            expect(result.current.id).toBe(examplePost.id);
+        });
+    });
 });

--- a/packages/antd/src/hooks/table/useEditableTable/useEditableTable.ts
+++ b/packages/antd/src/hooks/table/useEditableTable/useEditableTable.ts
@@ -35,7 +35,12 @@ type useEditableTableProps<
     useTableProps<TQueryFnData, TError, TSearchVariables, TData>,
     "successNotification" | "errorNotification"
 > &
-    UseFormProps<TQueryFnData, TError, TVariables>;
+    UseFormProps<TQueryFnData, TError, TVariables> & {
+        /**
+         * When true, row will be closed after successful submit.
+         */
+        autoSubmitClose?: boolean;
+    };
 
 /**
  * `useEditeableTable` allows you to implement edit feature on the table with ease,
@@ -58,15 +63,16 @@ export const useEditableTable = <
     TVariables = {},
     TSearchVariables = unknown,
     TData extends BaseRecord = TQueryFnData,
->(
-    props: useEditableTableProps<
-        TQueryFnData,
-        TError,
-        TVariables,
-        TSearchVariables,
-        TData
-    > = {},
-): useEditableTableReturnType<
+>({
+    autoSubmitClose = true,
+    ...props
+}: useEditableTableProps<
+    TQueryFnData,
+    TError,
+    TVariables,
+    TSearchVariables,
+    TData
+> = {}): useEditableTableReturnType<
     TQueryFnData,
     TError,
     TVariables,
@@ -103,6 +109,16 @@ export const useEditableTable = <
     return {
         ...table,
         ...edit,
+        formProps: {
+            ...edit.formProps,
+            onFinish: async (values) => {
+                const result = await edit.onFinish(values);
+                if (autoSubmitClose) {
+                    setId(undefined);
+                }
+                return result;
+            },
+        },
         saveButtonProps,
         cancelButtonProps,
         editButtonProps,


### PR DESCRIPTION
feat: added `autoSubmitClose` prop to `useEditableTable`.
Now you can choose whether to close the table's row after submitting the form or not.

```tsx
const editableTable = useEditableTable({
    autoSubmitClose: false,
});
```

closes #4274