### PR TITLE
fix(swizzle): add missing refine-config to npm files

### DIFF
--- a/.changeset/fast-pianos-rest.md
+++ b/.changeset/fast-pianos-rest.md
@@ -1,0 +1,12 @@
+---
+"@refinedev/airtable": patch
+"@refinedev/appwrite": patch
+"@refinedev/graphql": patch
+"@refinedev/hasura": patch
+"@refinedev/medusa": patch
+"@refinedev/nestjsx-crud": patch
+"@refinedev/strapi-v4": patch
+"@refinedev/supabase": patch
+---
+
+fixed: `./refine.config.js` added to `files` in `package.json` to include it in the npm package

--- a/packages/airtable/package.json
+++ b/packages/airtable/package.json
@@ -8,7 +8,8 @@
   "private": false,
   "files": [
     "dist",
-    "src"
+    "src",
+    "./refine.config.js"
   ],
   "engines": {
     "node": ">=10"

--- a/packages/appwrite/package.json
+++ b/packages/appwrite/package.json
@@ -6,7 +6,8 @@
   "private": false,
   "files": [
     "dist",
-    "src"
+    "src",
+    "./refine.config.js"
   ],
   "engines": {
     "node": ">=10"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -8,7 +8,8 @@
   "private": false,
   "files": [
     "dist",
-    "src"
+    "src",
+    "./refine.config.js"
   ],
   "engines": {
     "node": ">=10"

--- a/packages/hasura/package.json
+++ b/packages/hasura/package.json
@@ -8,7 +8,8 @@
   "private": false,
   "files": [
     "dist",
-    "src"
+    "src",
+    "./refine.config.js"
   ],
   "engines": {
     "node": ">=10"

--- a/packages/medusa/package.json
+++ b/packages/medusa/package.json
@@ -8,7 +8,8 @@
   "private": false,
   "files": [
     "dist",
-    "src"
+    "src",
+    "./refine.config.js"
   ],
   "engines": {
     "node": ">=10"

--- a/packages/nestjsx-crud/package.json
+++ b/packages/nestjsx-crud/package.json
@@ -8,7 +8,8 @@
   "private": false,
   "files": [
     "dist",
-    "src"
+    "src",
+    "./refine.config.js"
   ],
   "engines": {
     "node": ">=10"

--- a/packages/strapi-v4/package.json
+++ b/packages/strapi-v4/package.json
@@ -8,7 +8,8 @@
   "private": false,
   "files": [
     "dist",
-    "src"
+    "src",
+    "./refine.config.js"
   ],
   "engines": {
     "node": ">=10"

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -8,7 +8,8 @@
   "private": false,
   "files": [
     "dist",
-    "src"
+    "src",
+    "./refine.config.js"
   ],
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
fixed: `./refine.config.js` added to `files` in `package.json` to include it in the npm package

closes #4282