### PR TITLE
feat(mui): customize buttons in crud components

### DIFF
--- a/.changeset/cyan-rocks-laugh.md
+++ b/.changeset/cyan-rocks-laugh.md
@@ -1,0 +1,40 @@
+---
+"@refinedev/mui": minor
+---
+
+feat: added default button props into the renderer functions `headerButtons` and `footerButtons` in CRUD components.
+Now, customization of the header and footer buttons can be achieved without losing the default functionality.
+
+```tsx
+import {
+    Show,
+    ListButton,
+    RefreshButton,
+    EditButton,
+    DeleteButton,
+} from "@refinedev/mui";
+const PostShow = () => {
+    return (
+        <Show
+            headerButtons={({
+                deleteButtonProps,
+                editButtonProps,
+                listButtonProps,
+                refreshButtonProps,
+            }) => {
+                return (
+                    <>
+                        {/* custom components */}
+                        <ListButton {...listButtonProps} />
+                        <RefreshButton {...refreshButtonProps} />
+                        <EditButton {...editButtonProps} />
+                        <DeleteButton {...deleteButtonProps} />
+                    </>
+                );
+            }}
+        >
+            {/* ... */}
+        </Show>
+    );
+};
+```

--- a/documentation/docs/api-reference/mui/components/basic-views/create.md
+++ b/documentation/docs/api-reference/mui/components/basic-views/create.md
@@ -85,7 +85,9 @@ const SampleCreate = () => {
                                 );
                             }}
                             isOptionEqualToValue={(option, value) =>
-                                value === undefined || option?.id?.toString() === (value?.id ?? value)?.toString()
+                                value === undefined ||
+                                option?.id?.toString() ===
+                                    (value?.id ?? value)?.toString()
                             }
                             renderInput={(params) => (
                                 <TextField
@@ -649,7 +651,9 @@ render(
 
 ### `footerButtons`
 
-You can customize the buttons at the footer by using the `footerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
+By default, the `<Create/>` component has a [`<SaveButton>`][save-button] at the header.
+
+You can customize the buttons at the footer by using the `footerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons, saveButtonProps }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
 ```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/create
 // visible-block-start
@@ -665,6 +669,58 @@ const PostCreate: React.FC = () => {
             footerButtons={({ defaultButtons }) => (
                 <>
                     {defaultButtons}
+                    <Button type="primary">Custom Button</Button>
+                </>
+            )}
+            // highlight-end
+        >
+            <span>Rest of your page here</span>
+        </Create>
+    );
+};
+// visible-block-end
+
+render(
+    <RefineMuiDemo
+        initialRoutes={["/posts", "/posts/create"]}
+        resources={[
+            {
+                name: "posts",
+                list: () => (
+                    <div>
+                        <p>This page is empty.</p>
+                        <RefineMui.CreateButton />
+                    </div>
+                ),
+                create: PostCreate,
+            },
+        ]}
+    />,
+);
+```
+
+Or, instead of using the `defaultButtons`, you can create your own buttons. If you want, you can use `saveButtonProps` to utilize the default values of the [`<SaveButton>`][save-button] component.
+
+```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/create
+// visible-block-start
+import { Create, SaveButton } from "@refinedev/mui";
+import { Button } from "@mui/material";
+
+const PostCreate: React.FC = () => {
+    const [loading, setLoading] = React.useState(true);
+
+    return (
+        <Create
+            // highlight-start
+            footerButtons={({ saveButtonProps }) => (
+                <>
+                    <SaveButton
+                        {...saveButtonProps}
+                        type="primary"
+                        sx={{ marginRight: 8 }}
+                    >
+                        Save
+                    </SaveButton>
                     <Button type="primary">Custom Button</Button>
                 </>
             )}
@@ -837,3 +893,5 @@ const Wrapper = ({ children }) => {
     );
 };
 ```
+
+[save-button]: /docs/api-reference/mui/components/buttons/save-button/

--- a/documentation/docs/api-reference/mui/components/basic-views/edit.md
+++ b/documentation/docs/api-reference/mui/components/basic-views/edit.md
@@ -89,7 +89,9 @@ const SampleEdit = () => {
                                 );
                             }}
                             isOptionEqualToValue={(option, value) =>
-                                value === undefined || option?.id?.toString() === (value?.id ?? value)?.toString()
+                                value === undefined ||
+                                option?.id?.toString() ===
+                                    (value?.id ?? value)?.toString()
                             }
                             renderInput={(params) => (
                                 <TextField
@@ -516,7 +518,9 @@ const SampleEdit = () => {
                                 );
                             }}
                             isOptionEqualToValue={(option, value) =>
-                                value === undefined || option?.id?.toString() === (value?.id ?? value)?.toString()
+                                value === undefined ||
+                                option?.id?.toString() ===
+                                    (value?.id ?? value)?.toString()
                             }
                             renderInput={(params) => (
                                 <TextField
@@ -869,7 +873,9 @@ render(
 
 ### `headerButtons`
 
-You can customize the buttons at the header by using the `headerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
+By default, the `<Edit/>` component has a [`<ListButton>`][list-button] and a [`<RefreshButton>`][refresh-button] at the header.
+
+You can customize the buttons at the header by using the `headerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons, refreshButtonProps, listButtonProps }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
 ```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/edit/123
 // visible-block-start
@@ -885,6 +891,53 @@ const PostEdit: React.FC = () => {
             headerButtons={({ defaultButtons }) => (
                 <>
                     {defaultButtons}
+                    <Button type="primary">Custom Button</Button>
+                </>
+            )}
+            // highlight-end
+        >
+            <span>Rest of your page here</span>
+        </Edit>
+    );
+};
+// visible-block-end
+
+render(
+    <RefineMuiDemo
+        initialRoutes={["/posts", "/posts/edit/123"]}
+        resources={[
+            {
+                name: "posts",
+                list: () => (
+                    <div>
+                        <p>This page is empty.</p>
+                        <RefineMui.EditButton recordItemId={123} />
+                    </div>
+                ),
+                edit: PostEdit,
+            },
+        ]}
+    />,
+);
+```
+
+Or, instead of using the `defaultButtons`, you can create your own buttons. If you want, you can use `refreshButtonProps` and `listButtonProps` to utilize the default values of the `<ListButton>`[list-button] and `<RefreshButton>`[refresh-button] components.
+
+```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/edit/123
+// visible-block-start
+import { Edit, ListButton, RefreshButton } from "@refinedev/mui";
+import { Button } from "@mui/material";
+
+const PostEdit: React.FC = () => {
+    const [loading, setLoading] = React.useState(true);
+
+    return (
+        <Edit
+            // highlight-start
+            headerButtons={({ refreshButtonProps, listButtonProps }) => (
+                <>
+                    <RefreshButton {...refreshButtonProps} />
+                    <ListButton {...listButtonProps} />
                     <Button type="primary">Custom Button</Button>
                 </>
             )}
@@ -972,7 +1025,9 @@ render(
 
 ### `footerButtons`
 
-You can customize the buttons at the footer by using the `footerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
+By default, the `<Edit/>` component has a [`<SaveButton>`][save-button] and a [`<DeleteButton>`][delete-button] at the footer.
+
+You can customize the buttons at the footer by using the `footerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons, saveButtonProps, deleteButtonProps }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
 ```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/edit/123
 // visible-block-start
@@ -989,6 +1044,53 @@ const PostEdit: React.FC = () => {
                 <>
                     {defaultButtons}
                     <Button type="primary">Custom Button</Button>
+                </>
+            )}
+            // highlight-end
+        >
+            <span>Rest of your page here</span>
+        </Edit>
+    );
+};
+// visible-block-end
+
+render(
+    <RefineMuiDemo
+        initialRoutes={["/posts", "/posts/edit/123"]}
+        resources={[
+            {
+                name: "posts",
+                list: () => (
+                    <div>
+                        <p>This page is empty.</p>
+                        <RefineMui.EditButton recordItemId={123} />
+                    </div>
+                ),
+                edit: PostEdit,
+            },
+        ]}
+    />,
+);
+```
+
+Or, instead of using the `defaultButtons`, you can create your own buttons. If you want, you can use `saveButtonProps` and `deleteButtonProps` to utilize the default values of the [`<SaveButton>`][save-button] and [`<DeleteButton>`][delete-button] components.
+
+```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/edit/123
+// visible-block-start
+import { Edit, SaveButton, DeleteButton } from "@refinedev/mui";
+import { Button } from "@mui/material";
+
+const PostEdit: React.FC = () => {
+    const [loading, setLoading] = React.useState(true);
+
+    return (
+        <Edit
+            // highlight-start
+            footerButtons={({ saveButtonProps, deleteButtonProps }) => (
+                <>
+                    <Button type="primary">Custom Button</Button>
+                    <SaveButton {...saveButtonProps} />
+                    <DeleteButton {...deleteButtonProps} />
                 </>
             )}
             // highlight-end
@@ -1190,3 +1292,8 @@ const Wrapper = ({ children }) => {
     );
 };
 ```
+
+[list-button]: /docs/api-reference/mui/components/buttons/list-button/
+[refresh-button]: /docs/api-reference/mui/components/buttons/refresh-button/
+[save-button]: /docs/api-reference/mui/components/buttons/save-button/
+[delete-button]: /docs/api-reference/mui/components/buttons/delete-button/

--- a/documentation/docs/api-reference/mui/components/basic-views/list.md
+++ b/documentation/docs/api-reference/mui/components/basic-views/list.md
@@ -451,7 +451,9 @@ render(
 
 ### `headerButtons`
 
-You can customize the buttons at the header by using the `headerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
+By default, the `<List/>` component has a [`<CreateButton>`][create-button] at the header.
+
+You can customize the buttons at the header by using the `headerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons, createButtonProps }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
 ```tsx live disableScroll previewHeight=210px url=http://localhost:3000/posts
 // visible-block-start
@@ -467,6 +469,46 @@ const PostList: React.FC = () => {
             headerButtons={({ defaultButtons }) => (
                 <>
                     {defaultButtons}
+                    <Button type="primary">Custom Button</Button>
+                </>
+            )}
+            // highlight-end
+        >
+            <span>Rest of your page here</span>
+        </List>
+    );
+};
+// visible-block-end
+
+render(
+    <RefineMuiDemo
+        initialRoutes={["/posts"]}
+        resources={[
+            {
+                name: "posts",
+                list: PostList,
+            },
+        ]}
+    />,
+);
+```
+
+Or, instead of using the `defaultButtons`, you can create your own buttons. If you want, you can use `createButtonProps` to utilize the default values of the [`<CreateButton>`][create-button] component.
+
+```tsx live disableScroll previewHeight=210px url=http://localhost:3000/posts
+// visible-block-start
+import { List, CreateButton } from "@refinedev/mui";
+import { Button } from "@mui/material";
+
+const PostList: React.FC = () => {
+    const [loading, setLoading] = React.useState(true);
+
+    return (
+        <List
+            // highlight-start
+            headerButtons={({ createButtonProps }) => (
+                <>
+                    <CreateButton {...createButtonProps} />
                     <Button type="primary">Custom Button</Button>
                 </>
             )}
@@ -567,3 +609,5 @@ const Wrapper = ({ children }) => {
     );
 };
 ```
+
+[create-button]: /docs/api-reference/mui/components/buttons/create-button/

--- a/documentation/docs/api-reference/mui/components/basic-views/show.md
+++ b/documentation/docs/api-reference/mui/components/basic-views/show.md
@@ -661,6 +661,8 @@ render(
 
 ### `headerButtons`
 
+By default, the `<Show/>` component has a [`<ListButton>`][list-button], [`<EditButton>`][edit-button], [`<DeleteButton>`][delete-button], and, [`<RefreshButton>`][refresh-button] at the header.
+
 You can customize the buttons at the header by using the `headerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
 ```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/show/123
@@ -678,6 +680,66 @@ const PostShow: React.FC = () => {
                 <>
                     {defaultButtons}
                     <Button type="primary">Custom Button</Button>
+                </>
+            )}
+            // highlight-end
+        >
+            <span>Rest of your page here</span>
+        </Show>
+    );
+};
+// visible-block-end
+
+render(
+    <RefineMuiDemo
+        initialRoutes={["/posts", "/posts/show/123"]}
+        resources={[
+            {
+                name: "posts",
+                list: () => (
+                    <div>
+                        <p>This page is empty.</p>
+                        <RefineMui.ShowButton recordItemId={123} />
+                    </div>
+                ),
+                show: PostShow,
+            },
+        ]}
+    />,
+);
+```
+
+Or, instead of using the `defaultButtons`, you can create your own buttons. If you want, you can use `createButtonProps` to utilize the default values of the [`<ListButton>`][list-button], [`<EditButton>`][edit-button], [`<DeleteButton>`][delete-button], and, [`<RefreshButton>`][refresh-button] components.
+
+```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/show/123
+// visible-block-start
+import {
+    Show,
+    ListButton,
+    EditButton,
+    DeleteButton,
+    RefreshButton,
+} from "@refinedev/mui";
+import { Button } from "@mui/material";
+
+const PostShow: React.FC = () => {
+    const [loading, setLoading] = React.useState(true);
+
+    return (
+        <Show
+            // highlight-start
+            headerButtons={({
+                deleteButtonProps,
+                editButtonProps,
+                listButtonProps,
+                refreshButtonProps,
+            }) => (
+                <>
+                    <Button type="primary">Custom Button</Button>
+                    <ListButton {...listButtonProps} />
+                    <EditButton {...editButtonProps} />
+                    <DeleteButton {...deleteButtonProps} />
+                    <RefreshButton {...refreshButtonProps} />
                 </>
             )}
             // highlight-end
@@ -979,3 +1041,8 @@ const Wrapper = ({ children }) => {
     );
 };
 ```
+
+[list-button]: /docs/api-reference/mui/components/buttons/list-button/
+[refresh-button]: /docs/api-reference/mui/components/buttons/refresh-button/
+[edit-button]: /docs/api-reference/mui/components/buttons/edit-button/
+[delete-button]: /docs/api-reference/mui/components/buttons/delete-button/

--- a/packages/mui/src/components/crud/create/index.spec.tsx
+++ b/packages/mui/src/components/crud/create/index.spec.tsx
@@ -2,9 +2,11 @@ import React from "react";
 
 import { Route, Routes } from "react-router-dom";
 
-import { act, render, TestWrapper } from "@test";
+import { render, TestWrapper } from "@test";
 import { Create } from "./";
 import { crudCreateTests } from "@refinedev/ui-tests";
+import { SaveButton } from "@components/buttons";
+import { RefineButtonTestIds } from "@refinedev/ui-types";
 
 describe("Create", () => {
     crudCreateTests.bind(this)(Create);
@@ -26,6 +28,7 @@ describe("Create", () => {
 
         expect(getAllByLabelText("breadcrumb")).not.toBeNull();
     });
+
     it("should not render breadcrumb", async () => {
         const { queryByLabelText } = render(
             <Routes>
@@ -42,5 +45,37 @@ describe("Create", () => {
         );
 
         expect(queryByLabelText("breadcrumb")).not.toBeInTheDocument();
+    });
+
+    it("should customize default buttons with default props", async () => {
+        const { queryByTestId } = render(
+            <Routes>
+                <Route
+                    path="/:resource/:action"
+                    element={
+                        <Create
+                            resource="posts"
+                            saveButtonProps={{ className: "customize-test" }}
+                            footerButtons={({ saveButtonProps }) => {
+                                return (
+                                    <>
+                                        <SaveButton {...saveButtonProps} />
+                                    </>
+                                );
+                            }}
+                        />
+                    }
+                />
+            </Routes>,
+            {
+                wrapper: TestWrapper({
+                    routerInitialEntries: ["/posts/create"],
+                }),
+            },
+        );
+
+        expect(queryByTestId(RefineButtonTestIds.SaveButton)).toHaveClass(
+            "customize-test",
+        );
     });
 });

--- a/packages/mui/src/components/crud/create/index.tsx
+++ b/packages/mui/src/components/crud/create/index.tsx
@@ -33,7 +33,7 @@ import { CreateProps } from "../types";
 export const Create: React.FC<CreateProps> = ({
     title,
     children,
-    saveButtonProps,
+    saveButtonProps: saveButtonPropsFromProps,
     resource: resourceFromProps,
     isLoading = false,
     breadcrumb: breadcrumbFromProps,
@@ -68,12 +68,12 @@ export const Create: React.FC<CreateProps> = ({
             <Breadcrumb />
         );
 
-    const defaultFooterButtons = (
-        <SaveButton
-            {...(isLoading ? { disabled: true } : {})}
-            {...saveButtonProps}
-        />
-    );
+    const saveButtonProps = {
+        ...(isLoading ? { disabled: true } : {}),
+        ...saveButtonPropsFromProps,
+    };
+
+    const defaultFooterButtons = <SaveButton {...saveButtonProps} />;
 
     return (
         <Card {...(wrapperProps ?? {})}>
@@ -147,6 +147,7 @@ export const Create: React.FC<CreateProps> = ({
                     ? typeof footerButtons === "function"
                         ? footerButtons({
                               defaultButtons: defaultFooterButtons,
+                              saveButtonProps,
                           })
                         : footerButtons
                     : defaultFooterButtons}

--- a/packages/mui/src/components/crud/edit/index.spec.tsx
+++ b/packages/mui/src/components/crud/edit/index.spec.tsx
@@ -6,6 +6,12 @@ import { act, render, TestWrapper, waitFor } from "@test";
 import { Edit } from "./";
 import { crudEditTests } from "@refinedev/ui-tests";
 import { RefineButtonTestIds } from "@refinedev/ui-types";
+import {
+    DeleteButton,
+    ListButton,
+    RefreshButton,
+    SaveButton,
+} from "@components/buttons";
 
 const renderEdit = (
     edit: ReactNode,
@@ -26,13 +32,10 @@ const renderEdit = (
 
 describe("Edit", () => {
     crudEditTests.bind(this)(Edit);
-
     it("should render optional mutationMode with mutationModeProp prop", async () => {
         const container = renderEdit(<Edit mutationMode="undoable" />);
-
         expect(container).toBeTruthy();
     });
-
     it("should render optional resource with resource prop", async () => {
         const { getByText } = render(
             <Routes>
@@ -47,10 +50,8 @@ describe("Edit", () => {
                 }),
             },
         );
-
         getByText("Edit Post");
     });
-
     describe("render delete button", () => {
         it("should render delete button ", async () => {
             const { getByText, queryByTestId } = render(
@@ -64,14 +65,11 @@ describe("Edit", () => {
                     }),
                 },
             );
-
             expect(
                 queryByTestId(RefineButtonTestIds.DeleteButton),
             ).not.toBeNull();
-
             getByText("Edit Post");
         });
-
         it("should not render delete button on resource canDelete false", async () => {
             const { getByText, queryByTestId } = render(
                 <Routes>
@@ -87,12 +85,9 @@ describe("Edit", () => {
                     }),
                 },
             );
-
             expect(queryByTestId(RefineButtonTestIds.DeleteButton)).toBeNull();
-
             getByText("Edit Post");
         });
-
         it("should not render delete button on resource canDelete true & canDelete props false on component", async () => {
             const { queryByTestId } = render(
                 <Routes>
@@ -101,7 +96,6 @@ describe("Edit", () => {
                         element={<Edit canDelete={false} />}
                     ></Route>
                 </Routes>,
-
                 {
                     wrapper: TestWrapper({
                         resources: [{ name: "posts", canDelete: true }],
@@ -109,10 +103,8 @@ describe("Edit", () => {
                     }),
                 },
             );
-
             expect(queryByTestId(RefineButtonTestIds.DeleteButton)).toBeNull();
         });
-
         it("should render delete button on resource canDelete false & canDelete props true on component", async () => {
             const { queryByTestId } = render(
                 <Routes>
@@ -128,12 +120,10 @@ describe("Edit", () => {
                     }),
                 },
             );
-
             expect(
                 queryByTestId(RefineButtonTestIds.DeleteButton),
             ).not.toBeNull();
         });
-
         it("should render delete button on resource canDelete false & deleteButtonProps props not null on component", async () => {
             const { queryByTestId } = render(
                 <Routes>
@@ -149,13 +139,11 @@ describe("Edit", () => {
                     }),
                 },
             );
-
             expect(
                 queryByTestId(RefineButtonTestIds.DeleteButton),
             ).not.toBeNull();
         });
     });
-
     describe("accessibility of buttons by accessControlProvider", () => {
         it("should render disabled list button and not disabled delete button", async () => {
             const { queryByTestId } = renderEdit(<Edit canDelete />, {
@@ -169,7 +157,6 @@ describe("Edit", () => {
                     }
                 },
             });
-
             await waitFor(() =>
                 expect(
                     queryByTestId(RefineButtonTestIds.ListButton),
@@ -181,7 +168,6 @@ describe("Edit", () => {
                 ).toBeDisabled(),
             );
         });
-
         it("should render disabled list button and delete button", async () => {
             const { queryByTestId } = renderEdit(<Edit canDelete />, {
                 can: ({ action }) => {
@@ -194,7 +180,6 @@ describe("Edit", () => {
                     }
                 },
             });
-
             await waitFor(() =>
                 expect(
                     queryByTestId(RefineButtonTestIds.ListButton),
@@ -207,7 +192,6 @@ describe("Edit", () => {
             );
         });
     });
-
     describe("Breadcrumb ", () => {
         it("should render breadcrumb", async () => {
             const { getAllByLabelText } = render(
@@ -224,7 +208,6 @@ describe("Edit", () => {
                     }),
                 },
             );
-
             expect(getAllByLabelText("breadcrumb")).not.toBeNull();
         });
         it("should not render breadcrumb", async () => {
@@ -242,8 +225,58 @@ describe("Edit", () => {
                     }),
                 },
             );
-
             expect(queryByLabelText("breadcrumb")).not.toBeInTheDocument();
         });
+    });
+
+    it("should customize default buttons with default props", async () => {
+        const { queryByTestId } = renderEdit(
+            <Edit
+                canDelete
+                saveButtonProps={{ className: "customize-test" }}
+                headerButtons={({ listButtonProps, refreshButtonProps }) => {
+                    return (
+                        <>
+                            <RefreshButton {...refreshButtonProps} />
+                            <ListButton {...listButtonProps} />
+                        </>
+                    );
+                }}
+                footerButtons={({ deleteButtonProps, saveButtonProps }) => {
+                    return (
+                        <>
+                            <DeleteButton {...deleteButtonProps} />
+                            <SaveButton {...saveButtonProps} />
+                        </>
+                    );
+                }}
+            />,
+            {
+                can: ({ action }) => {
+                    switch (action) {
+                        case "list":
+                        case "delete":
+                            return Promise.resolve({ can: false });
+                        default:
+                            return Promise.resolve({ can: false });
+                    }
+                },
+            },
+        );
+
+        await waitFor(() =>
+            expect(
+                queryByTestId(RefineButtonTestIds.DeleteButton),
+            ).toBeDisabled(),
+        );
+        await waitFor(() =>
+            expect(
+                queryByTestId(RefineButtonTestIds.ListButton),
+            ).toBeDisabled(),
+        );
+        expect(queryByTestId(RefineButtonTestIds.SaveButton)).toHaveClass(
+            "customize-test",
+        );
+        expect(queryByTestId(RefineButtonTestIds.RefreshButton)).toBeTruthy();
     });
 });

--- a/packages/mui/src/components/crud/list/index.spec.tsx
+++ b/packages/mui/src/components/crud/list/index.spec.tsx
@@ -1,5 +1,23 @@
+import React, { ReactNode } from "react";
 import { crudListTests } from "@refinedev/ui-tests";
+import { RefineButtonTestIds } from "@refinedev/ui-types";
+import { Route, Routes } from "react-router-dom";
+import { CreateButton } from "@components/buttons";
+import { render, TestWrapper } from "@test";
 import { List } from "./index";
+
+const renderList = (list: ReactNode) => {
+    return render(
+        <Routes>
+            <Route path="/:resource" element={list} />
+        </Routes>,
+        {
+            wrapper: TestWrapper({
+                routerInitialEntries: ["/posts"],
+            }),
+        },
+    );
+};
 
 describe("<List/>", () => {
     beforeEach(() => {
@@ -14,4 +32,23 @@ describe("<List/>", () => {
     });
 
     crudListTests.bind(this)(List);
+
+    it("should customize default buttons with default props", async () => {
+        const { queryByTestId } = renderList(
+            <List
+                createButtonProps={{ className: "customize-test" }}
+                headerButtons={({ createButtonProps }) => {
+                    return (
+                        <>
+                            <CreateButton {...createButtonProps} />
+                        </>
+                    );
+                }}
+            />,
+        );
+
+        expect(queryByTestId(RefineButtonTestIds.CreateButton)).toHaveClass(
+            "customize-test",
+        );
+    });
 });

--- a/packages/mui/src/components/crud/list/index.tsx
+++ b/packages/mui/src/components/crud/list/index.tsx
@@ -23,7 +23,7 @@ export const List: React.FC<ListProps> = ({
     title,
     canCreate,
     children,
-    createButtonProps,
+    createButtonProps: createButtonPropsFromProps,
     resource: resourceFromProps,
     breadcrumb: breadcrumbFromProps,
     wrapperProps,
@@ -42,7 +42,8 @@ export const List: React.FC<ListProps> = ({
 
     const isCreateButtonVisible =
         canCreate ??
-        ((resource?.canCreate ?? !!resource?.create) || createButtonProps);
+        ((resource?.canCreate ?? !!resource?.create) ||
+            createButtonPropsFromProps);
 
     const breadcrumb =
         typeof breadcrumbFromProps === "undefined"
@@ -56,15 +57,16 @@ export const List: React.FC<ListProps> = ({
             <Breadcrumb />
         );
 
+    const createButtonProps = {
+        resource:
+            routerType === "legacy"
+                ? resource?.route
+                : resource?.identifier ?? resource?.name,
+        ...createButtonPropsFromProps,
+    };
+
     const defaultHeaderButtons = isCreateButtonVisible ? (
-        <CreateButton
-            resource={
-                routerType === "legacy"
-                    ? resource?.route
-                    : resource?.identifier ?? resource?.name
-            }
-            {...createButtonProps}
-        />
+        <CreateButton {...createButtonProps} />
     ) : null;
 
     return (
@@ -94,6 +96,7 @@ export const List: React.FC<ListProps> = ({
                             ? typeof headerButtons === "function"
                                 ? headerButtons({
                                       defaultButtons: defaultHeaderButtons,
+                                      createButtonProps,
                                   })
                                 : headerButtons
                             : defaultHeaderButtons}

--- a/packages/mui/src/components/crud/show/index.spec.tsx
+++ b/packages/mui/src/components/crud/show/index.spec.tsx
@@ -7,6 +7,12 @@ import { render, TestWrapper, waitFor } from "@test";
 
 import { Show } from "./index";
 import { RefineButtonTestIds } from "@refinedev/ui-types";
+import {
+    DeleteButton,
+    EditButton,
+    ListButton,
+    RefreshButton,
+} from "@components/buttons";
 
 const renderShow = (
     show: ReactNode,
@@ -314,5 +320,49 @@ describe("Show", () => {
                 expect(queryByLabelText("breadcrumb")).not.toBeInTheDocument();
             });
         });
+    });
+
+    it("should customize default buttons with default props", async () => {
+        const { queryByTestId } = render(
+            <Routes>
+                <Route
+                    path="/:resource/:action/:id"
+                    element={
+                        <Show
+                            canEdit
+                            canDelete
+                            headerButtons={({
+                                deleteButtonProps,
+                                editButtonProps,
+                                listButtonProps,
+                                refreshButtonProps,
+                            }) => {
+                                return (
+                                    <>
+                                        <DeleteButton {...deleteButtonProps} />
+                                        <EditButton {...editButtonProps} />
+                                        <ListButton {...listButtonProps} />
+                                        <RefreshButton
+                                            {...refreshButtonProps}
+                                        />
+                                    </>
+                                );
+                            }}
+                        />
+                    }
+                />
+            </Routes>,
+            {
+                wrapper: TestWrapper({
+                    resources: [{ name: "posts" }],
+                    routerInitialEntries: ["/posts/show/1"],
+                }),
+            },
+        );
+
+        expect(queryByTestId(RefineButtonTestIds.DeleteButton)).not.toBeNull();
+        expect(queryByTestId(RefineButtonTestIds.EditButton)).not.toBeNull();
+        expect(queryByTestId(RefineButtonTestIds.ListButton)).not.toBeNull();
+        expect(queryByTestId(RefineButtonTestIds.RefreshButton)).not.toBeNull();
     });
 });

--- a/packages/mui/src/components/crud/show/index.tsx
+++ b/packages/mui/src/components/crud/show/index.tsx
@@ -95,60 +95,55 @@ export const Show: React.FC<ShowProps> = ({
             <Breadcrumb />
         );
 
+    const listButtonProps = {
+        ...(isLoading ? { disabled: true } : {}),
+        resource:
+            routerType === "legacy"
+                ? resource?.route
+                : resource?.identifier ?? resource?.name,
+    };
+    const editButtonProps = {
+        ...(isLoading ? { disabled: true } : {}),
+        resource:
+            routerType === "legacy"
+                ? resource?.route
+                : resource?.identifier ?? resource?.name,
+        recordItemId: id,
+    };
+    const deleteButtonProps = {
+        ...(isLoading ? { disabled: true } : {}),
+        resource:
+            routerType === "legacy"
+                ? resource?.route
+                : resource?.identifier ?? resource?.name,
+        recordItemId: id,
+        onSuccess: () => {
+            if (routerType === "legacy") {
+                legacyGoList(resource?.route ?? resource?.name ?? "");
+            } else {
+                go({ to: goListPath });
+            }
+        },
+        dataProviderName,
+    };
+    const refreshButtonProps = {
+        ...(isLoading ? { disabled: true } : {}),
+        resource:
+            routerType === "legacy"
+                ? resource?.route
+                : resource?.identifier ?? resource?.name,
+        recordItemId: id,
+        dataProviderName,
+    };
+
     const defaultHeaderButtons = (
         <>
-            {!recordItemId && (
-                <ListButton
-                    {...(isLoading ? { disabled: true } : {})}
-                    resource={
-                        routerType === "legacy"
-                            ? resource?.route
-                            : resource?.identifier ?? resource?.name
-                    }
-                />
-            )}
-            {isEditButtonVisible && (
-                <EditButton
-                    {...(isLoading ? { disabled: true } : {})}
-                    resource={
-                        routerType === "legacy"
-                            ? resource?.route
-                            : resource?.identifier ?? resource?.name
-                    }
-                    recordItemId={id}
-                />
-            )}
+            {!recordItemId && <ListButton {...listButtonProps} />}
+            {isEditButtonVisible && <EditButton {...editButtonProps} />}
             {isDeleteButtonVisible && typeof id !== "undefined" && (
-                <DeleteButton
-                    {...(isLoading ? { disabled: true } : {})}
-                    resource={
-                        routerType === "legacy"
-                            ? resource?.route
-                            : resource?.identifier ?? resource?.name
-                    }
-                    recordItemId={id}
-                    onSuccess={() => {
-                        if (routerType === "legacy") {
-                            legacyGoList(
-                                resource?.route ?? resource?.name ?? "",
-                            );
-                        } else {
-                            go({ to: goListPath });
-                        }
-                    }}
-                    dataProviderName={dataProviderName}
-                />
+                <DeleteButton {...deleteButtonProps} />
             )}
-            <RefreshButton
-                {...(isLoading ? { disabled: true } : {})}
-                resource={
-                    routerType === "legacy"
-                        ? resource?.route
-                        : resource?.identifier ?? resource?.name
-                }
-                recordItemId={id}
-                dataProviderName={dataProviderName}
-            />
+            <RefreshButton {...refreshButtonProps} />
         </>
     );
 
@@ -201,6 +196,10 @@ export const Show: React.FC<ShowProps> = ({
                             ? typeof headerButtons === "function"
                                 ? headerButtons({
                                       defaultButtons: defaultHeaderButtons,
+                                      deleteButtonProps,
+                                      editButtonProps,
+                                      listButtonProps,
+                                      refreshButtonProps,
                                   })
                                 : headerButtons
                             : defaultHeaderButtons}


### PR DESCRIPTION
feat: added default button props into the renderer functions `headerButtons` and `footerButtons` in CRUD components.
Now, customization of the header and footer buttons can be achieved without losing the default functionality.

```tsx
import {
    Show,
    ListButton,
    RefreshButton,
    EditButton,
    DeleteButton,
} from "@refinedev/mui";
const PostShow = () => {
    return (
        <Show
            headerButtons={({
                deleteButtonProps,
                editButtonProps,
                listButtonProps,
                refreshButtonProps,
            }) => {
                return (
                    <>
                        {/* custom components */}
                        <ListButton {...listButtonProps} />
                        <RefreshButton {...refreshButtonProps} />
                        <EditButton {...editButtonProps} />
                        <DeleteButton {...deleteButtonProps} />
                    </>
                );
            }}
        >
            {/* ... */}
        </Show>
    );
};
```