### PR TITLE
docs: add graphql subscriptions section in live provider doc

### DIFF
--- a/documentation/docs/api-reference/core/providers/live-provider.md
+++ b/documentation/docs/api-reference/core/providers/live-provider.md
@@ -224,7 +224,7 @@ const App: React.FC = () => {
 };
 ```
 
-## Creating a live provider for GraphQL subscriptions
+## Creating a live provider with GraphQL subscriptions
 
 In this section, we will create a live provider for GraphQL subscriptions from scratch. We will use [Hasura](https://hasura.io/) as an example, but the same logic can be applied to any GraphQL subscription provider.
 
@@ -351,6 +351,24 @@ export const liveProvider = (client: Client): LiveProvider => {
 `genareteUseListSubscription`, `genareteUseOneSubscription` and `genareteUseManySubscription` are helper functions that generate subscription queries. They are same as the methods in the data provider of `@refinedev/hasura`. You can check them out [here](https://github.com/refinedev/refine/tree/next/packages/hasura/src/utils).
 
 :::
+
+
+**refine** will use this subscribe method in the [`useSubscription`](/api-reference/core/hooks/live/useSubscription.md) hook.
+
+```ts
+import { useSubscription } from "@refinedev/core";
+
+useSubscription({
+    channel: "channel-name",
+    onLiveEvent: (event) => {},
+});
+```
+
+:::caution
+The values returned from the `subscribe` method are passed to the `unsubscribe` method. Thus values needed for unsubscription must be returned from `subscribe` method.
+:::
+
+> For more information, refer to the [useSubscription documentation&#8594](/api-reference/core/hooks/live/useSubscription.md)
 
 ### `unsubscribe`
 

--- a/documentation/docs/api-reference/core/providers/live-provider.md
+++ b/documentation/docs/api-reference/core/providers/live-provider.md
@@ -35,21 +35,7 @@ const liveProvider = {
 
 :::
 
-## Usage
-
-You must pass a live provider to the `liveProvider` prop of `<Refine>`.
-
-```tsx title="App.tsx"
-import { Refine } from "@refinedev/core";
-
-import liveProvider from "./liveProvider";
-
-const App: React.FC = () => {
-    return <Refine liveProvider={liveProvider} />;
-};
-```
-
-## Creating a live provider
+## Creating a live provider with Ably
 
 We will build the **"Ably Live Provider"** of [`@refinedev/ably`](https://github.com/refinedev/refine/tree/master/packages/ably) from scratch to show the logic of how live provider methods interact with Ably.
 
@@ -224,6 +210,20 @@ const publish = usePublish();
 
 > For more information, refer to the [usePublish documentation&#8594](/api-reference/core/hooks/live/usePublish.md)
 
+### Usage
+
+Now that we have created our live provider, we can use it in our application like below:
+
+```tsx title="App.tsx"
+import { Refine } from "@refinedev/core";
+
+import liveProvider from "./liveProvider";
+
+const App: React.FC = () => {
+    return <Refine ... liveProvider={liveProvider} />;
+};
+```
+
 ## Creating a live provider for GraphQL subscriptions
 
 In this section, we will create a live provider for GraphQL subscriptions from scratch. We will use [Hasura](https://hasura.io/) as an example, but the same logic can be applied to any GraphQL subscription provider.
@@ -257,8 +257,6 @@ subscription GetPosts {
 ```
 
 As you can see, the only difference between queries and subscriptions is the `subscription` keyword. This means that we can use the same logic for both queries and subscriptions. We already have a data provider for creating GraphQL queries, so we will use the same logic for GraphQL subscriptions.
-
-Let's create a live provider for GraphQL subscriptions.
 
 ### `subscribe`
 
@@ -374,9 +372,9 @@ export const liveProvider = (client: Client): LiveProvider => {
 };
 ```
 
-### Usage of the live provider
+### Usage
 
-Now that we have created our live provider, we can use it in `<Refine>` like following:
+Now that we have created our live provider, we can use it in our application like below:
 
 ```tsx title="App.tsx"
 import { Refine } from "@refinedev/core";

--- a/documentation/docs/api-reference/core/providers/live-provider.md
+++ b/documentation/docs/api-reference/core/providers/live-provider.md
@@ -324,7 +324,7 @@ export const liveProvider = (client: Client): LiveProvider => {
                 sorters,
             });
 
-            const onNext = (payload: any) => {
+            const onNext = (payload: { data: any }) => {
                 callback(payload.data[operation]);
             };
 
@@ -354,16 +354,37 @@ export const liveProvider = (client: Client): LiveProvider => {
 
 **refine** will use this subscribe method in the [`useSubscription`](/api-reference/core/hooks/live/useSubscription.md) hook.
 
+It will create a subscription query using the parameters of the `useSubscription` hook and listen to it. When a live event is received, it will call the `onLiveEvent` method of the `useSubscription` hook.
+
 ```ts
 import { useSubscription } from "@refinedev/core";
 
 useSubscription({
-    channel: "resources/posts",
+    channel: "posts",
     enabled: true,
-    types: ["insert", "update", "delete"],
     onLiveEvent: (event) => {
         // called when a live event is received
         console.log(event);
+    },
+    params: {
+        resource: "posts",
+        meta: {
+            fields: [
+                "id",
+                "title",
+                {
+                    category: ["title"],
+                },
+                "content",
+                "category_id",
+                "created_at",
+            ],
+        },
+        pagination: {
+            current: 1,
+            pageSize: 10,
+        },
+        subscriptionType: "useList",
     },
 });
 ```

--- a/documentation/docs/api-reference/core/providers/live-provider.md
+++ b/documentation/docs/api-reference/core/providers/live-provider.md
@@ -362,6 +362,7 @@ useSubscription({
     enabled: true,
     types: ["insert", "update", "delete"],
     onLiveEvent: (event) => {
+        // called when a live event is received
         console.log(event);
     },
 });

--- a/documentation/docs/api-reference/core/providers/live-provider.md
+++ b/documentation/docs/api-reference/core/providers/live-provider.md
@@ -352,15 +352,18 @@ export const liveProvider = (client: Client): LiveProvider => {
 
 :::
 
-
 **refine** will use this subscribe method in the [`useSubscription`](/api-reference/core/hooks/live/useSubscription.md) hook.
 
 ```ts
 import { useSubscription } from "@refinedev/core";
 
 useSubscription({
-    channel: "channel-name",
-    onLiveEvent: (event) => {},
+    channel: "resources/posts",
+    enabled: true,
+    types: ["insert", "update", "delete"],
+    onLiveEvent: (event) => {
+        console.log(event);
+    },
 });
 ```
 


### PR DESCRIPTION
Added a part about graphql subscriptions to live provider doc.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
