### PR TITLE
fix(core): pass `queryOptions`or `defaultValueQueryOptions` to `useMany` on `useSelect`

### DIFF
--- a/.changeset/wise-jobs-rush.md
+++ b/.changeset/wise-jobs-rush.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": patch
+---
+
+fixed: `queryOptions` not working as expected in `useSelect` hook.

--- a/packages/core/src/hooks/useSelect/index.spec.ts
+++ b/packages/core/src/hooks/useSelect/index.spec.ts
@@ -465,6 +465,45 @@ describe("useSelect Hook", () => {
         expect(mockFunc).toBeCalled();
     });
 
+    it.each([true, false])(
+        `should use defaultValueQueryOptions as default queryOptions in useMany (case: %p)`,
+        async (enabled) => {
+            const { result } = renderHook(
+                () =>
+                    useSelect({
+                        resource: "posts",
+                        defaultValue: ["1", "2", "3", "4"],
+                        defaultValueQueryOptions: {
+                            enabled: !enabled,
+                        },
+                        queryOptions: {
+                            enabled: enabled,
+                        },
+                    }),
+                {
+                    wrapper: TestWrapper({
+                        dataProvider: MockJSONServer,
+                        resources: [{ name: "posts" }],
+                    }),
+                },
+            );
+
+            await waitFor(() => {
+                if (enabled) {
+                    expect(
+                        result.current.defaultValueQueryResult.isSuccess,
+                    ).toBeFalsy();
+                    expect(result.current.queryResult.isSuccess).toBeTruthy();
+                } else {
+                    expect(
+                        result.current.defaultValueQueryResult.isSuccess,
+                    ).toBeTruthy();
+                    expect(result.current.queryResult.isSuccess).toBeFalsy();
+                }
+            });
+        },
+    );
+
     it("should use fetchSize option as pageSize when fetching list", async () => {
         const posts = [
             {

--- a/packages/core/src/hooks/useSelect/index.spec.ts
+++ b/packages/core/src/hooks/useSelect/index.spec.ts
@@ -465,6 +465,8 @@ describe("useSelect Hook", () => {
         expect(mockFunc).toBeCalled();
     });
 
+    // case: undefined means defaultValueQueryOptions should not provided, queryOptions.enabled should be false
+    // case: true, false are inverted in queryOptions.enabled and defaultValueQueryOptions.enabled override each other
     it.each([true, false, undefined])(
         `should use defaultValueQueryOptions as default queryOptions in useMany (case: %p)`,
         async (enabled) => {

--- a/packages/core/src/hooks/useSelect/index.spec.ts
+++ b/packages/core/src/hooks/useSelect/index.spec.ts
@@ -466,7 +466,7 @@ describe("useSelect Hook", () => {
     });
 
     // case: undefined means defaultValueQueryOptions should not provided, queryOptions.enabled should be false
-    // case: true, false are inverted in queryOptions.enabled and defaultValueQueryOptions.enabled override each other
+    // case: true, false are inverted in queryOptions.enabled and defaultValueQueryOptions.enabled to test not override each other
     it.each([true, false, undefined])(
         `should use defaultValueQueryOptions as default queryOptions in useMany (case: %p)`,
         async (enabled) => {

--- a/packages/core/src/hooks/useSelect/index.ts
+++ b/packages/core/src/hooks/useSelect/index.ts
@@ -232,7 +232,7 @@ export const useSelect = <
             ...defaultValueQueryOptions,
             enabled:
                 defaultValues.length > 0 &&
-                (defaultValueQueryOptionsFromProps?.enabled ?? true),
+                (defaultValueQueryOptions?.enabled ?? true),
             onSuccess: (data) => {
                 defaultValueQueryOnSuccess(data);
                 defaultValueQueryOptions?.onSuccess?.(data);


### PR DESCRIPTION
`useMany` used to get default values data on `useSelect`.`queryOptions` were not being sent to `useMany`. From now, users can send `queryOptions` to `useMany`

### Test plan (required)

![image](https://github.com/refinedev/refine/assets/23058882/c81bdac1-8dee-4de6-b7b0-f42b560b2fd7)
![image](https://github.com/refinedev/refine/assets/23058882/aca9b176-e247-4ad4-b98f-90edc29839dd)


### Closing issues

closes #4408

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
