### PR TITLE
refactor: remove `mutate: () => 0,` method and minor changes

### DIFF
--- a/packages/core/src/hooks/auth/useForgotPassword/index.spec.ts
+++ b/packages/core/src/hooks/auth/useForgotPassword/index.spec.ts
@@ -42,9 +42,7 @@ describe("v3LegacyAuthProviderCompatible useForgotPassword Hook", () => {
             },
         );
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({ email: "test@test.com" });
@@ -60,7 +58,6 @@ describe("v3LegacyAuthProviderCompatible useForgotPassword Hook", () => {
         const legacyRouterProvider = {
             ...mockLegacyRouterProvider(),
             useHistory: () => ({
-                push: mockFn,
                 replace: mockFn,
             }),
         };
@@ -87,9 +84,7 @@ describe("v3LegacyAuthProviderCompatible useForgotPassword Hook", () => {
             },
         );
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({ email: "test@test.com" });
@@ -131,9 +126,7 @@ describe("v3LegacyAuthProviderCompatible useForgotPassword Hook", () => {
             },
         );
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({ email: "test@test.com" });
@@ -168,9 +161,7 @@ describe("v3LegacyAuthProviderCompatible useForgotPassword Hook", () => {
             },
         );
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -220,9 +211,7 @@ describe("useForgotPassword Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({ email: "test@test.com" });
@@ -251,9 +240,7 @@ describe("useForgotPassword Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({ email: "test@test.com" });
@@ -270,7 +257,6 @@ describe("useForgotPassword Hook", () => {
         const legacyRouterProvider = {
             ...mockLegacyRouterProvider(),
             useHistory: () => ({
-                push: mockFn,
                 replace: mockFn,
             }),
         };
@@ -292,9 +278,7 @@ describe("useForgotPassword Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({ email: "test@test.com" });
@@ -320,9 +304,7 @@ describe("useForgotPassword Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -355,9 +337,7 @@ describe("useForgotPassword Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -391,9 +371,7 @@ describe("useForgotPassword Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -426,9 +404,7 @@ describe("useForgotPassword Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -473,9 +449,7 @@ describe("useForgotPassword Hook authProvider selection", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -516,9 +490,7 @@ describe("useForgotPassword Hook authProvider selection", () => {
             },
         );
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});

--- a/packages/core/src/hooks/auth/useIsAuthenticated/index.spec.ts
+++ b/packages/core/src/hooks/auth/useIsAuthenticated/index.spec.ts
@@ -1,16 +1,12 @@
 import { renderHook, waitFor } from "@testing-library/react";
-
 import { TestWrapper, mockLegacyRouterProvider } from "@test";
-
 import { useIsAuthenticated } from ".";
-import { act } from "react-dom/test-utils";
 
 const mockFn = jest.fn();
 
 const mockRouterProvider = {
     ...mockLegacyRouterProvider(),
     useHistory: () => ({
-        push: mockFn,
         replace: mockFn,
     }),
 };

--- a/packages/core/src/hooks/auth/useLogin/index.spec.ts
+++ b/packages/core/src/hooks/auth/useLogin/index.spec.ts
@@ -554,9 +554,7 @@ describe("useLogin Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -592,9 +590,7 @@ describe("useLogin Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -630,9 +626,7 @@ describe("useLogin Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -675,9 +669,7 @@ describe("useLogin Hook authProvider selection", () => {
             }),
         });
 
-        const { mutate: login } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: login } = result.current;
 
         await act(async () => {
             login({});
@@ -715,9 +707,7 @@ describe("useLogin Hook authProvider selection", () => {
             },
         );
 
-        const { mutate: login } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: login } = result.current;
 
         await act(async () => {
             login({});

--- a/packages/core/src/hooks/auth/useLogout/index.spec.ts
+++ b/packages/core/src/hooks/auth/useLogout/index.spec.ts
@@ -50,7 +50,7 @@ describe("v3LegacyAuthProviderCompatible useLogout Hook", () => {
             },
         );
 
-        const { mutateAsync: logout } = result.current!;
+        const { mutateAsync: logout } = result.current;
 
         await act(async () => {
             await logout();
@@ -86,7 +86,7 @@ describe("v3LegacyAuthProviderCompatible useLogout Hook", () => {
             },
         );
 
-        const { mutateAsync: logout } = result.current!;
+        const { mutateAsync: logout } = result.current;
 
         await act(async () => {
             await logout();
@@ -125,7 +125,7 @@ describe("v3LegacyAuthProviderCompatible useLogout Hook", () => {
             },
         );
 
-        const { mutateAsync: logout } = result.current!;
+        const { mutateAsync: logout } = result.current;
 
         await act(async () => {
             await logout({ redirectPath: "/custom-path" });
@@ -159,7 +159,7 @@ describe("v3LegacyAuthProviderCompatible useLogout Hook", () => {
             },
         );
 
-        const { mutateAsync: logout } = result.current!;
+        const { mutateAsync: logout } = result.current;
 
         await act(async () => {
             try {
@@ -188,7 +188,7 @@ describe("v3LegacyAuthProviderCompatible useLogout Hook", () => {
             },
         );
 
-        const { mutateAsync: logout } = result.current!;
+        const { mutateAsync: logout } = result.current;
 
         await act(async () => {
             try {
@@ -214,7 +214,7 @@ describe("v3LegacyAuthProviderCompatible useLogout Hook", () => {
             }),
         });
 
-        const { mutate: checkError } = result.current!;
+        const { mutate: checkError } = result.current;
 
         await act(async () => {
             await checkError({});
@@ -245,7 +245,7 @@ describe("v3LegacyAuthProviderCompatible useLogout Hook", () => {
             }),
         });
 
-        const { mutate: checkError } = result.current!;
+        const { mutate: checkError } = result.current;
 
         await act(async () => {
             await checkError({});
@@ -279,7 +279,7 @@ describe("v3LegacyAuthProviderCompatible useLogout Hook", () => {
             },
         );
 
-        const { mutate: logout } = result.current!;
+        const { mutate: logout } = result.current;
 
         await act(async () => {
             await logout();
@@ -331,7 +331,7 @@ describe("useLogout Hook", () => {
             }),
         });
 
-        const { mutateAsync: logout } = result.current!;
+        const { mutateAsync: logout } = result.current;
 
         await act(async () => {
             await logout();
@@ -360,7 +360,7 @@ describe("useLogout Hook", () => {
             }),
         });
 
-        const { mutateAsync: logout } = result.current!;
+        const { mutateAsync: logout } = result.current;
 
         await act(async () => {
             await logout();
@@ -393,7 +393,7 @@ describe("useLogout Hook", () => {
             },
         );
 
-        const { mutateAsync: logout } = result.current!;
+        const { mutateAsync: logout } = result.current;
 
         await act(async () => {
             await logout({ redirectPath: "/custom-path" });
@@ -425,7 +425,7 @@ describe("useLogout Hook", () => {
             },
         );
 
-        const { mutateAsync: logout } = result.current!;
+        const { mutateAsync: logout } = result.current;
 
         await act(async () => {
             await logout();
@@ -453,7 +453,7 @@ describe("useLogout Hook", () => {
             }),
         });
 
-        const { mutateAsync: logout } = result.current!;
+        const { mutateAsync: logout } = result.current;
 
         await act(async () => {
             await logout();
@@ -481,7 +481,7 @@ describe("useLogout Hook", () => {
             }),
         });
 
-        const { mutateAsync: logout } = result.current!;
+        const { mutateAsync: logout } = result.current;
         await act(async () => {
             await logout();
         });
@@ -509,7 +509,7 @@ describe("useLogout Hook", () => {
             }),
         });
 
-        const { mutate: onError } = result.current!;
+        const { mutate: onError } = result.current;
 
         await act(async () => {
             await onError({});
@@ -543,9 +543,7 @@ describe("useLogout Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -576,9 +574,7 @@ describe("useLogout Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -612,9 +608,7 @@ describe("useLogout Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -658,9 +652,7 @@ describe("useLogout Hook authProvider selection", () => {
             }),
         });
 
-        const { mutate: login } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: login } = result.current;
 
         await act(async () => {
             login({});
@@ -698,9 +690,7 @@ describe("useLogout Hook authProvider selection", () => {
             },
         );
 
-        const { mutate: login } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: login } = result.current;
 
         await act(async () => {
             login({});

--- a/packages/core/src/hooks/auth/useOnError/index.spec.ts
+++ b/packages/core/src/hooks/auth/useOnError/index.spec.ts
@@ -9,19 +9,21 @@ import {
 
 import { useOnError } from ".";
 
-const mockFn = jest.fn();
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
 
 const mockRouterProvider = {
     ...mockLegacyRouterProvider(),
     useHistory: () => ({
-        push: mockFn,
-        replace: mockFn,
+        replace: mockReplace,
+        push: mockPush,
     }),
 };
 // NOTE : Will be removed in v5
 describe("v3LegacyAuthProviderCompatible useOnError Hook", () => {
     beforeEach(() => {
-        mockFn.mockReset();
+        mockReplace.mockReset();
+        mockPush.mockReset();
 
         jest.spyOn(console, "error").mockImplementation((message) => {
             if (message === "rejected" || message === "/customPath") return;
@@ -50,7 +52,7 @@ describe("v3LegacyAuthProviderCompatible useOnError Hook", () => {
             },
         );
 
-        const { mutate: checkError } = result.current!;
+        const { mutate: checkError } = result.current;
 
         await act(async () => {
             await checkError({});
@@ -61,7 +63,7 @@ describe("v3LegacyAuthProviderCompatible useOnError Hook", () => {
         });
 
         expect(onErrorMock).toBeCalledTimes(1);
-        expect(mockFn).toBeCalledWith("/login");
+        expect(mockPush).toBeCalledWith("/login");
     });
 
     it("logout and redirect to custom path if check error rejected", async () => {
@@ -85,7 +87,7 @@ describe("v3LegacyAuthProviderCompatible useOnError Hook", () => {
             },
         );
 
-        const { mutate: checkError } = result.current!;
+        const { mutate: checkError } = result.current;
 
         await act(async () => {
             await checkError({});
@@ -96,14 +98,15 @@ describe("v3LegacyAuthProviderCompatible useOnError Hook", () => {
         });
 
         await act(async () => {
-            expect(mockFn).toBeCalledWith("/customPath");
+            expect(mockPush).toBeCalledWith("/customPath");
         });
     });
 });
 
 describe("useOnError Hook", () => {
     beforeEach(() => {
-        mockFn.mockReset();
+        mockReplace.mockReset();
+        mockPush.mockReset();
 
         jest.spyOn(console, "error").mockImplementation((message) => {
             if (message === "rejected" || message === "/customPath") return;
@@ -130,7 +133,7 @@ describe("useOnError Hook", () => {
             }),
         });
 
-        const { mutate: checkError } = result.current!;
+        const { mutate: checkError } = result.current;
 
         await act(async () => {
             await checkError({});
@@ -141,7 +144,7 @@ describe("useOnError Hook", () => {
         });
 
         await act(async () => {
-            expect(mockFn).toBeCalledWith("/login");
+            expect(mockPush).toBeCalledWith("/login");
         });
     });
 
@@ -164,7 +167,7 @@ describe("useOnError Hook", () => {
             }),
         });
 
-        const { mutate: checkError } = result.current!;
+        const { mutate: checkError } = result.current;
 
         await act(async () => {
             await checkError({});
@@ -175,7 +178,7 @@ describe("useOnError Hook", () => {
         });
 
         await act(async () => {
-            expect(mockFn).toBeCalledWith("/login");
+            expect(mockReplace).toBeCalledWith("/login");
         });
     });
 
@@ -203,7 +206,7 @@ describe("useOnError Hook", () => {
             }),
         });
 
-        const { mutate: checkError } = result.current!;
+        const { mutate: checkError } = result.current;
 
         await act(async () => {
             await checkError({});
@@ -245,9 +248,7 @@ describe("useOnError Hook authProvider selection", () => {
             }),
         });
 
-        const { mutate: login } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: login } = result.current;
 
         await act(async () => {
             login({});
@@ -285,9 +286,7 @@ describe("useOnError Hook authProvider selection", () => {
             },
         );
 
-        const { mutate: login } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: login } = result.current;
 
         await act(async () => {
             login({});

--- a/packages/core/src/hooks/auth/useRegister/index.spec.ts
+++ b/packages/core/src/hooks/auth/useRegister/index.spec.ts
@@ -427,9 +427,7 @@ describe("useRegister Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -460,9 +458,7 @@ describe("useRegister Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -496,9 +492,7 @@ describe("useRegister Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -540,9 +534,7 @@ describe("useRegister Hook authProvider selection", () => {
             }),
         });
 
-        const { mutate: login } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: login } = result.current;
 
         await act(async () => {
             login({});
@@ -582,9 +574,7 @@ describe("useRegister Hook authProvider selection", () => {
             },
         );
 
-        const { mutate: login } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: login } = result.current;
 
         await act(async () => {
             login({});

--- a/packages/core/src/hooks/auth/useUpdatePassword/index.spec.ts
+++ b/packages/core/src/hooks/auth/useUpdatePassword/index.spec.ts
@@ -14,7 +14,6 @@ const mockFn = jest.fn();
 const mockRouterProvider = {
     ...mockLegacyRouterProvider(),
     useHistory: () => ({
-        push: mockFn,
         replace: mockFn,
     }),
     useLocation: () => ({}),
@@ -62,9 +61,7 @@ describe("v3LegacyAuthProviderCompatible useUpdatePassword Hook", () => {
             },
         );
 
-        const { mutate: updatePassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: updatePassword } = result.current;
 
         await act(async () => {
             updatePassword({ password: "123", confirmPassword: "321" });
@@ -97,9 +94,7 @@ describe("v3LegacyAuthProviderCompatible useUpdatePassword Hook", () => {
             },
         );
 
-        const { mutate: updatePassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: updatePassword } = result.current;
 
         await act(async () => {
             updatePassword({ password: "123" });
@@ -144,9 +139,7 @@ describe("useUpdatePassword Hook", () => {
             }),
         });
 
-        const { mutate: updatePassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: updatePassword } = result.current;
 
         await act(async () => {
             updatePassword({ password: "123", confirmPassword: "321" });
@@ -187,9 +180,7 @@ describe("useUpdatePassword Hook", () => {
             }),
         });
 
-        const { mutate: updatePassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: updatePassword } = result.current;
 
         await act(async () => {
             updatePassword({ password: "123", confirmPassword: "321" });
@@ -224,9 +215,7 @@ describe("useUpdatePassword Hook", () => {
             }),
         });
 
-        const { mutate: updatePassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: updatePassword } = result.current;
 
         await act(async () => {
             updatePassword({ password: "123" });
@@ -266,9 +255,7 @@ describe("useUpdatePassword Hook", () => {
             }),
         });
 
-        const { mutate: updatePassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: updatePassword } = result.current;
 
         await act(async () => {
             updatePassword({ password: "123", confirmPassword: "321" });
@@ -309,9 +296,7 @@ describe("useUpdatePassword Hook", () => {
             }),
         });
 
-        const { mutate: updatePassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: updatePassword } = result.current;
 
         await act(async () => {
             updatePassword({ confirmPassword: "321" });
@@ -349,9 +334,7 @@ describe("useUpdatePassword Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -383,9 +366,7 @@ describe("useUpdatePassword Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -420,9 +401,7 @@ describe("useUpdatePassword Hook", () => {
             }),
         });
 
-        const { mutate: forgotPassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: forgotPassword } = result.current;
 
         await act(async () => {
             forgotPassword({});
@@ -467,9 +446,7 @@ describe("useUpdatePassword Hook authProvider selection", () => {
             }),
         });
 
-        const { mutate: login } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: login } = result.current;
 
         await act(async () => {
             login({});
@@ -512,9 +489,7 @@ describe("useUpdatePassword Hook authProvider selection", () => {
             },
         );
 
-        const { mutate: login } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: login } = result.current;
 
         await act(async () => {
             login({});
@@ -565,9 +540,7 @@ describe("useUpdatePassword Hook with v3LegacyAuthProviderCompatible", () => {
             },
         );
 
-        const { mutate: updatePassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: updatePassword } = result.current;
 
         await act(async () => {
             updatePassword({ password: "123", confirmPassword: "321" });
@@ -613,9 +586,7 @@ describe("useUpdatePassword Hook with v3LegacyAuthProviderCompatible", () => {
             },
         );
 
-        const { mutate: updatePassword } = result.current ?? {
-            mutate: () => 0,
-        };
+        const { mutate: updatePassword } = result.current;
 
         await act(async () => {
             updatePassword({ password: "123", confirmPassword: "321" });


### PR DESCRIPTION
Refactor auth hook tests: 

| Before | After |
|--------|--------|
|`const { mutate: forgotPassword } = result.current ?? { mutate: () => 0, };` | `const { mutate: forgotPassword } = result.current;` |
| `const { mutateAsync: logout } = result.current!;` | `const { mutateAsync: logout } = result.current;` | 

### Test plan (required)

<img width="545" alt="image" src="https://github.com/refinedev/refine/assets/3484713/d4ac1c71-835d-44cb-b60b-3284a57c6195">

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
