### PR TITLE
fix(inferencer): assumes id is number in custom pages

### DIFF
--- a/.changeset/curvy-shirts-smash.md
+++ b/.changeset/curvy-shirts-smash.md
@@ -1,0 +1,6 @@
+---
+"@refinedev/inferencer": patch
+---
+
+fixed: Inferencer assumes `id` is number in custom pages.
+From now on, if `id` is `typeof string`, and `inferencer` will infer it as `string`.

--- a/packages/inferencer/src/index.tsx
+++ b/packages/inferencer/src/index.tsx
@@ -20,6 +20,7 @@ export {
     toSingular,
     printImports,
     removeRelationSuffix,
+    idQuoteWrapper,
 } from "./utilities";
 
 export type {

--- a/packages/inferencer/src/inferencers/antd/edit.tsx
+++ b/packages/inferencer/src/inferencers/antd/edit.tsx
@@ -15,6 +15,7 @@ import {
     translatePrettyString,
     getMetaProps,
     shouldDotAccess,
+    idQuoteWrapper,
 } from "../../utilities";
 
 import { ErrorComponent } from "./error";
@@ -468,7 +469,7 @@ export const renderer = ({
             isCustomPage
                 ? `{
                       resource: "${resource.name}",
-                      id: ${id},
+                      id: ${idQuoteWrapper(id)},
                       action: "edit",
                       ${getMetaProps(
                           resource?.identifier ?? resource?.name,

--- a/packages/inferencer/src/inferencers/antd/show.tsx
+++ b/packages/inferencer/src/inferencers/antd/show.tsx
@@ -23,6 +23,7 @@ import {
     getVariableName,
     translatePrettyString,
     getMetaProps,
+    idQuoteWrapper,
 } from "../../utilities";
 
 import { ErrorComponent } from "./error";
@@ -558,7 +559,7 @@ export const renderer = ({
             isCustomPage
                 ? `{ 
                     resource: "${resource.name}", 
-                    id: ${id},
+                    id: ${idQuoteWrapper(id)},
                     ${getMetaProps(
                         resource?.identifier ?? resource?.name,
                         meta,

--- a/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/index.test.tsx.snap
@@ -27129,10 +27129,10 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
                  
               </span>
               <span
-                class="token number"
-                style="color: rgb(181, 206, 168);"
+                class="token string"
+                style="color: rgb(206, 145, 120);"
               >
-                11
+                "11"
               </span>
               <span
                 class="token punctuation"
@@ -39331,10 +39331,10 @@ exports[`ChakraUIInferencer should match the snapshot 4`] = `
                  
               </span>
               <span
-                class="token number"
-                style="color: rgb(181, 206, 168);"
+                class="token string"
+                style="color: rgb(206, 145, 120);"
               >
-                21
+                "21"
               </span>
               <span
                 class="token punctuation"

--- a/packages/inferencer/src/inferencers/chakra-ui/edit.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/edit.tsx
@@ -23,6 +23,7 @@ import {
     getVariableName,
     translatePrettyString,
     getMetaProps,
+    idQuoteWrapper,
 } from "../../utilities";
 
 import { ErrorComponent } from "./error";
@@ -400,7 +401,7 @@ export const renderer = ({
             { 
                 refineCoreProps: {
                     resource: "${resource.name}",
-                    id: ${id},
+                    id: ${idQuoteWrapper(id)},
                     action: "edit",
                     ${getMetaProps(
                         resource?.identifier ?? resource?.name,

--- a/packages/inferencer/src/inferencers/chakra-ui/show.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/show.tsx
@@ -21,6 +21,7 @@ import {
     getVariableName,
     translatePrettyString,
     getMetaProps,
+    idQuoteWrapper,
 } from "../../utilities";
 
 import { ErrorComponent } from "./error";
@@ -577,7 +578,7 @@ export const renderer = ({
             isCustomPage
                 ? `{ 
                     resource: "${resource.name}", 
-                    id: ${id},
+                    id: ${idQuoteWrapper(id)},
                     ${getMetaProps(
                         resource?.identifier ?? resource?.name,
                         meta,

--- a/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/index.test.tsx.snap
@@ -27856,10 +27856,10 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
                  
               </span>
               <span
-                class="token number"
-                style="color: rgb(181, 206, 168);"
+                class="token string"
+                style="color: rgb(206, 145, 120);"
               >
-                11
+                "11"
               </span>
               <span
                 class="token punctuation"
@@ -41185,10 +41185,10 @@ exports[`ChakraUIInferencer should match the snapshot 4`] = `
                  
               </span>
               <span
-                class="token number"
-                style="color: rgb(181, 206, 168);"
+                class="token string"
+                style="color: rgb(206, 145, 120);"
               >
-                21
+                "21"
               </span>
               <span
                 class="token punctuation"

--- a/packages/inferencer/src/inferencers/headless/edit.tsx
+++ b/packages/inferencer/src/inferencers/headless/edit.tsx
@@ -16,6 +16,7 @@ import {
     translateActionTitle,
     translateButtonTitle,
     getMetaProps,
+    idQuoteWrapper,
 } from "../../utilities";
 
 import { ErrorComponent } from "./error";
@@ -374,7 +375,7 @@ export const renderer = ({
             { 
                 refineCoreProps: {
                     resource: "${resource.name}",
-                    id: ${id},
+                    id: ${idQuoteWrapper(id)},
                     action: "edit",
                     ${getMetaProps(
                         resource?.identifier ?? resource?.name,

--- a/packages/inferencer/src/inferencers/headless/show.tsx
+++ b/packages/inferencer/src/inferencers/headless/show.tsx
@@ -10,6 +10,7 @@ import {
     translateActionTitle,
     translateButtonTitle,
     getMetaProps,
+    idQuoteWrapper,
 } from "../../utilities";
 
 import { ErrorComponent } from "./error";
@@ -625,7 +626,7 @@ export const renderer = ({
             isCustomPage
                 ? `{ 
                     resource: "${resource.name}", 
-                    id: ${id},
+                    id: ${idQuoteWrapper(id)},
                     ${getMetaProps(
                         resource?.identifier ?? resource?.name,
                         meta,

--- a/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/index.test.tsx.snap
@@ -19775,10 +19775,10 @@ exports[`MantineInferencer should match the snapshot 3`] = `
                  
               </span>
               <span
-                class="token number"
-                style="color: rgb(181, 206, 168);"
+                class="token string"
+                style="color: rgb(206, 145, 120);"
               >
-                11
+                "11"
               </span>
               <span
                 class="token punctuation"
@@ -24882,10 +24882,10 @@ exports[`MantineInferencer should match the snapshot 4`] = `
                  
               </span>
               <span
-                class="token number"
-                style="color: rgb(181, 206, 168);"
+                class="token string"
+                style="color: rgb(206, 145, 120);"
               >
-                21
+                "21"
               </span>
               <span
                 class="token punctuation"

--- a/packages/inferencer/src/inferencers/mantine/edit.tsx
+++ b/packages/inferencer/src/inferencers/mantine/edit.tsx
@@ -22,6 +22,7 @@ import {
     getVariableName,
     translatePrettyString,
     getMetaProps,
+    idQuoteWrapper,
 } from "../../utilities";
 
 import { ErrorComponent } from "./error";
@@ -448,7 +449,7 @@ export const renderer = ({
                 isCustomPage
                     ? `refineCoreProps: {
                         resource: "${resource.name}",
-                        id: ${id},
+                        id: ${idQuoteWrapper(id)},
                         action: "edit",
                         ${getMetaProps(
                             resource?.identifier ?? resource?.name,

--- a/packages/inferencer/src/inferencers/mantine/show.tsx
+++ b/packages/inferencer/src/inferencers/mantine/show.tsx
@@ -22,6 +22,7 @@ import {
     getVariableName,
     translatePrettyString,
     getMetaProps,
+    idQuoteWrapper,
 } from "../../utilities";
 
 import { ErrorComponent } from "./error";
@@ -600,7 +601,7 @@ export const renderer = ({
             isCustomPage
                 ? `{ 
                     resource: "${resource.name}", 
-                    id: ${id},
+                    id: ${idQuoteWrapper(id)},
                     ${getMetaProps(
                         resource?.identifier ?? resource?.name,
                         meta,

--- a/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
@@ -26763,10 +26763,10 @@ exports[`MuiInferencer should match the snapshot 3`] = `
                  
               </span>
               <span
-                class="token number"
-                style="color: rgb(181, 206, 168);"
+                class="token string"
+                style="color: rgb(206, 145, 120);"
               >
-                11
+                "11"
               </span>
               <span
                 class="token punctuation"
@@ -42199,10 +42199,10 @@ exports[`MuiInferencer should match the snapshot 4`] = `
                  
               </span>
               <span
-                class="token number"
-                style="color: rgb(181, 206, 168);"
+                class="token string"
+                style="color: rgb(206, 145, 120);"
               >
-                21
+                "21"
               </span>
               <span
                 class="token punctuation"

--- a/packages/inferencer/src/inferencers/mui/edit.tsx
+++ b/packages/inferencer/src/inferencers/mui/edit.tsx
@@ -21,6 +21,7 @@ import {
     getVariableName,
     translatePrettyString,
     getMetaProps,
+    idQuoteWrapper,
 } from "../../utilities";
 
 import { ErrorComponent } from "./error";
@@ -456,7 +457,7 @@ export const renderer = ({
                     ? `{
                 refineCoreProps: {
                     resource: "${resource.name}",
-                    id: ${id},
+                    id: ${idQuoteWrapper(id)},
                     action: "edit",
                     ${getMetaProps(
                         resource?.identifier ?? resource?.name,

--- a/packages/inferencer/src/inferencers/mui/show.tsx
+++ b/packages/inferencer/src/inferencers/mui/show.tsx
@@ -23,6 +23,7 @@ import {
     getVariableName,
     translatePrettyString,
     getMetaProps,
+    idQuoteWrapper,
 } from "../../utilities";
 
 import { ErrorComponent } from "./error";
@@ -619,7 +620,7 @@ export const renderer = ({
             isCustomPage
                 ? `{ 
                     resource: "${resource.name}", 
-                    id: ${id},
+                    id: ${idQuoteWrapper(id)},
                     ${getMetaProps(
                         resource?.identifier ?? resource?.name,
                         meta,

--- a/packages/inferencer/src/utilities/id-quote-wrapper/index.test.ts
+++ b/packages/inferencer/src/utilities/id-quote-wrapper/index.test.ts
@@ -1,0 +1,22 @@
+import { idQuoteWrapper } from ".";
+
+describe("idQuoteWrapper", () => {
+    it.each([
+        [
+            "d1193402-1064-4b30-b1b1-0cb3042d4f93",
+            `"d1193402-1064-4b30-b1b1-0cb3042d4f93"`,
+        ],
+        ["abc", `"abc"`],
+        [123, 123],
+        ["123", `"123"`],
+        [-456, -456],
+        [0, 0],
+        ["", `""`],
+        ["-789", `"-789"`],
+        ["abc123", `"abc123"`],
+        [undefined, undefined],
+    ])("should handle different id types: %p", (id, expected) => {
+        const result = idQuoteWrapper(id);
+        expect(result).toBe(expected);
+    });
+});

--- a/packages/inferencer/src/utilities/id-quote-wrapper/index.ts
+++ b/packages/inferencer/src/utilities/id-quote-wrapper/index.ts
@@ -1,0 +1,11 @@
+/**
+ * If the `id` is a string, it will be wrapped in quotes.
+ */
+export const idQuoteWrapper = (
+    id: string | number | undefined,
+): string | number | undefined => {
+    if (id === undefined) return id;
+    if (typeof id === "string") return `"${id}"`;
+
+    return id;
+};

--- a/packages/inferencer/src/utilities/index.ts
+++ b/packages/inferencer/src/utilities/index.ts
@@ -44,3 +44,5 @@ export { noOp } from "./no-op";
 export { getVariableName } from "./get-variable-name";
 
 export { getMetaProps } from "./get-meta-props";
+
+export { idQuoteWrapper } from "./id-quote-wrapper";


### PR DESCRIPTION

- fixed: Inferencer assumes `id` is number in custom pages.
	From now on, if `id` is `typeof string`, and `inferencer` will infer it as `string`.
- snapshot tests updated

### Test plan (required)

![image](https://github.com/refinedev/refine/assets/23058882/3ec63c94-c176-4fc6-ade5-614c08f1d60d)


### Closing issues

closes #4390 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
