### PR TITLE
feat(antd): customize buttons in crud components

### DIFF
--- a/.changeset/gentle-cooks-sleep.md
+++ b/.changeset/gentle-cooks-sleep.md
@@ -15,26 +15,28 @@ import {
 } from "@refinedev/antd";
 
 const PostShow = () => {
-    <Show
-        isLoading={isLoading}
-        headerButtons={({
-            deleteButtonProps,
-            editButtonProps,
-            listButtonProps,
-            refreshButtonProps,
-        }) => {
-            return (
-                <>
-                    {/* custom components */}
-                    <ListButton {...listButtonProps} />
-                    <RefreshButton {...refreshButtonProps} />
-                    <EditButton {...editButtonProps} />
-                    <DeleteButton {...deleteButtonProps} />
-                </>
-            );
-        }}
-    >
-        {/* ... */}
-    </Show>;
+    return (
+        <Show
+            isLoading={isLoading}
+            headerButtons={({
+                deleteButtonProps,
+                editButtonProps,
+                listButtonProps,
+                refreshButtonProps,
+            }) => {
+                return (
+                    <>
+                        {/* custom components */}
+                        <ListButton {...listButtonProps} />
+                        <RefreshButton {...refreshButtonProps} />
+                        <EditButton {...editButtonProps} />
+                        <DeleteButton {...deleteButtonProps} />
+                    </>
+                );
+            }}
+        >
+            {/* ... */}
+        </Show>
+    );
 };
 ```

--- a/.changeset/gentle-cooks-sleep.md
+++ b/.changeset/gentle-cooks-sleep.md
@@ -17,7 +17,6 @@ import {
 const PostShow = () => {
     return (
         <Show
-            isLoading={isLoading}
             headerButtons={({
                 deleteButtonProps,
                 editButtonProps,

--- a/.changeset/gentle-cooks-sleep.md
+++ b/.changeset/gentle-cooks-sleep.md
@@ -1,0 +1,40 @@
+---
+"@refinedev/antd": minor
+---
+
+feat: added default button props into the renderer functions `headerButtons` and `footerButtons` in CRUD components.
+Now, customization of the header and footer buttons can be achieved without losing the default functionality.
+
+```tsx
+import {
+    Show,
+    ListButton,
+    RefreshButton,
+    EditButton,
+    DeleteButton,
+} from "@refinedev/antd";
+
+const PostShow = () => {
+    <Show
+        isLoading={isLoading}
+        headerButtons={({
+            deleteButtonProps,
+            editButtonProps,
+            listButtonProps,
+            refreshButtonProps,
+        }) => {
+            return (
+                <>
+                    {/* custom components */}
+                    <ListButton {...listButtonProps} />
+                    <RefreshButton {...refreshButtonProps} />
+                    <EditButton {...editButtonProps} />
+                    <DeleteButton {...deleteButtonProps} />
+                </>
+            );
+        }}
+    >
+        {/* ... */}
+    </Show>;
+};
+```

--- a/documentation/docs/api-reference/antd/components/basic-views/create.md
+++ b/documentation/docs/api-reference/antd/components/basic-views/create.md
@@ -627,7 +627,9 @@ render(
 
 ### `footerButtons`
 
-You can customize the buttons at the footer by using the `footerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
+By default, the `<Create/>` component has a [`<SaveButton>`][save-button] at the header.
+
+You can customize the buttons at the footer by using the `footerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons, saveButtonProps }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
 ```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/create
 const { CreateButton } = RefineAntd;
@@ -652,6 +654,56 @@ const PostCreate: React.FC = () => {
         </Create>
     );
 };
