### PR TITLE
docs(tutorial): add missing root page navigation to previews

### DIFF
--- a/documentation/docs/tutorial/1-getting-started/antd/3-generate-crud-pages.md
+++ b/documentation/docs/tutorial/1-getting-started/antd/3-generate-crud-pages.md
@@ -90,12 +90,7 @@ const App: React.FC = () => {
                                 </ThemedLayoutV2>
                             }
                         >
-                            <Route
-                                index
-                                element={
-                                    <NavigateToResource resource="blog_posts" />
-                                }
-                            />
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             {/* highlight-start */}
                             <Route path="blog-posts">
                                 <Route index element={<AntdInferencer />} />
@@ -163,6 +158,7 @@ import {
     RefineThemes,
 } from "@refinedev/antd";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -207,6 +203,7 @@ const App: React.FC = () => {
                                 </ThemedLayoutV2>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             {/* highlight-start */}
                             <Route path="blog-posts">
                                 <Route index element={<AntdInferencer />} />
@@ -254,6 +251,7 @@ import {
     RefineThemes,
 } from "@refinedev/antd";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -298,6 +296,7 @@ const App: React.FC = () => {
                                 </ThemedLayoutV2>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             {/* highlight-start */}
                             <Route path="blog-posts">
                                 <Route index element={<AntdInferencer />} />
@@ -345,6 +344,7 @@ import {
     RefineThemes,
 } from "@refinedev/antd";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -389,6 +389,7 @@ const App: React.FC = () => {
                                 </ThemedLayoutV2>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             {/* highlight-start */}
                             <Route path="blog-posts">
                                 <Route index element={<AntdInferencer />} />
@@ -436,6 +437,7 @@ import {
     RefineThemes,
 } from "@refinedev/antd";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -480,6 +482,7 @@ const App: React.FC = () => {
                                 </ThemedLayoutV2>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             {/* highlight-start */}
                             <Route path="blog-posts">
                                 <Route index element={<AntdInferencer />} />

--- a/documentation/docs/tutorial/1-getting-started/chakra-ui/3-generate-crud-pages.md
+++ b/documentation/docs/tutorial/1-getting-started/chakra-ui/3-generate-crud-pages.md
@@ -88,12 +88,7 @@ const App = () => {
                                 </ThemedLayoutV2>
                             }
                         >
-                            <Route
-                                index
-                                element={
-                                    <NavigateToResource resource="blog_posts" />
-                                }
-                            />
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             {/* highlight-start */}
                             <Route path="blog-posts">
                                 <Route index element={<ChakraUIInferencer />} />
@@ -162,6 +157,7 @@ import {
 } from "@refinedev/chakra-ui";
 import { Refine } from "@refinedev/core";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -203,6 +199,7 @@ const App = () => {
                                 </ThemedLayoutV2>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             {/* highlight-start */}
                             <Route path="blog-posts">
                                 <Route index element={<ChakraUIInferencer />} />
@@ -251,6 +248,7 @@ import {
 } from "@refinedev/chakra-ui";
 import { Refine } from "@refinedev/core";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -292,6 +290,7 @@ const App = () => {
                                 </ThemedLayoutV2>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             {/* highlight-start */}
                             <Route path="blog-posts">
                                 <Route index element={<ChakraUIInferencer />} />
@@ -340,6 +339,7 @@ import {
 } from "@refinedev/chakra-ui";
 import { Refine } from "@refinedev/core";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -379,6 +379,7 @@ const App = () => {
                                 </ThemedLayoutV2>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             {/* highlight-start */}
                             <Route path="blog-posts">
                                 <Route index element={<ChakraUIInferencer />} />
@@ -427,6 +428,7 @@ import {
 } from "@refinedev/chakra-ui";
 import { Refine } from "@refinedev/core";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -468,6 +470,7 @@ const App = () => {
                                 </ThemedLayoutV2>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             {/* highlight-start */}
                             <Route path="blog-posts">
                                 <Route index element={<ChakraUIInferencer />} />

--- a/documentation/docs/tutorial/1-getting-started/headless/3-generate-crud-pages.md
+++ b/documentation/docs/tutorial/1-getting-started/headless/3-generate-crud-pages.md
@@ -79,6 +79,7 @@ The `resources` prop will be explained in detail in [Unit 4](/docs/tutorial/unde
 ```tsx title="src/App.tsx"
 import { Refine } from "@refinedev/core";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -118,6 +119,7 @@ const App = () => {
                             </Layout>
                         }
                     >
+                        <Route index element={<NavigateToResource resource="blog_posts" />} />
                         {/* highlight-start */}
                         <Route path="blog-posts">
                             <Route index element={<HeadlessInferencer />} />
@@ -217,12 +219,7 @@ const App = () => {
                             </Layout>
                         }
                     >
-                        <Route
-                            index
-                            element={
-                                <NavigateToResource resource="blog_posts" />
-                            }
-                        />
+                        <Route index element={<NavigateToResource resource="blog_posts" />} />
                         <Route path="blog-posts">
                             <Route index element={<HeadlessInferencer />} />
                             <Route
@@ -261,6 +258,7 @@ setInitialRoutes(["/blog-posts/create"]);
 import { Refine } from "@refinedev/core";
 import { HeadlessInferencer } from "@refinedev/inferencer/headless";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -294,6 +292,7 @@ const App = () => {
                             </Layout>
                         }
                     >
+                        <Route index element={<NavigateToResource resource="blog_posts" />} />
                         <Route path="blog-posts">
                             <Route index element={<HeadlessInferencer />} />
                             <Route
@@ -331,6 +330,7 @@ setInitialRoutes(["/blog-posts/edit/123"]);
 import { Refine } from "@refinedev/core";
 import { HeadlessInferencer } from "@refinedev/inferencer/headless";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -364,6 +364,7 @@ const App = () => {
                             </Layout>
                         }
                     >
+                        <Route index element={<NavigateToResource resource="blog_posts" />} />
                         <Route path="blog-posts">
                             <Route index element={<HeadlessInferencer />} />
                             <Route
@@ -401,6 +402,7 @@ setInitialRoutes(["/blog-posts/show/123"]);
 import { Refine } from "@refinedev/core";
 import { HeadlessInferencer } from "@refinedev/inferencer/headless";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -436,6 +438,7 @@ const App = () => {
                             </Layout>
                         }
                     >
+                        <Route index element={<NavigateToResource resource="blog_posts" />} />
                         <Route path="blog-posts">
                             <Route index element={<HeadlessInferencer />} />
                             <Route

--- a/documentation/docs/tutorial/1-getting-started/mantine/3-generate-crud-pages.md
+++ b/documentation/docs/tutorial/1-getting-started/mantine/3-generate-crud-pages.md
@@ -97,12 +97,7 @@ const App = () => {
                                     </ThemedLayoutV2>
                                 }
                             >
-                                <Route
-                                    index
-                                    element={
-                                        <NavigateToResource resource="blog_posts" />
-                                    }
-                                />
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 {/* highlight-start */}
                                 <Route path="blog-posts">
                                     <Route
@@ -168,6 +163,7 @@ setInitialRoutes(["/blog-posts"]);
 
 import { Refine } from "@refinedev/core";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -223,6 +219,7 @@ const App = () => {
                                     </ThemedLayoutV2>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 {/* highlight-start */}
                                 <Route path="blog-posts">
                                     <Route
@@ -268,6 +265,7 @@ setInitialRoutes(["/blog-posts/create"]);
 
 import { Refine } from "@refinedev/core";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -323,6 +321,7 @@ const App = () => {
                                     </ThemedLayoutV2>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 {/* highlight-start */}
                                 <Route path="blog-posts">
                                     <Route
@@ -368,6 +367,7 @@ setInitialRoutes(["/blog-posts/edit/123"]);
 
 import { Refine } from "@refinedev/core";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -423,6 +423,7 @@ const App = () => {
                                     </ThemedLayoutV2>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 {/* highlight-start */}
                                 <Route path="blog-posts">
                                     <Route
@@ -468,6 +469,7 @@ setInitialRoutes(["/blog-posts/show/123"]);
 
 import { Refine } from "@refinedev/core";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -521,6 +523,7 @@ const App = () => {
                                     </ThemedLayoutV2>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 {/* highlight-start */}
                                 <Route path="blog-posts">
                                     <Route

--- a/documentation/docs/tutorial/1-getting-started/mui/3-generate-crud-pages.md
+++ b/documentation/docs/tutorial/1-getting-started/mui/3-generate-crud-pages.md
@@ -92,12 +92,7 @@ const App: React.FC = () => {
                                     </ThemedLayoutV2>
                                 }
                             >
-                                <Route
-                                    index
-                                    element={
-                                        <NavigateToResource resource="blog_posts" />
-                                    }
-                                />
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 {/* highlight-start */}
                                 <Route path="blog-posts">
                                     <Route index element={<MuiInferencer />} />
@@ -168,6 +163,7 @@ import {
 } from "@refinedev/mui";
 import { CssBaseline, GlobalStyles, ThemeProvider } from "@mui/material";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -212,6 +208,7 @@ const App: React.FC = () => {
                                     </ThemedLayoutV2>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 {/* highlight-start */}
                                 <Route path="blog-posts">
                                     <Route index element={<MuiInferencer />} />
@@ -262,6 +259,7 @@ import {
 } from "@refinedev/mui";
 import { CssBaseline, GlobalStyles, ThemeProvider } from "@mui/material";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -306,6 +304,7 @@ const App: React.FC = () => {
                                     </ThemedLayoutV2>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 {/* highlight-start */}
                                 <Route path="blog-posts">
                                     <Route index element={<MuiInferencer />} />
@@ -356,6 +355,7 @@ import {
 } from "@refinedev/mui";
 import { CssBaseline, GlobalStyles, ThemeProvider } from "@mui/material";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -400,6 +400,7 @@ const App: React.FC = () => {
                                     </ThemedLayoutV2>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 {/* highlight-start */}
                                 <Route path="blog-posts">
                                     <Route index element={<MuiInferencer />} />
@@ -450,6 +451,7 @@ import {
 } from "@refinedev/mui";
 import { CssBaseline, GlobalStyles, ThemeProvider } from "@mui/material";
 import routerBindings, {
+    NavigateToResource,
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 import dataProvider from "@refinedev/simple-rest";
@@ -494,6 +496,7 @@ const App: React.FC = () => {
                                     </ThemedLayoutV2>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 {/* highlight-start */}
                                 <Route path="blog-posts">
                                     <Route index element={<MuiInferencer />} />

--- a/documentation/docs/tutorial/4-adding-crud-pages/antd/add-create-page.md
+++ b/documentation/docs/tutorial/4-adding-crud-pages/antd/add-create-page.md
@@ -83,7 +83,6 @@ const App: React.FC = () => {
                                     <NavigateToResource resource="blog_posts" />
                                 }
                             />
-
                             {/* highlight-start */}
                             <Route path="blog-posts">
                                 <Route index element={<AntdInferencer />} />
@@ -221,7 +220,6 @@ const App: React.FC = () => {
                                     <NavigateToResource resource="blog_posts" />
                                 }
                             />
-
                             <Route path="blog-posts">
                                 <Route index element={<BlogPostList />} />
                                 <Route

--- a/documentation/docs/tutorial/4-adding-crud-pages/antd/add-edit-page.md
+++ b/documentation/docs/tutorial/4-adding-crud-pages/antd/add-edit-page.md
@@ -83,7 +83,6 @@ const App: React.FC = () => {
                                     <NavigateToResource resource="blog_posts" />
                                 }
                             />
-
                             {/* highlight-start */}
                             <Route path="blog-posts">
                                 <Route index element={<AntdInferencer />} />

--- a/documentation/docs/tutorial/5-understanding-authprovider/antd/2-auth-pages.md
+++ b/documentation/docs/tutorial/5-understanding-authprovider/antd/2-auth-pages.md
@@ -106,6 +106,7 @@ const App: React.FC = () => {
                                 </Authenticated>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             <Route path="blog-posts">
                                 <Route index element={<AntdInferencer />} />
                                 <Route
@@ -238,6 +239,7 @@ const App: React.FC = () => {
                                 </Authenticated>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             <Route path="blog-posts">
                                 <Route index element={<BlogPostList />} />
                             </Route>
@@ -361,6 +363,7 @@ const App: React.FC = () => {
                                 </Authenticated>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             <Route path="blog-posts">
                                 <Route index element={<BlogPostList />} />
                             </Route>
@@ -488,6 +491,7 @@ const App: React.FC = () => {
                                 </Authenticated>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             <Route path="blog-posts">
                                 <Route index element={<AntdInferencer />} />
                             </Route>
@@ -619,6 +623,7 @@ const App: React.FC = () => {
                                 </Authenticated>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             <Route path="blog-posts">
                                 <Route index element={<AntdInferencer />} />
                             </Route>

--- a/documentation/docs/tutorial/5-understanding-authprovider/chakra-ui/2-auth-pages.md
+++ b/documentation/docs/tutorial/5-understanding-authprovider/chakra-ui/2-auth-pages.md
@@ -104,6 +104,7 @@ const App = () => {
                                 </Authenticated>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             <Route path="blog-posts">
                                 <Route index element={<ChakraUIInferencer />} />
                                 <Route
@@ -235,6 +236,7 @@ const App = () => {
                                 </Authenticated>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             <Route path="blog-posts">
                                 <Route index element={<BlogPostList />} />
                             </Route>
@@ -357,6 +359,7 @@ const App = () => {
                                 </Authenticated>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             <Route path="blog-posts">
                                 <Route index element={<BlogPostList />} />
                             </Route>
@@ -481,6 +484,7 @@ const App = () => {
                                 </Authenticated>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             <Route path="blog-posts">
                                 <Route index element={<BlogPostList />} />
                             </Route>
@@ -612,6 +616,7 @@ const App = () => {
                                 </Authenticated>
                             }
                         >
+                            <Route index element={<NavigateToResource resource="blog_posts" />} />
                             <Route path="blog-posts">
                                 <Route index element={<BlogPostList />} />
                             </Route>

--- a/documentation/docs/tutorial/5-understanding-authprovider/headless/2-auth-pages.md
+++ b/documentation/docs/tutorial/5-understanding-authprovider/headless/2-auth-pages.md
@@ -90,6 +90,7 @@ const App = () => {
                             </Authenticated>
                         }
                     >
+                        <Route index element={<NavigateToResource resource="blog_posts" />} />
                         <Route path="blog-posts">
                             <Route index element={<HeadlessInferencer />} />
                             <Route
@@ -195,6 +196,7 @@ const App = () => {
                             </Authenticated>
                         }
                     >
+                        <Route index element={<NavigateToResource resource="blog_posts" />} />
                         <Route path="blog-posts">
                             <Route index element={<BlogPostList />} />
                         </Route>
@@ -291,6 +293,7 @@ const App = () => {
                             </Authenticated>
                         }
                     >
+                        <Route index element={<NavigateToResource resource="blog_posts" />} />
                         <Route path="blog-posts">
                             <Route index element={<BlogPostList />} />
                         </Route>
@@ -391,6 +394,7 @@ const App = () => {
                             </Authenticated>
                         }
                     >
+                        <Route index element={<NavigateToResource resource="blog_posts" />} />
                         <Route path="blog-posts">
                             <Route index element={<BlogPostList />} />
                         </Route>
@@ -496,6 +500,7 @@ const App = () => {
                             </Authenticated>
                         }
                     >
+                        <Route index element={<NavigateToResource resource="blog_posts" />} />
                         <Route path="blog-posts">
                             <Route index element={<BlogPostList />} />
                         </Route>

--- a/documentation/docs/tutorial/5-understanding-authprovider/mantine/2-auth-pages.md
+++ b/documentation/docs/tutorial/5-understanding-authprovider/mantine/2-auth-pages.md
@@ -113,6 +113,7 @@ const App = () => {
                                     </Authenticated>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 <Route path="blog-posts">
                                     <Route
                                         index
@@ -256,6 +257,7 @@ const App = () => {
                                     </Authenticated>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 <Route path="blog-posts">
                                     <Route index element={<BlogPostList />} />
                                 </Route>
@@ -387,6 +389,7 @@ const App = () => {
                                     </Authenticated>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 <Route path="blog-posts">
                                     <Route index element={<BlogPostList />} />
                                 </Route>
@@ -522,6 +525,7 @@ const App = () => {
                                     </Authenticated>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 <Route path="blog-posts">
                                     <Route index element={<BlogPostList />} />
                                 </Route>
@@ -662,6 +666,7 @@ const App = () => {
                                     </Authenticated>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 <Route path="blog-posts">
                                     <Route index element={<BlogPostList />} />
                                 </Route>

--- a/documentation/docs/tutorial/5-understanding-authprovider/mui/2-auth-pages.md
+++ b/documentation/docs/tutorial/5-understanding-authprovider/mui/2-auth-pages.md
@@ -110,6 +110,7 @@ const App: React.FC = () => {
                                     </Authenticated>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 <Route path="blog-posts">
                                     <Route index element={<MuiInferencer />} />
                                     <Route
@@ -247,6 +248,7 @@ const App: React.FC = () => {
                                     </Authenticated>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 <Route path="blog-posts">
                                     <Route index element={<BlogPostList />} />
                                 </Route>
@@ -375,6 +377,7 @@ const App: React.FC = () => {
                                     </Authenticated>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 <Route path="blog-posts">
                                     <Route index element={<BlogPostList />} />
                                 </Route>
@@ -507,6 +510,7 @@ const App: React.FC = () => {
                                     </Authenticated>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 <Route path="blog-posts">
                                     <Route index element={<BlogPostList />} />
                                 </Route>
@@ -644,6 +648,7 @@ const App: React.FC = () => {
                                     </Authenticated>
                                 }
                             >
+                                <Route index element={<NavigateToResource resource="blog_posts" />} />
                                 <Route path="blog-posts">
                                     <Route index element={<BlogPostList />} />
                                 </Route>


### PR DESCRIPTION
Added missing root page navigation to the first resource's list route in tutorial previews; this was causing the refine logo to navigate to a 404 page.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
