### PR TITLE
fix(live-previews): add missing translations

### DIFF
--- a/packages/live-previews/public/locales/de/common.json
+++ b/packages/live-previews/public/locales/de/common.json
@@ -128,6 +128,26 @@
       "show": "Eintrag zeigen"
     }
   },
+  "blog-posts": {
+    "blog_posts": "Blogeinträge",
+    "fields": {
+      "id": "Id",
+      "title": "Titel",
+      "content": "Inhalt",
+      "status": "Status",
+      "category": "Kategorien",
+      "categoryId": "Kategorien",
+      "category_id": "Kategorien",
+      "createdAt": "Erstellt am",
+      "created_at": "Erstellt am"
+    },
+    "titles": {
+      "create": "Erstellen",
+      "edit": "Bearbeiten",
+      "list": "Einträge",
+      "show": "Eintrag zeigen"
+    }
+  },
   "categories": {
     "categories": "Kategorien",
     "fields": {

--- a/packages/live-previews/public/locales/de/common.json
+++ b/packages/live-previews/public/locales/de/common.json
@@ -116,7 +116,10 @@
       "content": "Inhalt",
       "status": "Status",
       "category": "Kategorien",
-      "createdAt": "Erstellt am"
+      "categoryId": "Kategorien",
+      "category_id": "Kategorien",
+      "createdAt": "Erstellt am",
+      "created_at": "Erstellt am"
     },
     "titles": {
       "create": "Erstellen",
@@ -130,7 +133,8 @@
     "fields": {
       "id": "Id",
       "title": "Titel",
-      "createdAt": "Erstellt am"
+      "createdAt": "Erstellt am",
+      "created_at": "Erstellt am"
     },
     "titles": {
       "create": "Erstellen",

--- a/packages/live-previews/public/locales/en/common.json
+++ b/packages/live-previews/public/locales/en/common.json
@@ -116,7 +116,10 @@
       "content": "Content",
       "status": "Status",
       "category": "Category",
-      "createdAt": "Created At"
+      "categoryId" : "Category",
+      "category_id": "Category",
+      "createdAt": "Created At",
+      "created_at": "Created At"
     },
     "titles": {
       "create": "Create Blog Post",
@@ -130,7 +133,8 @@
     "fields": {
       "id": "Id",
       "title": "Title",
-      "createdAt": "Created At"
+      "createdAt": "Created At",
+      "created_at": "Created At"
     },
     "titles": {
       "create": "Create Category",

--- a/packages/live-previews/public/locales/en/common.json
+++ b/packages/live-previews/public/locales/en/common.json
@@ -128,6 +128,26 @@
       "show": "Show Blog Post"
     }
   },
+  "blog-posts": {
+    "blog_posts": "Blog Posts",
+    "fields": {
+      "id": "Id",
+      "title": "Title",
+      "content": "Content",
+      "status": "Status",
+      "category": "Category",
+      "categoryId" : "Category",
+      "category_id": "Category",
+      "createdAt": "Created At",
+      "created_at": "Created At"
+    },
+    "titles": {
+      "create": "Create Blog Post",
+      "edit": "Edit Blog Post",
+      "list": "Blog Posts",
+      "show": "Show Blog Post"
+    }
+  },
   "categories": {
     "categories": "Categories",
     "fields": {


### PR DESCRIPTION
Added missing locale for live previews.

In `strapi-v4` templates, we have `blog-posts` resource which has no match in `live-previews` and caused `i18n` to fail.

In some data providers we have `created_at` instead of `createdAt` and `category_id` or `categoryId` instead of `category`.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
