### PR TITLE
fix(inferencer): add missing `translate` to dependency arrays

### DIFF
--- a/.changeset/healthy-chairs-sneeze.md
+++ b/.changeset/healthy-chairs-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/inferencer": patch
+---
+
+Added missing `translate` function dependency to the table hooks if `i18n` is enabled.

--- a/packages/inferencer/src/inferencers/chakra-ui/list.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/list.tsx
@@ -768,7 +768,7 @@ export const renderer = ({
         ${useTranslateHook}
         const columns = React.useMemo<ColumnDef<any>[]>(() => [
             ${[...renderedFields, actionButtons].filter(Boolean).join(",")}
-        ], []);
+        ], [${i18n ? "translate" : ""}]);
 
         const {
             getHeaderGroups,

--- a/packages/inferencer/src/inferencers/headless/list.tsx
+++ b/packages/inferencer/src/inferencers/headless/list.tsx
@@ -702,7 +702,7 @@ export const renderer = ({
         ${useTranslateHook}
         const columns = React.useMemo<ColumnDef<any>[]>(() => [
             ${[...renderedFields, actionButtons].filter(Boolean).join(",")}
-        ], []);
+        ], [${i18n ? "translate" : ""}]);
 
         ${
             canEdit || canShow

--- a/packages/inferencer/src/inferencers/mantine/list.tsx
+++ b/packages/inferencer/src/inferencers/mantine/list.tsx
@@ -741,7 +741,7 @@ export const renderer = ({
         ${useTranslateHook}
         const columns = React.useMemo<ColumnDef<any>[]>(() => [
             ${[...renderedFields, actionButtons].filter(Boolean).join(",")}
-        ], []);
+        ], [${i18n ? "translate" : ""}]);
 
         const {
             getHeaderGroups,

--- a/packages/inferencer/src/inferencers/mui/list.tsx
+++ b/packages/inferencer/src/inferencers/mui/list.tsx
@@ -813,7 +813,7 @@ export const renderer = ({
 
         const columns = React.useMemo<GridColumns<any>>(() => [
             ${[...renderedFields, actionButtons].filter(Boolean).join(",\r\n")}
-        ], [${relationVariableNames.join(",")}]);
+        ], [${i18n ? "translate, " : ""}${relationVariableNames.join(",")}]);
 
         return (
             <List>


### PR DESCRIPTION
`translate` key was missing in table columns hooks, which causes headers of the table to not to change when selected locale is changed.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