+// visible-block-end
+
+render(
+    <RefineAntdDemo
+        initialRoutes={["/posts/create"]}
+        resources={[
+            {
+                name: "posts",
+                list: () => (
+                    <div>
+                        <p>This page is empty.</p>
+                        <CreateButton />
+                    </div>
+                ),
+                create: PostCreate,
+            },
+        ]}
+    />,
+);
+```
+
+Or, instead of using the `defaultButtons`, you can create your own buttons. If you want, you can use `saveButtonProps` to utilize the default values of the [`<SaveButton>`][save-button] component.
+
+```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/create
+// visible-block-start
+import { Create, SaveButton } from "@refinedev/antd";
+
+const PostCreate: React.FC = () => {
+    return (
+        <Create
+            // highlight-start
+            footerButtons={({ saveButtonProps }) => (
+                <>
+                    <SaveButton
+                        {...saveButtonProps}
+                        type="primary"
+                        style={{ marginRight: 8 }}
+                    >
+                        Save
+                    </SaveButton>
+                    <Button type="primary">Custom Button</Button>
+                </>
+            )}
+            // highlight-end
+        >
+            <p>Rest of your page here</p>
+        </Create>
+    );
+};
+
 // visible-block-end
 
 render(
@@ -734,3 +786,4 @@ render(
 <PropsTable module="@refinedev/antd/Create" goBack-default="`<ArrowLeft />`" headerProps-type="[`PageHeaderProps`](https://procomponents.ant.design/en-US/components/page-header)" />
 
 [breadcrumb-component]: /api-reference/antd/components/breadcrumb.md
+[save-button]: /docs/api-reference/antd/components/buttons/save-button/

--- a/documentation/docs/api-reference/antd/components/basic-views/edit.md
+++ b/documentation/docs/api-reference/antd/components/basic-views/edit.md
@@ -859,7 +859,9 @@ render(
 
 ### `headerButtons`
 
-You can customize the buttons at the header by using the `headerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
+By default, the `<Edit/>` component has a [`<ListButton>`][list-button] and a [`<RefreshButton>`][refresh-button] at the header.
+
+You can customize the buttons at the header by using the `headerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons, refreshButtonProps, listButtonProps }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
 ```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/edit/2
 const { EditButton } = RefineAntd;
@@ -876,6 +878,53 @@ const PostEdit: React.FC = () => {
                 <>
                     {defaultButtons}
                     <Button type="primary">Custom Button</Button>
+                </>
+            )}
+            // highlight-end
+        >
+            <p>Rest of your page here</p>
+        </Edit>
+    );
+};
+// visible-block-end
+
+render(
+    <RefineAntdDemo
+        initialRoutes={["/posts/edit/2"]}
+        resources={[
+            {
+                name: "posts",
+                list: () => (
+                    <div>
+                        <p>This page is empty.</p>
+                        <EditButton />
+                    </div>
+                ),
+                edit: PostEdit,
+            },
+        ]}
+    />,
+);
+```
+
+Or, instead of using the `defaultButtons`, you can create your own buttons. If you want, you can use `refreshButtonProps` and `listButtonProps` to utilize the default values of the `<ListButton>`[list-button] and `<RefreshButton>`[refresh-button] components.
+
+```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/edit/2
+const { EditButton } = RefineAntd;
+
+// visible-block-start
+import { Edit, ListButton, RefreshButton } from "@refinedev/antd";
+import { Button } from "antd";
+
+const PostEdit: React.FC = () => {
+    return (
+        <Edit
+            // highlight-start
+            headerButtons={({ refreshButtonProps, listButtonProps }) => (
+                <>
+                    <Button type="primary">Custom Button</Button>
+                    <RefreshButton {...refreshButtonProps} />
+                    <ListButton {...listButtonProps} />
                 </>
             )}
             // highlight-end
@@ -958,7 +1007,9 @@ render(
 
 ### `footerButtons`
 
-You can customize the buttons at the footer by using the `footerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
+By default, the `<Edit/>` component has a [`<SaveButton>`][save-button] and a [`<DeleteButton>`][delete-button] at the footer.
+
+You can customize the buttons at the footer by using the `footerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons, saveButtonProps, deleteButtonProps }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
 ```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/edit/2
 const { EditButton } = RefineAntd;
@@ -975,6 +1026,53 @@ const PostEdit: React.FC = () => {
                 <>
                     {defaultButtons}
                     <Button type="primary">Custom Button</Button>
+                </>
+            )}
+            // highlight-end
+        >
+            <p>Rest of your page here</p>
+        </Edit>
+    );
+};
+// visible-block-end
+
+render(
+    <RefineAntdDemo
+        initialRoutes={["/posts/edit"]}
+        resources={[
+            {
+                name: "posts",
+                list: () => (
+                    <div>
+                        <p>This page is empty.</p>
+                        <EditButton />
+                    </div>
+                ),
+                edit: PostEdit,
+            },
+        ]}
+    />,
+);
+```
+
+Or, instead of using the `defaultButtons`, you can create your own buttons. If you want, you can use `saveButtonProps` and `deleteButtonProps` to utilize the default values of the [`<SaveButton>`][save-button] and [`<DeleteButton>`][delete-button] components.
+
+```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/edit/2
+const { EditButton } = RefineAntd;
+
+// visible-block-start
+import { Edit, SaveButton, DeleteButton } from "@refinedev/antd";
+import { Button } from "antd";
+
+const PostEdit: React.FC = () => {
+    return (
+        <Edit
+            // highlight-start
+            footerButtons={({ saveButtonProps, deleteButtonProps }) => (
+                <>
+                    <Button type="primary">Custom Button</Button>
+                    <SaveButton {...saveButtonProps} />
+                    <DeleteButton {...deleteButtonProps} />
                 </>
             )}
             // highlight-end
@@ -1079,3 +1177,7 @@ goBack-type="`ReactNode`"
 > `*`: These properties have default values in `RefineContext` and can also be set on the **<[Refine](/api-reference/core/components/refine-config.md)>** component.
 
 [breadcrumb-component]: /api-reference/antd/components/breadcrumb.md
+[list-button]: /docs/api-reference/antd/components/buttons/list-button/
+[refresh-button]: /docs/api-reference/antd/components/buttons/refresh-button/
+[save-button]: /docs/api-reference/antd/components/buttons/save-button/
+[delete-button]: /docs/api-reference/antd/components/buttons/delete-button/

--- a/documentation/docs/api-reference/antd/components/basic-views/list.md
+++ b/documentation/docs/api-reference/antd/components/basic-views/list.md
@@ -448,7 +448,9 @@ render(
 
 ### `headerButtons`
 
-You can customize the buttons at the header by using the `headerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
+By default, the `<List/>` component has a [`<CreateButton>`][create-button] at the header.
+
+You can customize the buttons at the header by using the `headerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons, createButtonProps }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
 ```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts
 // visible-block-start
@@ -462,6 +464,44 @@ const PostList: React.FC = () => {
             headerButtons={({ defaultButtons }) => (
                 <>
                     {defaultButtons}
+                    <Button type="primary">Custom Button</Button>
+                </>
+            )}
+            // highlight-end
+        >
+            <p>Rest of your page here</p>
+        </List>
+    );
+};
+// visible-block-end
+
+render(
+    <RefineAntdDemo
+        initialRoutes={["/posts"]}
+        resources={[
+            {
+                name: "posts",
+                list: PostList,
+            },
+        ]}
+    />,
+);
+```
+
+Or, instead of using the `defaultButtons`, you can create your own buttons. If you want, you can use `createButtonProps` to utilize the default values of the [`<CreateButton>`][create-button] component.
+
+```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts
+// visible-block-start
+import { List, CreateButton } from "@refinedev/antd";
+import { Button } from "antd";
+
+const PostList: React.FC = () => {
+    return (
+        <List
+            // highlight-start
+            headerButtons={({ createButtonProps }) => (
+                <>
+                    <CreateButton {...createButtonProps} />
                     <Button type="primary">Custom Button</Button>
                 </>
             )}
@@ -542,3 +582,4 @@ canCreate-default="If the resource is passed a create component, `true` else `fa
 />
 
 [breadcrumb-component]: /api-reference/antd/components/breadcrumb.md
+[create-button]: /docs/api-reference/antd/components/buttons/create-button/

--- a/documentation/docs/api-reference/antd/components/basic-views/show.md
+++ b/documentation/docs/api-reference/antd/components/basic-views/show.md
@@ -649,7 +649,9 @@ render(
 
 ### `headerButtons`
 
-You can customize the buttons at the header by using the `headerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
+By default, the `<Show/>` component has a [`<ListButton>`][list-button], [`<EditButton>`][edit-button], [`<DeleteButton>`][delete-button], and, [`<RefreshButton>`][refresh-button] at the header.
+
+You can customize the buttons at the header by using the `headerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons, listButtonProps, editButtonProps, deleteButtonProps, refreshButtonProps }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
 ```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/show/2
 const { ShowButton } = RefineAntd;
@@ -666,6 +668,66 @@ const PostShow: React.FC = () => {
                 <>
                     {defaultButtons}
                     <Button type="primary">Custom Button</Button>
+                </>
+            )}
+            // highlight-end
+        >
+            <p>Rest of your page here</p>
+        </Show>
+    );
+};
+// visible-block-end
+
+render(
+    <RefineAntdDemo
+        initialRoutes={["/posts/show/2"]}
+        resources={[
+            {
+                name: "posts",
+                list: () => (
+                    <div>
+                        <p>This page is empty.</p>
+                        <ShowButton />
+                    </div>
+                ),
+                show: PostShow,
+            },
+        ]}
+    />,
+);
+```
+
+Or, instead of using the `defaultButtons`, you can create your own buttons. If you want, you can use `createButtonProps` to utilize the default values of the [`<ListButton>`][list-button], [`<EditButton>`][edit-button], [`<DeleteButton>`][delete-button], and, [`<RefreshButton>`][refresh-button] components.
+
+```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/show/2
+const { ShowButton } = RefineAntd;
+
+// visible-block-start
+import {
+    Show,
+    ListButton,
+    EditButton,
+    DeleteButton,
+    RefreshButton,
+} from "@refinedev/antd";
+import { Button } from "antd";
+
+const PostShow: React.FC = () => {
+    return (
+        <Show
+            // highlight-start
+            headerButtons={({
+                deleteButtonProps,
+                editButtonProps,
+                listButtonProps,
+                refreshButtonProps,
+            }) => (
+                <>
+                    <Button type="primary">Custom Button</Button>
+                    <ListButton {...listButtonProps} />
+                    <EditButton {...editButtonProps} />
+                    <DeleteButton {...deleteButtonProps} />
+                    <RefreshButton {...refreshButtonProps} />
                 </>
             )}
             // highlight-end
@@ -870,3 +932,8 @@ breadcrumb-default="[`<Breadcrumb>`](https://ant.design/components/breadcrumb/)"
 goBack-default="`<ArrowLeft />`"
 goBack-type="`ReactNode`"
 />
+
+[list-button]: /docs/api-reference/antd/components/buttons/list-button/
+[refresh-button]: /docs/api-reference/antd/components/buttons/refresh-button/
+[edit-button]: /docs/api-reference/antd/components/buttons/edit-button/
+[delete-button]: /docs/api-reference/antd/components/buttons/delete-button/

--- a/packages/antd/src/components/crud/create/index.spec.tsx
+++ b/packages/antd/src/components/crud/create/index.spec.tsx
@@ -1,6 +1,43 @@
+import React, { ReactNode } from "react";
+import { Route, Routes } from "react-router-dom";
 import { crudCreateTests } from "@refinedev/ui-tests";
+import { render, TestWrapper } from "@test";
 import { Create } from "./";
+import { SaveButton } from "@components/buttons";
+import { RefineButtonTestIds } from "@refinedev/ui-types";
+
+const renderCreate = (create: ReactNode) => {
+    return render(
+        <Routes>
+            <Route path="/:resource/create" element={create} />
+        </Routes>,
+        {
+            wrapper: TestWrapper({
+                routerInitialEntries: ["/posts/create"],
+            }),
+        },
+    );
+};
 
 describe("Create", () => {
     crudCreateTests.bind(this)(Create);
+
+    it("should customize default buttons with default props", async () => {
+        const { queryByTestId } = renderCreate(
+            <Create
+                saveButtonProps={{ className: "customize-test" }}
+                footerButtons={({ saveButtonProps }) => {
+                    return (
+                        <>
+                            <SaveButton {...saveButtonProps} />
+                        </>
+                    );
+                }}
+            />,
+        );
+
+        expect(queryByTestId(RefineButtonTestIds.SaveButton)).toHaveClass(
+            "customize-test",
+        );
+    });
 });

--- a/packages/antd/src/components/crud/create/index.tsx
+++ b/packages/antd/src/components/crud/create/index.tsx
@@ -10,7 +10,12 @@ import {
     useBack,
 } from "@refinedev/core";
 
-import { Breadcrumb, SaveButton, PageHeader } from "@components";
+import {
+    Breadcrumb,
+    SaveButton,
+    PageHeader,
+    SaveButtonProps,
+} from "@components";
 import { CreateProps } from "../types";
 
 /**
@@ -21,7 +26,7 @@ import { CreateProps } from "../types";
  */
 export const Create: React.FC<CreateProps> = ({
     title,
-    saveButtonProps,
+    saveButtonProps: saveButtonPropsFromProps,
     children,
     resource: resourceFromProps,
     isLoading = false,
@@ -50,13 +55,15 @@ export const Create: React.FC<CreateProps> = ({
             ? globalBreadcrumb
             : breadcrumbFromProps;
 
+    const saveButtonProps: SaveButtonProps = {
+        ...(isLoading ? { disabled: true } : {}),
+        ...saveButtonPropsFromProps,
+        htmlType: "submit",
+    };
+
     const defaultFooterButtons = (
         <>
-            <SaveButton
-                {...(isLoading ? { disabled: true } : {})}
-                {...saveButtonProps}
-                htmlType="submit"
-            />
+            <SaveButton {...saveButtonProps} />
         </>
     );
 
@@ -119,6 +126,7 @@ export const Create: React.FC<CreateProps> = ({
                                         ? footerButtons({
                                               defaultButtons:
                                                   defaultFooterButtons,
+                                              saveButtonProps: saveButtonProps,
                                           })
                                         : footerButtons
                                     : defaultFooterButtons}

--- a/packages/antd/src/components/crud/edit/index.spec.tsx
+++ b/packages/antd/src/components/crud/edit/index.spec.tsx
@@ -2,10 +2,16 @@ import React, { ReactNode } from "react";
 import { Route, Routes } from "react-router-dom";
 import { AccessControlProvider } from "@refinedev/core";
 
-import { act, render, TestWrapper, waitFor } from "@test";
+import { render, TestWrapper, waitFor } from "@test";
 import { Edit } from "./";
 import { crudEditTests } from "@refinedev/ui-tests";
 import { RefineButtonTestIds } from "@refinedev/ui-types";
+import {
+    DeleteButton,
+    ListButton,
+    RefreshButton,
+    SaveButton,
+} from "@components/buttons";
 
 const renderEdit = (
     edit: ReactNode,
@@ -25,7 +31,7 @@ const renderEdit = (
 };
 
 describe("Edit", () => {
-    crudEditTests.bind(this)(Edit);
+    crudEditTests.bind(this)(Edit as any);
 
     it("should render optional mutationMode with mutationModeProp prop", async () => {
         const container = renderEdit(<Edit mutationMode="undoable" />);
@@ -187,6 +193,62 @@ describe("Edit", () => {
                     queryByTestId(RefineButtonTestIds.DeleteButton),
                 ).toBeDisabled(),
             );
+        });
+
+        it("should customize default buttons with default props", async () => {
+            const { queryByTestId } = renderEdit(
+                <Edit
+                    canDelete
+                    saveButtonProps={{ className: "customize-test" }}
+                    headerButtons={({
+                        listButtonProps,
+                        refreshButtonProps,
+                    }) => {
+                        return (
+                            <>
+                                <RefreshButton {...refreshButtonProps} />
+                                <ListButton {...listButtonProps} />
+                            </>
+                        );
+                    }}
+                    footerButtons={({ deleteButtonProps, saveButtonProps }) => {
+                        return (
+                            <>
+                                <DeleteButton {...deleteButtonProps} />
+                                <SaveButton {...saveButtonProps} />
+                            </>
+                        );
+                    }}
+                />,
+                {
+                    can: ({ action }) => {
+                        switch (action) {
+                            case "list":
+                            case "delete":
+                                return Promise.resolve({ can: false });
+                            default:
+                                return Promise.resolve({ can: false });
+                        }
+                    },
+                },
+            );
+
+            await waitFor(() =>
+                expect(
+                    queryByTestId(RefineButtonTestIds.DeleteButton),
+                ).toBeDisabled(),
+            );
+            await waitFor(() =>
+                expect(
+                    queryByTestId(RefineButtonTestIds.ListButton),
+                ).toBeDisabled(),
+            );
+            expect(queryByTestId(RefineButtonTestIds.SaveButton)).toHaveClass(
+                "customize-test",
+            );
+            expect(
+                queryByTestId(RefineButtonTestIds.RefreshButton),
+            ).toBeTruthy();
         });
     });
 });

--- a/packages/antd/src/components/crud/edit/index.tsx
+++ b/packages/antd/src/components/crud/edit/index.tsx
@@ -21,6 +21,7 @@ import {
     SaveButton,
     Breadcrumb,
     PageHeader,
+    DeleteButtonProps,
 } from "@components";
 import { EditProps } from "../types";
 
@@ -32,11 +33,11 @@ import { EditProps } from "../types";
  */
 export const Edit: React.FC<EditProps> = ({
     title,
-    saveButtonProps,
+    saveButtonProps: saveButtonPropsFromProps,
     mutationMode: mutationModeProp,
     recordItemId,
     children,
-    deleteButtonProps,
+    deleteButtonProps: deleteButtonPropsFromProps,
     canDelete,
     resource: resourceFromProps,
     isLoading = false,
@@ -83,62 +84,63 @@ export const Edit: React.FC<EditProps> = ({
     const isDeleteButtonVisible =
         canDelete ??
         ((resource?.meta?.canDelete ?? resource?.canDelete) ||
-            deleteButtonProps);
+            deleteButtonPropsFromProps);
+
+    const listButtonProps = {
+        ...(isLoading ? { disabled: true } : {}),
+        resource:
+            routerType === "legacy"
+                ? resource?.route
+                : resource?.identifier ?? resource?.name,
+        recordItemId: id,
+        dataProviderName,
+    };
+
+    const refreshButtonProps = {
+        ...(isLoading ? { disabled: true } : {}),
+        resource:
+            routerType === "legacy"
+                ? resource?.route
+                : resource?.identifier ?? resource?.name,
+        recordItemId: id,
+        dataProviderName,
+    };
+
+    const deleteButtonProps: DeleteButtonProps = {
+        ...(isLoading ? { disabled: true } : {}),
+        resource:
+            routerType === "legacy"
+                ? resource?.route
+                : resource?.identifier ?? resource?.name,
+        mutationMode,
+        onSuccess: () => {
+            if (routerType === "legacy") {
+                legacyGoList(resource?.route ?? resource?.name ?? "");
+            } else {
+                go({ to: goListPath });
+            }
+        },
+        recordItemId: id,
+        dataProviderName,
+        ...deleteButtonPropsFromProps,
+    };
+
+    const saveButtonProps = {
+        ...(isLoading ? { disabled: true } : {}),
+        ...saveButtonPropsFromProps,
+    };
 
     const defaultHeaderButtons = (
         <>
-            {!recordItemId && (
-                <ListButton
-                    {...(isLoading ? { disabled: true } : {})}
-                    resource={
-                        routerType === "legacy"
-                            ? resource?.route
-                            : resource?.identifier ?? resource?.name
-                    }
-                />
-            )}
-            <RefreshButton
-                {...(isLoading ? { disabled: true } : {})}
-                resource={
-                    routerType === "legacy"
-                        ? resource?.route
-                        : resource?.identifier ?? resource?.name
-                }
-                recordItemId={id}
-                dataProviderName={dataProviderName}
-            />
+            {!recordItemId && <ListButton {...listButtonProps} />}
+            <RefreshButton {...refreshButtonProps} />
         </>
     );
 
     const defaultFooterButtons = (
         <>
-            {isDeleteButtonVisible && (
-                <DeleteButton
-                    {...(isLoading ? { disabled: true } : {})}
-                    resource={
-                        routerType === "legacy"
-                            ? resource?.route
-                            : resource?.identifier ?? resource?.name
-                    }
-                    mutationMode={mutationMode}
-                    onSuccess={() => {
-                        if (routerType === "legacy") {
-                            legacyGoList(
-                                resource?.route ?? resource?.name ?? "",
-                            );
-                        } else {
-                            go({ to: goListPath });
-                        }
-                    }}
-                    recordItemId={id}
-                    dataProviderName={dataProviderName}
-                    {...deleteButtonProps}
-                />
-            )}
-            <SaveButton
-                {...(isLoading ? { disabled: true } : {})}
-                {...saveButtonProps}
-            />
+            {isDeleteButtonVisible && <DeleteButton {...deleteButtonProps} />}
+            <SaveButton {...saveButtonProps} />
         </>
     );
 
@@ -173,6 +175,8 @@ export const Edit: React.FC<EditProps> = ({
                             ? typeof headerButtons === "function"
                                 ? headerButtons({
                                       defaultButtons: defaultHeaderButtons,
+                                      listButtonProps,
+                                      refreshButtonProps,
                                   })
                                 : headerButtons
                             : defaultHeaderButtons}
@@ -205,6 +209,8 @@ export const Edit: React.FC<EditProps> = ({
                                         ? footerButtons({
                                               defaultButtons:
                                                   defaultFooterButtons,
+                                              deleteButtonProps,
+                                              saveButtonProps,
                                           })
                                         : footerButtons
                                     : defaultFooterButtons}

--- a/packages/antd/src/components/crud/list/index.spec.tsx
+++ b/packages/antd/src/components/crud/list/index.spec.tsx
@@ -1,6 +1,43 @@
+import React, { ReactNode } from "react";
 import { crudListTests } from "@refinedev/ui-tests";
+import { RefineButtonTestIds } from "@refinedev/ui-types";
+import { Route, Routes } from "react-router-dom";
+import { CreateButton } from "@components/buttons";
+import { render, TestWrapper } from "@test";
 import { List } from "./index";
+
+const renderList = (list: ReactNode) => {
+    return render(
+        <Routes>
+            <Route path="/:resource" element={list} />
+        </Routes>,
+        {
+            wrapper: TestWrapper({
+                routerInitialEntries: ["/posts"],
+            }),
+        },
+    );
+};
 
 describe("<List/>", () => {
     crudListTests.bind(this)(List);
+
+    it("should customize default buttons with default props", async () => {
+        const { queryByTestId } = renderList(
+            <List
+                createButtonProps={{ className: "customize-test" }}
+                headerButtons={({ createButtonProps }) => {
+                    return (
+                        <>
+                            <CreateButton {...createButtonProps} />
+                        </>
+                    );
+                }}
+            />,
+        );
+
+        expect(queryByTestId(RefineButtonTestIds.CreateButton)).toHaveClass(
+            "customize-test",
+        );
+    });
 });

--- a/packages/antd/src/components/crud/list/index.tsx
+++ b/packages/antd/src/components/crud/list/index.tsx
@@ -8,7 +8,12 @@ import {
     useResource,
 } from "@refinedev/core";
 
-import { Breadcrumb, CreateButton, PageHeader } from "@components";
+import {
+    Breadcrumb,
+    CreateButton,
+    CreateButtonProps,
+    PageHeader,
+} from "@components";
 import { ListProps } from "../types";
 
 /**
@@ -21,7 +26,7 @@ export const List: React.FC<ListProps> = ({
     canCreate,
     title,
     children,
-    createButtonProps,
+    createButtonProps: createButtonPropsFromProps,
     resource: resourceFromProps,
     wrapperProps,
     contentProps,
@@ -40,23 +45,25 @@ export const List: React.FC<ListProps> = ({
 
     const isCreateButtonVisible =
         canCreate ??
-        ((resource?.canCreate ?? !!resource?.create) || createButtonProps);
+        ((resource?.canCreate ?? !!resource?.create) ||
+            createButtonPropsFromProps);
 
     const breadcrumb =
         typeof breadcrumbFromProps === "undefined"
             ? globalBreadcrumb
             : breadcrumbFromProps;
 
+    const createButtonProps: CreateButtonProps = {
+        size: "middle",
+        resource:
+            routerType === "legacy"
+                ? resource?.route
+                : resource?.identifier ?? resource?.name,
+        ...createButtonPropsFromProps,
+    };
+
     const defaultExtra = isCreateButtonVisible ? (
-        <CreateButton
-            size="middle"
-            resource={
-                routerType === "legacy"
-                    ? resource?.route
-                    : resource?.identifier ?? resource?.name
-            }
-            {...createButtonProps}
-        />
+        <CreateButton {...createButtonProps} />
     ) : null;
 
     return (
@@ -82,6 +89,7 @@ export const List: React.FC<ListProps> = ({
                             {typeof headerButtons === "function"
                                 ? headerButtons({
                                       defaultButtons: defaultExtra,
+                                      createButtonProps,
                                   })
                                 : headerButtons}
                         </Space>

--- a/packages/antd/src/components/crud/show/index.spec.tsx
+++ b/packages/antd/src/components/crud/show/index.spec.tsx
@@ -3,10 +3,16 @@ import { Route, Routes } from "react-router-dom";
 import { RefineButtonTestIds } from "@refinedev/ui-types";
 import { AccessControlProvider } from "@refinedev/core";
 
-import { act, render, TestWrapper, waitFor } from "@test";
+import { render, TestWrapper } from "@test";
 
 import { Show } from "./index";
 import { crudShowTests } from "@refinedev/ui-tests";
+import {
+    DeleteButton,
+    EditButton,
+    ListButton,
+    RefreshButton,
+} from "@components/buttons";
 
 const renderShow = (
     show: ReactNode,
@@ -25,7 +31,7 @@ const renderShow = (
     );
 };
 describe("Show", () => {
-    crudShowTests.bind(this)(Show);
+    crudShowTests.bind(this)(Show as any);
 
     it("should render optional recordItemId with resource prop, not render list button", async () => {
         const { getByText, queryByTestId } = renderShow(
@@ -237,6 +243,60 @@ describe("Show", () => {
 
             expect(
                 queryByTestId(RefineButtonTestIds.DeleteButton),
+            ).not.toBeNull();
+        });
+
+        it("should customize default buttons with default props", async () => {
+            const { queryByTestId } = render(
+                <Routes>
+                    <Route
+                        path="/:resource/:action/:id"
+                        element={
+                            <Show
+                                canEdit
+                                canDelete
+                                headerButtons={({
+                                    deleteButtonProps,
+                                    editButtonProps,
+                                    listButtonProps,
+                                    refreshButtonProps,
+                                }) => {
+                                    return (
+                                        <>
+                                            <DeleteButton
+                                                {...deleteButtonProps}
+                                            />
+                                            <EditButton {...editButtonProps} />
+                                            <ListButton {...listButtonProps} />
+                                            <RefreshButton
+                                                {...refreshButtonProps}
+                                            />
+                                        </>
+                                    );
+                                }}
+                            />
+                        }
+                    />
+                </Routes>,
+                {
+                    wrapper: TestWrapper({
+                        resources: [{ name: "posts" }],
+                        routerInitialEntries: ["/posts/show/1"],
+                    }),
+                },
+            );
+
+            expect(
+                queryByTestId(RefineButtonTestIds.DeleteButton),
+            ).not.toBeNull();
+            expect(
+                queryByTestId(RefineButtonTestIds.EditButton),
+            ).not.toBeNull();
+            expect(
+                queryByTestId(RefineButtonTestIds.ListButton),
+            ).not.toBeNull();
+            expect(
+                queryByTestId(RefineButtonTestIds.RefreshButton),
             ).not.toBeNull();
         });
     });

--- a/packages/antd/src/components/crud/show/index.tsx
+++ b/packages/antd/src/components/crud/show/index.tsx
@@ -79,60 +79,53 @@ export const Show: React.FC<ShowProps> = ({
     const isEditButtonVisible =
         canEdit ?? resource?.canEdit ?? !!resource?.edit;
 
+    const listButtonProps = {
+        resource:
+            routerType === "legacy"
+                ? resource?.route
+                : resource?.identifier ?? resource?.name,
+    };
+    const editButtonProps = {
+        ...(isLoading ? { disabled: true } : {}),
+        type: "primary",
+        resource:
+            routerType === "legacy"
+                ? resource?.route
+                : resource?.identifier ?? resource?.name,
+        recordItemId: id,
+    } as const;
+    const deleteButtonProps = {
+        ...(isLoading ? { disabled: true } : {}),
+        resource:
+            routerType === "legacy"
+                ? resource?.route
+                : resource?.identifier ?? resource?.name,
+        recordItemId: id,
+        onSuccess: () => {
+            if (routerType === "legacy") {
+                legacyGoList(resource?.route ?? resource?.name ?? "");
+            } else {
+                go({ to: goListPath });
+            }
+        },
+        dataProviderName,
+    };
+    const refreshButtonProps = {
+        ...(isLoading ? { disabled: true } : {}),
+        resource:
+            routerType === "legacy"
+                ? resource?.route
+                : resource?.identifier ?? resource?.name,
+        recordItemId: id,
+        dataProviderName,
+    };
+
     const defaultHeaderButtons = (
         <>
-            {!recordItemId && (
-                <ListButton
-                    resource={
-                        routerType === "legacy"
-                            ? resource?.route
-                            : resource?.identifier ?? resource?.name
-                    }
-                />
-            )}
-            {isEditButtonVisible && (
-                <EditButton
-                    {...(isLoading ? { disabled: true } : {})}
-                    type="primary"
-                    resource={
-                        routerType === "legacy"
-                            ? resource?.route
-                            : resource?.identifier ?? resource?.name
-                    }
-                    recordItemId={id}
-                />
-            )}
-            {isDeleteButtonVisible && (
-                <DeleteButton
-                    {...(isLoading ? { disabled: true } : {})}
-                    resource={
-                        routerType === "legacy"
-                            ? resource?.route
-                            : resource?.identifier ?? resource?.name
-                    }
-                    recordItemId={id}
-                    onSuccess={() => {
-                        if (routerType === "legacy") {
-                            legacyGoList(
-                                resource?.route ?? resource?.name ?? "",
-                            );
-                        } else {
-                            go({ to: goListPath });
-                        }
-                    }}
-                    dataProviderName={dataProviderName}
-                />
-            )}
-            <RefreshButton
-                {...(isLoading ? { disabled: true } : {})}
-                resource={
-                    routerType === "legacy"
-                        ? resource?.route
-                        : resource?.identifier ?? resource?.name
-                }
-                recordItemId={id}
-                dataProviderName={dataProviderName}
-            />
+            {!recordItemId && <ListButton {...listButtonProps} />}
+            {isEditButtonVisible && <EditButton {...editButtonProps} />}
+            {isDeleteButtonVisible && <DeleteButton {...deleteButtonProps} />}
+            <RefreshButton {...refreshButtonProps} />
         </>
     );
 
@@ -171,6 +164,10 @@ export const Show: React.FC<ShowProps> = ({
                             ? typeof headerButtons === "function"
                                 ? headerButtons({
                                       defaultButtons: defaultHeaderButtons,
+                                      deleteButtonProps,
+                                      editButtonProps,
+                                      listButtonProps,
+                                      refreshButtonProps,
                                   })
                                 : headerButtons
                             : defaultHeaderButtons}

--- a/packages/antd/src/components/crud/types.ts
+++ b/packages/antd/src/components/crud/types.ts
@@ -2,6 +2,9 @@ import { CardProps, SpaceProps } from "antd";
 import {
     CreateButtonProps,
     DeleteButtonProps,
+    EditButtonProps,
+    ListButtonProps,
+    RefreshButtonProps,
     SaveButtonProps,
 } from "@components/buttons";
 import {
@@ -34,7 +37,10 @@ export type EditProps = RefineCrudEditProps<
         HTMLDivElement
     >,
     PageHeaderProps,
-    CardProps
+    CardProps,
+    {},
+    RefreshButtonProps,
+    ListButtonProps
 >;
 
 export type ListProps = RefineCrudListProps<
@@ -59,5 +65,10 @@ export type ShowProps = RefineCrudShowProps<
         HTMLDivElement
     >,
     PageHeaderProps,
-    CardProps
+    CardProps,
+    {},
+    EditButtonProps,
+    DeleteButtonProps,
+    RefreshButtonProps,
+    ListButtonProps
 >;


### PR DESCRIPTION

feat: added default button props into the renderer functions `headerButtons` and `footerButtons` in CRUD components.
Now, customization of the header and footer buttons can be achieved without losing the default functionality.

```tsx
import {
    Show,
    ListButton,
    RefreshButton,
    EditButton,
    DeleteButton,
} from "@refinedev/antd";
const PostShow = () => {
    return (
        <Show
            isLoading={isLoading}
            headerButtons={({
                deleteButtonProps,
                editButtonProps,
                listButtonProps,
                refreshButtonProps,
            }) => {
                return (
                    <>
                        {/* custom components */}
                        <ListButton {...listButtonProps} />
                        <RefreshButton {...refreshButtonProps} />
                        <EditButton {...editButtonProps} />
                        <DeleteButton {...deleteButtonProps} />
                    </>
                );
            }}
        >
            {/* ... */}
        </Show>
    );
};
```