### PR TITLE
fix(react-router-v6): `params` fallback with `matchedRoute`

### DIFF
--- a/.changeset/famous-houses-compete.md
+++ b/.changeset/famous-houses-compete.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/react-router-v6": patch
+---
+
+Fix the issue of `matchPath` when the resource action is defined as a function or an object. Switched to using matched route string instead of using the route value from the `resource` definition.

--- a/packages/react-router-v6/src/bindings.tsx
+++ b/packages/react-router-v6/src/bindings.tsx
@@ -95,14 +95,13 @@ export const routerBindings: RouterBindings = {
         const { pathname, search } = useLocation();
         const { resources } = useContext(ResourceContext);
 
-        const { resource, action } = React.useMemo(() => {
+        const { resource, action, matchedRoute } = React.useMemo(() => {
             return matchResourceFromRoute(pathname, resources);
         }, [resources, pathname]);
 
         // params is empty when useParams is used in a component that is not a child of a Route
-        if (Object.entries(params).length === 0 && resource && action) {
-            params = matchPath(resource[action] as string, pathname)
-                ?.params as any;
+        if (Object.entries(params).length === 0 && matchedRoute) {
+            params = matchPath(matchedRoute, pathname)?.params || {};
         }
 
         const fn = useCallback(() => {


### PR DESCRIPTION
Fix the issue of `matchPath` when the resource action is defined as a function or an object. Switched to using matched route string instead of using the route value from the `resource` definition.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
