### PR TITLE
fix(live-previews): subpath import supports for material ui packages

### DIFF
--- a/packages/live-previews/src/scope/map.tsx
+++ b/packages/live-previews/src/scope/map.tsx
@@ -50,3 +50,11 @@ export const packageMap: Record<string, string> = {
     "i18next-browser-languagedetector": "I18NextBrowserLanguageDetector",
     "i18next-xhr-backend": "I18NextXhrBackend",
 };
+
+export const packageScopeMap: Record<string, RegExp> = {
+    "@mui/lab": /@mui\/lab\/.*/,
+    "@mui/material/styles": /@mui\/material\/styles\/.*/,
+    "@mui/material": /@mui\/material\/.*/,
+    "@mui/icons-material": /@mui\/icons-material\/.*/,
+    "@mui/x-data-grid": /@mui\/x-data-grid\/.*/,
+};


### PR DESCRIPTION
Added a package import replacement logic for subpath imports such as `@mui/material/*` and `@mui/icons-material/*`. Since we're replacing the imports with variables from our scope, we'll be translating the subpath imports into named imports to `@mui/material` or `@mui/icons-material` etc.
 
### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
