### PR TITLE
feat(inferencer): use multiple records for inference

### DIFF
--- a/.changeset/little-boats-complain.md
+++ b/.changeset/little-boats-complain.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/inferencer": minor
+---
+
+Updated the inference process for `list` and `create` actions to use all items in the list instead of just the first item. This is done to avoid breaking the output when a single record is corrupted or wrongfully inferred.
+
+Now, for the `list` and `create` actions, each item in the list response will be used to infer the fields then the most repeated fields will be accepted as the type for the field. 

--- a/packages/inferencer/src/create-inferencer/index.tsx
+++ b/packages/inferencer/src/create-inferencer/index.tsx
@@ -72,12 +72,135 @@ export const createInferencer: CreateInferencer = ({
 
         const {
             data: record,
+            datas: records,
             loading: recordLoading,
             initial: isInitialLoad,
             error: inferError,
         } = useInferFetch(type, resourceName ?? resource?.name, id, meta);
 
-        const rawResults: InferField[] = React.useMemo(() => {
+        const inferSingleField = (
+            key: string,
+            value: any,
+            record: Record<string, unknown>,
+        ) => {
+            const inferResult = infer(key, value, record, infer);
+
+            if (inferResult) {
+                if (resource) {
+                    const transformed = transform(
+                        [inferResult] as InferField[],
+                        resources,
+                        resource,
+                        record,
+                        infer,
+                    );
+
+                    const customTransformedFields = fieldTransformer
+                        ? transformed.flatMap((field) => {
+                              const result = fieldTransformer(field);
+
+                              return result ? [result] : [];
+                          })
+                        : transformed;
+
+                    return customTransformedFields?.[0];
+                }
+            }
+
+            return undefined;
+        };
+
+        const inferSingleRecord = (record: Record<string, unknown>) => {
+            const inferred = Object.keys(record)
+                .map((key) => {
+                    const value = record[key];
+
+                    const inferResult = inferSingleField(key, value, record);
+
+                    return inferResult;
+                })
+                .filter(Boolean);
+
+            return inferred as InferField[];
+        };
+
+        const inferMultipleRecords = (records: Record<string, unknown>[]) => {
+            // infer each record
+            // get the most common one for each field
+            // also get the first occurence of the each most common field/key and construct a fresh record from them.
+            // return the fresh record and the inferred fields
+
+            const inferred = records.map((record) => inferSingleRecord(record));
+
+            const allUniqueKeys = records
+                .flatMap((record) => Object.keys(record))
+                .filter((key, index, self) => self.indexOf(key) === index);
+
+            const mostCommonRecord: Record<string, unknown> = {};
+
+            const mostCommonFields = allUniqueKeys.map((key) => {
+                const fields = inferred.map((fields) =>
+                    fields.find((field) => field.key === key),
+                );
+
+                const mostCommonField = fields.reduce(
+                    (acc, field, index) => {
+                        if (!field) {
+                            return acc;
+                        }
+
+                        const count = fields.filter(
+                            (f) =>
+                                f?.key === field.key && f?.type === field.type,
+                        ).length;
+
+                        if (count > acc.count) {
+                            mostCommonRecord[key] = records[index][key];
+
+                            return {
+                                count,
+                                field,
+                            };
+                        }
+
+                        return acc;
+                    },
+                    { count: 0, field: undefined } as {
+                        count: number;
+                        field: undefined | InferField;
+                    },
+                );
+
+                return mostCommonField.field;
+            });
+
+            const response = {
+                commonRecord: mostCommonRecord,
+                inferredFields: mostCommonFields,
+            };
+
+            console.log({
+                allUniqueKeys,
+                inferred,
+                mostCommonFields,
+                mostCommonRecord,
+            });
+
+            return response;
+        };
+
+        const [rawResults, recordInUse]: [
+            InferField[],
+            Record<string, unknown> | undefined,
+        ] = React.useMemo(() => {
+            if (records && (type === "list" || type === "create")) {
+                const inferred = inferMultipleRecords(records);
+
+                return [
+                    inferred.inferredFields as InferField[],
+                    inferred.commonRecord,
+                ];
+            }
             if (record) {
                 const inferred = Object.keys(record)
                     .map((key) => {
@@ -106,21 +229,21 @@ export const createInferencer: CreateInferencer = ({
                           })
                         : transformed;
 
-                    return customTransformedFields;
+                    return [customTransformedFields, record];
                 }
 
-                return [];
+                return [[], record];
             }
 
-            return [];
-        }, [record, resources, resource, fieldTransformer]);
+            return [[], undefined];
+        }, [record, records, resources, resource, fieldTransformer]);
 
         const {
             fields: results,
             loading: relationLoading,
             // initial: relationInitial,
         } = useRelationFetch({
-            record,
+            record: recordInUse,
             fields: rawResults,
             infer,
             meta,

--- a/packages/inferencer/src/create-inferencer/index.tsx
+++ b/packages/inferencer/src/create-inferencer/index.tsx
@@ -179,13 +179,6 @@ export const createInferencer: CreateInferencer = ({
                 inferredFields: mostCommonFields,
             };
 
-            console.log({
-                allUniqueKeys,
-                inferred,
-                mostCommonFields,
-                mostCommonRecord,
-            });
-
             return response;
         };
 

--- a/packages/inferencer/src/use-infer-fetch/index.tsx
+++ b/packages/inferencer/src/use-infer-fetch/index.tsx
@@ -30,6 +30,9 @@ export const useInferFetch = (
     const [data, setData] = React.useState<Record<string, unknown> | undefined>(
         undefined,
     );
+    const [datas, setDatas] = React.useState<
+        Array<Record<string, unknown>> | undefined
+    >(undefined);
     const [initial, setInitial] = React.useState<boolean>(true);
     const [loading, setLoading] = React.useState<boolean>(false);
 
@@ -64,6 +67,7 @@ export const useInferFetch = (
                             );
                         }
                         setData(r);
+                        setDatas(response.data);
                         setTimeout(() => {
                             setLoading(false);
                         }, 500);
@@ -121,6 +125,7 @@ export const useInferFetch = (
 
     return {
         data,
+        datas,
         loading,
         initial,
         error,


### PR DESCRIPTION
Updated the inference process for `list` and `create` actions to use all items in the list instead of just the first item. This is done to avoid breaking the output when a single record is corrupted or wrongfully inferred.

Now, for the `list` and `create` actions, each item in the list response will be used to infer the fields then the most repeated fields will be accepted as the type for the field. 

### Test plan (required)

All snapshots are passing with no required changes.

### Closing issues

Resolves #4330

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
