### PR TITLE
docs: fix wrong hash for options property

### DIFF
--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -173,7 +173,7 @@ export interface RefineProps {
     onLiveEvent?: LiveModeProps["onLiveEvent"];
     /**
      * `options` is used to configure the app.
-     * @type [`IRefineOptions`](/docs/api-reference/core/components/refine-config/#options-1)
+     * @type [`IRefineOptions`](/docs/api-reference/core/components/refine-config/#options)
      * */
     options?: IRefineOptions;
 }


### PR DESCRIPTION
Currently it's redirecting to `#options-1` which is not accessible because `options` should points to `#options`.