### PR TITLE
fix: lock @npmcli/package-json version to prevent babel issue

### DIFF
--- a/.changeset/little-buttons-try.md
+++ b/.changeset/little-buttons-try.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/codemod": patch
+---
+
+fix: babel transformation error

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -30,7 +30,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@npmcli/package-json": "^3.0.0",
+    "@npmcli/package-json": "3.0.0",
     "chalk": "^4.1.2",
     "cheerio": "1.0.0-rc.9",
     "execa": "^5.1.1",


### PR DESCRIPTION
Fixed babel issue with codemod.
![Screenshot 2023-05-31 at 11 32 32](https://github.com/refinedev/refine/assets/16444991/49a4d875-57df-48c9-9895-1b5f551b3caf)
