### PR TITLE
test(examples): add e2e to antd forms

### DIFF
--- a/cypress/support/commands/antd/index.ts
+++ b/cypress/support/commands/antd/index.ts
@@ -1,0 +1,31 @@
+export const getAntdNotification = () => {
+    return cy.get(".ant-notification-notice");
+};
+
+export const setAntdDropdown = ({
+    id,
+    selectIndex,
+}: ISetAntdDropdownParams) => {
+    return cy
+        .get(`#${id}`)
+        .click({ force: true })
+        .get(".ant-select-item-option")
+        .eq(selectIndex || 0)
+        .click({ force: true })
+        .get(`#${id}`)
+        .blur();
+};
+
+export const setAntdSelect = ({ id, value }: ISetAntdSelectParams) => {
+    return cy
+        .get(`#${id}`)
+        .click({ force: true })
+        .get(`.ant-select-item[title="${value}"]`)
+        .click({ force: true })
+        .get(`#${id}`)
+        .blur();
+};
+
+export const getAntdFormItemError = ({ id }: IGetAntdFormItemErrorParams) => {
+    return cy.get(`#${id}_help > .ant-form-item-explain-error`);
+};

--- a/cypress/support/commands/refine/index.ts
+++ b/cypress/support/commands/refine/index.ts
@@ -1,0 +1,11 @@
+export const getSaveButton = () => {
+    return cy.get(".refine-save-button");
+};
+
+export const getCreateButton = () => {
+    return cy.get(".refine-create-button");
+};
+
+export const getDeleteButton = () => {
+    return cy.get(".refine-delete-button");
+};

--- a/cypress/support/commands/resource.ts
+++ b/cypress/support/commands/resource.ts
@@ -6,7 +6,7 @@ export const list = () => {
 };
 
 export const create = () => {
-    cy.get(".refine-create-button").click();
+    cy.getCreateButton().click();
     cy.url().should("include", "/posts/create");
     // TODO: Fill all form fields and submit
 };

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,7 +1,25 @@
 /// <reference types="cypress" />
+import {
+    getAntdNotification,
+    setAntdSelect,
+    setAntdDropdown,
+    getAntdFormItemError,
+} from "./commands/antd";
+import {
+    getCreateButton,
+    getDeleteButton,
+    getSaveButton,
+} from "./commands/refine";
 import { list, create, edit, show } from "./commands/resource";
 
 Cypress.Commands.add("resourceList", list);
 Cypress.Commands.add("resourceCreate", create);
 Cypress.Commands.add("resourceEdit", edit);
 Cypress.Commands.add("resourceShow", show);
+Cypress.Commands.add("getSaveButton", getSaveButton);
+Cypress.Commands.add("getCreateButton", getCreateButton);
+Cypress.Commands.add("getDeleteButton", getDeleteButton);
+Cypress.Commands.add("getAntdNotification", getAntdNotification);
+Cypress.Commands.add("setAntdSelect", setAntdSelect);
+Cypress.Commands.add("setAntdDropdown", setAntdDropdown);
+Cypress.Commands.add("getAntdFormItemError", getAntdFormItemError);

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,4 +1,6 @@
 /// <reference types="cypress" />
