### PR TITLE
feat: `syncWithLocation.syncId` default to `true` for `useDrawerForm` and `useModalForm`

### DIFF
--- a/.changeset/curvy-carpets-push.md
+++ b/.changeset/curvy-carpets-push.md
@@ -1,5 +1,5 @@
 ---
-"@refinedev/mantine": patch
+"@refinedev/mantine": minor
 ---
 
 feat: `syncWithLocation.syncId` default to `true` for `useModalForm`.

--- a/.changeset/curvy-carpets-push.md
+++ b/.changeset/curvy-carpets-push.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mantine": patch
+---
+
+feat: `syncWithLocation.syncId` default to `true` for `useModalForm`.

--- a/.changeset/plenty-ducks-learn.md
+++ b/.changeset/plenty-ducks-learn.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/react-hook-form": patch
+---
+
+feat: `syncWithLocation.syncId` default to `true` for `useModalForm`.

--- a/.changeset/plenty-ducks-learn.md
+++ b/.changeset/plenty-ducks-learn.md
@@ -1,5 +1,5 @@
 ---
-"@refinedev/react-hook-form": patch
+"@refinedev/react-hook-form": minor
 ---
 
 feat: `syncWithLocation.syncId` default to `true` for `useModalForm`.

--- a/.changeset/tidy-poems-hear.md
+++ b/.changeset/tidy-poems-hear.md
@@ -1,5 +1,5 @@
 ---
-"@refinedev/antd": patch
+"@refinedev/antd": minor
 ---
 
 feat: `syncWithLocation.syncId` default to `true` for `useDrawerForm` and `useModalForm`.

--- a/.changeset/tidy-poems-hear.md
+++ b/.changeset/tidy-poems-hear.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/antd": patch
+---
+
+feat: `syncWithLocation.syncId` default to `true` for `useDrawerForm` and `useModalForm`.

--- a/packages/antd/src/hooks/form/useDrawerForm/useDrawerForm.ts
+++ b/packages/antd/src/hooks/form/useDrawerForm/useDrawerForm.ts
@@ -144,9 +144,10 @@ export const useDrawerForm = <
 
     const action = rest.action ?? actionFromParams ?? "";
 
-    const syncingId =
-        syncWithLocation === true ||
-        (typeof syncWithLocation === "object" && syncWithLocation.syncId);
+    const syncingId = !(
+        typeof syncWithLocation === "object" &&
+        syncWithLocation?.syncId === false
+    );
 
     const syncWithLocationKey =
         typeof syncWithLocation === "object" && "key" in syncWithLocation

--- a/packages/antd/src/hooks/form/useDrawerForm/useDrawerForm.ts
+++ b/packages/antd/src/hooks/form/useDrawerForm/useDrawerForm.ts
@@ -120,8 +120,6 @@ export const useDrawerForm = <
     TResponse,
     TResponseError
 > => {
-    const initiallySynced = React.useRef(false);
-
     const { visible, show, close } = useModal({
         defaultVisible,
     });
@@ -136,7 +134,7 @@ export const useDrawerForm = <
     >({
         ...rest,
     });
-
+    const [initiallySynced, setInitiallySynced] = React.useState(false);
     const { form, formProps, formLoading, id, setId, onFinish } = useFormProps;
 
     const { resource, action: actionFromParams } = useResource(rest.resource);
@@ -147,7 +145,8 @@ export const useDrawerForm = <
     const action = rest.action ?? actionFromParams ?? "";
 
     const syncingId =
-        typeof syncWithLocation === "object" && syncWithLocation.syncId;
+        syncWithLocation === true ||
+        (typeof syncWithLocation === "object" && syncWithLocation.syncId);
 
     const syncWithLocationKey =
         typeof syncWithLocation === "object" && "key" in syncWithLocation
@@ -157,7 +156,7 @@ export const useDrawerForm = <
             : undefined;
 
     React.useEffect(() => {
-        if (initiallySynced.current === false && syncWithLocationKey) {
+        if (initiallySynced === false && syncWithLocationKey) {
             const openStatus = parsed?.params?.[syncWithLocationKey]?.open;
             if (typeof openStatus === "boolean") {
                 openStatus ? show() : close();
@@ -174,12 +173,12 @@ export const useDrawerForm = <
                 }
             }
 
-            initiallySynced.current = true;
+            setInitiallySynced(true);
         }
-    }, [syncWithLocationKey, parsed, syncingId, setId]);
+    }, [syncWithLocationKey, parsed, syncingId, setId, initiallySynced]);
 
     React.useEffect(() => {
-        if (initiallySynced.current === true) {
+        if (initiallySynced === true) {
             if (visible && syncWithLocationKey) {
                 go({
                     query: {
@@ -202,7 +201,15 @@ export const useDrawerForm = <
                 });
             }
         }
-    }, [id, visible, show, close, syncWithLocationKey, syncingId]);
+    }, [
+        id,
+        visible,
+        show,
+        close,
+        syncWithLocationKey,
+        syncingId,
+        initiallySynced,
+    ]);
 
     const translate = useTranslate();
 

