### PR TITLE
fix(inferencer): missing type definitions

### DIFF
--- a/.changeset/light-news-hide.md
+++ b/.changeset/light-news-hide.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/inferencer": patch
+---
+
+Updated the type imports in the files to get the `tsc` working for the type definitions in the `dist` folder. This will fix the issue with the components not being properly typed in user projects.

--- a/packages/inferencer/src/components/live/index.tsx
+++ b/packages/inferencer/src/components/live/index.tsx
@@ -3,8 +3,8 @@ import * as RefineCore from "@refinedev/core";
 
 import { LivePreview, LiveProvider, ContextProps } from "@aliemir/react-live";
 
-import { replaceImports, replaceExports } from "@/utilities";
-import { AdditionalScopeType, LiveComponentProps } from "@/types";
+import { replaceImports, replaceExports } from "../../utilities";
+import { AdditionalScopeType, LiveComponentProps } from "../../types";
 
 const defaultScope: Array<AdditionalScopeType> = [
     ["react", "React", React],

--- a/packages/inferencer/src/components/shared-code-viewer/index.tsx
+++ b/packages/inferencer/src/components/shared-code-viewer/index.tsx
@@ -1,8 +1,9 @@
 import React, { SVGProps } from "react";
-import { CreateInferencerConfig } from "@/types";
-import { prettierFormat } from "@/utilities";
 import Highlight, { defaultProps } from "prism-react-renderer";
 import theme from "prism-react-renderer/themes/vsDark";
+
+import { CreateInferencerConfig } from "../../types";
+import { prettierFormat } from "../../utilities";
 
 export const SharedCodeViewer: CreateInferencerConfig["codeViewerComponent"] =
     ({ code: rawCode, loading }) => {

--- a/packages/inferencer/src/compose-inferencers/index.ts
+++ b/packages/inferencer/src/compose-inferencers/index.ts
@@ -1,5 +1,5 @@
-import { FieldInferencer } from "@/types";
-import { pickInferredField } from "@/utilities";
+import { FieldInferencer } from "../types";
+import { pickInferredField } from "../utilities";
 
 /**
  * Compose multiple field inferencers into one

--- a/packages/inferencer/src/compose-transformers/index.ts
+++ b/packages/inferencer/src/compose-transformers/index.ts
@@ -1,4 +1,4 @@
-import { FieldTransformer } from "@/types";
+import { FieldTransformer } from "../types";
 
 /**
  * Compose multiple field transformers into one

--- a/packages/inferencer/src/create-inferencer/index.tsx
+++ b/packages/inferencer/src/create-inferencer/index.tsx
@@ -6,18 +6,18 @@ import {
     InferencerComponentProps,
     InferencerResultComponent,
     InferField,
-} from "@/types";
+} from "../types";
 
-import { composeInferencers } from "@/compose-inferencers";
-import { composeTransformers } from "@/compose-transformers";
+import { composeInferencers } from "../compose-inferencers";
+import { composeTransformers } from "../compose-transformers";
 
-import { defaultElements } from "@/field-inferencers";
-import { defaultTransformers } from "@/field-transformers";
-import { LiveComponent } from "@/components";
-import { useInferFetch } from "@/use-infer-fetch";
-import { useRelationFetch } from "@/use-relation-fetch";
+import { defaultElements } from "../field-inferencers";
+import { defaultTransformers } from "../field-transformers";
+import { LiveComponent } from "../components";
+import { useInferFetch } from "../use-infer-fetch";
+import { useRelationFetch } from "../use-relation-fetch";
 
-import { prepareLiveCode, componentName, removeHiddenCode } from "@/utilities";
+import { prepareLiveCode, componentName, removeHiddenCode } from "../utilities";
 
 /**
  * CreateInferencer is a function that creates a Inferencer component.

--- a/packages/inferencer/src/field-inferencers/array.ts
+++ b/packages/inferencer/src/field-inferencers/array.ts
@@ -1,4 +1,4 @@
-import { FieldInferencer, InferType } from "@/types";
+import { FieldInferencer, InferType } from "../types";
 
 export const arrayInfer: FieldInferencer = (key, value, record, infer) => {
     const isArray = Array.isArray(value);

--- a/packages/inferencer/src/field-inferencers/boolean.ts
+++ b/packages/inferencer/src/field-inferencers/boolean.ts
@@ -1,4 +1,4 @@
-import { FieldInferencer } from "@/types";
+import { FieldInferencer } from "../types";
 
 export const booleanInfer: FieldInferencer = (key, value) => {
     const isBoolean = typeof value === "boolean";

--- a/packages/inferencer/src/field-inferencers/date.ts
+++ b/packages/inferencer/src/field-inferencers/date.ts
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import { FieldInferencer } from "@/types";
+import { FieldInferencer } from "../types";
 
 const dateSuffixRegexp = /(_at|_on|At|On|AT|ON)(\[\])?$/;
 

--- a/packages/inferencer/src/field-inferencers/email.ts
+++ b/packages/inferencer/src/field-inferencers/email.ts
@@ -1,4 +1,4 @@
-import { FieldInferencer } from "@/types";
+import { FieldInferencer } from "../types";
 
 const emailRegexp =
     /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;

--- a/packages/inferencer/src/field-inferencers/image.ts
+++ b/packages/inferencer/src/field-inferencers/image.ts
@@ -1,4 +1,4 @@
-import { FieldInferencer } from "@/types";
+import { FieldInferencer } from "../types";
 
 const imageRegexp = /\.(gif|jpe?g|tiff?|png|webp|bmp|svg)$/i;
 

--- a/packages/inferencer/src/field-inferencers/nullish.ts
+++ b/packages/inferencer/src/field-inferencers/nullish.ts
@@ -1,4 +1,4 @@
-import { FieldInferencer } from "@/types";
+import { FieldInferencer } from "../types";
 
 export const nullishInfer: FieldInferencer = (key, value) => {
     const isUndefined = typeof value === "undefined";

--- a/packages/inferencer/src/field-inferencers/number.ts
+++ b/packages/inferencer/src/field-inferencers/number.ts
@@ -1,4 +1,4 @@
-import { FieldInferencer } from "@/types";
+import { FieldInferencer } from "../types";
 
 export const numberInfer: FieldInferencer = (key, value) => {
     const isNonEmptyString = typeof value === "string" && value.length > 0;

--- a/packages/inferencer/src/field-inferencers/object.ts
+++ b/packages/inferencer/src/field-inferencers/object.ts
@@ -1,5 +1,5 @@
-import { getFieldableKeys } from "@/utilities";
-import { FieldInferencer } from "@/types";
+import { getFieldableKeys } from "../utilities";
+import { FieldInferencer } from "../types";
 
 const idPropertyRegexp = /id$/i;
 

--- a/packages/inferencer/src/field-inferencers/relation.ts
+++ b/packages/inferencer/src/field-inferencers/relation.ts
@@ -1,4 +1,4 @@
-import { FieldInferencer } from "@/types";
+import { FieldInferencer } from "../types";
 
 export const relationRegexp = /(-id|-ids|_id|_ids|Id|Ids|ID|IDs)(\[\])?$/;
 

--- a/packages/inferencer/src/field-inferencers/richtext.ts
+++ b/packages/inferencer/src/field-inferencers/richtext.ts
@@ -1,4 +1,4 @@
-import { FieldInferencer } from "@/types";
+import { FieldInferencer } from "../types";
 
 export const richtextInfer: FieldInferencer = (key, value) => {
     const isLongText = typeof value === "string" && value.length > 100;

--- a/packages/inferencer/src/field-inferencers/text.ts
+++ b/packages/inferencer/src/field-inferencers/text.ts
@@ -1,4 +1,4 @@
-import { FieldInferencer } from "@/types";
+import { FieldInferencer } from "../types";
 
 export const textInfer: FieldInferencer = (key, value) => {
     const isText = typeof value === "string";

--- a/packages/inferencer/src/field-inferencers/url.ts
+++ b/packages/inferencer/src/field-inferencers/url.ts
@@ -1,4 +1,4 @@
-import { FieldInferencer } from "@/types";
+import { FieldInferencer } from "../types";
 
 const urlRegexp = /^(https?|ftp):\/\/(-\.)?([^\s/?\.#-]+\.?)+(\/[^\s]*)?$/i;
 

--- a/packages/inferencer/src/field-transformers/basic-to-relation.ts
+++ b/packages/inferencer/src/field-transformers/basic-to-relation.ts
@@ -1,4 +1,4 @@
-import { FieldTransformer, InferField } from "@/types";
+import { FieldTransformer, InferField } from "../types";
 
 export const basicToRelation: FieldTransformer = (
     fields,

--- a/packages/inferencer/src/field-transformers/image-by-key.ts
+++ b/packages/inferencer/src/field-transformers/image-by-key.ts
@@ -1,4 +1,4 @@
-import { FieldTransformer, InferField } from "@/types";
+import { FieldTransformer, InferField } from "../types";
 
 const imageFieldLikeRegexp = /(image|photo|avatar|cover|thumbnail|icon)/i;
 

--- a/packages/inferencer/src/field-transformers/relation-by-resource.ts
+++ b/packages/inferencer/src/field-transformers/relation-by-resource.ts
@@ -1,5 +1,5 @@
-import { resourceFromInferred } from "@/utilities";
-import { FieldTransformer, InferField } from "@/types";
+import { resourceFromInferred } from "../utilities";
+import { FieldTransformer, InferField } from "../types";
 
 export const relationByResource: FieldTransformer = (
     fields,

--- a/packages/inferencer/src/field-transformers/relation-to-fieldable.ts
+++ b/packages/inferencer/src/field-transformers/relation-to-fieldable.ts
@@ -1,4 +1,4 @@
-import { FieldTransformer, InferField } from "@/types";
+import { FieldTransformer, InferField } from "../types";
 
 export const relationToFieldable: FieldTransformer = (
     fields,

--- a/packages/inferencer/src/inferencers/antd/code-viewer.tsx
+++ b/packages/inferencer/src/inferencers/antd/code-viewer.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import * as Icons from "@ant-design/icons";
 import { Button, Modal, Space } from "antd";
 
-import { prettierFormat } from "@/utilities";
-import { CreateInferencerConfig } from "@/types";
-import { CodeHighlight } from "@/components";
+import { prettierFormat } from "../../utilities";
+import { CreateInferencerConfig } from "../../types";
+import { CodeHighlight } from "../../components";
 
 /**
  * @deprecated Please use `SharedCodeViewer` instead

--- a/packages/inferencer/src/inferencers/antd/create.tsx
+++ b/packages/inferencer/src/inferencers/antd/create.tsx
@@ -2,7 +2,7 @@ import { Create, useForm, useSelect, getValueFromEvent } from "@refinedev/antd";
 import { Form, Input, Select, Upload, Checkbox, DatePicker } from "antd";
 import dayjs from "dayjs";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -14,20 +14,20 @@ import {
     getOptionLabel,
     getVariableName,
     translatePrettyString,
-} from "@/utilities";
+    getMetaProps,
+    shouldDotAccess,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     ImportElement,
     RendererContext,
-} from "@/types";
-import { shouldDotAccess } from "@/utilities/accessor";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for create page in Ant Design

--- a/packages/inferencer/src/inferencers/antd/edit.tsx
+++ b/packages/inferencer/src/inferencers/antd/edit.tsx
@@ -2,7 +2,7 @@ import { Edit, useForm, useSelect, getValueFromEvent } from "@refinedev/antd";
 import { Form, Input, Select, Upload, Checkbox, DatePicker } from "antd";
 import dayjs from "dayjs";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -13,20 +13,20 @@ import {
     noOp,
     getVariableName,
     translatePrettyString,
-} from "@/utilities";
+    getMetaProps,
+    shouldDotAccess,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     ImportElement,
     RendererContext,
-} from "@/types";
-import { shouldDotAccess } from "@/utilities/accessor";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for edit page in Ant Design

--- a/packages/inferencer/src/inferencers/antd/error.tsx
+++ b/packages/inferencer/src/inferencers/antd/error.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Alert, Row, Col } from "antd";
 
-import { CreateInferencerConfig } from "@/types";
+import { CreateInferencerConfig } from "../../types";
 
 export const ErrorComponent: CreateInferencerConfig["errorComponent"] = ({
     error,

--- a/packages/inferencer/src/inferencers/antd/index.tsx
+++ b/packages/inferencer/src/inferencers/antd/index.tsx
@@ -5,6 +5,7 @@ import { ShowInferencer } from "./show";
 import { ListInferencer } from "./list";
 import { CreateInferencer } from "./create";
 import { EditInferencer } from "./edit";
+
 import type { InferencerComponentProps } from "../../types";
 
 const AntdInferencer: React.FC<InferencerComponentProps> = ({

--- a/packages/inferencer/src/inferencers/antd/list.tsx
+++ b/packages/inferencer/src/inferencers/antd/list.tsx
@@ -14,7 +14,7 @@ import {
 } from "@refinedev/antd";
 import { Table, Space } from "antd";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -23,19 +23,19 @@ import {
     printImports,
     noOp,
     getVariableName,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     ImportElement,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for list page in Ant Design

--- a/packages/inferencer/src/inferencers/antd/loading.tsx
+++ b/packages/inferencer/src/inferencers/antd/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Spin, Row, Col } from "antd";
 
-import { CreateInferencerConfig } from "@/types";
+import { CreateInferencerConfig } from "../../types";
 
 export const LoadingComponent: CreateInferencerConfig["loadingComponent"] =
     () => {

--- a/packages/inferencer/src/inferencers/antd/show.tsx
+++ b/packages/inferencer/src/inferencers/antd/show.tsx
@@ -12,7 +12,7 @@ import {
 } from "@refinedev/antd";
 import { Typography } from "antd";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -22,19 +22,19 @@ import {
     noOp,
     getVariableName,
     translatePrettyString,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     ImportElement,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for show page in Ant Design

--- a/packages/inferencer/src/inferencers/chakra-ui/code-viewer.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/code-viewer.tsx
@@ -17,9 +17,9 @@ import {
     IconCheck,
 } from "@tabler/icons";
 
-import { prettierFormat } from "@/utilities";
-import { CreateInferencerConfig } from "@/types";
-import { CodeHighlight } from "@/components";
+import { prettierFormat } from "../../utilities";
+import { CreateInferencerConfig } from "../../types";
+import { CodeHighlight } from "../../components";
 
 /**
  * @deprecated Please use `SharedCodeViewer` instead

--- a/packages/inferencer/src/inferencers/chakra-ui/create.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/create.tsx
@@ -9,7 +9,7 @@ import {
 } from "@chakra-ui/react";
 import { useForm } from "@refinedev/react-hook-form";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -22,19 +22,19 @@ import {
     noOp,
     getVariableName,
     translatePrettyString,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     ImportElement,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for create page in Chakra UI

--- a/packages/inferencer/src/inferencers/chakra-ui/edit.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/edit.tsx
@@ -9,11 +9,10 @@ import {
 } from "@chakra-ui/react";
 import { useForm } from "@refinedev/react-hook-form";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
-    prettyString,
     accessor,
     printImports,
     toSingular,
@@ -23,19 +22,19 @@ import {
     noOp,
     getVariableName,
     translatePrettyString,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     ImportElement,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for edit page in Chakra UI

--- a/packages/inferencer/src/inferencers/chakra-ui/error.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/error.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Center, Alert, AlertIcon, AlertDescription } from "@chakra-ui/react";
 
-import { CreateInferencerConfig } from "@/types";
+import { CreateInferencerConfig } from "../../types";
 
 export const ErrorComponent: CreateInferencerConfig["errorComponent"] = ({
     error,

--- a/packages/inferencer/src/inferencers/chakra-ui/list.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/list.tsx
@@ -29,7 +29,7 @@ import { useTable } from "@refinedev/react-table";
 import { flexRender } from "@tanstack/react-table";
 import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -39,18 +39,18 @@ import {
     noOp,
     getVariableName,
     translatePrettyString,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 const getAccessorKey = (field: InferField) => {
     return Array.isArray(field.accessor) || field.multiple

--- a/packages/inferencer/src/inferencers/chakra-ui/loading.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/loading.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Box, Spinner } from "@chakra-ui/react";
 
-import { CreateInferencerConfig } from "@/types";
+import { CreateInferencerConfig } from "../../types";
 
 export const LoadingComponent: CreateInferencerConfig["loadingComponent"] =
     () => {

--- a/packages/inferencer/src/inferencers/chakra-ui/show.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/show.tsx
@@ -11,7 +11,7 @@ import {
 } from "@refinedev/chakra-ui";
 import { Heading, HStack, Image } from "@chakra-ui/react";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -20,18 +20,18 @@ import {
     noOp,
     getVariableName,
     translatePrettyString,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for show page in Chakra UI

--- a/packages/inferencer/src/inferencers/headless/code-viewer.tsx
+++ b/packages/inferencer/src/inferencers/headless/code-viewer.tsx
@@ -6,9 +6,9 @@ import {
     IconCheck,
 } from "@tabler/icons";
 
-import { prettierFormat } from "@/utilities";
-import { CreateInferencerConfig } from "@/types";
-import { CodeHighlight } from "@/components";
+import { prettierFormat } from "../../utilities";
+import { CreateInferencerConfig } from "../../types";
+import { CodeHighlight } from "../../components";
 
 type ModalProps = {
     visible: boolean;

--- a/packages/inferencer/src/inferencers/headless/create.tsx
+++ b/packages/inferencer/src/inferencers/headless/create.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "@refinedev/react-hook-form";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -15,19 +15,19 @@ import {
     translatePrettyString,
     translateActionTitle,
     translateButtonTitle,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     ImportElement,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for create page with unstyled html elements

--- a/packages/inferencer/src/inferencers/headless/edit.tsx
+++ b/packages/inferencer/src/inferencers/headless/edit.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "@refinedev/react-hook-form";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -15,19 +15,19 @@ import {
     translatePrettyString,
     translateActionTitle,
     translateButtonTitle,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     ImportElement,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for edit page with unstyled html elements

--- a/packages/inferencer/src/inferencers/headless/error.tsx
+++ b/packages/inferencer/src/inferencers/headless/error.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { CreateInferencerConfig } from "@/types";
+import { CreateInferencerConfig } from "../../types";
 
 export const ErrorComponent: CreateInferencerConfig["errorComponent"] = ({
     error,

--- a/packages/inferencer/src/inferencers/headless/list.tsx
+++ b/packages/inferencer/src/inferencers/headless/list.tsx
@@ -1,7 +1,7 @@
 import { useTable } from "@refinedev/react-table";
 import { flexRender } from "@tanstack/react-table";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -13,19 +13,19 @@ import {
     translatePrettyString,
     translateButtonTitle,
     translateActionTitle,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     ImportElement,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 const getAccessorKey = (field: InferField) => {
     return Array.isArray(field.accessor) || field.multiple

--- a/packages/inferencer/src/inferencers/headless/loading.tsx
+++ b/packages/inferencer/src/inferencers/headless/loading.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { CreateInferencerConfig } from "@/types";
+import { CreateInferencerConfig } from "../../types";
 
 export const LoadingComponent: CreateInferencerConfig["loadingComponent"] =
     () => {

--- a/packages/inferencer/src/inferencers/headless/show.tsx
+++ b/packages/inferencer/src/inferencers/headless/show.tsx
@@ -1,4 +1,4 @@
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -9,19 +9,19 @@ import {
     translatePrettyString,
     translateActionTitle,
     translateButtonTitle,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     ImportElement,
     InferencerResultComponent,
     InferField,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for show page with unstyled html elements

--- a/packages/inferencer/src/inferencers/mantine/code-viewer.tsx
+++ b/packages/inferencer/src/inferencers/mantine/code-viewer.tsx
@@ -8,9 +8,9 @@ import {
     IconCheck,
 } from "@tabler/icons";
 
-import { prettierFormat } from "@/utilities";
-import { CreateInferencerConfig } from "@/types";
-import { CodeHighlight } from "@/components";
+import { prettierFormat } from "../../utilities";
+import { CreateInferencerConfig } from "../../types";
+import { CodeHighlight } from "../../components";
 
 /**
  * @deprecated Please use `SharedCodeViewer` instead

--- a/packages/inferencer/src/inferencers/mantine/create.tsx
+++ b/packages/inferencer/src/inferencers/mantine/create.tsx
@@ -8,7 +8,7 @@ import {
     NumberInput,
 } from "@mantine/core";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -19,18 +19,18 @@ import {
     noOp,
     getVariableName,
     translatePrettyString,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for create page in Mantine

--- a/packages/inferencer/src/inferencers/mantine/edit.tsx
+++ b/packages/inferencer/src/inferencers/mantine/edit.tsx
@@ -9,7 +9,7 @@ import {
     NumberInput,
 } from "@mantine/core";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -21,18 +21,18 @@ import {
     noOp,
     getVariableName,
     translatePrettyString,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for edit page in Mantine

--- a/packages/inferencer/src/inferencers/mantine/error.tsx
+++ b/packages/inferencer/src/inferencers/mantine/error.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { Alert, Center } from "@mantine/core";
 import { IconAlertCircle } from "@tabler/icons";
 
-import { CreateInferencerConfig } from "@/types";
+import { CreateInferencerConfig } from "../../types";
 
 export const ErrorComponent: CreateInferencerConfig["errorComponent"] = ({
     error,

--- a/packages/inferencer/src/inferencers/mantine/list.tsx
+++ b/packages/inferencer/src/inferencers/mantine/list.tsx
@@ -14,7 +14,7 @@ import { useTable } from "@refinedev/react-table";
 import { ScrollArea, Table, Pagination, Group, Image } from "@mantine/core";
 import { flexRender } from "@tanstack/react-table";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -24,18 +24,18 @@ import {
     noOp,
     getVariableName,
     translatePrettyString,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 const getAccessorKey = (field: InferField) => {
     return Array.isArray(field.accessor) || field.multiple

--- a/packages/inferencer/src/inferencers/mantine/loading.tsx
+++ b/packages/inferencer/src/inferencers/mantine/loading.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { LoadingOverlay } from "@mantine/core";
 
-import { CreateInferencerConfig } from "@/types";
+import { CreateInferencerConfig } from "../../types";
 
 export const LoadingComponent: CreateInferencerConfig["loadingComponent"] =
     () => {

--- a/packages/inferencer/src/inferencers/mantine/show.tsx
+++ b/packages/inferencer/src/inferencers/mantine/show.tsx
@@ -11,29 +11,28 @@ import {
 } from "@refinedev/mantine";
 import { Title, Group, Image } from "@mantine/core";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
-    prettyString,
     accessor,
     printImports,
     toSingular,
     noOp,
     getVariableName,
     translatePrettyString,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for show page in Mantine

--- a/packages/inferencer/src/inferencers/mui/code-viewer.tsx
+++ b/packages/inferencer/src/inferencers/mui/code-viewer.tsx
@@ -13,9 +13,9 @@ import {
     IconCheck,
 } from "@tabler/icons";
 
-import { prettierFormat } from "@/utilities";
-import { CreateInferencerConfig } from "@/types";
-import { CodeHighlight } from "@/components";
+import { prettierFormat } from "../../utilities";
+import { CreateInferencerConfig } from "../../types";
+import { CodeHighlight } from "../../components";
 
 /**
  * @deprecated Please use `SharedCodeViewer` instead

--- a/packages/inferencer/src/inferencers/mui/create.tsx
+++ b/packages/inferencer/src/inferencers/mui/create.tsx
@@ -10,7 +10,7 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 
 import { Controller } from "react-hook-form";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 
 import {
     jsx,
@@ -22,19 +22,19 @@ import {
     noOp,
     getVariableName,
     translatePrettyString,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     ImportElement,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for create page in Material UI

--- a/packages/inferencer/src/inferencers/mui/edit.tsx
+++ b/packages/inferencer/src/inferencers/mui/edit.tsx
@@ -9,7 +9,7 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 
 import { Controller } from "react-hook-form";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -20,19 +20,19 @@ import {
     noOp,
     getVariableName,
     translatePrettyString,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     ImportElement,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for edit page in Material UI

--- a/packages/inferencer/src/inferencers/mui/error.tsx
+++ b/packages/inferencer/src/inferencers/mui/error.tsx
@@ -4,7 +4,7 @@ import Alert from "@mui/material/Alert";
 import AlertTitle from "@mui/material/AlertTitle";
 import Box from "@mui/material/Box";
 
-import { CreateInferencerConfig } from "@/types";
+import { CreateInferencerConfig } from "../../types";
 
 export const ErrorComponent: CreateInferencerConfig["errorComponent"] = ({
     error,

--- a/packages/inferencer/src/inferencers/mui/list.tsx
+++ b/packages/inferencer/src/inferencers/mui/list.tsx
@@ -15,7 +15,7 @@ import {
 import { DataGrid } from "@mui/x-data-grid";
 import Checkbox from "@mui/material/Checkbox";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -25,19 +25,19 @@ import {
     noOp,
     getVariableName,
     translatePrettyString,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     ImportElement,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for list page in Material UI

--- a/packages/inferencer/src/inferencers/mui/loading.tsx
+++ b/packages/inferencer/src/inferencers/mui/loading.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
 
-import { CreateInferencerConfig } from "@/types";
+import { CreateInferencerConfig } from "../../types";
 
 export const LoadingComponent: CreateInferencerConfig["loadingComponent"] =
     () => {

--- a/packages/inferencer/src/inferencers/mui/show.tsx
+++ b/packages/inferencer/src/inferencers/mui/show.tsx
@@ -13,7 +13,7 @@ import {
 import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
 
-import { createInferencer } from "@/create-inferencer";
+import { createInferencer } from "../../create-inferencer";
 import {
     jsx,
     componentName,
@@ -22,19 +22,19 @@ import {
     noOp,
     getVariableName,
     translatePrettyString,
-} from "@/utilities";
+    getMetaProps,
+} from "../../utilities";
 
 import { ErrorComponent } from "./error";
 import { LoadingComponent } from "./loading";
-import { SharedCodeViewer } from "@/components/shared-code-viewer";
+import { SharedCodeViewer } from "../../components/shared-code-viewer";
 
 import {
     InferencerResultComponent,
     InferField,
     ImportElement,
     RendererContext,
-} from "@/types";
-import { getMetaProps } from "@/utilities/get-meta-props";
+} from "../../types";
 
 /**
  * a renderer function for show page in Material UI

--- a/packages/inferencer/src/use-infer-fetch/index.tsx
+++ b/packages/inferencer/src/use-infer-fetch/index.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { useDataProvider, useResource, BaseKey } from "@refinedev/core";
 
-import { pickDataProvider, dataProviderFromResource } from "@/utilities";
-import { InferencerComponentProps } from "@/types";
-import { pickMeta } from "@/utilities/get-meta-props";
+import { pickDataProvider, dataProviderFromResource } from "../utilities";
+import { InferencerComponentProps } from "../types";
+import { pickMeta } from "../utilities/get-meta-props";
 
 /**
  * This hook will handle the data fetching for the inferencer with `loading` and `initial` states.

--- a/packages/inferencer/src/use-relation-fetch/index.ts
+++ b/packages/inferencer/src/use-relation-fetch/index.ts
@@ -6,15 +6,15 @@ import {
     removeRelationSuffix,
     toPlural,
     toSingular,
-} from "@/utilities";
+} from "../utilities";
 import {
     FieldInferencer,
     InferField,
     InferencerComponentProps,
     ResourceInferenceAttempt,
-} from "@/types";
+} from "../types";
 import { get } from "lodash";
-import { pickMeta } from "@/utilities/get-meta-props";
+import { pickMeta } from "../utilities/get-meta-props";
 
 type UseRelationFetchProps = {
     record?: Record<string, unknown>;

--- a/packages/inferencer/src/utilities/accessor/index.ts
+++ b/packages/inferencer/src/utilities/accessor/index.ts
@@ -1,4 +1,4 @@
-import { InferField } from "@/types";
+import { InferField } from "../../types";
 
 const dotAccessableRegex = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
 

--- a/packages/inferencer/src/utilities/get-meta-props/index.ts
+++ b/packages/inferencer/src/utilities/get-meta-props/index.ts
@@ -1,4 +1,4 @@
-import { InferencerComponentProps } from "@/types";
+import { InferencerComponentProps } from "../../types";
 
 type Action = keyof NonNullable<InferencerComponentProps["meta"]>[string];
 

--- a/packages/inferencer/src/utilities/get-option-label/index.ts
+++ b/packages/inferencer/src/utilities/get-option-label/index.ts
@@ -1,4 +1,4 @@
-import { InferField } from "@/types";
+import { InferField } from "../../types";
 
 export const getOptionLabel = (field: InferField) => {
     if (field.relationInfer && field.relationInfer.accessor) {

--- a/packages/inferencer/src/utilities/index.ts
+++ b/packages/inferencer/src/utilities/index.ts
@@ -42,3 +42,5 @@ export { isIDKey } from "./is-id-key";
 export { getOptionLabel } from "./get-option-label";
 export { noOp } from "./no-op";
 export { getVariableName } from "./get-variable-name";
+
+export { getMetaProps } from "./get-meta-props";

--- a/packages/inferencer/src/utilities/pick-inferred-field/index.ts
+++ b/packages/inferencer/src/utilities/pick-inferred-field/index.ts
@@ -1,4 +1,4 @@
-import { InferField } from "@/types";
+import { InferField } from "../../types";
 
 /**
  * Each field inferencer will run with every property of a record and output a result.

--- a/packages/inferencer/src/utilities/print-imports/index.ts
+++ b/packages/inferencer/src/utilities/print-imports/index.ts
@@ -1,4 +1,4 @@
-import { ImportElement } from "@/types";
+import { ImportElement } from "../../types";
 
 export const printImports = (imports: Array<ImportElement>) => {
     const byModule = imports.reduce((acc, [element, module, isDefault]) => {

--- a/packages/inferencer/src/utilities/remove-relation-suffix/index.ts
+++ b/packages/inferencer/src/utilities/remove-relation-suffix/index.ts
@@ -1,4 +1,4 @@
-import { relationRegexp } from "@/field-inferencers/relation";
+import { relationRegexp } from "../../field-inferencers/relation";
 
 /**
  * Removes the relation suffix from a string.

--- a/packages/inferencer/src/utilities/resource-from-inferred/index.ts
+++ b/packages/inferencer/src/utilities/resource-from-inferred/index.ts
@@ -1,7 +1,7 @@
 import pluralize from "pluralize";
 import { IResourceItem } from "@refinedev/core";
 
-import { InferField } from "@/types";
+import { InferField } from "../../types";
 
 import { removeRelationSuffix } from "../remove-relation-suffix";
 

--- a/packages/inferencer/src/utilities/translate-button-title/index.ts
+++ b/packages/inferencer/src/utilities/translate-button-title/index.ts
@@ -1,4 +1,5 @@
 import { prettyString } from "../pretty-string";
+
 export const translateButtonTitle = (payload: {
     action: "list" | "create" | "edit" | "show" | "save" | "delete";
     i18n?: boolean;


### PR DESCRIPTION
Updated file imports in the inferencer components to make it work nicely with `tsc` while generating declarations after the build. 

This is fixing the issue for inferencer components to not having the proper types and fallbacking to `any`. 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
