### PR TITLE
fix(inferencer): redundant braces in Mantine forms with `meta`

### DIFF
--- a/.changeset/nasty-toys-doubt.md
+++ b/.changeset/nasty-toys-doubt.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/inferencer": patch
+---
+
+Fixed the code generation issue with Mantine's `create` and `edit` inferencers when used with `meta` values.

--- a/packages/inferencer/src/inferencers/mantine/create.tsx
+++ b/packages/inferencer/src/inferencers/mantine/create.tsx
@@ -335,13 +335,13 @@ export const renderer = ({
                           meta,
                           "getOne",
                       )
-                    ? `{
+                    ? `
                       refineCoreProps: { ${getMetaProps(
                           resource.identifier ?? resource.name,
                           meta,
                           "getOne",
                       )} }
-                      }`
+                      `
                     : ""
             }
         });

--- a/packages/inferencer/src/inferencers/mantine/create.tsx
+++ b/packages/inferencer/src/inferencers/mantine/create.tsx
@@ -335,13 +335,11 @@ export const renderer = ({
                           meta,
                           "getOne",
                       )
-                    ? `
-                      refineCoreProps: { ${getMetaProps(
+                    ? `refineCoreProps: { ${getMetaProps(
                           resource.identifier ?? resource.name,
                           meta,
                           "getOne",
-                      )} }
-                      `
+                      )} }`
                     : ""
             }
         });

--- a/packages/inferencer/src/inferencers/mantine/edit.tsx
+++ b/packages/inferencer/src/inferencers/mantine/edit.tsx
@@ -425,12 +425,12 @@ export const renderer = ({
                           meta,
                           "getOne",
                       )
-                    ? `{ refineCoreProps: { ${getMetaProps(
+                    ? `refineCoreProps: { ${getMetaProps(
                           resource?.identifier ?? resource?.name,
                           meta,
                           "getOne",
                       )} }
-                      }`
+                      `
                     : ""
             }
         });


### PR DESCRIPTION
Fixed the code generation issue with Mantine's `create` and `edit` inferencers when used with `meta` values.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
