### PR TITLE
fix(live-previews): add max-http-header to start script

### DIFF
--- a/packages/live-previews/package.json
+++ b/packages/live-previews/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "start": "PORT=3030 nodemon --watch ./node_modules --watch ./src --watch ./pages --ext ts,tsx,js,jsx --exec \"next build --no-lint && next start\"",
-        "dev": "PORT=3030 next dev",
+        "dev": "NODE_OPTIONS='--max-http-header-size=32767' PORT=3030 next dev",
         "build": "next build && rm -rf .next/cache",
         "start:prod": "NODE_OPTIONS='--max-http-header-size=32767' next start",
         "lint": "next lint",

--- a/packages/live-previews/package.json
+++ b/packages/live-previews/package.json
@@ -6,7 +6,7 @@
         "start": "PORT=3030 nodemon --watch ./node_modules --watch ./src --watch ./pages --ext ts,tsx,js,jsx --exec \"next build --no-lint && next start\"",
         "dev": "PORT=3030 next dev",
         "build": "next build && rm -rf .next/cache",
-        "start:prod": "next start",
+        "start:prod": "NODE_OPTIONS='--max-http-header-size=32767' next start",
         "lint": "next lint",
         "test": "jest --passWithNoTests"
     },


### PR DESCRIPTION
added `--max-http-header-size` to live previews start and dev scripts to prevent 431 status code.