### PR TITLE
test(examples): add e2e tets to Material UI form examples

### DIFF
--- a/cypress/support/commands/material-ui/index.ts
+++ b/cypress/support/commands/material-ui/index.ts
@@ -1,0 +1,16 @@
+/// <reference types="cypress" />
+/// <reference types="../../index.d.ts" />
+
+export const getMaterialUINotifications = () => {
+    return cy.get("#notistack-snackbar .MuiBox-root > h6");
+};
+
+export const getMaterialUIDeletePopoverButton = () => {
+    return cy.get(".MuiDialogActions-root > button").contains(/delete/i);
+};
+
+export const getMaterialUIFormItemError = ({
+    id,
+}: IGetMaterialUIFormItemErrorParams) => {
+    return cy.get(`#${id}-helper-text`);
+};

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -25,6 +25,11 @@ import { list, create, edit, show } from "./commands/resource";
 
 // add commands to the Cypress chain
 import "./commands/intercepts";
+import {
+    getMaterialUIDeletePopoverButton,
+    getMaterialUIFormItemError,
+    getMaterialUINotifications,
+} from "./commands/material-ui";
 
 Cypress.Keyboard.defaults({
     keystrokeDelay: 0,
@@ -53,3 +58,10 @@ Cypress.Commands.add(
     getChakraUIDeletePopoverButton,
 );
 Cypress.Commands.add("getChakraUILoadingOverlay", getChakraUILoadingOverlay);
+
+Cypress.Commands.add("getMaterialUINotification", getMaterialUINotifications);
+Cypress.Commands.add(
+    "getMaterialUIDeletePopoverButton",
+    getMaterialUIDeletePopoverButton,
+);
+Cypress.Commands.add("getMaterialUIFormItemError", getMaterialUIFormItemError);

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -19,6 +19,10 @@ interface IGetChakraUIFormItemErrorParams {
     type?: "text" | "select";
 }
 
+interface IGetMaterialUIFormItemErrorParams {
+    id: string;
+}
+
 interface IResourceCreateParams {
     ui: "antd" | "material-ui" | "chakra-ui" | "mantine";
 }
@@ -64,12 +68,17 @@ declare namespace Cypress {
         getChakraUIDeletePopoverButton(): Chainable<JQuery<HTMLElement>>;
         getChakraUILoadingOverlay(): Chainable<JQuery<HTMLElement>>;
 
+        getMaterialUINotification(): Chainable<JQuery<HTMLElement>>;
+        getMaterialUIDeletePopoverButton(): Chainable<JQuery<HTMLElement>>;
+        getMaterialUIFormItemError(
+            params: IGetChakraUIFormItemErrorParams,
+        ): Chainable<JQuery<HTMLElement>>;
+
         interceptGETPost(): Chainable<null>;
         interceptGETPosts(): Chainable<null>;
         interceptPOSTPost(): Chainable<null>;
         interceptPATCHPost(): Chainable<null>;
         interceptDELETEPost(): Chainable<null>;
-
         interceptGETCategories(): Chainable<null>;
     }
 }

--- a/examples/form-material-ui-use-drawer-form/cypress.config.ts
+++ b/examples/form-material-ui-use-drawer-form/cypress.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+    projectId: "sq5j3e",
+    e2e: {
+        fixturesFolder: "../../cypress/fixtures",
+        supportFile: "../../cypress/support/e2e.ts",
+    },
+    chromeWebSecurity: false,
+    experimentalMemoryManagement: true,
+    numTestsKeptInMemory: 1,
+});

--- a/examples/form-material-ui-use-drawer-form/cypress/e2e/all.cy.ts
+++ b/examples/form-material-ui-use-drawer-form/cypress/e2e/all.cy.ts
@@ -1,0 +1,116 @@
+/// <reference types="cypress" />
+/// <reference types="../../cypress/support" />
+
+describe("form-material-ui-use-modal-form", () => {
+    const BASE_URL = "http://localhost:3000";
+
+    const mockPost = {
+        title: "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
+        content:
+            "Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+        status: "published",
+    };
+
+    const fillForm = () => {
+        cy.get("#title").clear();
+        cy.get("#title").type(mockPost.title);
+        cy.get("#content").clear();
+        cy.get("#content").type(mockPost.content);
+        cy.get("#status").click();
+        cy.get("#status-option-0").click();
+        cy.get("#category").click();
+        cy.get("#category-option-0").click();
+    };
+
+    const assertSuccessResponse = (response: any) => {
+        const body = response?.body;
+
+        expect(response?.statusCode).to.eq(200);
+        expect(body).to.have.property("id");
+        expect(body).to.have.property("category");
+        expect(body?.title).to.eq(mockPost.title);
+        expect(body?.content).to.eq(mockPost.content);
+        expect(body?.status?.toLowerCase()).to.eq(
+            mockPost?.status?.toLowerCase(),
+        );
+
+        isDrawerClosed();
+        cy.getMaterialUINotification().contains(/success/i);
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq("/posts");
+        });
+    };
+
+    const submitForm = () => {
+        return cy.getSaveButton().click();
+    };
+
+    const closeDrawer = () => {
+        return cy
+            .get(".MuiCardHeader-action > .MuiButtonBase-root > svg")
+            .click();
+    };
+
+    const isDrawerOpen = () => {
+        return cy.get(".MuiDrawer-paperAnchorRight").should("be.visible");
+    };
+
+    const isDrawerClosed = () => {
+        return cy.get(".MuiDrawer-paperAnchorRight").should("not.exist");
+    };
+
+    beforeEach(() => {
+        cy.interceptGETPost();
+        cy.interceptPOSTPost();
+        cy.interceptPATCHPost();
+        cy.interceptDELETEPost();
+        cy.interceptGETPosts();
+        cy.interceptGETCategories();
+
+        cy.clearAllCookies();
+        cy.clearAllLocalStorage();
+        cy.clearAllSessionStorage();
+
+        cy.visit(BASE_URL);
+    });
+
+    it("open - close modal", () => {
+        isDrawerClosed();
+
+        cy.getCreateButton().click();
+        isDrawerOpen();
+
+        closeDrawer();
+        isDrawerClosed();
+    });
+
+    it("should create record", () => {
+        cy.getCreateButton().click();
+        isDrawerOpen();
+
+        fillForm();
+        submitForm();
+
+        cy.wait("@postPost").then((interception) => {
+            const response = interception?.response;
+            assertSuccessResponse(response);
+        });
+    });
+
+    it("should edit record", () => {
+        cy.getEditButton().first().click();
+        isDrawerOpen();
+
+        // wait loading state and render to be finished
+        cy.wait("@getPost");
+        cy.getSaveButton().should("not.be.disabled");
+
+        fillForm();
+        submitForm();
+
+        cy.wait("@patchPost").then((interception) => {
+            const response = interception?.response;
+            assertSuccessResponse(response);
+        });
+    });
+});

--- a/examples/form-material-ui-use-drawer-form/package.json
+++ b/examples/form-material-ui-use-drawer-form/package.json
@@ -25,11 +25,15 @@
     "typescript": "^4.7.4",
     "react-hook-form": "^7.30.0"
   },
+  "devDependencies": {
+    "cypress": "^12.11.0"
+  },
   "scripts": {
     "start": "cross-env DISABLE_ESLINT_PLUGIN=true refine start",
     "build": "cross-env DISABLE_ESLINT_PLUGIN=true refine build",
     "eject": "react-scripts eject",
-    "refine": "refine"
+    "refine": "refine",
+    "cypress": "cypress open -C ./cypress.config.ts"
   },
   "browserslist": {
     "production": [

--- a/examples/form-material-ui-use-drawer-form/src/components/createPostDrawer.tsx
+++ b/examples/form-material-ui-use-drawer-form/src/components/createPostDrawer.tsx
@@ -53,6 +53,7 @@ export const CreatePostDrawer: React.FC<
                     sx={{ display: "flex", flexDirection: "column" }}
                 >
                     <TextField
+                        id="title"
                         {...register("title", {
                             required: "This field is required",
                         })}
@@ -69,6 +70,7 @@ export const CreatePostDrawer: React.FC<
                         rules={{ required: "This field is required" }}
                         render={({ field }) => (
                             <Autocomplete
+                                id="status"
                                 options={["published", "draft", "rejected"]}
                                 {...field}
                                 onChange={(_, value) => {
@@ -94,6 +96,7 @@ export const CreatePostDrawer: React.FC<
                         rules={{ required: "This field is required" }}
                         render={({ field }) => (
                             <Autocomplete
+                                id="category"
                                 {...autocompleteProps}
                                 {...field}
                                 onChange={(_, value) => {
@@ -127,6 +130,7 @@ export const CreatePostDrawer: React.FC<
                         )}
                     />
                     <TextField
+                        id="content"
                         {...register("content", {
                             required: "This field is required",
                         })}

--- a/examples/form-material-ui-use-drawer-form/src/components/editPostDrawer.tsx
+++ b/examples/form-material-ui-use-drawer-form/src/components/editPostDrawer.tsx
@@ -55,6 +55,7 @@ export const EditPostDrawer: React.FC<
                     sx={{ display: "flex", flexDirection: "column" }}
                 >
                     <TextField
+                        id="title"
                         {...register("title", {
                             required: "This field is required",
                         })}
@@ -74,6 +75,7 @@ export const EditPostDrawer: React.FC<
                         defaultValue={null as any}
                         render={({ field }) => (
                             <Autocomplete
+                                id="status"
                                 options={["published", "draft", "rejected"]}
                                 {...field}
                                 onChange={(_, value) => {
@@ -101,6 +103,7 @@ export const EditPostDrawer: React.FC<
                         defaultValue={null as any}
                         render={({ field }) => (
                             <Autocomplete
+                                id="category"
                                 {...autocompleteProps}
                                 {...field}
                                 onChange={(_, value) => {
@@ -134,6 +137,7 @@ export const EditPostDrawer: React.FC<
                         )}
                     />
                     <TextField
+                        id="content"
                         {...register("content", {
                             required: "This field is required",
                         })}

--- a/examples/form-material-ui-use-form/cypress.config.ts
+++ b/examples/form-material-ui-use-form/cypress.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+    projectId: "sq5j3e",
+    e2e: {
+        fixturesFolder: "../../cypress/fixtures",
+        supportFile: "../../cypress/support/e2e.ts",
+    },
+    chromeWebSecurity: false,
+    experimentalMemoryManagement: true,
+    numTestsKeptInMemory: 1,
+});

--- a/examples/form-material-ui-use-form/cypress/e2e/all.cy.ts
+++ b/examples/form-material-ui-use-form/cypress/e2e/all.cy.ts
@@ -1,0 +1,169 @@
+/// <reference types="cypress" />
+/// <reference types="../../cypress/support" />
+
+describe("form-material-ui-use-form", () => {
+    const BASE_URL = "http://localhost:3000";
+
+    const mockPost = {
+        title: "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
+        content:
+            "Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+        status: "published",
+    };
+
+    const fillForm = () => {
+        cy.get("#title").clear();
+        cy.get("#title").type(mockPost.title);
+        cy.get("#content").clear();
+        cy.get("#content").type(mockPost.content);
+        cy.get("#status").click();
+        cy.get("#status-option-0").click();
+        cy.get("#category").click();
+        cy.get("#category-option-0").click();
+    };
+
+    const assertSuccessResponse = (response: any) => {
+        const body = response?.body;
+
+        expect(response?.statusCode).to.eq(200);
+        expect(body).to.have.property("id");
+        expect(body).to.have.property("category");
+        expect(body?.title).to.eq(mockPost.title);
+        expect(body?.content).to.eq(mockPost.content);
+        expect(body?.status?.toLowerCase()).to.eq(
+            mockPost?.status?.toLowerCase(),
+        );
+
+        cy.getMaterialUINotification().contains(/success/i);
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq("/posts");
+        });
+    };
+
+    const submitForm = () => {
+        return cy.getSaveButton().click();
+    };
+
+    beforeEach(() => {
+        cy.interceptGETPost();
+        cy.interceptPOSTPost();
+        cy.interceptPATCHPost();
+        cy.interceptDELETEPost();
+        cy.interceptGETPosts();
+        cy.interceptGETCategories();
+
+        cy.clearAllCookies();
+        cy.clearAllLocalStorage();
+        cy.clearAllSessionStorage();
+
+        cy.visit(BASE_URL);
+    });
+
+    it("should create record", () => {
+        cy.getCreateButton().click();
+
+        fillForm();
+        submitForm();
+
+        cy.wait("@postPost").then((interception) => {
+            const response = interception?.response;
+            assertSuccessResponse(response);
+        });
+    });
+
+    it("should edit record", () => {
+        cy.getEditButton().first().click();
+
+        // wait loading state and render to be finished
+        cy.wait("@getPost").then((interception) => {
+            const response = interception?.response;
+            const body = response?.body;
+
+            expect(response?.statusCode).to.eq(200);
+            // assert form values are filled with record data
+            cy.get("#title").should("have.value", body?.title);
+            cy.get("#content").should("have.value", body?.content);
+            cy.get("#status").should("have.value", body?.status);
+        });
+
+        cy.getSaveButton().should("not.be.disabled");
+        fillForm();
+        submitForm();
+
+        cy.wait("@patchPost").then((interception) => {
+            const response = interception?.response;
+            assertSuccessResponse(response);
+        });
+    });
+
+    it("should delete record", () => {
+        cy.getEditButton().first().click();
+
+        // wait loading state and render to be finished
+        cy.wait("@getPost");
+        cy.getSaveButton().should("not.be.disabled");
+
+        cy.getDeleteButton()
+            .first()
+            .click()
+            .getMaterialUIDeletePopoverButton()
+            .click();
+
+        cy.wait("@deletePost").then((interception) => {
+            const response = interception?.response;
+
+            expect(response?.statusCode).to.eq(200);
+            cy.getMaterialUINotification().should("contain", "Success");
+            cy.location().should((loc) => {
+                expect(loc.pathname).to.eq("/posts");
+            });
+        });
+    });
+
+    it("should create form render errors", () => {
+        cy.getCreateButton().click();
+
+        submitForm();
+
+        cy.getMaterialUIFormItemError({ id: "title" }).contains(/required/gi);
+        cy.getMaterialUIFormItemError({ id: "status" }).contains(/required/gi);
+        cy.getMaterialUIFormItemError({ id: "category" }).contains(
+            /required/gi,
+        );
+        cy.getMaterialUIFormItemError({ id: "content" }).contains(/required/gi);
+
+        fillForm();
+
+        cy.getMaterialUIFormItemError({ id: "title" }).should("not.exist");
+        cy.getMaterialUIFormItemError({ id: "status" }).should("not.exist");
+        cy.getMaterialUIFormItemError({ id: "content" }).should("not.exist");
+        cy.getMaterialUIFormItemError({ id: "category" }).should("not.exist");
+    });
+
+    it("should edit form render errors", () => {
+        cy.getEditButton().first().click();
+
+        // wait loading state and render to be finished
+        cy.wait("@getPost");
+        cy.getSaveButton().should("not.be.disabled");
+
+        cy.get("#title").should("not.have.value", "").clear();
+        cy.get("#content").should("not.have.value", "").clear();
+        cy.get("#status").should("not.have.value", "").clear({ force: true });
+        cy.get("#category").should("not.have.value", "").clear({ force: true });
+
+        submitForm();
+
+        cy.getMaterialUIFormItemError({ id: "title" }).contains(/required/gi);
+        cy.getMaterialUIFormItemError({ id: "content" }).contains(/required/gi);
+        cy.getMaterialUIFormItemError({ id: "status" }).contains(/required/gi);
+        cy.getMaterialUIFormItemError({ id: "category" }).contains(
+            /required/gi,
+        );
+
+        fillForm();
+
+        cy.getMaterialUIFormItemError({ id: "title" }).should("not.exist");
+        cy.getMaterialUIFormItemError({ id: "content" }).should("not.exist");
+    });
+});

--- a/examples/form-material-ui-use-form/package.json
+++ b/examples/form-material-ui-use-form/package.json
@@ -25,11 +25,15 @@
     "typescript": "^4.7.4",
     "react-hook-form": "^7.30.0"
   },
+  "devDependencies": {
+    "cypress": "^12.11.0"
+  },
   "scripts": {
     "start": "cross-env DISABLE_ESLINT_PLUGIN=true refine start",
     "build": "cross-env DISABLE_ESLINT_PLUGIN=true refine build",
     "eject": "react-scripts eject",
-    "refine": "refine"
+    "refine": "refine",
+    "cypress": "cypress open -C ./cypress.config.ts"
   },
   "browserslist": {
     "production": [

--- a/examples/form-material-ui-use-form/src/App.tsx
+++ b/examples/form-material-ui-use-form/src/App.tsx
@@ -39,6 +39,9 @@ const App: React.FC = () => {
                                 list: "/posts",
                                 create: "/posts/create",
                                 edit: "/posts/edit/:id",
+                                meta: {
+                                    canDelete: true,
+                                },
                             },
                         ]}
                         options={{

--- a/examples/form-material-ui-use-form/src/pages/posts/create.tsx
+++ b/examples/form-material-ui-use-form/src/pages/posts/create.tsx
@@ -33,6 +33,7 @@ export const PostCreate: React.FC = () => {
                 autoComplete="off"
             >
                 <TextField
+                    id="title"
                     {...register("title", {
                         required: "This field is required",
                     })}
@@ -50,6 +51,7 @@ export const PostCreate: React.FC = () => {
                     rules={{ required: "This field is required" }}
                     render={({ field }) => (
                         <Autocomplete
+                            id="status"
                             options={["published", "draft", "rejected"]}
                             {...field}
                             onChange={(_, value) => {
@@ -75,6 +77,7 @@ export const PostCreate: React.FC = () => {
                     rules={{ required: "This field is required" }}
                     render={({ field }) => (
                         <Autocomplete
+                            id="category"
                             {...autocompleteProps}
                             {...field}
                             onChange={(_, value) => {
@@ -109,6 +112,7 @@ export const PostCreate: React.FC = () => {
                     )}
                 />
                 <TextField
+                    id="content"
                     {...register("content", {
                         required: "This field is required",
                     })}

--- a/examples/form-material-ui-use-form/src/pages/posts/edit.tsx
+++ b/examples/form-material-ui-use-form/src/pages/posts/edit.tsx
@@ -35,6 +35,7 @@ export const PostEdit: React.FC = () => {
                 autoComplete="off"
             >
                 <TextField
+                    id="title"
                     {...register("title", {
                         required: "This field is required",
                     })}
@@ -54,6 +55,7 @@ export const PostEdit: React.FC = () => {
                     defaultValue={null as any}
                     render={({ field }) => (
                         <Autocomplete
+                            id="status"
                             {...field}
                             options={["published", "draft", "rejected"]}
                             onChange={(_, value) => {
@@ -81,6 +83,7 @@ export const PostEdit: React.FC = () => {
                     defaultValue={null as any}
                     render={({ field }) => (
                         <Autocomplete
+                            id="category"
                             {...autocompleteProps}
                             {...field}
                             onChange={(_, value) => {
@@ -115,6 +118,7 @@ export const PostEdit: React.FC = () => {
                     )}
                 />
                 <TextField
+                    id="content"
                     {...register("content", {
                         required: "This field is required",
                     })}

--- a/examples/form-material-ui-use-modal-form/cypress.config.ts
+++ b/examples/form-material-ui-use-modal-form/cypress.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+    projectId: "sq5j3e",
+    e2e: {
+        fixturesFolder: "../../cypress/fixtures",
+        supportFile: "../../cypress/support/e2e.ts",
+    },
+    chromeWebSecurity: false,
+    experimentalMemoryManagement: true,
+    numTestsKeptInMemory: 1,
+});

--- a/examples/form-material-ui-use-modal-form/cypress/e2e/all.cy.ts
+++ b/examples/form-material-ui-use-modal-form/cypress/e2e/all.cy.ts
@@ -1,0 +1,117 @@
+/// <reference types="cypress" />
+/// <reference types="../../cypress/support" />
+
+describe("form-material-ui-use-modal-form", () => {
+    const BASE_URL = "http://localhost:3000";
+
+    const mockPost = {
+        title: "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
+        content:
+            "Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+        status: "published",
+    };
+
+    const fillForm = () => {
+        cy.get("#title").clear();
+        cy.get("#title").type(mockPost.title);
+        cy.get("#content").clear();
+        cy.get("#content").type(mockPost.content);
+        cy.get("#status").click();
+        cy.get("#status-option-0").click();
+        cy.get("#category").click();
+        cy.get("#category-option-0").click();
+    };
+
+    const assertSuccessResponse = (response: any) => {
+        const body = response?.body;
+
+        expect(response?.statusCode).to.eq(200);
+        expect(body).to.have.property("id");
+        expect(body).to.have.property("category");
+        expect(body?.title).to.eq(mockPost.title);
+        expect(body?.content).to.eq(mockPost.content);
+        expect(body?.status?.toLowerCase()).to.eq(
+            mockPost?.status?.toLowerCase(),
+        );
+
+        isModalClosed();
+        cy.getMaterialUINotification().contains(/success/i);
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq("/posts");
+        });
+    };
+
+    const submitForm = () => {
+        return cy.getSaveButton().click();
+    };
+
+    const closeModal = () => {
+        return cy
+            .get(".MuiDialogActions-root > .MuiButton-text")
+            .contains(/cancel/i)
+            .click();
+    };
+
+    const isModalOpen = () => {
+        return cy.get(".MuiDialog-container").should("be.visible");
+    };
+
+    const isModalClosed = () => {
+        return cy.get(".MuiDialog-container").should("not.exist");
+    };
+
+    beforeEach(() => {
+        cy.interceptGETPost();
+        cy.interceptPOSTPost();
+        cy.interceptPATCHPost();
+        cy.interceptDELETEPost();
+        cy.interceptGETPosts();
+        cy.interceptGETCategories();
+
+        cy.clearAllCookies();
+        cy.clearAllLocalStorage();
+        cy.clearAllSessionStorage();
+
+        cy.visit(BASE_URL);
+    });
+
+    it("open - close modal", () => {
+        isModalClosed();
+
+        cy.getCreateButton().click();
+        isModalOpen();
+
+        closeModal();
+        isModalClosed();
+    });
+
+    it("should create record", () => {
+        cy.getCreateButton().click();
+        isModalOpen();
+
+        fillForm();
+        submitForm();
+
+        cy.wait("@postPost").then((interception) => {
+            const response = interception?.response;
+            assertSuccessResponse(response);
+        });
+    });
+
+    it("should edit record", () => {
+        cy.getEditButton().first().click();
+        isModalOpen();
+
+        // wait loading state and render to be finished
+        cy.wait("@getPost");
+        cy.getSaveButton().should("not.be.disabled");
+
+        fillForm();
+        submitForm();
+
+        cy.wait("@patchPost").then((interception) => {
+            const response = interception?.response;
+            assertSuccessResponse(response);
+        });
+    });
+});

--- a/examples/form-material-ui-use-modal-form/package.json
+++ b/examples/form-material-ui-use-modal-form/package.json
@@ -25,11 +25,15 @@
     "typescript": "^4.7.4",
     "react-hook-form": "^7.30.0"
   },
+  "devDependencies": {
+    "cypress": "^12.11.0"
+  },
   "scripts": {
     "start": "cross-env DISABLE_ESLINT_PLUGIN=true refine start",
     "build": "cross-env DISABLE_ESLINT_PLUGIN=true refine build",
     "eject": "react-scripts eject",
-    "refine": "refine"
+    "refine": "refine",
+    "cypress": "cypress open -C ./cypress.config.ts"
   },
   "browserslist": {
     "production": [

--- a/examples/form-material-ui-use-modal-form/src/components/createPostModal.tsx
+++ b/examples/form-material-ui-use-modal-form/src/components/createPostModal.tsx
@@ -45,6 +45,7 @@ export const CreatePostModal: React.FC<
                     sx={{ display: "flex", flexDirection: "column" }}
                 >
                     <TextField
+                        id="title"
                         {...register("title", {
                             required: "This field is required",
                         })}
@@ -61,6 +62,7 @@ export const CreatePostModal: React.FC<
                         rules={{ required: "This field is required" }}
                         render={({ field }) => (
                             <Autocomplete
+                                id="status"
                                 options={["published", "draft", "rejected"]}
                                 {...field}
                                 onChange={(_, value) => {
@@ -86,6 +88,7 @@ export const CreatePostModal: React.FC<
                         rules={{ required: "This field is required" }}
                         render={({ field }) => (
                             <Autocomplete
+                                id="category"
                                 {...autocompleteProps}
                                 {...field}
                                 onChange={(_, value) => {
@@ -119,6 +122,7 @@ export const CreatePostModal: React.FC<
                         )}
                     />
                     <TextField
+                        id="content"
                         {...register("content", {
                             required: "This field is required",
                         })}

--- a/examples/form-material-ui-use-modal-form/src/components/editPostModal.tsx
+++ b/examples/form-material-ui-use-modal-form/src/components/editPostModal.tsx
@@ -47,6 +47,7 @@ export const EditPostModal: React.FC<
                     sx={{ display: "flex", flexDirection: "column" }}
                 >
                     <TextField
+                        id="title"
                         {...register("title", {
                             required: "This field is required",
                         })}
@@ -66,6 +67,7 @@ export const EditPostModal: React.FC<
                         defaultValue={null as any}
                         render={({ field }) => (
                             <Autocomplete
+                                id="status"
                                 options={["published", "draft", "rejected"]}
                                 {...field}
                                 onChange={(_, value) => {
@@ -93,6 +95,7 @@ export const EditPostModal: React.FC<
                         defaultValue={null as any}
                         render={({ field }) => (
                             <Autocomplete
+                                id="category"
                                 {...autocompleteProps}
                                 {...field}
                                 onChange={(_, value) => {
@@ -126,6 +129,7 @@ export const EditPostModal: React.FC<
                         )}
                     />
                     <TextField
+                        id="content"
                         {...register("content", {
                             required: "This field is required",
                         })}

--- a/examples/form-material-ui-use-steps-form/cypress.config.ts
+++ b/examples/form-material-ui-use-steps-form/cypress.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+    projectId: "sq5j3e",
+    e2e: {
+        fixturesFolder: "../../cypress/fixtures",
+        supportFile: "../../cypress/support/e2e.ts",
+    },
+    chromeWebSecurity: false,
+    experimentalMemoryManagement: true,
+    numTestsKeptInMemory: 1,
+});

--- a/examples/form-material-ui-use-steps-form/cypress/e2e/all.cy.ts
+++ b/examples/form-material-ui-use-steps-form/cypress/e2e/all.cy.ts
@@ -1,0 +1,175 @@
+/// <reference types="cypress" />
+/// <reference types="../../cypress/support" />
+
+describe("form-material-ui-use-modal-form", () => {
+    const BASE_URL = "http://localhost:3000";
+
+    const mockPost = {
+        title: "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
+        content:
+            "Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+        status: "published",
+        slug: "lorem-ipsum-is-simply-dummy-text-of-the-printing-and-typesetting-industry",
+    };
+
+    const getNextButton = () => {
+        return cy.get("button").contains(/next/i);
+    };
+
+    const getPreviousButton = () => {
+        return cy.get("button").contains(/previous/i);
+    };
+
+    const fillForm = () => {
+        cy.get("#title").clear();
+        cy.get("#title").type(mockPost.title);
+
+        getNextButton().click();
+
+        cy.get("#status").click();
+        cy.get("#status-option-0").click();
+        cy.get("#category").click();
+        cy.get("#category-option-0").click();
+
+        getNextButton().click();
+
+        cy.get("#slug").clear();
+        cy.get("#slug").type(mockPost.slug);
+        cy.get("#content").clear();
+        cy.get("#content").type(mockPost.content);
+    };
+
+    const assertSuccessResponse = (response: any) => {
+        const body = response?.body;
+
+        expect(response?.statusCode).to.eq(200);
+        expect(body).to.have.property("id");
+        expect(body).to.have.property("category");
+        expect(body?.title).to.eq(mockPost.title);
+        expect(body?.content).to.eq(mockPost.content);
+        expect(body?.slug).to.eq(mockPost.slug);
+        expect(body?.status?.toLowerCase()).to.eq(
+            mockPost?.status?.toLowerCase(),
+        );
+
+        cy.getMaterialUINotification().contains(/success/i);
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq("/posts");
+        });
+    };
+
+    const submitForm = () => {
+        cy.getSaveButton().click();
+    };
+
+    beforeEach(() => {
+        cy.interceptGETPost();
+        cy.interceptPOSTPost();
+        cy.interceptPATCHPost();
+        cy.interceptDELETEPost();
+        cy.interceptGETPosts();
+        cy.interceptGETCategories();
+
+        cy.clearAllCookies();
+        cy.clearAllLocalStorage();
+        cy.clearAllSessionStorage();
+
+        cy.visit(BASE_URL);
+    });
+
+    it("should create record", () => {
+        cy.getCreateButton().click();
+
+        fillForm();
+        submitForm();
+
+        cy.wait("@postPost").then((interception) => {
+            const response = interception?.response;
+            assertSuccessResponse(response);
+        });
+    });
+
+    it("should edit record", () => {
+        cy.getEditButton().first().click();
+
+        // wait loading state and render to be finished
+        cy.wait("@getPost");
+        getNextButton().should("not.be.disabled");
+
+        fillForm();
+
+        cy.getSaveButton().should("not.be.disabled");
+        submitForm();
+
+        cy.wait("@patchPost").then((interception) => {
+            const response = interception?.response;
+            assertSuccessResponse(response);
+        });
+    });
+
+    it("should preserve form data when navigating between steps", () => {
+        cy.getCreateButton().click();
+
+        fillForm();
+
+        // traverse back and forth and assert that the form data is preserved
+        getPreviousButton().click();
+        cy.get("#status").should("have.value", mockPost.status);
+        cy.get("#category").should("not.have.value", "");
+        getPreviousButton().click();
+        cy.get("#title").should("have.value", mockPost.title);
+        getNextButton().click();
+        getNextButton().click();
+        cy.get("#slug").should("have.value", mockPost.slug);
+        cy.get("#content").should("have.value", mockPost.content);
+
+        // traverse back and forth and change the form data
+        cy.get("#slug").clear();
+        cy.get("#slug").type("changed");
+        cy.get("#content").clear();
+        cy.get("#content").type("changed");
+        getPreviousButton().click();
+        cy.get("#status").click();
+        cy.get("#status-option-1").click();
+        cy.get("#category").click();
+        cy.get("#category-option-1").click();
+        getPreviousButton().click();
+        cy.get("#title").clear();
+        cy.get("#title").type("changed");
+
+        // traverse back and forth and assert that the form data is preserved
+        getNextButton().click();
+        getNextButton().click();
+        cy.get("#slug").should("have.value", "changed");
+        cy.get("#content").should("have.value", "changed");
+        getPreviousButton().click();
+        cy.get("#status").should("have.value", "draft");
+        cy.get("#category").should("not.have.value", "");
+        getPreviousButton().click();
+        cy.get("#title").should("have.value", "changed");
+
+        // submit the form
+        getNextButton().click();
+        getNextButton().click();
+        cy.getSaveButton().should("not.be.disabled");
+        submitForm();
+
+        cy.wait("@postPost").then((interception) => {
+            const response = interception?.response;
+            const body = response?.body;
+
+            expect(response?.statusCode).to.eq(200);
+            expect(body).to.have.property("id");
+            expect(body).to.have.property("category");
+            expect(body?.title).to.eq("changed");
+            expect(body?.content).to.eq("changed");
+            expect(body?.slug).to.eq("changed");
+            expect(body?.status?.toLowerCase()).to.eq("draft");
+
+            cy.getMaterialUINotification().contains(/success/i);
+            cy.location().should((loc) => {
+                expect(loc.pathname).to.eq("/posts");
+            });
+        });
+    });
+});

--- a/examples/form-material-ui-use-steps-form/package.json
+++ b/examples/form-material-ui-use-steps-form/package.json
@@ -25,11 +25,15 @@
     "typescript": "^4.7.4",
     "react-hook-form": "^7.30.0"
   },
+  "devDependencies": {
+    "cypress": "^12.11.0"
+  },
   "scripts": {
     "start": "cross-env DISABLE_ESLINT_PLUGIN=true refine start",
     "build": "cross-env DISABLE_ESLINT_PLUGIN=true refine build",
     "eject": "react-scripts eject",
-    "refine": "refine"
+    "refine": "refine",
+    "cypress": "cypress open -C ./cypress.config.ts"
   },
   "browserslist": {
     "production": [

--- a/examples/form-material-ui-use-steps-form/src/pages/posts/create.tsx
+++ b/examples/form-material-ui-use-steps-form/src/pages/posts/create.tsx
@@ -48,6 +48,7 @@ export const PostCreate: React.FC = () => {
             case 0:
                 return (
                     <TextField
+                        id="title"
                         {...register("title", {
                             required: "This field is required",
                         })}
@@ -69,6 +70,7 @@ export const PostCreate: React.FC = () => {
                             rules={{ required: "This field is required" }}
                             render={({ field }) => (
                                 <Autocomplete
+                                    id="status"
                                     options={["published", "draft", "rejected"]}
                                     {...field}
                                     onChange={(_, value) => {
@@ -94,6 +96,7 @@ export const PostCreate: React.FC = () => {
                             rules={{ required: "This field is required" }}
                             render={({ field }) => (
                                 <Autocomplete
+                                    id="category"
                                     {...autocompleteProps}
                                     {...field}
                                     onChange={(_, value) => {
@@ -135,6 +138,7 @@ export const PostCreate: React.FC = () => {
                 return (
                     <>
                         <TextField
+                            id="slug"
                             {...register("slug", {
                                 required: "This field is required",
                             })}
@@ -145,6 +149,7 @@ export const PostCreate: React.FC = () => {
                             label="Slug"
                         />
                         <TextField
+                            id="content"
                             {...register("content", {
                                 required: "This field is required",
                             })}

--- a/examples/form-material-ui-use-steps-form/src/pages/posts/edit.tsx
+++ b/examples/form-material-ui-use-steps-form/src/pages/posts/edit.tsx
@@ -53,6 +53,7 @@ export const PostEdit: React.FC = () => {
             case 0:
                 return (
                     <TextField
+                        id="title"
                         {...register("title", {
                             required: "This field is required",
                         })}
@@ -76,6 +77,7 @@ export const PostEdit: React.FC = () => {
                             defaultValue={null as any}
                             render={({ field }) => (
                                 <Autocomplete
+                                    id="status"
                                     options={["published", "draft", "rejected"]}
                                     {...field}
                                     onChange={(_, value) => {
@@ -103,6 +105,7 @@ export const PostEdit: React.FC = () => {
                             defaultValue={null as any}
                             render={({ field }) => (
                                 <Autocomplete
+                                    id="category"
                                     {...autocompleteProps}
                                     {...field}
                                     onChange={(_, value) => {
@@ -144,6 +147,7 @@ export const PostEdit: React.FC = () => {
                 return (
                     <>
                         <TextField
+                            id="slug"
                             {...register("slug", {
                                 required: "This field is required",
                             })}
@@ -154,6 +158,7 @@ export const PostEdit: React.FC = () => {
                             label="Slug"
                         />
                         <TextField
+                            id="content"
                             {...register("content", {
                                 required: "This field is required",
                             })}
@@ -177,6 +182,7 @@ export const PostEdit: React.FC = () => {
                 <>
                     {currentStep > 0 && (
                         <Button
+                            disabled={formLoading}
                             onClick={() => {
                                 gotoStep(currentStep - 1);
                             }}
@@ -186,6 +192,7 @@ export const PostEdit: React.FC = () => {
                     )}
                     {currentStep < stepTitles.length - 1 && (
                         <Button
+                            disabled={formLoading}
                             onClick={() => {
                                 gotoStep(currentStep + 1);
                             }}


### PR DESCRIPTION
End-to-end (e2e) tests are added to examples.
Adding e2e tests to our examples will prevent us from introducing bugs when developing new features.


Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed