### PR TITLE
fix: `queryKey` method params for `useDelete`, `useDeleteMany` and `useUpdate`

### DIFF
--- a/.changeset/sweet-tables-laugh.md
+++ b/.changeset/sweet-tables-laugh.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": patch
+---
+
+fix: queryKey method params for `useDelete`, `useDeleteMany` and`useUpdate` hooks

--- a/packages/core/src/hooks/data/useDelete.ts
+++ b/packages/core/src/hooks/data/useDelete.ts
@@ -217,10 +217,15 @@ export const useDelete = <
                 resource,
                 mutationMode,
                 dataProviderName,
+                meta,
+                metaData,
             }) => {
+                const preferredMeta = pickNotDeprecated(meta, metaData);
                 const queryKey = queryKeys(
                     resource,
                     pickDataProvider(resource, dataProviderName, resources),
+                    preferredMeta,
+                    preferredMeta,
                 );
 
                 const mutationModePropOrContext =

--- a/packages/core/src/hooks/data/useDeleteMany.ts
+++ b/packages/core/src/hooks/data/useDeleteMany.ts
@@ -223,10 +223,15 @@ export const useDeleteMany = <
                 resource,
                 mutationMode,
                 dataProviderName,
+                meta,
+                metaData,
             }) => {
+                const preferredMeta = pickNotDeprecated(meta, metaData);
                 const queryKey = queryKeys(
                     resource,
                     pickDataProvider(resource, dataProviderName, resources),
+                    preferredMeta,
+                    preferredMeta,
                 );
 
                 const mutationModePropOrContext =

--- a/packages/core/src/hooks/data/useUpdate.ts
+++ b/packages/core/src/hooks/data/useUpdate.ts
@@ -248,10 +248,15 @@ export const useUpdate = <
                 mutationMode,
                 values,
                 dataProviderName,
+                meta,
+                metaData,
             }) => {
+                const preferredMeta = pickNotDeprecated(meta, metaData);
                 const queryKey = queryKeys(
                     resource,
                     pickDataProvider(resource, dataProviderName, resources),
+                    preferredMeta,
+                    preferredMeta,
                 );
 
                 const previousQueries: PreviousQuery<TData>[] =


### PR DESCRIPTION
Fix `queryKey` method params for `useDelete`, `useDeleteMany` and `useUpdate`