--- a/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
+++ b/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
@@ -128,7 +128,7 @@ export const useModalForm = <
     TResponse,
     TResponseError
 > => {
-    const initiallySynced = React.useRef(false);
+    const [initiallySynced, setInitiallySynced] = React.useState(false);
 
     const useFormProps = useForm<
         TQueryFnData,
@@ -151,7 +151,8 @@ export const useModalForm = <
     const action = rest.action ?? actionFromParams ?? "";
 
     const syncingId =
-        typeof syncWithLocation === "object" && syncWithLocation.syncId;
+        syncWithLocation === true ||
+        (typeof syncWithLocation === "object" && syncWithLocation.syncId);
 
     const syncWithLocationKey =
         typeof syncWithLocation === "object" && "key" in syncWithLocation
@@ -191,7 +192,7 @@ export const useModalForm = <
     };
 
     React.useEffect(() => {
-        if (initiallySynced.current === false && syncWithLocationKey) {
+        if (initiallySynced === false && syncWithLocationKey) {
             const openStatus = parsed?.params?.[syncWithLocationKey]?.open;
             if (typeof openStatus === "boolean") {
                 if (openStatus) {
@@ -210,12 +211,12 @@ export const useModalForm = <
                 }
             }
 
-            initiallySynced.current = true;
+            setInitiallySynced(true);
         }
     }, [syncWithLocationKey, parsed, syncingId, setId]);
 
     React.useEffect(() => {
-        if (initiallySynced.current === true) {
+        if (initiallySynced === true) {
             if (visible && syncWithLocationKey) {
                 go({
                     query: {

--- a/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
+++ b/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
@@ -150,9 +150,10 @@ export const useModalForm = <
 
     const action = rest.action ?? actionFromParams ?? "";
 
-    const syncingId =
-        syncWithLocation === true ||
-        (typeof syncWithLocation === "object" && syncWithLocation.syncId);
+    const syncingId = !(
+        typeof syncWithLocation === "object" &&
+        syncWithLocation?.syncId === false
+    );
 
     const syncWithLocationKey =
         typeof syncWithLocation === "object" && "key" in syncWithLocation

--- a/packages/mantine/src/hooks/form/useModalForm/index.ts
+++ b/packages/mantine/src/hooks/form/useModalForm/index.ts
@@ -106,7 +106,7 @@ export const useModalForm = <
     TResponse,
     TResponseError
 > => {
-    const initiallySynced = React.useRef(false);
+    const [initiallySynced, setInitiallySynced] = React.useState(false);
 
     const translate = useTranslate();
 
@@ -125,8 +125,10 @@ export const useModalForm = <
 
     const action = actionProp ?? actionFromParams ?? "";
 
-    const syncingId =
-        typeof syncWithLocation === "object" && syncWithLocation.syncId;
+    const syncingId = !(
+        typeof syncWithLocation === "object" &&
+        syncWithLocation?.syncId === false
+    );
 
     const syncWithLocationKey =
         typeof syncWithLocation === "object" && "key" in syncWithLocation
@@ -160,7 +162,7 @@ export const useModalForm = <
     });
 
     React.useEffect(() => {
-        if (initiallySynced.current === false && syncWithLocationKey) {
+        if (initiallySynced === false && syncWithLocationKey) {
             const openStatus = parsed?.params?.[syncWithLocationKey]?.open;
             if (typeof openStatus === "boolean") {
                 if (openStatus) {
@@ -179,12 +181,12 @@ export const useModalForm = <
                 }
             }
 
-            initiallySynced.current = true;
+            setInitiallySynced(true);
         }
     }, [syncWithLocationKey, parsed, syncingId, setId]);
 
     React.useEffect(() => {
-        if (initiallySynced.current === true) {
+        if (initiallySynced === true) {
             if (visible && syncWithLocationKey) {
                 go({
                     query: {

--- a/packages/react-hook-form/src/useModalForm/index.ts
+++ b/packages/react-hook-form/src/useModalForm/index.ts
@@ -111,7 +111,7 @@ export const useModalForm = <
     TResponse,
     TResponseError
 > => {
-    const initiallySynced = React.useRef(false);
+    const [initiallySynced, setInitiallySynced] = React.useState(false);
 
     const translate = useTranslate();
 
@@ -125,8 +125,10 @@ export const useModalForm = <
 
     const action = actionProp ?? actionFromParams ?? "";
 
-    const syncingId =
-        typeof syncWithLocation === "object" && syncWithLocation.syncId;
+    const syncingId = !(
+        typeof syncWithLocation === "object" &&
+        syncWithLocation?.syncId === false
+    );
 
     const syncWithLocationKey =
         typeof syncWithLocation === "object" && "key" in syncWithLocation
@@ -166,7 +168,7 @@ export const useModalForm = <
     });
 
     React.useEffect(() => {
-        if (initiallySynced.current === false && syncWithLocationKey) {
+        if (initiallySynced === false && syncWithLocationKey) {
             const openStatus = parsed?.params?.[syncWithLocationKey]?.open;
             if (typeof openStatus === "boolean") {
                 if (openStatus) {
@@ -185,12 +187,12 @@ export const useModalForm = <
                 }
             }
 
-            initiallySynced.current = true;
+            setInitiallySynced(true);
         }
     }, [syncWithLocationKey, parsed, syncingId, setId]);
 
     React.useEffect(() => {
-        if (initiallySynced.current === true) {
+        if (initiallySynced === true) {
             if (visible && syncWithLocationKey) {
                 go({
                     query: {


### PR DESCRIPTION
`syncWithLocation.syncId` default to `true` for `useDrawerForm` and `useModalForm`