### PR TITLE
fix: wrong className

### DIFF
--- a/.changeset/smooth-goats-knock.md
+++ b/.changeset/smooth-goats-knock.md
@@ -1,0 +1,8 @@
+---
+"@refinedev/antd": patch
+"@refinedev/chakra-ui": patch
+"@refinedev/mantine": patch
+"@refinedev/mui": patch
+---
+
+fix: fixed `className` for easier selection of all buttons and titles of CRUD components

--- a/packages/antd/src/components/buttons/save/index.tsx
+++ b/packages/antd/src/components/buttons/save/index.tsx
@@ -27,7 +27,7 @@ export const SaveButton: React.FC<SaveButtonProps> = ({
             type="primary"
             icon={<SaveOutlined />}
             data-testid={RefineButtonTestIds.SaveButton}
-            className={RefineButtonClassNames.RefreshButton}
+            className={RefineButtonClassNames.SaveButton}
             {...rest}
         >
             {!hideText && (children ?? translate("buttons.save", "Save"))}

--- a/packages/chakra-ui/src/components/buttons/delete/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/delete/index.tsx
@@ -123,7 +123,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
                             (recordItemId ?? id) === variables?.id && isLoading
                         }
                         data-testid={RefineButtonTestIds.DeleteButton}
-                        className={RefineButtonClassNames.CloneButton}
+                        className={RefineButtonClassNames.DeleteButton}
                         {...rest}
                     >
                         <IconTrash size={20} {...svgIconProps} />
@@ -137,7 +137,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
                         isLoading={id === variables?.id && isLoading}
                         leftIcon={<IconTrash size={20} {...svgIconProps} />}
                         data-testid={RefineButtonTestIds.DeleteButton}
-                        className={RefineButtonClassNames.CloneButton}
+                        className={RefineButtonClassNames.DeleteButton}
                         {...rest}
                     >
                         {children ?? translate("buttons.delete", "Delete")}

--- a/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
@@ -10497,7 +10497,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
         class="MuiCardActions-root MuiCardActions-spacing css-otuins-MuiCardActions-root"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium refine-refresh-button css-1jmqb42-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium refine-save-button css-1jmqb42-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
           id=":rq:"
           tabindex="0"
           type="button"
@@ -25559,7 +25559,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
         class="MuiCardActions-root MuiCardActions-spacing css-otuins-MuiCardActions-root"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium refine-refresh-button css-1jmqb42-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium refine-save-button css-1jmqb42-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
           id=":r1c:"
           tabindex="0"
           type="button"

--- a/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/create.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/create.test.tsx.snap
@@ -623,7 +623,7 @@ exports[`MuiCreateInferencer should match the snapshot 1`] = `
         class="MuiCardActions-root MuiCardActions-spacing css-otuins-MuiCardActions-root"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium refine-refresh-button css-1jmqb42-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium refine-save-button css-1jmqb42-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
           id=":rf:"
           tabindex="0"
           type="button"

--- a/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/edit.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/edit.test.tsx.snap
@@ -725,7 +725,7 @@ exports[`MuiEditInferencer should match the snapshot 1`] = `
         class="MuiCardActions-root MuiCardActions-spacing css-otuins-MuiCardActions-root"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium refine-refresh-button css-1jmqb42-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium refine-save-button css-1jmqb42-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
           id=":rh:"
           tabindex="0"
           type="button"

--- a/packages/mantine/src/components/buttons/create/index.tsx
+++ b/packages/mantine/src/components/buttons/create/index.tsx
@@ -101,7 +101,7 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
                           }
                         : { variant: "filled" })}
                     data-testid={RefineButtonTestIds.CreateButton}
-                    className={RefineButtonClassNames.CloneButton}
+                    className={RefineButtonClassNames.CreateButton}
                     {...commonProps}
                 >
                     <IconSquarePlus size={18} {...svgIconProps} />

--- a/packages/mui/src/components/buttons/save/index.tsx
+++ b/packages/mui/src/components/buttons/save/index.tsx
@@ -31,7 +31,7 @@ export const SaveButton: React.FC<SaveButtonProps> = ({
             sx={{ minWidth: 0, ...sx }}
             variant="contained"
             data-testid={RefineButtonTestIds.SaveButton}
-            className={RefineButtonClassNames.RefreshButton}
+            className={RefineButtonClassNames.SaveButton}
             {...restProps}
         >
             {hideText ? (


### PR DESCRIPTION
This fixes some of the classNames added in PR #4312.

### Test plan (required)

<img width="759" alt="image" src="https://github.com/refinedev/refine/assets/3484713/daa0faf2-5b73-4810-bdcb-6f74cb53ae0a">

<!-- Make sure tests pass. -->

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