+/// <reference types="./index.d.ts" />
+
 import {
     getAntdNotification,
     setAntdSelect,

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="cypress" />
+
 interface ISetAntdDropdownParams {
     id: string;
     selectIndex?: number;
@@ -24,10 +26,10 @@ declare namespace Cypress {
         getAntdNotification(): Chainable<JQuery<HTMLElement>>;
         setAntdDropdown(
             params: ISetAntdDropdownParams,
-        ): Cypress.Chainable<JQuery<HTMLElement>>;
+        ): Chainable<JQuery<HTMLElement>>;
         setAntdSelect(
             params: ISetAntdSelectParams,
-        ): Cypress.Chainable<JQuery<HTMLElement>>;
+        ): Chainable<JQuery<HTMLElement>>;
         getAntdFormItemError(
             params: IGetAntdFormItemErrorParams,
         ): Chainable<JQuery<HTMLElement>>;

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,8 +1,35 @@
+interface ISetAntdDropdownParams {
+    id: string;
+    selectIndex?: number;
+}
+
+interface ISetAntdSelectParams {
+    id: string;
+    value: string;
+}
+
+interface IGetAntdFormItemErrorParams {
+    id: string;
+}
+
 declare namespace Cypress {
     interface Chainable {
         resourceList(): Chainable<void>;
         resourceCreate(): Chainable<void>;
         resourceEdit(): Chainable<void>;
         resourceShow(): Chainable<void>;
+        getSaveButton(): Chainable<JQuery<HTMLElement>>;
+        getCreateButton(): Chainable<JQuery<HTMLElement>>;
+        getDeleteButton(): Chainable<JQuery<HTMLElement>>;
+        getAntdNotification(): Chainable<JQuery<HTMLElement>>;
+        setAntdDropdown(
+            params: ISetAntdDropdownParams,
+        ): Cypress.Chainable<JQuery<HTMLElement>>;
+        setAntdSelect(
+            params: ISetAntdSelectParams,
+        ): Cypress.Chainable<JQuery<HTMLElement>>;
+        getAntdFormItemError(
+            params: IGetAntdFormItemErrorParams,
+        ): Chainable<JQuery<HTMLElement>>;
     }
 }

--- a/examples/form-antd-custom-validation/cypress.config.ts
+++ b/examples/form-antd-custom-validation/cypress.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+    projectId: "sq5j3e",
+    e2e: {
+        supportFile: "../../cypress/support/e2e.ts",
+    },
+    chromeWebSecurity: false,
+    experimentalMemoryManagement: true,
+    numTestsKeptInMemory: 1,
+});

--- a/examples/form-antd-custom-validation/cypress.config.ts
+++ b/examples/form-antd-custom-validation/cypress.config.ts
@@ -8,4 +8,6 @@ export default defineConfig({
     chromeWebSecurity: false,
     experimentalMemoryManagement: true,
     numTestsKeptInMemory: 1,
+    viewportWidth: 1920,
+    viewportHeight: 1080,
 });

--- a/examples/form-antd-custom-validation/cypress/e2e/all.cy.ts
+++ b/examples/form-antd-custom-validation/cypress/e2e/all.cy.ts
@@ -28,14 +28,6 @@ describe("form-antd-use-form", () => {
         cy.resourceList();
     });
 
