### PR TITLE
chore(examples): fix `http-proxy-middleware` error

### DIFF
--- a/examples/data-provider-strapi-v4/package.json
+++ b/examples/data-provider-strapi-v4/package.json
@@ -42,6 +42,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.13.14",
-    "http-proxy-middleware": "^2.0.3"
+    "http-proxy-middleware": "^2.0.6"
   }
 }

--- a/examples/data-provider-strapi/package.json
+++ b/examples/data-provider-strapi/package.json
@@ -46,6 +46,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.13.14",
-    "http-proxy-middleware": "^2.0.3"
+    "http-proxy-middleware": "^2.0.6"
   }
 }

--- a/examples/store/package.json
+++ b/examples/store/package.json
@@ -44,7 +44,7 @@
     "@medusajs/medusa": "^1.3.5",
     "medusa-react": "^0.3.5",
     "tailwindcss": "^3.0.11",
-    "http-proxy-middleware": "^2.0.3",
+    "http-proxy-middleware": "^2.0.6",
     "react-hook-form": "^7.30.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated `http-proxy-middleware` version to match `@refinedev/cli`.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
