### PR TITLE
fix(tsdoc): broken links on tsdoc comments

### DIFF
--- a/.changeset/hot-mirrors-run.md
+++ b/.changeset/hot-mirrors-run.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/antd": patch
+"@refinedev/chakra-ui": patch
+"@refinedev/core": patch
+"@refinedev/mantine": patch
+"@refinedev/mui": patch
+---
+
+Updated the TSDoc comments to fix the broken links in the documentation.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,6 @@ jobs:
   #      run: |
   #        npm ci
   #        npm run lint
-
   build:
     runs-on: ubuntu-latest
     concurrency:
@@ -57,3 +56,16 @@ jobs:
       - name: Test
         run: |
           npm run test:all --skip-nx-cache
+
+  tsdoc-check:
+    runs-on: ubuntu-latest
+    name: Check TSDoc Links
+    concurrency:
+      group: ${{ github.ref }}-tsdoc-check
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+      - name: Check TSDoc Links
+        run: npx tsdoc-link-check --patterns packages/**

--- a/packages/antd/src/components/buttons/clone/index.tsx
+++ b/packages/antd/src/components/buttons/clone/index.tsx
@@ -19,10 +19,10 @@ import { CloneButtonProps } from "../types";
 
 /**
  * `<CloneButton>` uses Ant Design's {@link https://ant.design/components/button/ `<Button> component`}.
- * It uses the {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#clone `clone`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation useNavigation} under the hood.
+ * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#clone `clone`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation useNavigation} under the hood.
  * It can be useful when redirecting the app to the create page with the record id route of resource.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/buttons/clone-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/buttons/clone-button} for more details.
  */
 export const CloneButton: React.FC<CloneButtonProps> = ({
     resourceNameOrRouteName: propResourceNameOrRouteName,

--- a/packages/antd/src/components/buttons/create/index.tsx
+++ b/packages/antd/src/components/buttons/create/index.tsx
@@ -19,10 +19,10 @@ import { CreateButtonProps } from "../types";
 
 /**
  * <CreateButton> uses Ant Design's {@link https://ant.design/components/button/ `<Button> component`}.
- * It uses the {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#create `create`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
+ * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#create `create`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful to redirect the app to the create page route of resource}.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/buttons/create-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/buttons/create-button} for more details.
  */
 export const CreateButton: React.FC<CreateButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/antd/src/components/buttons/delete/index.tsx
+++ b/packages/antd/src/components/buttons/delete/index.tsx
@@ -21,7 +21,7 @@ import { DeleteButtonProps } from "../types";
  * `<DeleteButton>` uses Ant Design's {@link https://ant.design/components/button/ `<Button>`} and {@link https://ant.design/components/button/ `<Popconfirm>`} components.
  * When you try to delete something, a pop-up shows up and asks for confirmation. When confirmed it executes the `useDelete` method provided by your `dataProvider`.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/buttons/delete-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/buttons/delete-button} for more details.
  */
 export const DeleteButton: React.FC<DeleteButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/antd/src/components/buttons/edit/index.tsx
+++ b/packages/antd/src/components/buttons/edit/index.tsx
@@ -19,10 +19,10 @@ import { EditButtonProps } from "../types";
 
 /**
  * `<EditButton>` uses Ant Design's {@link https://ant.design/components/button/ `<Button>`} component.
- * It uses the {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#edit `edit`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
+ * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#edit `edit`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful when redirecting the app to the edit page with the record id route of resource}.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/buttons/edit-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/buttons/edit-button} for more details.
  */
 export const EditButton: React.FC<EditButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/antd/src/components/buttons/export/index.tsx
+++ b/packages/antd/src/components/buttons/export/index.tsx
@@ -13,7 +13,7 @@ import { ExportButtonProps } from "../types";
  * `<ExportButton>` is an Ant Design {@link https://ant.design/components/button/ `<Button>`} with a default export icon and a default text with "Export".
  * It only has presentational value.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/buttons/export-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/buttons/export-button} for more details.
  */
 export const ExportButton: React.FC<ExportButtonProps> = ({
     hideText = false,

--- a/packages/antd/src/components/buttons/import/index.tsx
+++ b/packages/antd/src/components/buttons/import/index.tsx
@@ -10,11 +10,11 @@ import {
 import { ImportButtonProps } from "../types";
 
 /**
- * `<ImportButton>` is compatible with the {@link https://refine.dev/docs/ui-frameworks/antd/hooks/import/useImport `useImport`} hook and is meant to be used as it's upload button.
+ * `<ImportButton>` is compatible with the {@link https://refine.dev/docs/api-reference/antd/hooks/import/useImport `useImport`} hook and is meant to be used as it's upload button.
  * It uses Ant Design's {@link https://ant.design/components/button/ `<Button>`} and {@link https://ant.design/components/upload/ `<Upload>`} components.
  * It wraps a `<Button>` component with an `<Upload>` component and accepts properties for `<Button>` and `<Upload>` components separately.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/buttons/import-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/buttons/import-button} for more details.
  */
 export const ImportButton: React.FC<ImportButtonProps> = ({
     uploadProps,

--- a/packages/antd/src/components/buttons/list/index.tsx
+++ b/packages/antd/src/components/buttons/list/index.tsx
@@ -21,10 +21,10 @@ import { ListButtonProps } from "../types";
 
 /**
  * `<ListButton>` is using Ant Design's {@link https://ant.design/components/button/ `<Button>`} component.
- * It uses the  {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#list `list`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
+ * It uses the  {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#list `list`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful when redirecting the app to the list page route of resource}.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/buttons/list-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/buttons/list-button} for more details.
  */
 export const ListButton: React.FC<ListButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/antd/src/components/buttons/refresh/index.tsx
+++ b/packages/antd/src/components/buttons/refresh/index.tsx
@@ -16,9 +16,9 @@ import { RefreshButtonProps } from "../types";
 
 /**
  * `<RefreshButton>` uses Ant Design's {@link https://ant.design/components/button/ `<Button>`} component
- * to update the data shown on the page via the {@link https://refine.dev/docs/core/hooks/data/useOne `useOne`} method provided by your dataProvider.
+ * to update the data shown on the page via the {@link https://refine.dev/docs/api-reference/core/hooks/data/useOne `useOne`} method provided by your dataProvider.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/buttons/refresh-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/buttons/refresh-button} for more details.
  */
 export const RefreshButton: React.FC<RefreshButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/antd/src/components/buttons/save/index.tsx
+++ b/packages/antd/src/components/buttons/save/index.tsx
@@ -13,7 +13,7 @@ import { SaveButtonProps } from "../types";
  * `<SaveButton>` uses Ant Design's {@link https://ant.design/components/button/ `<Button>`} component.
  * It uses it for presantation purposes only. Some of the hooks that refine has adds features to this button.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/buttons/save-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/buttons/save-button} for more details.
  */
 export const SaveButton: React.FC<SaveButtonProps> = ({
     hideText = false,

--- a/packages/antd/src/components/buttons/show/index.tsx
+++ b/packages/antd/src/components/buttons/show/index.tsx
@@ -19,10 +19,10 @@ import { ShowButtonProps } from "../types";
 
 /**
  * `<ShowButton>` uses Ant Design's {@link https://ant.design/components/button/ `<Button>`} component.
- * It uses the {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#show `show`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
+ * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#show `show`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful when redirecting the app to the show page with the record id route of resource.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/buttons/show-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/buttons/show-button} for more details.
  */
 export const ShowButton: React.FC<ShowButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/antd/src/components/fields/boolean/index.tsx
+++ b/packages/antd/src/components/fields/boolean/index.tsx
@@ -8,7 +8,7 @@ import { BooleanFieldProps } from "../types";
 /**
  * This field is used to display boolean values. It uses the {@link https://ant.design/components/tooltip/#header `<Tooltip>`} values from Ant Design.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/fields/boolean} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/fields/boolean} for more details.
  */
 export const BooleanField: React.FC<BooleanFieldProps> = ({
     value,

--- a/packages/antd/src/components/fields/date/index.tsx
+++ b/packages/antd/src/components/fields/date/index.tsx
@@ -13,7 +13,7 @@ import { DateFieldProps } from "../types";
 /**
  * This field is used to display dates. It uses {@link https://day.js.org/docs/en/display/format `Day.js`} to display date format.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/fields/date} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/fields/date} for more details.
  */
 export const DateField: React.FC<DateFieldProps> = ({
     value,

--- a/packages/antd/src/components/fields/email/index.tsx
+++ b/packages/antd/src/components/fields/email/index.tsx
@@ -9,7 +9,7 @@ import { EmailFieldProps } from "../types";
  * This field is used to display email values. It uses the {@link https://ant.design/components/typography/#FAQ `<Link>`} component
  * of {@link https://ant.design/components/typography `<Typography>`} from Ant Design.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/fields/email} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/fields/email} for more details.
  */
 export const EmailField: React.FC<EmailFieldProps> = ({ value, ...rest }) => {
     return (

--- a/packages/antd/src/components/fields/file/index.tsx
+++ b/packages/antd/src/components/fields/file/index.tsx
@@ -6,7 +6,7 @@ import { FileFieldProps } from "../types";
 /**
  * This field is used to display files and uses {@link https://ant.design/components/typography `<Typography.Link>`} from Ant Design.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/fields/file} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/fields/file} for more details.
  */
 export const FileField: React.FC<FileFieldProps> = ({
     title,

--- a/packages/antd/src/components/fields/image/index.tsx
+++ b/packages/antd/src/components/fields/image/index.tsx
@@ -6,7 +6,7 @@ import { ImageFieldProps } from "../types";
 /**
  * This field is used to display images and uses {@link https://ant.design/components/image/#header `<Image>`} from Ant Design.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/fields/image} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/fields/image} for more details.
  */
 export const ImageField: React.FC<ImageFieldProps> = ({
     value,

--- a/packages/antd/src/components/fields/markdown/index.tsx
+++ b/packages/antd/src/components/fields/markdown/index.tsx
@@ -7,7 +7,7 @@ import { RefineFieldMarkdownProps } from "../types";
 /**
  * This field lets you display markdown content. It supports {@link https://github.github.com/gfm/ GitHub Flavored Markdown}.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/fields/markdown} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/fields/markdown} for more details.
  */
 export const MarkdownField: React.FC<RefineFieldMarkdownProps> = ({
     value = "",

--- a/packages/antd/src/components/fields/number/index.tsx
+++ b/packages/antd/src/components/fields/number/index.tsx
@@ -16,7 +16,7 @@ import { NumberFieldProps } from "../types";
 /**
  * This field is used to display a number formatted according to the browser locale, right aligned. and uses {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl `Intl`} to display date format.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/fields/number} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/fields/number} for more details.
  */
 export const NumberField: React.FC<NumberFieldProps> = ({
     value,

--- a/packages/antd/src/components/fields/tag/index.tsx
+++ b/packages/antd/src/components/fields/tag/index.tsx
@@ -6,7 +6,7 @@ import { TagFieldProps } from "../types";
 /**
  * This field lets you display a value in a tag. It uses Ant Design's {@link https://ant.design/components/tag/ `<Tag>`} component.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/fields/tag} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/fields/tag} for more details.
  */
 export const TagField: React.FC<TagFieldProps> = ({ value, ...rest }) => {
     return <Tag {...rest}>{value?.toString()}</Tag>;

--- a/packages/antd/src/components/fields/text/index.tsx
+++ b/packages/antd/src/components/fields/text/index.tsx
@@ -8,7 +8,7 @@ import { TextFieldProps } from "../types";
 /**
  * This field lets you show basic text. It uses Ant Design's {@link https://ant.design/components/typography/#Typography.Text `<Typography.Text>`} component.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/fields/text} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/fields/text} for more details.
  */
 export const TextField: React.FC<TextFieldProps> = ({ value, ...rest }) => {
     return <Text {...rest}>{value}</Text>;

--- a/packages/antd/src/components/fields/url/index.tsx
+++ b/packages/antd/src/components/fields/url/index.tsx
@@ -9,7 +9,7 @@ import { UrlFieldProps } from "../types";
  * This field lets you embed a link. It uses Ant Design's {@link https://ant.design/components/typography/ `<Typography.Link>`} component.
  * You can pass a URL in its `value` property and you can show a text in its place by passing any `children`.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/fields/url} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/fields/url} for more details.
  */
 export const UrlField: React.FC<UrlFieldProps> = ({
     children,

--- a/packages/antd/src/components/pages/auth/index.tsx
+++ b/packages/antd/src/components/pages/auth/index.tsx
@@ -20,7 +20,7 @@ export type AuthProps = AuthPageProps<LayoutProps, CardProps, FormProps> & {
 /**
  * **refine** has a default auth page form served on the `/login` route when the `authProvider` configuration is provided.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/authpage/} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/components/antd-auth-page/} for more details.
  */
 export const AuthPage: React.FC<AuthProps> = (props) => {
     const { type } = props;

--- a/packages/antd/src/components/pages/error/index.tsx
+++ b/packages/antd/src/components/pages/error/index.tsx
@@ -11,7 +11,7 @@ const { Text } = Typography;
  * When the app is navigated to a non-existent route, refine shows a default error page.
  * A custom error component can be used for this error page.
  *
- * @see {@link https://refine.dev/docs/api-references/components/refine-config#catchall} for more details.
+ * @see {@link https://refine.dev/docs/packages/documentation/routers/} for more details.
  */
 export const ErrorComponent: React.FC<RefineErrorPageProps> = () => {
     const [errorMessage, setErrorMessage] = useState<string>();

--- a/packages/antd/src/components/pages/login/index.tsx
+++ b/packages/antd/src/components/pages/login/index.tsx
@@ -31,7 +31,7 @@ export interface ILoginForm {
  * @deprecated LoginPage is deprecated. Use AuthPage instead. @see {@link https://refine.dev/docs/api-reference/antd/components/antd-auth-page} for more details.
  * **refine** has a default login page form which is served on `/login` route when the `authProvider` configuration is provided.
  *
- * @see {@link https://refine.dev/docs/api-references/components/refine-config#loginpage} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/components/refine-config/#loginpage} for more details.
  */
 export const LoginPage: React.FC<LoginPageProps> = () => {
     const [form] = Form.useForm<ILoginForm>();

--- a/packages/antd/src/components/pages/ready/index.tsx
+++ b/packages/antd/src/components/pages/ready/index.tsx
@@ -38,7 +38,6 @@ const { Title } = Typography;
 /**
  * **refine** shows a default ready page on root route when no `resources` is passed to the `<Refine>` component as a property.
  *
- * @see {@link https://refine.dev/docs/api-references/components/refine-config#readypage} for more details.
  * @deprecated `ReadyPage` is deprecated and will be removed in the next major release.
  */
 export const ReadyPage: React.FC<RefineReadyPageProps> = () => {

--- a/packages/antd/src/hooks/form/useDrawerForm/useDrawerForm.ts
+++ b/packages/antd/src/hooks/form/useDrawerForm/useDrawerForm.ts
@@ -83,10 +83,10 @@ export type UseDrawerFormReturnType<
 /**
  * `useDrawerForm` hook allows you to manage a form within a drawer. It returns Ant Design {@link https://ant.design/components/form/ Form} and {@link https://ant.design/components/drawer/ Drawer} components props.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/hooks/form/useDrawerForm} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/hooks/form/useDrawerForm} for more details.
  *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-references/interfaceReferences#baserecord `BaseRecord`}
- * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-references/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences/#httperror `HttpError`}
  * @typeParam TVariables - Values for params. default `{}`
  *
  *

--- a/packages/antd/src/hooks/form/useForm.ts
+++ b/packages/antd/src/hooks/form/useForm.ts
@@ -65,10 +65,10 @@ export type UseFormReturnType<
 /**
  * `useForm` is used to manage forms. It uses Ant Design {@link https://ant.design/components/form/ Form} data scope management under the hood and returns the required props for managing the form actions.
  *
- * @see {@link https://refine.dev/docs/api-references/hooks/form/useForm} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/useForm} for more details.
  *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-references/interfaceReferences#baserecord `BaseRecord`}
- * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-references/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences/#httperror `HttpError`}
  * @typeParam TVariables - Values for params. default `{}`
  * @typeParam TData - Result data returned by the `select` function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TQueryFnData`
  * @typeParam TResponse - Result data returned by the mutation function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}. Defaults to `TData`

--- a/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
+++ b/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
@@ -92,10 +92,10 @@ export type UseModalFormProps<
 /**
  * `useModalForm` hook allows you to manage a form within a modal. It returns Ant Design {@link https://ant.design/components/form/ Form} and {@link https://ant.design/components/modal/ Modal} components props.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/hooks/form/useModalForm} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/hooks/form/useModalForm} for more details.
  *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-references/interfaceReferences#baserecord `BaseRecord`}
- * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-references/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences/#httperror `HttpError`}
  * @typeParam TVariables - Values for params. default `{}`
  *
  *

--- a/packages/antd/src/hooks/form/useStepsForm/useStepsForm.ts
+++ b/packages/antd/src/hooks/form/useStepsForm/useStepsForm.ts
@@ -74,10 +74,10 @@ export type UseStepsFormProps<
 /**
  * `useStepsForm` hook allows you to split your form under an Ant Design based {@link https://ant.design/components/steps/ Steps} component and provides you with a few useful functionalities that will help you manage your form.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/hooks/form/useStepsForm} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/hooks/form/useStepsForm} for more details.
  *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-references/interfaceReferences#baserecord `BaseRecord`}
- * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-references/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences/#httperror `HttpError`}
  * @typeParam TVariables - Values for params. default `{}`
  *
  *

--- a/packages/antd/src/hooks/import/index.tsx
+++ b/packages/antd/src/hooks/import/index.tsx
@@ -14,11 +14,11 @@ import {
 /**
  * `useImport` hook allows you to handle your csv import logic easily.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/hooks/import/useImport} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/hooks/import/useImport} for more details.
  *
  * @typeParam TItem - Interface of parsed csv data
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-references/interfaceReferences#baserecord `BaseRecord`}
- * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-references/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences/#httperror `HttpError`}
  * @typeParam TVariables - Values for mutation function
  *
  */

--- a/packages/antd/src/hooks/list/useSimpleList/useSimpleList.ts
+++ b/packages/antd/src/hooks/list/useSimpleList/useSimpleList.ts
@@ -35,7 +35,7 @@ export type useSimpleListReturnType<
  * By using `useSimpleList` you get props for your records from API in accordance with Ant Design {@link https://ant.design/components/list/ `<List>`} component.
  * All features such as pagination, sorting come out of the box.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/hooks/list/useSimpleList} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/hooks/list/useSimpleList} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/antd/src/hooks/modal/useModal/index.tsx
+++ b/packages/antd/src/hooks/modal/useModal/index.tsx
@@ -18,7 +18,7 @@ export type useModalProps = {
 /**
  * By using `useModal` you get props for your records from API in accordance with Ant Design {@link https://ant.design/components/modal/ `<Modal>`} component.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/antd/hooks/ui/useModal} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/antd/hooks/ui/useModal} for more details.
  */
 export const useModal = ({
     modalProps = {},

--- a/packages/chakra-ui/src/components/buttons/clone/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/clone/index.tsx
@@ -19,10 +19,10 @@ import { CloneButtonProps } from "../types";
 
 /**
  * `<CloneButton>` uses Mantine {@link https://chakra-ui.com/docs/components/button `<Button> component`}.
- * It uses the {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#clone `clone`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation useNavigation} under the hood.
+ * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#clone `clone`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation useNavigation} under the hood.
  * It can be useful when redirecting the app to the create page with the record id route of resource.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/buttons/clone-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/buttons/clone-button} for more details.
  *
  */
 export const CloneButton: React.FC<CloneButtonProps> = ({

--- a/packages/chakra-ui/src/components/buttons/delete/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/delete/index.tsx
@@ -32,7 +32,7 @@ import { DeleteButtonProps } from "../types";
  * `<DeleteButton>` uses Chakra UI {@link https://chakra-ui.com/docs/components/button `<Button>`} and {@link https://chakra-ui.com/docs/components/popover `<Popover>`} components.
  * When you try to delete something, a dialog modal shows up and asks for confirmation. When confirmed it executes the `useDelete` method provided by your `dataProvider`.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/buttons/delete-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/buttons/delete-button} for more details.
  */
 export const DeleteButton: React.FC<DeleteButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/chakra-ui/src/components/buttons/edit/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/edit/index.tsx
@@ -19,10 +19,10 @@ import { EditButtonProps } from "../types";
 
 /**
  * `<EditButton>` uses Chakra UI {@link https://chakra-ui.com/docs/components/button `<Button> component`}.
- * It uses the {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#edit `edit`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
+ * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#edit `edit`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful when redirecting the app to the edit page with the record id route of resource}.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/buttons/edit-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/buttons/edit-button} for more details.
  */
 export const EditButton: React.FC<EditButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/chakra-ui/src/components/buttons/export/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/export/index.tsx
@@ -13,7 +13,7 @@ import { ExportButtonProps } from "../types";
  * `<ExportButton>` uses Chakra UI {@link https://chakra-ui.com/docs/components/button `<Button> `} component with a default export icon and a default text with "Export".
  * It only has presentational value.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/buttons/export-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/buttons/export-button} for more details.
  */
 export const ExportButton: React.FC<ExportButtonProps> = ({
     hideText = false,

--- a/packages/chakra-ui/src/components/buttons/import/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/import/index.tsx
@@ -10,10 +10,10 @@ import { IconFileImport } from "@tabler/icons";
 import { ImportButtonProps } from "../types";
 
 /**
- * `<ImportButton>` is compatible with the {@link https://refine.dev/docs/core/hooks/import-export/useImport/ `useImport`} core hook.
+ * `<ImportButton>` is compatible with the {@link https://refine.dev/docs/api-reference/core/hooks/import-export/useImport/ `useImport`} core hook.
  * It uses uses Chakra UI {@link https://chakra-ui.com/docs/components/button `<Button> component`} and native html {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input  `<input>`} element.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/buttons/import-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/buttons/import-button} for more details.
  */
 export const ImportButton: React.FC<ImportButtonProps> = ({
     inputProps,

--- a/packages/chakra-ui/src/components/buttons/list/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/list/index.tsx
@@ -21,10 +21,10 @@ import { ListButtonProps } from "../types";
 
 /**
  * `<ListButton>` is using uses Mantine {@link https://chakra-ui.com/docs/components/button `<Button> `} component.
- * It uses the  {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#list `list`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
+ * It uses the  {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#list `list`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful when redirecting the app to the list page route of resource}.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/buttons/list-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/buttons/list-button} for more details.
  **/
 export const ListButton: React.FC<ListButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/chakra-ui/src/components/buttons/refresh/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/refresh/index.tsx
@@ -16,9 +16,9 @@ import { RefreshButtonProps } from "../types";
 
 /**
  * `<RefreshButton>` uses Chakra UI {@link https://chakra-ui.com/docs/components/button `<Button> `} component.
- * to update the data shown on the page via the {@link https://refine.dev/docs/core/hooks/data/useOne `useOne`} method provided by your dataProvider.
+ * to update the data shown on the page via the {@link https://refine.dev/docs/api-reference/core/hooks/data/useOne `useOne`} method provided by your dataProvider.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/buttons/refresh-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/buttons/refresh-button} for more details.
  */
 export const RefreshButton: React.FC<RefreshButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/chakra-ui/src/components/buttons/save/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/save/index.tsx
@@ -13,7 +13,7 @@ import { SaveButtonProps } from "../types";
  * `<SaveButton>` uses Chakra UI {@link https://chakra-ui.com/docs/components/button `<Button> `}.
  * It uses it for presantation purposes only. Some of the hooks that refine has adds features to this button.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/buttons/save-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/buttons/save-button} for more details.
  */
 export const SaveButton: React.FC<SaveButtonProps> = ({
     hideText = false,

--- a/packages/chakra-ui/src/components/buttons/show/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/show/index.tsx
@@ -19,10 +19,10 @@ import { ShowButtonProps } from "../types";
 
 /**
  * `<ShowButton>` uses Chakra UI {@link https://chakra-ui.com/docs/components/button `<Button> `} component.
- * It uses the {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#show `show`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
+ * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#show `show`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful when red sirecting the app to the show page with the record id route of resource.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/buttons/show-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/buttons/show-button} for more details.
  */
 export const ShowButton: React.FC<ShowButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/chakra-ui/src/components/fields/boolean/index.tsx
+++ b/packages/chakra-ui/src/components/fields/boolean/index.tsx
@@ -7,7 +7,7 @@ import { BooleanFieldProps } from "../types";
 /**
  * This field is used to display boolean values. It uses the {@link https://chakra-ui.com/docs/components/tooltip `<Tooltip>`} values from Chakra UI.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/fields/boolean} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/fields/boolean} for more details.
  */
 export const BooleanField: React.FC<BooleanFieldProps> = ({
     value,

--- a/packages/chakra-ui/src/components/fields/date/index.tsx
+++ b/packages/chakra-ui/src/components/fields/date/index.tsx
@@ -15,7 +15,7 @@ import { DateFieldProps } from "../types";
  * This field is used to display dates. It uses {@link https://day.js.org/docs/en/display/format `Day.js`} to display date format and
  * Mantine {@link https://chakra-ui.com/docs/components/text `<Text>`} component
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/fields/date} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/fields/date} for more details.
  */
 export const DateField: React.FC<DateFieldProps> = ({
     value,

--- a/packages/chakra-ui/src/components/fields/email/index.tsx
+++ b/packages/chakra-ui/src/components/fields/email/index.tsx
@@ -7,7 +7,7 @@ import { EmailFieldProps } from "../types";
  * This field is used to display email values. It uses the {@link https://chakra-ui.com/docs/components/text  `<Text>` }
  * and {@link https://chakra-ui.com/docs/components/link/usage <Link>`} components from Chakra UI.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/fields/email} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/fields/email} for more details.
  */
 export const EmailField: React.FC<EmailFieldProps> = ({ value, ...rest }) => {
     return (

--- a/packages/chakra-ui/src/components/fields/markdown/index.tsx
+++ b/packages/chakra-ui/src/components/fields/markdown/index.tsx
@@ -7,7 +7,7 @@ import { MarkdownFieldProps } from "../types";
 /**
  * This field lets you display markdown content. It supports {@link https://github.github.com/gfm/ GitHub Flavored Markdown}.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/fields/markdown} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/fields/markdown} for more details.
  */
 export const MarkdownField: React.FC<MarkdownFieldProps> = ({ value = "" }) => {
     return <ReactMarkdown plugins={[gfm]}>{value}</ReactMarkdown>;

--- a/packages/chakra-ui/src/components/fields/number/index.tsx
+++ b/packages/chakra-ui/src/components/fields/number/index.tsx
@@ -13,7 +13,7 @@ function toLocaleStringSupportsOptions() {
 /**
  * This field is used to display a number formatted according to the browser locale, right aligned. and uses {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl `Intl`} to display date format
  * and Chakra UI {@link https://chakra-ui.com/docs/components/text  `<Text>`} component.
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/fields/number} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/fields/number} for more details.
  */
 export const NumberField: React.FC<NumberFieldProps> = ({
     value,

--- a/packages/chakra-ui/src/components/fields/tag/index.tsx
+++ b/packages/chakra-ui/src/components/fields/tag/index.tsx
@@ -6,7 +6,7 @@ import { TagFieldProps } from "../types";
 /**
  * This field lets you display a value in a tag. It uses Chakra UI {@link https://chakra-ui.com/docs/components/tag `<Tag>`} component.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/fields/tag} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/fields/tag} for more details.
  */
 export const TagField: React.FC<TagFieldProps> = ({ value, ...rest }) => {
     return <Tag {...rest}>{value?.toString()}</Tag>;

--- a/packages/chakra-ui/src/components/fields/text/index.tsx
+++ b/packages/chakra-ui/src/components/fields/text/index.tsx
@@ -6,7 +6,7 @@ import { TextFieldProps } from "../types";
 /**
  * This field lets you show basic text. It uses Chakra UI {@link https://chakra-ui.com/docs/components/text  `<Text>`} component.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/fields/text} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/fields/text} for more details.
  */
 export const TextField: React.FC<TextFieldProps> = ({ value, ...rest }) => {
     return <Text {...rest}>{value}</Text>;

--- a/packages/chakra-ui/src/components/fields/url/index.tsx
+++ b/packages/chakra-ui/src/components/fields/url/index.tsx
@@ -7,7 +7,7 @@ import { UrlFieldProps } from "../types";
  * This field is used to display email values. It uses the {@link https://chakra-ui.com/docs/components/text  `<Text>` } component from Chakra UI.
  * You can pass a URL in its `value` property and you can show a text in its place by passing any `children`.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/chakra-ui/components/fields/url} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/fields/url} for more details.
  */
 export const UrlField: React.FC<UrlFieldProps> = ({
     children,

--- a/packages/chakra-ui/src/components/pages/auth/index.tsx
+++ b/packages/chakra-ui/src/components/pages/auth/index.tsx
@@ -18,7 +18,7 @@ export type AuthProps = AuthPageProps<BoxProps, BoxProps, FormPropsType<any>>;
 /**
  * **refine** has a default auth page form which is served on `/login` route when the `authProvider` configuration is provided.
  * @param title is not implemented yet.
- * @see {@link https://refine.dev/docs/api-references/components/refine-config#authpage} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/chakra-auth-page/} for more details.
  */
 export const AuthPage: React.FC<AuthProps> = (props) => {
     const { type } = props;

--- a/packages/core/src/components/authenticated/index.tsx
+++ b/packages/core/src/components/authenticated/index.tsx
@@ -86,7 +86,7 @@ export function Authenticated(
 export function Authenticated(props: AuthenticatedProps): JSX.Element | null;
 
 /**
- * `<Authenticated>` is the component form of {@link https://refine.dev/docs/core/hooks/auth/useAuthenticated `useAuthenticated`}. It internally uses `useAuthenticated` to provide it's functionality.
+ * `<Authenticated>` is the component form of {@link https://refine.dev/docs/api-reference/core/hooks/auth/useAuthenticated `useAuthenticated`}. It internally uses `useAuthenticated` to provide it's functionality.
  *
  * @see {@link https://refine.dev/docs/core/components/auth/authenticated `<Authenticated>`} component for more details.
  */

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -179,11 +179,11 @@ export interface RefineProps {
 }
 
 /**
- * {@link https://refine.dev/docs/api-references/components/refine-config `<Refine> component`} is the entry point of a refine app.
+ * {@link https://refine.dev/docs/api-reference/core/components/refine-config `<Refine> component`} is the entry point of a refine app.
  * It is where the highest level of configuration of the app occurs.
  * Only a dataProvider is required to bootstrap the app. After adding a dataProvider, resources can be added as property.
  *
- * @see {@link https://refine.dev/docs/api-references/components/refine-config} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/components/refine-config} for more details.
  */
 export const Refine: React.FC<RefineProps> = ({
     legacyAuthProvider,

--- a/packages/core/src/components/pages/auth/index.tsx
+++ b/packages/core/src/components/pages/auth/index.tsx
@@ -31,7 +31,7 @@ export type AuthProps = AuthPageProps<
 /**
  * **refine** has a default auth page form which is served on `/login` route when the `authProvider` configuration is provided.
  * @param title is not implemented yet.
- * @see {@link https://refine.dev/docs/api-references/components/refine-config#authpage} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/components/auth-page/} for more details.
  */
 export const AuthPage: React.FC<AuthProps> = (props) => {
     const { type } = props;

--- a/packages/core/src/components/pages/error/index.tsx
+++ b/packages/core/src/components/pages/error/index.tsx
@@ -12,7 +12,7 @@ import {
  * When the app is navigated to a non-existent route, refine shows a default error page.
  * A custom error component can be used for this error page.
  *
- * @see {@link https://refine.dev/docs/api-references/components/refine-config#catchall} for more details.
+ * @see {@link https://refine.dev/docs/packages/documentation/routers/} for more details.
  */
 export const ErrorComponent: React.FC = () => {
     const [errorMessage, setErrorMessage] = useState<string>();

--- a/packages/core/src/components/pages/login/index.tsx
+++ b/packages/core/src/components/pages/login/index.tsx
@@ -11,7 +11,7 @@ export interface ILoginForm {
  * @deprecated LoginPage is deprecated. Use AuthPage instead. @see {@link https://refine.dev/docs/core/components/auth-page} for more details.
  * **refine** has a default login page form which is served on `/login` route when the `authProvider` configuration is provided.
  *
- * @see {@link https://refine.dev/docs/api-references/components/refine-config#loginpage} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/components/refine-config/#loginpage} for more details.
  */
 export const LoginPage: React.FC = () => {
     const [username, setUsername] = useState("");

--- a/packages/core/src/components/pages/ready/index.tsx
+++ b/packages/core/src/components/pages/ready/index.tsx
@@ -3,7 +3,6 @@ import React from "react";
 /**
  * **refine** shows a default ready page on root route when no `resources` is passed to the `<Refine>` component as a property.
  *
- * @see {@link https://refine.dev/docs/api-references/components/refine-config#readypage} for more details.
  * @deprecated `ReadyPage` is deprecated and will be removed in the next major release.
  */
 export const ReadyPage: React.FC = () => {

--- a/packages/core/src/hooks/accessControl/useCan/index.ts
+++ b/packages/core/src/hooks/accessControl/useCan/index.ts
@@ -18,7 +18,7 @@ export type UseCanProps = CanParams & {
 
 /**
  * `useCan` uses the `can` as the query function for `react-query`'s {@link https://react-query.tanstack.com/guides/queries `useQuery`}. It takes the parameters that `can` takes. It can also be configured with `queryOptions` for `useQuery`. Returns the result of `useQuery`.
- * @see {@link https://refine.dev/docs/core/hooks/accessControl/useCan} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/accessControl/useCan} for more details.
  *
  * @typeParam CanParams {@link https://refine.dev/docs/core/interfaceReferences#canparams}
  * @typeParam CanReturnType {@link https://refine.dev/docs/core/interfaceReferences#canreturntype}

--- a/packages/core/src/hooks/auditLog/useLog/index.ts
+++ b/packages/core/src/hooks/auditLog/useLog/index.ts
@@ -57,7 +57,7 @@ export type UseLogMutationProps<
 
 /**
  * useLog is used to `create` a new and `rename` the existing audit log.
- * @see {@link https://refine.dev/docs/core/hooks/audit-log/useLog} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/audit-log/useLog} for more details.
  */
 
 export const useLog = <

--- a/packages/core/src/hooks/auditLog/useLogList/index.ts
+++ b/packages/core/src/hooks/auditLog/useLogList/index.ts
@@ -21,7 +21,7 @@ export type UseLogProps<TQueryFnData, TError, TData> = {
 /**
  * useLogList is used to get and filter audit logs.
  *
- * @see {@link https://refine.dev/docs/core/hooks/audit-log/useLogList} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/audit-log/useLogList} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function.
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/core/src/hooks/auth/useForgotPassword/index.ts
+++ b/packages/core/src/hooks/auth/useForgotPassword/index.ts
@@ -87,9 +87,9 @@ export function useForgotPassword<TVariables = {}>(
 ): UseForgotPasswordCombinedReturnType<TVariables>;
 
 /**
- * `useForgotPassword` calls `forgotPassword` method from {@link https://refine.dev/docs/api-references/providers/auth-provider `authProvider`} under the hood.
+ * `useForgotPassword` calls `forgotPassword` method from {@link https://refine.dev/docs/api-reference/core/providers/auth-provider `authProvider`} under the hood.
  *
- * @see {@link https://refine.dev/docs/core/hooks/auth/useForgotPassword} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/auth/useForgotPassword} for more details.
  *
  * @typeParam TData - Result data of the query
  * @typeParam TVariables - Values for mutation function. default `{}`

--- a/packages/core/src/hooks/auth/useGetIdentity/index.ts
+++ b/packages/core/src/hooks/auth/useGetIdentity/index.ts
@@ -51,7 +51,7 @@ export function useGetIdentity<TData = any>(
 /**
  * `useGetIdentity` calls the `getUserIdentity` method from the {@link https://refine.dev/docs/core/providers/auth-provider `authProvider`} under the hood.
  *
- * @see {@link https://refine.dev/docs/core/hooks/auth/useGetIdentity} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/auth/useGetIdentity} for more details.
  *
  * @typeParam TData - Result data of the query
  *

--- a/packages/core/src/hooks/auth/useIsAuthenticated/index.ts
+++ b/packages/core/src/hooks/auth/useIsAuthenticated/index.ts
@@ -42,7 +42,7 @@ export function useIsAuthenticated(
 /**
  *  `useIsAuthenticated` calls the `checkAuth` method from the {@link https://refine.dev/docs/core/providers/auth-provider `authProvider`} under the hood.
  *
- * @see {@link https://refine.dev/docs/core/hooks/auth/useAuthenticated} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/auth/useAuthenticated} for more details.
  */
 export function useIsAuthenticated({
     v3LegacyAuthProviderCompatible = false,

--- a/packages/core/src/hooks/auth/useLogin/index.ts
+++ b/packages/core/src/hooks/auth/useLogin/index.ts
@@ -97,9 +97,9 @@ export function useLogin<TVariables = {}>(
 ): UseLoginCombinedReturnType<TVariables>;
 
 /**
- * `useLogin` calls `login` method from {@link https://refine.dev/docs/api-references/providers/auth-provider `authProvider`} under the hood.
+ * `useLogin` calls `login` method from {@link https://refine.dev/docs/api-reference/core/providers/auth-provider `authProvider`} under the hood.
  *
- * @see {@link https://refine.dev/docs/core/hooks/auth/useLogin} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/auth/useLogin} for more details.
  *
  * @typeParam TData - Result data of the query
  * @typeParam TVariables - Values for mutation function. default `{}`

--- a/packages/core/src/hooks/auth/useLogout/index.ts
+++ b/packages/core/src/hooks/auth/useLogout/index.ts
@@ -91,9 +91,9 @@ export function useLogout<TVariables = {}>(
 ): UseLogoutCombinedReturnType<TVariables>;
 
 /**
- * `useLogout` calls the `logout` method from the {@link https://refine.dev/docs/api-references/providers/auth-provider `authProvider`} under the hood.
+ * `useLogout` calls the `logout` method from the {@link https://refine.dev/docs/api-reference/core/providers/auth-provider `authProvider`} under the hood.
  *
- * @see {@link https://refine.dev/docs/core/hooks/auth/useLogout} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/auth/useLogout} for more details.
  *
  */
 export function useLogout<TVariables = {}>({

--- a/packages/core/src/hooks/auth/useOnError/index.ts
+++ b/packages/core/src/hooks/auth/useOnError/index.ts
@@ -49,7 +49,7 @@ export function useOnError(
 /**
  * `useOnError` calls the `checkError` method from the {@link https://refine.dev/docs/core/providers/auth-provider `authProvider`} under the hood.
  *
- * @see {@link https://refine.dev/docs/core/hooks/auth/useCheckError} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/auth/useCheckError} for more details.
  *
  */
 export function useOnError({

--- a/packages/core/src/hooks/auth/usePermissions/index.ts
+++ b/packages/core/src/hooks/auth/usePermissions/index.ts
@@ -48,7 +48,7 @@ export function usePermissions<TData = any>(
 /**
  * `usePermissions` calls the `getPermissions` method from the {@link https://refine.dev/docs/core/providers/auth-provider `authProvider`} under the hood.
  *
- * @see {@link https://refine.dev/docs/core/hooks/auth/usePermissions} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/auth/usePermissions} for more details.
  *
  * @typeParam TData - Result data of the query
  *

--- a/packages/core/src/hooks/auth/useRegister/index.ts
+++ b/packages/core/src/hooks/auth/useRegister/index.ts
@@ -89,9 +89,9 @@ export function useRegister<TVariables = {}>(
 ): UseRegisterCombinedReturnType<TVariables>;
 
 /**
- * `useRegister` calls `register` method from {@link https://refine.dev/docs/api-references/providers/auth-provider `authProvider`} under the hood.
+ * `useRegister` calls `register` method from {@link https://refine.dev/docs/api-reference/core/providers/auth-provider `authProvider`} under the hood.
  *
- * @see {@link https://refine.dev/docs/core/hooks/auth/useRegister} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/auth/useRegister} for more details.
  *
  * @typeParam TData - Result data of the query
  * @typeParam TVariables - Values for mutation function. default `{}`

--- a/packages/core/src/hooks/auth/useUpdatePassword/index.ts
+++ b/packages/core/src/hooks/auth/useUpdatePassword/index.ts
@@ -107,9 +107,9 @@ export function useUpdatePassword<TVariables extends UpdatePasswordFormTypes>(
 ): UseUpdatePasswordCombinedReturnType<TVariables>;
 
 /**
- * `useUpdatePassword` calls `updatePassword` method from {@link https://refine.dev/docs/api-references/providers/auth-provider `authProvider`} under the hood.
+ * `useUpdatePassword` calls `updatePassword` method from {@link https://refine.dev/docs/api-reference/core/providers/auth-provider `authProvider`} under the hood.
  *
- * @see {@link https://refine.dev/docs/core/hooks/auth/useUpdatePassword} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/auth/useUpdatePassword} for more details.
  *
  * @typeParam TData - Result data of the query
  * @typeParam TVariables - Values for mutation function. default `{}`

--- a/packages/core/src/hooks/breadcrumb/index.ts
+++ b/packages/core/src/hooks/breadcrumb/index.ts
@@ -113,7 +113,7 @@ export const useBreadcrumb = ({
         if (typeof i18nProvider !== "undefined" && actionLabel === key) {
             warnOnce(
                 true,
-                `[useBreadcrumb]: Breadcrumb missing translate key for the "${action}" action. Please add "actions.${action}" key to your translation file.\nFor more information, see https://refine.dev/docs/core/hooks/useBreadcrumb/#i18n-support`,
+                `[useBreadcrumb]: Breadcrumb missing translate key for the "${action}" action. Please add "actions.${action}" key to your translation file.\nFor more information, see https://refine.dev/docs/api-reference/core/hooks/useBreadcrumb/#i18n-support`,
             );
             breadcrumbs.push({
                 label: translate(`buttons.${action}`, humanizeString(action)),

--- a/packages/core/src/hooks/data/useCreate.ts
+++ b/packages/core/src/hooks/data/useCreate.ts
@@ -90,10 +90,10 @@ export type UseCreateProps<
  *
  * It uses `create` method as mutation function from the `dataProvider` which is passed to `<Refine>`.
  *
- * @see {@link https://refine.dev/docs/api-references/hooks/data/useCreate} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/data/useCreate} for more details.
  *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-references/interfaceReferences#baserecord `BaseRecord`}
- * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-references/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences/#httperror `HttpError`}
  * @typeParam TVariables - Values for mutation function
  *
  */

--- a/packages/core/src/hooks/data/useCreateMany.ts
+++ b/packages/core/src/hooks/data/useCreateMany.ts
@@ -69,7 +69,7 @@ export type UseCreateManyProps<
  *
  * It uses `createMany` method as mutation function from the `dataProvider` which is passed to `<Refine>`.
  *
- * @see {@link https://refine.dev/docs/core/hooks/data/useCreateMany} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/data/useCreateMany} for more details.
  *
  * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/core/interfaceReferences#httperror `HttpError`}

--- a/packages/core/src/hooks/data/useCustom.ts
+++ b/packages/core/src/hooks/data/useCustom.ts
@@ -80,7 +80,7 @@ export type UseCustomProps<TQueryFnData, TError, TQuery, TPayload, TData> = {
  *
  * It uses the `custom` method from the `dataProvider` which is passed to `<Refine>`.
  *
- * @see {@link https://refine.dev/docs/core/hooks/data/useCustom} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/data/useCustom} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/core/src/hooks/data/useCustomMutation.ts
+++ b/packages/core/src/hooks/data/useCustomMutation.ts
@@ -78,10 +78,10 @@ export type UseCustomMutationProps<
  *
  * It uses the `custom` method from the `dataProvider` which is passed to `<Refine>`.
  *
- * @see {@link https://refine.dev/docs/api-references/hooks/data/useCustomMutation} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/data/useCustomMutation} for more details.
  *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-references/interfaceReferences#baserecord `BaseRecord`}
- * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-references/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences/#httperror `HttpError`}
  * @typeParam TVariables - Values for mutation function
  *
  */

--- a/packages/core/src/hooks/data/useDelete.ts
+++ b/packages/core/src/hooks/data/useDelete.ts
@@ -88,10 +88,10 @@ export type UseDeleteProps<
  *
  * It uses `deleteOne` method as mutation function from the `dataProvider` which is passed to `<Refine>`.
  *
- * @see {@link https://refine.dev/docs/api-references/hooks/data/useDelete} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/data/useDelete} for more details.
  *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-references/interfaceReferences#baserecord `BaseRecord`}
- * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-references/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences/#httperror `HttpError`}
  * @typeParam TVariables - Values for params. default `{}`
  *
  */

--- a/packages/core/src/hooks/data/useDeleteMany.ts
+++ b/packages/core/src/hooks/data/useDeleteMany.ts
@@ -89,7 +89,7 @@ export type UseDeleteManyProps<
  *
  * It uses `deleteMany` method as mutation function from the `dataProvider` which is passed to `<Refine>`.
  *
- * @see {@link https://refine.dev/docs/core/hooks/data/useDeleteMany} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/data/useDeleteMany} for more details.
  *
  * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/core/interfaceReferences#httperror `HttpError`}

--- a/packages/core/src/hooks/data/useInfiniteList.ts
+++ b/packages/core/src/hooks/data/useInfiniteList.ts
@@ -107,7 +107,7 @@ export type UseInfiniteListProps<TQueryFnData, TError, TData> = {
  *
  * It uses the `getList` method as the query function from the `dataProvider` which is passed to `<Refine>`.
  *
- * @see {@link https://refine.dev/docs/core/hooks/data/useInfiniteList} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/data/useInfiniteList} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -105,7 +105,7 @@ export type UseListProps<TQueryFnData, TError, TData> = {
  *
  * It uses the `getList` method as the query function from the `dataProvider` which is passed to `<Refine>`.
  *
- * @see {@link https://refine.dev/docs/core/hooks/data/useList} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/data/useList} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/core/src/hooks/data/useMany.ts
+++ b/packages/core/src/hooks/data/useMany.ts
@@ -70,7 +70,7 @@ export type UseManyProps<TQueryFnData, TError, TData> = {
  *
  * It uses `getMany` method as query function from the `dataProvider` which is passed to `<Refine>`.
  *
- * @see {@link https://refine.dev/docs/core/hooks/data/useMany} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/data/useMany} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/core/src/hooks/data/useOne.ts
+++ b/packages/core/src/hooks/data/useOne.ts
@@ -74,7 +74,7 @@ export type UseOneProps<TQueryFnData, TError, TData> = {
  *
  * It uses `getOne` method as query function from the `dataProvider` which is passed to `<Refine>`.
  *
- * @see {@link https://refine.dev/docs/core/hooks/data/useOne} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/data/useOne} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/core/src/hooks/data/useUpdate.ts
+++ b/packages/core/src/hooks/data/useUpdate.ts
@@ -121,10 +121,10 @@ export type UseUpdateProps<
  *
  * It uses `update` method as mutation function from the `dataProvider` which is passed to `<Refine>`.
  *
- * @see {@link https://refine.dev/docs/api-references/hooks/data/useUpdate} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/data/useUpdate} for more details.
  *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-references/interfaceReferences#baserecord `BaseRecord`}
- * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-references/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences/#httperror `HttpError`}
  * @typeParam TVariables - Values for mutation function
  *
  */

--- a/packages/core/src/hooks/data/useUpdateMany.ts
+++ b/packages/core/src/hooks/data/useUpdateMany.ts
@@ -97,7 +97,7 @@ export type UseUpdateManyProps<
  *
  * It uses `updateMany` method as mutation function from the `dataProvider` which is passed to `<Refine>`.
  *
- * @see {@link https://refine.dev/docs/core/hooks/data/useUpdateMany} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/data/useUpdateMany} for more details.
  *
  * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/core/interfaceReferences#httperror `HttpError`}

--- a/packages/core/src/hooks/export/index.ts
+++ b/packages/core/src/hooks/export/index.ts
@@ -83,9 +83,9 @@ type UseExportReturnType = {
 /**
  * `useExport` hook allows you to make your resources exportable.
  *
- * @see {@link https://refine.dev/docs/core/hooks/import-export/useExport} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/import-export/useExport} for more details.
  *
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-references/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TVariables - Values for params.
  *
  */

--- a/packages/core/src/hooks/form/useForm.ts
+++ b/packages/core/src/hooks/form/useForm.ts
@@ -200,7 +200,7 @@ export type UseFormReturnType<
 /**
  * `useForm` is used to manage forms. It uses Ant Design {@link https://ant.design/components/form/ Form} data scope management under the hood and returns the required props for managing the form actions.
  *
- * @see {@link https://refine.dev/docs/api-references/hooks/form/useForm} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/useForm} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/core/src/hooks/import/index.tsx
+++ b/packages/core/src/hooks/import/index.tsx
@@ -118,11 +118,11 @@ export type UseImportReturnType<
 /**
  * `useImport` hook allows you to handle your csv import logic easily.
  *
- * @see {@link https://refine.dev/docs/core/hooks/import-export/useImport} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/import-export/useImport} for more details.
  *
  * @typeParam TItem - Interface of parsed csv data
- * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-references/interfaceReferences#baserecord `BaseRecord`}
- * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-references/interfaceReferences#httperror `HttpError`}
+ * @typeParam TData - Result data of the query extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
+ * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences/#httperror `HttpError`}
  * @typeParam TVariables - Values for mutation function
  *
  */

--- a/packages/core/src/hooks/menu/useMenu.tsx
+++ b/packages/core/src/hooks/menu/useMenu.tsx
@@ -41,7 +41,7 @@ const getCleanPath = (pathname: string) => {
  * (passed as children to {@link https://refine.dev/docs/core/components/refine-config `<Refine>`}).
  * This hook can also be used to build custom menus, which is also used by default sidebar to show menu items.
  *
- * @see {@link https://refine.dev/docs/core/hooks/ui/useMenu} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/ui/useMenu} for more details.
  */
 export const useMenu = (
     { meta, hideOnMissingParameter }: UseMenuProps = {

--- a/packages/core/src/hooks/navigation/index.ts
+++ b/packages/core/src/hooks/navigation/index.ts
@@ -11,13 +11,13 @@ import { useBack } from "@hooks/router/use-back";
 export type HistoryType = "push" | "replace";
 
 /**
- * `refine` uses {@link https://reactrouter.com/web/api/Hooks `React Router`} and comes with all redirects out of the box.
+ * `refine` uses {@link https://reactrouter.com/en/hooks/use-navigate `React Router`} and comes with all redirects out of the box.
  * It allows you to manage your routing operations in refine.
  * Using this hook, you can manage all the routing operations of your application very easily.
  *
  * @internal This is an internal hook of refine. Do not use it directly.
  *
- * @see {@link https://refine.dev/docs/core/hooks/navigation/useNavigation} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation} for more details.
  */
 export const useNavigation = () => {
     const { resources } = useResource();

--- a/packages/core/src/hooks/refine/useSyncWithLocation.ts
+++ b/packages/core/src/hooks/refine/useSyncWithLocation.ts
@@ -11,7 +11,7 @@ type UseSyncWithLocationType = () => {
  * List query parameter values can be edited manually by typing directly in the URL.
  * To activate this feature `syncWithLocation` needs to be set to `true`.
  *
- * @see {@link https://refine.dev/docs/api-references/components/refine-config#syncwithlocation} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/components/refine-config/#syncwithlocation} for more details.
  */
 export const useSyncWithLocation: UseSyncWithLocationType = () => {
     const { syncWithLocation } = useContext(RefineContext);

--- a/packages/core/src/hooks/refine/useTitle.tsx
+++ b/packages/core/src/hooks/refine/useTitle.tsx
@@ -6,7 +6,7 @@ import { TitleProps } from "../../interfaces";
  * `useTitle` returns a component that calls the `<Title>` passed to the `<Refine>`.
  * In this way, it becomes easier for us to access this component in various parts of the application.
  *
- * @see {@link https://refine.dev/docs/core/hooks/refine/useTitle} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/refine/useTitle} for more details.
  */
 export const useTitle: () => React.FC<TitleProps> | undefined = () => {
     const { Title } = useContext(RefineContext);

--- a/packages/core/src/hooks/refine/useWarnAboutChange/index.ts
+++ b/packages/core/src/hooks/refine/useWarnAboutChange/index.ts
@@ -17,7 +17,7 @@ type UseWarnAboutChangeType = () => {
  * When you have unsaved changes and try to leave the current page, **refine** shows a confirmation modal box.
  * To activate this feature, set the `warnWhenUnsavedChanges` to `true`.
  *
- * @see {@link https://refine.dev/docs/api-references/components/refine-config#warnwhenunsavedchanges} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/components/refine-config#warnwhenunsavedchanges} for more details.
  */
 export const useWarnAboutChange: UseWarnAboutChangeType = () => {
     const { warnWhenUnsavedChanges } = useContext(RefineContext);

--- a/packages/core/src/hooks/resource/useResource/index.ts
+++ b/packages/core/src/hooks/resource/useResource/index.ts
@@ -67,7 +67,7 @@ export function useResource<TIdentifier = UseResourceParam>(
 /**
  * `useResource` is used to get `resources` that are defined as property of the `<Refine>` component.
  *
- * @see {@link https://refine.dev/docs/core/hooks/resource/useResource} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/resource/useResource} for more details.
  */
 export function useResource(
     args?: UseResourceLegacyProps | UseResourceParam,

--- a/packages/core/src/hooks/show/useShow.ts
+++ b/packages/core/src/hooks/show/useShow.ts
@@ -82,7 +82,7 @@ export type useShowProps<
  * It uses `getOne` method as query function from the dataProvider that is
  * passed to {@link https://refine.dev/docs/api-reference/core/components/refine-config/ `<Refine>`}.
  *
- * @see {@link https://refine.dev/docs/core/hooks/show/useShow} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/show/useShow} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/core/src/hooks/translate/useGetLocale.ts
+++ b/packages/core/src/hooks/translate/useGetLocale.ts
@@ -7,7 +7,7 @@ export type UseGetLocaleType = () => () => string | undefined;
  * If you need to know the current locale, refine provides the `useGetLocale` hook.
  * It returns the `getLocale` method from `i18nProvider` under the hood.
  *
- * @see {@link https://refine.dev/docs/core/hooks/translate/useGetLocale} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/translate/useGetLocale} for more details.
  */
 export const useGetLocale: UseGetLocaleType = () => {
     const { i18nProvider } = useContext(TranslationContext);

--- a/packages/core/src/hooks/translate/useSetLocale.ts
+++ b/packages/core/src/hooks/translate/useSetLocale.ts
@@ -5,7 +5,7 @@ import { TranslationContext } from "@contexts/translation";
  * If you need to change the locale at runtime, refine provides the `useSetLocale` hook.
  * It returns the changeLocale method from `i18nProvider` under the hood.
  *
- * @see {@link https://refine.dev/docs/core/hooks/translate/useSetLocale} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/translate/useSetLocale} for more details.
  */
 export const useSetLocale = () => {
     const { i18nProvider } = useContext(TranslationContext);

--- a/packages/core/src/hooks/translate/useTranslate.ts
+++ b/packages/core/src/hooks/translate/useTranslate.ts
@@ -5,7 +5,7 @@ import { TranslationContext } from "@contexts/translation";
  * If you need to translate the texts in your own components, refine provides the `useTranslate` hook.
  * It returns the translate method from `i18nProvider` under the hood.
  *
- * @see {@link https://refine.dev/docs/core/hooks/translate/useTranslate} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/translate/useTranslate} for more details.
  */
 export const useTranslate = () => {
     const { i18nProvider } = useContext(TranslationContext);

--- a/packages/core/src/hooks/useSelect/index.ts
+++ b/packages/core/src/hooks/useSelect/index.ts
@@ -147,7 +147,7 @@ export type UseSelectReturnType<TData extends BaseRecord = BaseRecord> = {
  * It uses `getList` method as query function from the dataProvider that is
  * passed to {@link https://refine.dev/docs/api-reference/core/components/refine-config/ `<Refine>`}.
  *
- * @see {@link https://refine.dev/docs/core/hooks/useSelect} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/useSelect} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -218,7 +218,7 @@ export type useTableReturnType<
  * Ant Design {@link https://ant.design/components/table/ `<Table>`} component.
  * All features such as sorting, filtering and pagination comes as out of box.
  *
- * @see {@link https://refine.dev/docs/api-references/hooks/table/useTable} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/hooks/useTable} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/mantine/src/components/buttons/clone/index.tsx
+++ b/packages/mantine/src/components/buttons/clone/index.tsx
@@ -20,10 +20,10 @@ import { CloneButtonProps } from "../types";
 
 /**
  * `<CloneButton>` uses Mantine {@link https://mantine.dev/core/button/ `<Button> component`}.
- * It uses the {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#clone `clone`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation useNavigation} under the hood.
+ * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#clone `clone`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation useNavigation} under the hood.
  * It can be useful when redirecting the app to the create page with the record id route of resource.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mantine/components/buttons/clone-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mantine/components/buttons/clone-button} for more details.
  *
  */
 export const CloneButton: React.FC<CloneButtonProps> = ({

--- a/packages/mantine/src/components/buttons/delete/index.tsx
+++ b/packages/mantine/src/components/buttons/delete/index.tsx
@@ -22,7 +22,7 @@ import { DeleteButtonProps } from "../types";
  * `<DeleteButton>` uses Mantine {@link https://mantine.dev/core/button/ `<Button>`} and {@link https://mantine.dev/core/modal/ `<Modal>`} components.
  * When you try to delete something, a dialog modal shows up and asks for confirmation. When confirmed it executes the `useDelete` method provided by your `dataProvider`.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mantine/components/buttons/delete-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mantine/components/buttons/delete-button} for more details.
  */
 export const DeleteButton: React.FC<DeleteButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/mantine/src/components/buttons/edit/index.tsx
+++ b/packages/mantine/src/components/buttons/edit/index.tsx
@@ -20,10 +20,10 @@ import { EditButtonProps } from "../types";
 
 /**
  * `<EditButton>` uses Mantine {@link https://mantine.dev/core/button/ `<Button> component`}.
- * It uses the {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#edit `edit`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
+ * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#edit `edit`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful when redirecting the app to the edit page with the record id route of resource}.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mantine/components/buttons/edit-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mantine/components/buttons/edit-button} for more details.
  */
 export const EditButton: React.FC<EditButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/mantine/src/components/buttons/export/index.tsx
+++ b/packages/mantine/src/components/buttons/export/index.tsx
@@ -14,7 +14,7 @@ import { ExportButtonProps } from "../types";
  * `<ExportButton>` uses Mantine {@link https://mantine.dev/core/button/ `<Button> `} component with a default export icon and a default text with "Export".
  * It only has presentational value.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mantine/components/buttons/export-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mantine/components/buttons/export-button} for more details.
  */
 export const ExportButton: React.FC<ExportButtonProps> = ({
     hideText = false,

--- a/packages/mantine/src/components/buttons/import/index.tsx
+++ b/packages/mantine/src/components/buttons/import/index.tsx
@@ -11,10 +11,10 @@ import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { ImportButtonProps } from "../types";
 
 /**
- * `<ImportButton>` is compatible with the {@link https://refine.dev/docs/core/hooks/import-export/useImport/ `useImport`} core hook.
+ * `<ImportButton>` is compatible with the {@link https://refine.dev/docs/api-reference/core/hooks/import-export/useImport/ `useImport`} core hook.
  * It uses uses Mantine {@link https://mantine.dev/core/button/ `<Button> component`} and native html {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input  `<input>`} element.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mantine/components/buttons/import-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mantine/components/buttons/import-button} for more details.
  */
 export const ImportButton: React.FC<ImportButtonProps> = ({
     inputProps,

--- a/packages/mantine/src/components/buttons/list/index.tsx
+++ b/packages/mantine/src/components/buttons/list/index.tsx
@@ -22,10 +22,10 @@ import { ListButtonProps } from "../types";
 
 /**
  * `<ListButton>` is using uses Mantine {@link https://mantine.dev/core/button/ `<Button> `} component.
- * It uses the  {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#list `list`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
+ * It uses the  {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#list `list`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful when redirecting the app to the list page route of resource}.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mantine/components/buttons/list-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mantine/components/buttons/list-button} for more details.
  **/
 export const ListButton: React.FC<ListButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/mantine/src/components/buttons/refresh/index.tsx
+++ b/packages/mantine/src/components/buttons/refresh/index.tsx
@@ -17,9 +17,9 @@ import { RefreshButtonProps } from "../types";
 
 /**
  * `<RefreshButton>` uses Mantine {@link https://mantine.dev/core/button/ `<Button> `} component.
- * to update the data shown on the page via the {@link https://refine.dev/docs/core/hooks/data/useOne `useOne`} method provided by your dataProvider.
+ * to update the data shown on the page via the {@link https://refine.dev/docs/api-reference/core/hooks/data/useOne `useOne`} method provided by your dataProvider.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mantine/components/buttons/refresh-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mantine/components/buttons/refresh-button} for more details.
  */
 export const RefreshButton: React.FC<RefreshButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/mantine/src/components/buttons/save/index.tsx
+++ b/packages/mantine/src/components/buttons/save/index.tsx
@@ -14,7 +14,7 @@ import { SaveButtonProps } from "../types";
  * `<SaveButton>` uses Mantine {@link https://mantine.dev/core/button/ `<Button> `}.
  * It uses it for presantation purposes only. Some of the hooks that refine has adds features to this button.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mantine/components/buttons/save-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mantine/components/buttons/save-button} for more details.
  */
 export const SaveButton: React.FC<SaveButtonProps> = ({
     hideText = false,

--- a/packages/mantine/src/components/buttons/show/index.tsx
+++ b/packages/mantine/src/components/buttons/show/index.tsx
@@ -20,10 +20,10 @@ import { ShowButtonProps } from "../types";
 
 /**
  * `<ShowButton>` uses Mantine {@link https://mantine.dev/core/button/ `<Button> `} component.
- * It uses the {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#show `show`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
+ * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#show `show`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful when red sirecting the app to the show page with the record id route of resource.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mantine/components/buttons/show-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mantine/components/buttons/show-button} for more details.
  */
 export const ShowButton: React.FC<ShowButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/mantine/src/hooks/useSelect/index.ts
+++ b/packages/mantine/src/hooks/useSelect/index.ts
@@ -20,9 +20,9 @@ export type UseSelectReturnType<TData extends BaseRecord = BaseRecord> = {
  * `useSelect` hook is used to fetch data from the dataProvider and return the options for the select box.
  *
  * It uses `getList` method as query function from the dataProvider that is
- * passed to {@link https://refine.dev/docs/api-references/components/refine-config `<Refine>`}.
+ * passed to {@link https://refine.dev/docs/api-reference/core/components/refine-config `<Refine>`}.
  *
- * @see {@link https://refine.dev/docs/mantine/hooks/useSelect} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mantine/hooks/useSelect} for more details.
  *
  * @typeParam TQueryFnData - Result data returned by the query function. Extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#baserecord `BaseRecord`}
  * @typeParam TError - Custom error object that extends {@link https://refine.dev/docs/api-reference/core/interfaceReferences#httperror `HttpError`}

--- a/packages/mui/src/components/buttons/clone/index.tsx
+++ b/packages/mui/src/components/buttons/clone/index.tsx
@@ -20,10 +20,10 @@ import { CloneButtonProps } from "../types";
 
 /**
  * `<CloneButton>` uses Material UI {@link https://mui.com/components/buttons/ `<Button> component`}.
- * It uses the {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#clone `clone`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation useNavigation} under the hood.
+ * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#clone `clone`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation useNavigation} under the hood.
  * It can be useful when redirecting the app to the create page with the record id route of resource.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/buttons/clone-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/buttons/clone-button} for more details.
  *
  */
 export const CloneButton: React.FC<CloneButtonProps> = ({

--- a/packages/mui/src/components/buttons/create/index.tsx
+++ b/packages/mui/src/components/buttons/create/index.tsx
@@ -20,10 +20,10 @@ import { CreateButtonProps } from "../types";
 
 /**
  * <CreateButton> uses Material UI {@link https://mui.com/components/buttons/ `<Button> component`}.
- * It uses the {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#create `create`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
+ * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#create `create`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful to redirect the app to the create page route of resource}.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/buttons/create-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/buttons/create-button} for more details.
  */
 export const CreateButton: React.FC<CreateButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/mui/src/components/buttons/delete/index.tsx
+++ b/packages/mui/src/components/buttons/delete/index.tsx
@@ -28,7 +28,7 @@ import { DeleteButtonProps } from "../types";
  * `<DeleteButton>` uses Material UI {@link https://mui.com/material-ui/api/loading-button/#main-content `<LoadingButton>`} and {@link https://mui.com/material-ui/react-dialog/#main-content `<Dialog>`} components.
  * When you try to delete something, a dialog modal shows up and asks for confirmation. When confirmed it executes the `useDelete` method provided by your `dataProvider`.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/buttons/delete-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/buttons/delete-button} for more details.
  */
 export const DeleteButton: React.FC<DeleteButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/mui/src/components/buttons/edit/index.tsx
+++ b/packages/mui/src/components/buttons/edit/index.tsx
@@ -20,10 +20,10 @@ import { EditButtonProps } from "../types";
 
 /**
  * `<EditButton>` uses uses Material UI {@link https://mui.com/components/buttons/ `<Button>`} component.
- * It uses the {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#edit `edit`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
+ * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#edit `edit`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful when redirecting the app to the edit page with the record id route of resource}.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/buttons/edit-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/buttons/edit-button} for more details.
  */
 export const EditButton: React.FC<EditButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/mui/src/components/buttons/export/index.tsx
+++ b/packages/mui/src/components/buttons/export/index.tsx
@@ -14,7 +14,7 @@ import { ExportButtonProps } from "../types";
  * `<ExportButton>` uses Material UI {@link https://mui.com/material-ui/api/loading-button/#main-content `<LoadingButton>`} with a default export icon and a default text with "Export".
  * It only has presentational value.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/buttons/export-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/buttons/export-button} for more details.
  */
 export const ExportButton: React.FC<ExportButtonProps> = ({
     hideText = false,

--- a/packages/mui/src/components/buttons/import/index.tsx
+++ b/packages/mui/src/components/buttons/import/index.tsx
@@ -11,10 +11,10 @@ import ImportExportOutlined from "@mui/icons-material/ImportExportOutlined";
 import { ImportButtonProps } from "../types";
 
 /**
- * `<ImportButton>` is compatible with the {@link https://refine.dev/docs/core/hooks/import-export/useImport/ `useImport`} core hook.
+ * `<ImportButton>` is compatible with the {@link https://refine.dev/docs/api-reference/core/hooks/import-export/useImport/ `useImport`} core hook.
  * It uses Material UI {@link https://mui.com/material-ui/api/loading-button/#main-content  `<LoadingButton>`} and native html {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input  `<input>`} element.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/buttons/import-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/buttons/import-button} for more details.
  */
 export const ImportButton: React.FC<ImportButtonProps> = ({
     inputProps,

--- a/packages/mui/src/components/buttons/list/index.tsx
+++ b/packages/mui/src/components/buttons/list/index.tsx
@@ -22,10 +22,10 @@ import { ListButtonProps } from "../types";
 
 /**
  * `<ListButton>` is using uses Material UI {@link https://mui.com/components/buttons/ `<Button>`} component.
- * It uses the  {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#list `list`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
+ * It uses the  {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#list `list`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful when redirecting the app to the list page route of resource}.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/buttons/list-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/buttons/list-button} for more details.
  */
 export const ListButton: React.FC<ListButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/mui/src/components/buttons/refresh/index.tsx
+++ b/packages/mui/src/components/buttons/refresh/index.tsx
@@ -17,9 +17,9 @@ import { RefreshButtonProps } from "../types";
 
 /**
  * `<RefreshButton>` uses uses Material UI {@link https://mui.com/material-ui/api/loading-button/#main-content `<LoadingButton>`} component
- * to update the data shown on the page via the {@link https://refine.dev/docs/core/hooks/data/useOne `useOne`} method provided by your dataProvider.
+ * to update the data shown on the page via the {@link https://refine.dev/docs/api-reference/core/hooks/data/useOne `useOne`} method provided by your dataProvider.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/buttons/refresh-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/buttons/refresh-button} for more details.
  */
 export const RefreshButton: React.FC<RefreshButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/mui/src/components/buttons/save/index.tsx
+++ b/packages/mui/src/components/buttons/save/index.tsx
@@ -14,7 +14,7 @@ import { SaveButtonProps } from "../types";
  * `<SaveButton>` uses Material UI {@link https://mui.com/material-ui/api/loading-button/#main-content `<LoadingButton>`} component.
  * It uses it for presantation purposes only. Some of the hooks that refine has adds features to this button.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/buttons/save-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/buttons/save-button} for more details.
  */
 export const SaveButton: React.FC<SaveButtonProps> = ({
     hideText = false,

--- a/packages/mui/src/components/buttons/show/index.tsx
+++ b/packages/mui/src/components/buttons/show/index.tsx
@@ -20,10 +20,10 @@ import { ShowButtonProps } from "../types";
 
 /**
  * `<ShowButton>` uses uses Material UI {@link https://mui.com/components/buttons/ `<Button>`} component.
- * It uses the {@link https://refine.dev/docs/core/hooks/navigation/useNavigation#show `show`} method from {@link https://refine.dev/docs/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
+ * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#show `show`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful when red sirecting the app to the show page with the record id route of resource.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/buttons/show-button} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/buttons/show-button} for more details.
  */
 export const ShowButton: React.FC<ShowButtonProps> = ({
     resource: resourceNameFromProps,

--- a/packages/mui/src/components/fields/boolean/index.tsx
+++ b/packages/mui/src/components/fields/boolean/index.tsx
@@ -9,7 +9,7 @@ import { BooleanFieldProps } from "../types";
 /**
  * This field is used to display boolean values. It uses the {@link https://mui.com/material-ui/react-tooltip/#main-content `<Tooltip>`} values from Materila UI.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/fields/boolean} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/fields/boolean} for more details.
  */
 export const BooleanField: React.FC<BooleanFieldProps> = ({
     value,

--- a/packages/mui/src/components/fields/date/index.tsx
+++ b/packages/mui/src/components/fields/date/index.tsx
@@ -16,7 +16,7 @@ const defaultLocale = dayjs.locale();
  * This field is used to display dates. It uses {@link https://day.js.org/docs/en/display/format `Day.js`} to display date format and
  * Material UI {@link https://mui.com/material-ui/react-typography/#main-content `<Typography>`} component
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/fields/date} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/fields/date} for more details.
  */
 export const DateField: React.FC<DateFieldProps> = ({
     value,

--- a/packages/mui/src/components/fields/email/index.tsx
+++ b/packages/mui/src/components/fields/email/index.tsx
@@ -8,7 +8,7 @@ import { EmailFieldProps } from "../types";
  * This field is used to display email values. It uses the {@link https://mui.com/material-ui/react-typography/#main-content `<Typography>` }
  * and {@link https://mui.com/material-ui/react-link/#main-content `<Link>`} components from Material UI.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/fields/email} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/fields/email} for more details.
  */
 export const EmailField: React.FC<EmailFieldProps> = ({ value, ...rest }) => {
     return (

--- a/packages/mui/src/components/fields/file/index.tsx
+++ b/packages/mui/src/components/fields/file/index.tsx
@@ -7,7 +7,7 @@ import { FileFieldProps } from "../types";
 /**
  * This field is used to display files and  uses Material UI {@link https://mui.com/material-ui/react-typography/#main-content `<Typography>`}  and {@link https://mui.com/material-ui/react-link/#main-content `<Link>`} components.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/fields/file} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/fields/file} for more details.
  */
 export const FileField: React.FC<FileFieldProps> = ({
     title,

--- a/packages/mui/src/components/fields/markdown/index.tsx
+++ b/packages/mui/src/components/fields/markdown/index.tsx
@@ -7,7 +7,7 @@ import { MarkdownFieldProps } from "../types";
 /**
  * This field lets you display markdown content. It supports {@link https://github.github.com/gfm/ GitHub Flavored Markdown}.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/fields/markdown} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/fields/markdown} for more details.
  */
 export const MarkdownField: React.FC<MarkdownFieldProps> = ({ value = "" }) => {
     return <ReactMarkdown plugins={[gfm]}>{value}</ReactMarkdown>;

--- a/packages/mui/src/components/fields/number/index.tsx
+++ b/packages/mui/src/components/fields/number/index.tsx
@@ -14,7 +14,7 @@ function toLocaleStringSupportsOptions() {
 /**
  * This field is used to display a number formatted according to the browser locale, right aligned. and uses {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl `Intl`} to display date format
  * and Material UI {@link https://mui.com/material-ui/react-typography/#main-content `<Typography>`} component.
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/fields/number} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/fields/number} for more details.
  */
 export const NumberField: React.FC<NumberFieldProps> = ({
     value,

--- a/packages/mui/src/components/fields/tag/index.tsx
+++ b/packages/mui/src/components/fields/tag/index.tsx
@@ -6,7 +6,7 @@ import { TagFieldProps } from "../types";
 /**
  * This field lets you display a value in a tag. It uses Material UI {@link https://mui.com/material-ui/react-chip/#main-content `<Chip>`} component.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/fields/tag} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/fields/tag} for more details.
  */
 export const TagField: React.FC<TagFieldProps> = ({ value, ...rest }) => {
     return <Chip label={value?.toString()} {...rest} />;

--- a/packages/mui/src/components/fields/text/index.tsx
+++ b/packages/mui/src/components/fields/text/index.tsx
@@ -6,7 +6,7 @@ import { TextFieldProps } from "../types";
 /**
  * This field lets you show basic text. It uses Materail UI {@link https://mui.com/material-ui/react-typography/#main-content `<Typography>`} component.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/fields/text} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/fields/text} for more details.
  */
 const TextField: React.FC<TextFieldProps> = ({ value, ...rest }) => {
     return (

--- a/packages/mui/src/components/fields/url/index.tsx
+++ b/packages/mui/src/components/fields/url/index.tsx
@@ -9,7 +9,7 @@ import { UrlFieldProps } from "../types";
  * and {@link https://mui.com/material-ui/react-link/#main-content `<Link>`} components from Material UI.
  * You can pass a URL in its `value` property and you can show a text in its place by passing any `children`.
  *
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/fields/url} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/fields/url} for more details.
  */
 export const UrlField: React.FC<UrlFieldProps> = ({
     children,

--- a/packages/mui/src/components/pages/auth/index.tsx
+++ b/packages/mui/src/components/pages/auth/index.tsx
@@ -21,7 +21,7 @@ export type AuthProps = AuthPageProps<BoxProps, CardProps, FormPropsType>;
 
 /**
  * **refine** has a default auth page form served on the `/login` route when the `authProvider` configuration is provided.
- * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/mui-auth-page/} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/mui/components/mui-auth-page/} for more details.
  */
 export const AuthPage: React.FC<AuthProps> = (props) => {
     const { type } = props;

--- a/packages/mui/src/components/pages/login/index.tsx
+++ b/packages/mui/src/components/pages/login/index.tsx
@@ -25,7 +25,7 @@ type ILoginForm = {
  * @deprecated LoginPage is deprecated. Use AuthPage instead. @see {@link https://refine.dev/docs/api-reference/mui/components/mui-auth-page} for more details.
  * **refine** has a default login page form which is served on `/login` route when the `authProvider` configuration is provided.
  *
- * @see {@link https://refine.dev/docs/api-references/components/refine-config#loginpage} for more details.
+ * @see {@link https://refine.dev/docs/api-reference/core/components/refine-config/#loginpage} for more details.
  */
 export const LoginPage: React.FC<LoginPageProps> = () => {
     const {

--- a/packages/mui/src/hooks/useAutocomplete/index.ts
+++ b/packages/mui/src/hooks/useAutocomplete/index.ts
@@ -38,7 +38,7 @@ export type UseAutocompleteReturnType<TData extends BaseRecord> = Omit<
  * `useAutocomplete` hook is used to fetch data from the dataProvider and return the options for the select box.
  *
  * It uses `getList` method as query function from the dataProvider that is
- * passed to {@link https://refine.dev/docs/api-references/components/refine-config `<Refine>`}.
+ * passed to {@link https://refine.dev/docs/api-reference/core/components/refine-config `<Refine>`}.
  *
  * @see {@link https://refine.dev/docs/api-reference/mui/hooks/useAutocomplete/} for more details.
  *


### PR DESCRIPTION
This PR will include fixes for broken links of tsdoc comments in all refine packages. Additionally, we're adding a workflow to check the status of links using [`tsdoc-link-check`](https://github.com/aliemir/tsdoc-link-check).

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [ ] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [ ] Changesets are provided or not needed
