### PR TITLE
feat(mantine): add name attribute to input fields in auth components

### DIFF
--- a/.changeset/sour-camels-switch.md
+++ b/.changeset/sour-camels-switch.md
@@ -1,5 +1,5 @@
 ---
-"@refinedev/mantine": minor
+"@refinedev/mantine": patch
 ---
 
 added: name attribute to input fields in `forgotPassword`, `register` and `updatePassword` forms

--- a/.changeset/sour-camels-switch.md
+++ b/.changeset/sour-camels-switch.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mantine": minor
+---
+
+added: name attribute to input fields in `forgotPassword`, `register` and `updatePassword` forms

--- a/packages/mantine/src/components/pages/auth/components/forgotPassword/index.tsx
+++ b/packages/mantine/src/components/pages/auth/components/forgotPassword/index.tsx
@@ -112,6 +112,7 @@ export const ForgotPasswordPage: React.FC<ResetPassworProps> = ({
                     })}
                 >
                     <TextInput
+                        name="email"
                         label={translate(
                             "pages.forgotPassword.fields.email",
                             "Email",

--- a/packages/mantine/src/components/pages/auth/components/register/index.tsx
+++ b/packages/mantine/src/components/pages/auth/components/register/index.tsx
@@ -150,6 +150,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                     })}
                 >
                     <TextInput
+                        name="email"
                         label={translate(
                             "pages.register.fields.email",
                             "Email",
@@ -162,6 +163,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                     />
                     <PasswordInput
                         mt="md"
+                        name="password"
                         label={translate(
                             "pages.register.fields.password",
                             "Password",

--- a/packages/mantine/src/components/pages/auth/components/updatePassword/index.tsx
+++ b/packages/mantine/src/components/pages/auth/components/updatePassword/index.tsx
@@ -100,6 +100,7 @@ export const UpdatePasswordPage: React.FC<UpdatePassworProps> = ({
                     })}
                 >
                     <TextInput
+                        name="password"
                         type="password"
                         label={translate(
                             "pages.updatePassword.fields.password",
@@ -110,6 +111,7 @@ export const UpdatePasswordPage: React.FC<UpdatePassworProps> = ({
                     />
                     <TextInput
                         mt="md"
+                        name="confirmPassword"
                         type="password"
                         label={translate(
                             "pages.updatePassword.fields.confirmPassword",


### PR DESCRIPTION
added: name attribute to input fields in `forgotPassword`, `register` and `updatePassword` forms.


### Test plan (required)

![image](https://github.com/refinedev/refine/assets/23058882/9c189d37-264e-49a4-b70b-05423d5cd5ca)


### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
