### PR TITLE
fix(live-previews): replace `ThemedTitle` mock with `ThemedTitleV2`

### DIFF
--- a/packages/live-previews/src/scope/antd.tsx
+++ b/packages/live-previews/src/scope/antd.tsx
@@ -51,7 +51,7 @@ const RefineAntdDemo: React.FC<
     );
 };
 
-const ThemedTitle: typeof RefineAntd.ThemedTitle = ({
+const ThemedTitleV2: typeof RefineAntd.ThemedTitleV2 = ({
     collapsed,
     wrapperStyles,
     text: textFromProps,
@@ -116,7 +116,7 @@ const ThemedTitle: typeof RefineAntd.ThemedTitle = ({
     }, []);
 
     return (
-        <RefineAntd.ThemedTitle
+        <RefineAntd.ThemedTitleV2
             collapsed={collapsed}
             wrapperStyles={wrapperStyles}
             text={title || textFromProps}
@@ -176,7 +176,7 @@ const AntdScope = {
     RefineAntdDemo,
     RefineAntd: {
         ...RefineAntd,
-        ThemedTitle,
+        ThemedTitleV2,
     },
     AntdCore: {
         ...AntdCore,

--- a/packages/live-previews/src/scope/chakra.tsx
+++ b/packages/live-previews/src/scope/chakra.tsx
@@ -43,7 +43,7 @@ const RefineChakraDemo: React.FC<
     );
 };
 
-const ThemedTitle: typeof RefineChakra.ThemedTitle = ({
+const ThemedTitleV2: typeof RefineChakra.ThemedTitleV2 = ({
     collapsed,
     wrapperStyles,
     text: textFromProps,
@@ -108,7 +108,7 @@ const ThemedTitle: typeof RefineChakra.ThemedTitle = ({
     }, []);
 
     return (
-        <RefineChakra.ThemedTitle
+        <RefineChakra.ThemedTitleV2
             collapsed={collapsed}
             wrapperStyles={wrapperStyles}
             text={title || textFromProps}
@@ -173,7 +173,7 @@ const AntdScope = {
     // RefineMantineDemo,
     RefineChakra: {
         ...RefineChakra,
-        ThemedTitle,
+        ThemedTitleV2,
     },
     RefineChakraDemo,
     ChakraUI: {

--- a/packages/live-previews/src/scope/mantine.tsx
+++ b/packages/live-previews/src/scope/mantine.tsx
@@ -52,7 +52,7 @@ const RefineMantineDemo: React.FC<
     );
 };
 
-const ThemedTitle: typeof RefineMantine.ThemedTitle = ({
+const ThemedTitleV2: typeof RefineMantine.ThemedTitleV2 = ({
     collapsed,
     wrapperStyles,
     text: textFromProps,
@@ -117,7 +117,7 @@ const ThemedTitle: typeof RefineMantine.ThemedTitle = ({
     }, []);
 
     return (
-        <RefineMantine.ThemedTitle
+        <RefineMantine.ThemedTitleV2
             collapsed={collapsed}
             wrapperStyles={wrapperStyles}
             text={title || textFromProps}
@@ -179,7 +179,7 @@ const MantineProvider = ({
 const MantineScope = {
     RefineMantine: {
         ...RefineMantine,
-        ThemedTitle,
+        ThemedTitleV2,
     },
     RefineMantineDemo,
     MantineCore: {

--- a/packages/live-previews/src/scope/mui.tsx
+++ b/packages/live-previews/src/scope/mui.tsx
@@ -73,7 +73,7 @@ const RefineMuiDemo: React.FC<
     );
 };
 
-const ThemedTitle: typeof RefineMui.ThemedTitle = ({
+const ThemedTitleV2: typeof RefineMui.ThemedTitleV2 = ({
     collapsed,
     wrapperStyles,
     text: textFromProps,
@@ -138,7 +138,7 @@ const ThemedTitle: typeof RefineMui.ThemedTitle = ({
     }, []);
 
     return (
-        <RefineMui.ThemedTitle
+        <RefineMui.ThemedTitleV2
             collapsed={collapsed}
             wrapperStyles={wrapperStyles}
             text={title || textFromProps}
@@ -210,7 +210,7 @@ const MuiScope = {
     RefineMuiDemo,
     RefineMui: {
         ...RefineMui,
-        ThemedTitle,
+        ThemedTitleV2,
     },
     EmotionReact,
     EmotionStyled,


### PR DESCRIPTION
`ThemedTitle` was mocked on live-previews to allow changing the title and the icon dynamically on the interactive builder (refine.new).

While making the switch from `ThemedTitle` to `ThemedTitleV2`, we've forgot to update the mocks to use the V2 component which broke the title and logo inputs which no longer updates the live preview accordingly. 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