-    it("should be create page", () => {
-        cy.resourceCreate();
-    });
-
-    it("should be edit page", () => {
-        cy.resourceEdit();
-    });
-
     // first create a record with a random title,
     // after that try to create a record with the same title to check unique title validation
     it("should render error", () => {

--- a/examples/form-antd-custom-validation/cypress/e2e/all.cy.ts
+++ b/examples/form-antd-custom-validation/cypress/e2e/all.cy.ts
@@ -38,7 +38,7 @@ describe("form-antd-use-form", () => {
 
     // first create a record with a random title,
     // after that try to create a record with the same title to check unique title validation
-    it.only("should render error", () => {
+    it("should render error", () => {
         cy.intercept("POST", "/posts").as("createPost");
 
         // create a record

--- a/examples/form-antd-custom-validation/cypress/e2e/all.cy.ts
+++ b/examples/form-antd-custom-validation/cypress/e2e/all.cy.ts
@@ -1,0 +1,47 @@
+/// <reference types="cypress" />
+/// <reference types="../../cypress/support" />
+
+describe("form-antd-use-form", () => {
+    const BASE_URL = "http://localhost:3000";
+
+    beforeEach(() => {
+        cy.visit(BASE_URL);
+        cy.clearAllCookies();
+        cy.clearAllLocalStorage();
+        cy.clearAllSessionStorage();
+    });
+
+    it("should be view list page", () => {
+        cy.resourceList();
+    });
+
+    it("should be create page", () => {
+        cy.resourceCreate();
+    });
+
+    it("should be edit page", () => {
+        cy.resourceEdit();
+    });
+
+    it.only("should render error", () => {
+        // find first row and get title
+        cy.get(".ant-table-row-level-0")
+            .first()
+            .find("td")
+            .eq(1)
+            .then((el) => {
+                const title = el.text();
+
+                // create record with title to check unique validation is working
+                cy.getCreateButton().click();
+                cy.get("#title")
+                    .clear()
+                    .type(title)
+                    .then(() => {
+                        cy.getAntdFormItemError({ id: "title" }).contains(
+                            /unique/gi,
+                        );
+                    });
+            });
+    });
+});

--- a/examples/form-antd-custom-validation/package.json
+++ b/examples/form-antd-custom-validation/package.json
@@ -20,11 +20,15 @@
     "typescript": "^4.7.4",
     "antd": "^5.0.5"
   },
+  "devDependencies": {
+    "cypress": "^12.11.0"
+  },
   "scripts": {
     "start": "cross-env DISABLE_ESLINT_PLUGIN=true refine start",
     "build": "cross-env DISABLE_ESLINT_PLUGIN=true refine build",
     "eject": "react-scripts eject",
-    "refine": "refine"
+    "refine": "refine",
+    "cypress": "cypress open -C ./cypress.config.ts"
   },
   "browserslist": {
     "production": [

--- a/examples/form-antd-use-drawer-form/cypress.config.ts
+++ b/examples/form-antd-use-drawer-form/cypress.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+    projectId: "sq5j3e",
+    e2e: {
+        supportFile: "../../cypress/support/e2e.ts",
+    },
+    chromeWebSecurity: false,
+    experimentalMemoryManagement: true,
+    numTestsKeptInMemory: 1,
+    viewportWidth: 1920,
+    viewportHeight: 1080,
+});

--- a/examples/form-antd-use-drawer-form/cypress/e2e/all.cy.ts
+++ b/examples/form-antd-use-drawer-form/cypress/e2e/all.cy.ts
@@ -1,0 +1,126 @@
+/// <reference types="cypress" />
+/// <reference types="../../cypress/support" />
+
+describe("form-antd-use-form", () => {
+    const BASE_URL = "http://localhost:3000";
+
+    const mockPost = {
+        title: "test title",
+        status: "Published",
+    };
+
+    const openDrawer = () => {
+        return cy.getCreateButton().click();
+    };
+
+    const closeDrawer = () => {
+        return cy.get(".ant-drawer-close").eq(0).click();
+    };
+
+    const isDrawerVisible = () => {
+        return cy.get(".ant-drawer-content").should("be.visible");
+    };
+
+    const isDrawerNotVisible = () => {
+        return cy.get(".ant-drawer-content").should("not.be.visible");
+    };
+
+    const findFirstRecordFromTable = () => {
+        return cy
+            .get(".ant-table-row-level-0")
+            .first()
+            .find("td")
+            .last()
+            .within(() => {
+                cy.get(".refine-edit-button").click();
+            });
+    };
+
+    const assertSuccessResponse = (response: any) => {
+        const body = response?.body;
+
+        expect(response?.statusCode).to.eq(200);
+        expect(body?.title).to.eq("test title");
+        expect(body?.status?.toLowerCase()).to.eq("published");
+        isDrawerNotVisible();
+        cy.getAntdNotification().should("contain", "Success");
+    };
+
+    beforeEach(() => {
+        cy.visit(BASE_URL);
+        cy.clearAllCookies();
+        cy.clearAllLocalStorage();
+        cy.clearAllSessionStorage();
+    });
+
+    it("should open and close drawer", () => {
+        openDrawer();
+        isDrawerVisible();
+        closeDrawer();
+        isDrawerNotVisible();
+
+        openDrawer();
+        isDrawerVisible();
+        // outside click
+        cy.get(".ant-drawer-mask").click({ force: true });
+        isDrawerNotVisible();
+    });
+
+    it("should create a new record", () => {
+        cy.intercept("POST", "/posts").as("createPost");
+
+        openDrawer();
+        cy.get("#title").type(mockPost.title);
+        cy.setAntdSelect({ id: "status", value: mockPost.status });
+        cy.getSaveButton().eq(0).click();
+
+        cy.wait("@createPost").then((interception) => {
+            const response = interception?.response;
+            assertSuccessResponse(response);
+        });
+    });
+
+    it("should edit a record", () => {
+        cy.intercept("GET", "/posts/*").as("getPost");
+        cy.intercept("PATCH", "/posts/*").as("patchPost");
+
+        findFirstRecordFromTable();
+
+        cy.wait("@getPost");
+        cy.wait(500);
+
+        cy.get("#title.ant-input").eq(1).clear();
+        cy.get("#title.ant-input").eq(1).type(mockPost.title);
+        cy.get("input#status")
+            .eq(1)
+            .click({ force: true })
+            .get(`.ant-select-item[title="Published"]`)
+            .click({ force: true })
+            .get("input#status")
+            .eq(1)
+            .blur();
+        cy.getSaveButton().eq(1).click();
+
+        cy.wait("@patchPost").then((interception) => {
+            const response = interception?.response;
+            assertSuccessResponse(response);
+        });
+    });
+
+    it.only("should delete a record", () => {
+        cy.intercept("GET", "/posts/*").as("getPost");
+        cy.intercept("DELETE", "/posts/*").as("deletePost");
+
+        findFirstRecordFromTable();
+
+        cy.getDeleteButton().click();
+        cy.get(".ant-popconfirm-buttons > .ant-btn-dangerous").click();
+
+        cy.wait("@deletePost").then((interception) => {
+            const response = interception?.response;
+            expect(response?.statusCode).to.eq(200);
+            cy.getAntdNotification().should("contain", "Success");
+            isDrawerNotVisible();
+        });
+    });
+});

--- a/examples/form-antd-use-drawer-form/cypress/e2e/all.cy.ts
+++ b/examples/form-antd-use-drawer-form/cypress/e2e/all.cy.ts
@@ -107,7 +107,7 @@ describe("form-antd-use-form", () => {
         });
     });
 
-    it.only("should delete a record", () => {
+    it("should delete a record", () => {
         cy.intercept("GET", "/posts/*").as("getPost");
         cy.intercept("DELETE", "/posts/*").as("deletePost");
 

--- a/examples/form-antd-use-drawer-form/package.json
+++ b/examples/form-antd-use-drawer-form/package.json
@@ -19,11 +19,15 @@
     "typescript": "^4.7.4",
     "antd": "^5.0.5"
   },
+  "devDependencies": {
+    "cypress": "^12.11.0"
+  },
   "scripts": {
     "start": "cross-env DISABLE_ESLINT_PLUGIN=true refine start",
     "build": "cross-env DISABLE_ESLINT_PLUGIN=true refine build",
     "eject": "react-scripts eject",
-    "refine": "refine"
+    "refine": "refine",
+    "cypress": "cypress open -C ./cypress.config.ts"
   },
   "browserslist": {
     "production": [

--- a/examples/form-antd-use-form/cypress.config.ts
+++ b/examples/form-antd-use-form/cypress.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+    projectId: "sq5j3e",
+    e2e: {
+        supportFile: "../../cypress/support/e2e.ts",
+    },
+    chromeWebSecurity: false,
+    experimentalMemoryManagement: true,
+    numTestsKeptInMemory: 1,
+});

--- a/examples/form-antd-use-form/cypress/e2e/all.cy.ts
+++ b/examples/form-antd-use-form/cypress/e2e/all.cy.ts
@@ -115,7 +115,7 @@ describe("form-antd-use-form", () => {
         cy.getAntdFormItemError({ id: "status" }).should("not.exist");
     });
 
-    it.only("should edit form render errors", () => {
+    it("should edit form render errors", () => {
         cy.intercept("GET", "/posts/*").as("getPost");
 
         cy.visit(`${BASE_URL}/posts/edit/123`);

--- a/examples/form-antd-use-form/cypress/e2e/all.cy.ts
+++ b/examples/form-antd-use-form/cypress/e2e/all.cy.ts
@@ -50,14 +50,6 @@ describe("form-antd-use-form", () => {
         cy.resourceList();
     });
 
-    it("should be create page", () => {
-        cy.resourceCreate();
-    });
-
-    it("should be edit page", () => {
-        cy.resourceEdit();
-    });
-
     it("should create record", () => {
         cy.intercept("POST", "/posts").as("createPost");
 

--- a/examples/form-antd-use-form/cypress/e2e/all.cy.ts
+++ b/examples/form-antd-use-form/cypress/e2e/all.cy.ts
@@ -1,0 +1,141 @@
+/// <reference types="cypress" />
+/// <reference types="../../cypress/support" />
+
+describe("form-antd-use-form", () => {
+    const BASE_URL = "http://localhost:3000";
+
+    const mockPost = {
+        title: "test title",
+        content: "test content",
+        status: "Published",
+    };
+
+    const fillForm = () => {
+        cy.get("#title").clear().type(mockPost.title);
+        cy.get("#content textarea").clear().type(mockPost.content);
+        cy.setAntdDropdown({ id: "category_id", selectIndex: 0 });
+        cy.setAntdSelect({ id: "status", value: mockPost.status });
+    };
+
+    const assertSuccessResponse = (response: any) => {
+        const body = response?.body;
+
+        expect(response?.statusCode).to.eq(200);
+        expect(body).to.have.property("id");
+        expect(body).to.have.property("category");
+        expect(body?.title).to.eq(mockPost.title);
+        expect(body?.content).to.eq(mockPost.content);
+        expect(body?.status?.toLowerCase()).to.eq(
+            mockPost?.status?.toLowerCase(),
+        );
+
+        cy.getAntdNotification().should("contain", "Success");
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq("/posts");
+        });
+    };
+
+    const submitForm = () => {
+        return cy.getSaveButton().click();
+    };
+
+    beforeEach(() => {
+        cy.visit(BASE_URL);
+        cy.clearAllCookies();
+        cy.clearAllLocalStorage();
+        cy.clearAllSessionStorage();
+    });
+
+    it("should be view list page", () => {
+        cy.resourceList();
+    });
+
+    it("should be create page", () => {
+        cy.resourceCreate();
+    });
+
+    it("should be edit page", () => {
+        cy.resourceEdit();
+    });
+
+    it("should create record", () => {
+        cy.intercept("POST", "/posts").as("createPost");
+
+        cy.resourceCreate();
+
+        fillForm();
+        submitForm();
+
+        cy.wait("@createPost").then((interception) => {
+            const response = interception?.response;
+            assertSuccessResponse(response);
+        });
+    });
+
+    it("should edit a record", () => {
+        cy.intercept("GET", "/posts/*").as("getPost");
+        cy.intercept("PATCH", "/posts/*").as("patchPost");
+
+        cy.visit(`${BASE_URL}/posts/edit/123`);
+
+        cy.wait("@getPost");
+        cy.wait(500);
+
+        fillForm();
+        submitForm();
+
+        cy.wait("@patchPost").then((interception) => {
+            const response = interception?.response;
+            assertSuccessResponse(response);
+        });
+    });
+
+    it("should create form render errors", () => {
+        cy.resourceCreate();
+
+        submitForm();
+        cy.getAntdFormItemError({ id: "title" }).contains(
+            /please enter title/gi,
+        );
+        cy.getAntdFormItemError({ id: "content" }).contains(
+            /please enter content/gi,
+        );
+        cy.getAntdFormItemError({ id: "category_id" }).contains(
+            /please enter category/gi,
+        );
+        cy.getAntdFormItemError({ id: "status" }).contains(
+            /please enter status/gi,
+        );
+
+        fillForm();
+
+        cy.getAntdFormItemError({ id: "title" }).should("not.exist");
+        cy.getAntdFormItemError({ id: "content" }).should("not.exist");
+        cy.getAntdFormItemError({ id: "category_id" }).should("not.exist");
+        cy.getAntdFormItemError({ id: "status" }).should("not.exist");
+    });
+
+    it.only("should edit form render errors", () => {
+        cy.intercept("GET", "/posts/*").as("getPost");
+
+        cy.visit(`${BASE_URL}/posts/edit/123`);
+
+        cy.wait("@getPost");
+        cy.wait(500);
+
+        cy.get("#title").clear();
+        cy.get("#content textarea").clear();
+
+        cy.getAntdFormItemError({ id: "title" }).contains(
+            /please enter title/gi,
+        );
+        cy.getAntdFormItemError({ id: "content" }).contains(
+            /please enter content/gi,
+        );
+
+        fillForm();
+
+        cy.getAntdFormItemError({ id: "title" }).should("not.exist");
+        cy.getAntdFormItemError({ id: "content" }).should("not.exist");
+    });
+});

--- a/examples/form-antd-use-form/package.json
+++ b/examples/form-antd-use-form/package.json
@@ -20,11 +20,15 @@
     "typescript": "^4.7.4",
     "antd": "^5.0.5"
   },
+  "devDependencies": {
+    "cypress": "^12.11.0"
+  },
   "scripts": {
     "start": "cross-env DISABLE_ESLINT_PLUGIN=true refine start",
     "build": "cross-env DISABLE_ESLINT_PLUGIN=true refine build",
     "eject": "react-scripts eject",
-    "refine": "refine"
+    "refine": "refine",
+    "cypress": "cypress open -C ./cypress.config.ts"
   },
   "browserslist": {
     "production": [

--- a/examples/form-antd-use-modal-form/cypress.config.ts
+++ b/examples/form-antd-use-modal-form/cypress.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+    projectId: "sq5j3e",
+    e2e: {
+        supportFile: "../../cypress/support/e2e.ts",
+    },
+    chromeWebSecurity: false,
+    experimentalMemoryManagement: true,
+    numTestsKeptInMemory: 1,
+    viewportWidth: 1920,
+    viewportHeight: 1080,
+});

--- a/examples/form-antd-use-modal-form/cypress/e2e/all.cy.ts
+++ b/examples/form-antd-use-modal-form/cypress/e2e/all.cy.ts
@@ -1,0 +1,110 @@
+/// <reference types="cypress" />
+/// <reference types="../../cypress/support" />
+
+describe("form-antd-use-form", () => {
+    const BASE_URL = "http://localhost:3000";
+
+    const openModal = () => {
+        return cy.getCreateButton().click();
+    };
+
+    const closeModal = () => {
+        return cy
+            .get(".ant-modal-footer > .ant-btn")
+            .contains(/cancel/gi)
+            .click();
+    };
+
+    const isModalVisible = () => {
+        return cy.get(".ant-modal-content").should("be.visible");
+    };
+
+    const isModalNotVisible = () => {
+        return cy.get(".ant-modal-content").should("not.be.visible");
+    };
+
+    beforeEach(() => {
+        cy.visit(BASE_URL);
+        cy.clearAllCookies();
+        cy.clearAllLocalStorage();
+        cy.clearAllSessionStorage();
+    });
+
+    it("should open and close modal", () => {
+        openModal();
+        isModalVisible();
+        // by X button
+        cy.get(".ant-modal-close").click({ multiple: true, force: true });
+        isModalNotVisible();
+
+        openModal();
+        isModalVisible();
+        closeModal();
+        isModalNotVisible();
+    });
+
+    it("should create a new record", () => {
+        cy.intercept("POST", "/posts").as("createPost");
+
+        openModal();
+        cy.get("#title").type("test title");
+        cy.setAntdSelect({ id: "status", value: "Published" });
+        cy.get(".ant-modal-footer > .ant-btn-primary")
+            .eq(0)
+            .click({ force: true });
+
+        cy.wait("@createPost").then((interception) => {
+            const response = interception?.response;
+            const body = response?.body;
+
+            expect(response?.statusCode).to.eq(200);
+            expect(body?.title).to.eq("test title");
+            expect(body?.status?.toLowerCase()).to.eq("published");
+            isModalNotVisible();
+            cy.getAntdNotification().should("contain", "Success");
+        });
+    });
+
+    it("should edit a record", () => {
+        cy.intercept("GET", "/posts/*").as("getPost");
+        cy.intercept("PATCH", "/posts/*").as("patchPost");
+
+        // find first record and click .refine-edit-button button
+        cy.get(".ant-table-row-level-0")
+            .first()
+            .find("td")
+            .last()
+            .within(() => {
+                cy.get(".refine-edit-button").click();
+            });
+
+        cy.wait("@getPost");
+        cy.wait(500);
+
+        cy.get("#title.ant-input")
+            .eq(1)
+            .clear({
+                force: true,
+            })
+            .type("test title", { force: true });
+        cy.get("input#status")
+            .eq(1)
+            .click({ force: true })
+            .get(`.ant-select-item[title="Published"]`)
+            .click({ force: true });
+        cy.get(".ant-modal-footer > .ant-btn-primary")
+            .eq(1)
+            .click({ force: true });
+
+        cy.wait("@patchPost").then((interception) => {
+            const response = interception?.response;
+            const body = response?.body;
+
+            expect(response?.statusCode).to.eq(200);
+            expect(body?.title).to.eq("test title");
+            expect(body?.status?.toLowerCase()).to.eq("published");
+            isModalNotVisible();
+            cy.getAntdNotification().should("contain", "Success");
+        });
+    });
+});

--- a/examples/form-antd-use-modal-form/package.json
+++ b/examples/form-antd-use-modal-form/package.json
@@ -19,11 +19,15 @@
     "typescript": "^4.7.4",
     "antd": "^5.0.5"
   },
+  "devDependencies": {
+    "cypress": "^12.11.0"
+  },
   "scripts": {
     "start": "cross-env DISABLE_ESLINT_PLUGIN=true refine start",
     "build": "cross-env DISABLE_ESLINT_PLUGIN=true refine build",
     "eject": "react-scripts eject",
-    "refine": "refine"
+    "refine": "refine",
+    "cypress": "cypress open -C ./cypress.config.ts"
   },
   "browserslist": {
     "production": [

--- a/examples/form-antd-use-modal-form/src/pages/posts/list.tsx
+++ b/examples/form-antd-use-modal-form/src/pages/posts/list.tsx
@@ -89,7 +89,7 @@ export const PostList: React.FC<IResourceComponentsProps> = () => {
                     />
                 </Table>
             </List>
-            <Modal {...createModalProps} destroyOnClose>
+            <Modal {...createModalProps}>
                 <Form {...createFormProps} layout="vertical">
                     <Form.Item
                         label="Title"
@@ -130,7 +130,7 @@ export const PostList: React.FC<IResourceComponentsProps> = () => {
                     </Form.Item>
                 </Form>
             </Modal>
-            <Modal {...editModalProps} destroyOnClose>
+            <Modal {...editModalProps}>
                 <Form {...editFormProps} layout="vertical">
                     <Form.Item
                         label="Title"

--- a/examples/form-antd-use-modal-form/src/pages/posts/list.tsx
+++ b/examples/form-antd-use-modal-form/src/pages/posts/list.tsx
@@ -7,6 +7,7 @@ import {
     ShowButton,
     useTable,
     useModalForm,
+    DeleteButton,
 } from "@refinedev/antd";
 
 import { Table, Form, Select, Input, Modal, Space, Typography } from "antd";
@@ -78,12 +79,17 @@ export const PostList: React.FC<IResourceComponentsProps> = () => {
                                         setVisibleShowModal(true);
                                     }}
                                 />
+                                <DeleteButton
+                                    hideText
+                                    size="small"
+                                    recordItemId={record.id}
+                                />
                             </Space>
                         )}
                     />
                 </Table>
             </List>
-            <Modal {...createModalProps}>
+            <Modal {...createModalProps} destroyOnClose>
                 <Form {...createFormProps} layout="vertical">
                     <Form.Item
                         label="Title"
@@ -124,7 +130,7 @@ export const PostList: React.FC<IResourceComponentsProps> = () => {
                     </Form.Item>
                 </Form>
             </Modal>
-            <Modal {...editModalProps}>
+            <Modal {...editModalProps} destroyOnClose>
                 <Form {...editFormProps} layout="vertical">
                     <Form.Item
                         label="Title"

--- a/examples/form-antd-use-steps-form/cypress.config.ts
+++ b/examples/form-antd-use-steps-form/cypress.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+    projectId: "sq5j3e",
+    e2e: {
+        supportFile: "../../cypress/support/e2e.ts",
+    },
+    chromeWebSecurity: false,
+    experimentalMemoryManagement: true,
+    numTestsKeptInMemory: 1,
+    viewportWidth: 1920,
+    viewportHeight: 1080,
+});

--- a/examples/form-antd-use-steps-form/cypress/e2e/all.cy.ts
+++ b/examples/form-antd-use-steps-form/cypress/e2e/all.cy.ts
@@ -1,0 +1,104 @@
+/// <reference types="cypress" />
+/// <reference types="../../cypress/support" />
+
+describe("form-antd-use-form", () => {
+    const BASE_URL = "http://localhost:3000";
+
+    const mockPost = {
+        title: "test title",
+        content: "test content",
+        status: "Published",
+    };
+
+    const fillForm = () => {
+        cy.get("#title").clear().type("test title");
+        cy.setAntdDropdown({ id: "category_id", selectIndex: 0 });
+        cy.setAntdSelect({ id: "status", value: "Published" });
+        cy.get(".ant-btn").contains(/next/gi).click();
+        cy.get("#content textarea").clear().type("test content");
+    };
+
+    const assertSuccessResponse = (response: any) => {
+        const body = response?.body;
+
+        expect(response?.statusCode).to.eq(200);
+        expect(body).to.have.property("id");
+        expect(body).to.have.property("category");
+        expect(body?.title).to.eq(mockPost.title);
+        expect(body?.content).to.eq(mockPost.content);
+        expect(body?.status?.toLowerCase()).to.eq(
+            mockPost?.status?.toLowerCase(),
+        );
+
+        cy.getAntdNotification().should("contain", "Success");
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq("/posts");
+        });
+    };
+
+    const submitForm = () => {
+        return cy.get(".ant-btn").contains(/save/gi).click();
+    };
+
+    beforeEach(() => {
+        cy.visit(BASE_URL);
+        cy.clearAllCookies();
+        cy.clearAllLocalStorage();
+        cy.clearAllSessionStorage();
+    });
+
+    it("should create a new record", () => {
+        cy.intercept("POST", "/posts").as("createPost");
+
+        cy.getCreateButton().click();
+        fillForm();
+        submitForm();
+
+        cy.wait("@createPost").then((interception) => {
+            const response = interception?.response;
+            assertSuccessResponse(response);
+        });
+    });
+
+    it("should edit a record", () => {
+        cy.intercept("GET", "/posts/*").as("getPost");
+        cy.intercept("PATCH", "/posts/*").as("patchPost");
+
+        cy.visit(`${BASE_URL}/posts/edit/123`);
+
+        cy.wait("@getPost");
+        cy.wait(500);
+
+        fillForm();
+        submitForm();
+
+        cy.wait("@patchPost").then((interception) => {
+            const response = interception?.response;
+            assertSuccessResponse(response);
+        });
+    });
+
+    it("should preserve form data when navigating between steps", () => {
+        cy.getCreateButton().click();
+
+        cy.get(".ant-select-selection-item").should("not.exist");
+        cy.get(`.ant-select-selection-item[title="${mockPost.status}"]`).should(
+            "not.exist",
+        );
+
+        fillForm();
+        cy.get(".ant-btn")
+            .contains(/previous/gi)
+            .click();
+
+        cy.get("#title").should("have.value", mockPost.title);
+        cy.get(".ant-select-selection-item").eq(0).should("exist");
+        cy.get(`.ant-select-selection-item[title="${mockPost.status}"]`).should(
+            "exist",
+        );
+
+        cy.get(".ant-btn").contains(/next/gi).click();
+
+        cy.get("#content textarea").should("have.value", mockPost.content);
+    });
+});

--- a/examples/form-antd-use-steps-form/package.json
+++ b/examples/form-antd-use-steps-form/package.json
@@ -20,11 +20,15 @@
     "typescript": "^4.7.4",
     "antd": "^5.0.5"
   },
+  "devDependencies": {
+    "cypress": "^12.11.0"
+  },
   "scripts": {
     "start": "cross-env DISABLE_ESLINT_PLUGIN=true refine start",
     "build": "cross-env DISABLE_ESLINT_PLUGIN=true refine build",
     "eject": "react-scripts eject",
-    "refine": "refine"
+    "refine": "refine",
+    "cypress": "cypress open -C ./cypress.config.ts"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
End-to-end (e2e) tests are added to examples.
Adding e2e tests to our examples will prevent us from introducing bugs when developing new features.

### Test plan (required)

WIP

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed