### PR TITLE
fix(core): missing `clone` action on document title generation

### DIFF
--- a/.changeset/chilled-actors-sneeze.md
+++ b/.changeset/chilled-actors-sneeze.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/core": patch
+---
+
+Added missing `clone` action for document title generation. This fixes the issue of the document title not being generated when the `clone` action is used.
+
+This change introduces the `documentTitle.{resourceName}.clone` key to the list of `i18n` keys that are used to generate the document title.
+
+Default title for the `clone` action is `"#{{id}} Clone {{resourceName}} | refine"`.

--- a/.changeset/unlucky-teachers-type.md
+++ b/.changeset/unlucky-teachers-type.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": patch
+---
+
+Fixed the issue of `label` not taken into account with auto generated document titles. `label` will be prioritized over the resource name when generating the document title and the `label` will not be capitalized.

--- a/documentation/docs/api-reference/core/providers/i18n-provider.md
+++ b/documentation/docs/api-reference/core/providers/i18n-provider.md
@@ -322,6 +322,7 @@ Before we get started, let's look at which parts are going to be translated:
             "show": "#{{id}} Show Post | refine",
             "edit": "#{{id}} Edit Post | refine",
             "create": "Create new Post | refine",
+            "clone": "#{{id}} Clone Post | refine"
         }
     }
 }
@@ -495,6 +496,7 @@ values={[{ label: "English", value: "en" }, { label: "German", value: "de" }]}>
             "show": "#{{id}} Show Post | refine",
             "edit": "#{{id}} Edit Post | refine",
             "create": "Create new Post | refine",
+            "clone": "#{{id}} Clone Post | refine"
         }
     }
 }
@@ -651,7 +653,8 @@ values={[{ label: "English", value: "en" }, { label: "German", value: "de" }]}>
             "list": "Beiträge | refine",
             "show": "#{{id}} Beitrag anzeigen | refine",
             "edit": "#{{id}} Beitrag bearbeiten | refine",
-            "create": "Neuen Beitrag erstellen | refine"
+            "create": "Neuen Beitrag erstellen | refine",
+            "clone" : "#{{id}} Beitrag klonen | refine"
         }
     }
 }

--- a/documentation/docs/packages/documentation/routers/nextjs-router.md
+++ b/documentation/docs/packages/documentation/routers/nextjs-router.md
@@ -560,6 +560,7 @@ The default title generation rules are as follows:
 -   edit    : `#{id} Edit Post | refine`
 -   show    : `#{id} Show Post | refine`
 -   create  : `Create new Post | refine`
+-   clone   : `#{id} Clone Post | refine`
 -   default : `refine`
 
 

--- a/documentation/docs/packages/documentation/routers/react-router-v6.md
+++ b/documentation/docs/packages/documentation/routers/react-router-v6.md
@@ -698,6 +698,7 @@ The default title generation rules are as follows:
 -   edit    : `#{id} Edit Post | refine`
 -   show    : `#{id} Show Post | refine`
 -   create  : `Create new Post | refine`
+-   clone   : `#{id} Clone Post | refine`
 -   default : `refine`
 
 

--- a/packages/core/src/definitions/helpers/generateDocumentTitle/index.spec.ts
+++ b/packages/core/src/definitions/helpers/generateDocumentTitle/index.spec.ts
@@ -11,6 +11,10 @@ describe("generateDocumentTitle", () => {
         translateMock.mockClear();
     });
 
+    it("should return the default title when resource is undefined", () => {
+        expect(generateDefaultDocumentTitle(translateMock)).toBe("refine");
+    });
+
     it("should return `resource name` when action is `list`", () => {
         expect(
             generateDefaultDocumentTitle(
@@ -21,6 +25,16 @@ describe("generateDocumentTitle", () => {
         ).toBe("Posts | refine");
     });
 
+    it("should return the label of the resource when it is provided", () => {
+        expect(
+            generateDefaultDocumentTitle(
+                translateMock,
+                { name: "posts", label: "Posts Label" },
+                "list",
+            ),
+        ).toBe("Posts Label | refine");
+    });
+
     it("should return `Create new resource name` when action is `create`", () => {
         expect(
             generateDefaultDocumentTitle(
@@ -29,6 +43,17 @@ describe("generateDocumentTitle", () => {
                 "create",
             ),
         ).toBe("Create new Post | refine");
+    });
+
+    it("should return `#id Clone resource name` when action is `clone`", () => {
+        expect(
+            generateDefaultDocumentTitle(
+                translateMock,
+                { name: "posts" },
+                "clone",
+                "1",
+            ),
+        ).toBe("#1 Clone Post | refine");
     });
 
     it("should return `#id Edit resource name` when action is `edit`", () => {

--- a/packages/core/src/definitions/helpers/generateDocumentTitle/index.ts
+++ b/packages/core/src/definitions/helpers/generateDocumentTitle/index.ts
@@ -20,6 +20,7 @@ export function generateDefaultDocumentTitle(
 ) {
     const actionPrefixMatcher = {
         create: "Create new ",
+        clone: `#${id ?? ""} Clone `,
         edit: `#${id ?? ""} Edit `,
         show: `#${id ?? ""} Show `,
         list: "",
@@ -39,7 +40,9 @@ export function generateDefaultDocumentTitle(
             `documentTitle.${resource.name}.${action}`,
             { id },
             `${
-                actionPrefixMatcher[action as keyof typeof actionPrefixMatcher]
+                actionPrefixMatcher[
+                    action as keyof typeof actionPrefixMatcher
+                ] ?? ""
             }${capitalize(resourceName)}${suffix}`,
         );
     }

--- a/packages/core/src/definitions/helpers/generateDocumentTitle/index.ts
+++ b/packages/core/src/definitions/helpers/generateDocumentTitle/index.ts
@@ -26,10 +26,15 @@ export function generateDefaultDocumentTitle(
         list: "",
     };
 
-    const resourceName = userFriendlyResourceName(
-        resource?.name,
-        action === "list" ? "plural" : "singular",
-    );
+    const resourceName =
+        resource?.label ??
+        resource?.meta?.label ??
+        capitalize(
+            userFriendlyResourceName(
+                resource?.name,
+                action === "list" ? "plural" : "singular",
+            ),
+        );
 
     const defaultTitle = translate("documentTitle.default", "refine");
     const suffix = translate("documentTitle.suffix", " | refine");
@@ -43,7 +48,7 @@ export function generateDefaultDocumentTitle(
                 actionPrefixMatcher[
                     action as keyof typeof actionPrefixMatcher
                 ] ?? ""
-            }${capitalize(resourceName)}${suffix}`,
+            }${resourceName}${suffix}`,
         );
     }
 


### PR DESCRIPTION
#### `clone` action is missing on document title generation

Added missing `clone` action for document title generation. This fixes the issue of the document title not being generated when the `clone` action is used.

This change introduces the `documentTitle.{resourceName}.clone` key to the list of `i18n` keys that are used to generate the document title.

Default title for the `clone` action is `"#{{id}} Clone {{resourceName}} | refine"`.

#### Document titles not using `label` of the resource

Fixed the issue of `label` not taken into account with auto generated document titles. `label` will be prioritized over the resource name when generating the document title and the `label` will not be capitalized.

### Test plan

<img width="682" alt="Screenshot 2023-05-27 at 17 38 59" src="https://github.com/refinedev/refine/assets/11361964/42778f26-fb5e-48a6-932c-2ae401da2f99">

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
