### PR TITLE
test: increase test coverages of under the `/pages` folder

### DIFF
--- a/.changeset/loud-suns-deny.md
+++ b/.changeset/loud-suns-deny.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+refactor: increase accessibility of auth page components
+
+add `htmlFor` to `label` elements to associate them with their inputs

--- a/packages/core/src/components/pages/auth/components/forgotPassword/index.spec.tsx
+++ b/packages/core/src/components/pages/auth/components/forgotPassword/index.spec.tsx
@@ -1,0 +1,172 @@
+import React from "react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+
+import { ForgotPasswordPage } from ".";
+import { TestWrapper, mockLegacyRouterProvider } from "@test/index";
+import { AuthBindings } from "src/interfaces";
+
+const mockAuthProvider: AuthBindings = {
+    login: async () => ({ success: true }),
+    check: async () => ({ authenticated: true }),
+    onError: async () => ({}),
+    logout: async () => ({ success: true }),
+};
+
+describe("Auth Page Forgot Password", () => {
+    it("should render card title", async () => {
+        const { getByText } = render(<ForgotPasswordPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(getByText(/forgot your password?/i)).toBeInTheDocument();
+    });
+
+    it("should render email input", async () => {
+        const { getByLabelText } = render(<ForgotPasswordPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(getByLabelText(/email/i)).toBeInTheDocument();
+    });
+
+    it("should login link", async () => {
+        const { getByRole } = render(<ForgotPasswordPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(
+            getByRole("link", {
+                name: /sign in/i,
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it("should not render login link when is false", async () => {
+        const { queryByRole } = render(
+            <ForgotPasswordPage loginLink={false} />,
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        expect(
+            queryByRole("link", {
+                name: /sign in/i,
+            }),
+        ).not.toBeInTheDocument();
+    });
+
+    it("should render reset button", async () => {
+        const { getByRole } = render(<ForgotPasswordPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(
+            getByRole("button", {
+                name: /send reset/i,
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it("should renderContent only", async () => {
+        const { queryByText, queryByTestId, queryByRole, queryByLabelText } =
+            render(
+                <ForgotPasswordPage
+                    renderContent={() => <div data-testid="custom-content" />}
+                />,
+                {
+                    wrapper: TestWrapper({}),
+                },
+            );
+
+        expect(queryByLabelText(/email/i)).not.toBeInTheDocument();
+        expect(queryByText(/refine project/i)).not.toBeInTheDocument();
+        expect(queryByTestId("refine-logo")).not.toBeInTheDocument();
+        expect(
+            queryByRole("button", {
+                name: /reset/i,
+            }),
+        ).not.toBeInTheDocument();
+        expect(queryByTestId("custom-content")).toBeInTheDocument();
+    });
+
+    it("should customizable with renderContent", async () => {
+        const { queryByText, queryByTestId, queryByRole, queryByLabelText } =
+            render(
+                <ForgotPasswordPage
+                    renderContent={(content: any, title: any) => (
+                        <div>
+                            {title}
+                            <div data-testid="custom-content">
+                                <div>Custom Content</div>
+                            </div>
+                            {content}
+                        </div>
+                    )}
+                />,
+                {
+                    wrapper: TestWrapper({}),
+                },
+            );
+
+        expect(queryByText(/custom content/i)).toBeInTheDocument();
+        expect(queryByTestId("custom-content")).toBeInTheDocument();
+        expect(queryByLabelText(/email/i)).toBeInTheDocument();
+        expect(
+            queryByRole("button", {
+                name: /reset/i,
+            }),
+        ).toBeInTheDocument();
+        expect(queryByTestId("custom-content")).toBeInTheDocument();
+    });
+
+    it("should run forgotPassword mutation when form is submitted", async () => {
+        const forgotPasswordMock = jest.fn();
+        const { getByLabelText, getByDisplayValue } = render(
+            <ForgotPasswordPage />,
+            {
+                wrapper: TestWrapper({
+                    authProvider: {
+                        ...mockAuthProvider,
+                        forgotPassword: forgotPasswordMock,
+                    },
+                }),
+            },
+        );
+
+        fireEvent.change(getByLabelText(/email/i), {
+            target: { value: "demo@refine.dev" },
+        });
+
+        fireEvent.click(getByDisplayValue(/send reset/i));
+
+        await waitFor(() => {
+            expect(forgotPasswordMock).toBeCalledTimes(1);
+        });
+
+        expect(forgotPasswordMock).toBeCalledWith({
+            email: "demo@refine.dev",
+        });
+    });
+
+    it("should work with legacy router provider Link", async () => {
+        const LinkComponentMock = jest.fn();
+
+        render(<ForgotPasswordPage />, {
+            wrapper: TestWrapper({
+                legacyRouterProvider: {
+                    ...mockLegacyRouterProvider(),
+                    Link: LinkComponentMock,
+                },
+            }),
+        });
+
+        expect(LinkComponentMock).toBeCalledWith(
+            {
+                to: "/login",
+                children: "Sign in",
+            },
+            {},
+        );
+    });
+});

--- a/packages/core/src/components/pages/auth/components/forgotPassword/index.tsx
+++ b/packages/core/src/components/pages/auth/components/forgotPassword/index.tsx
@@ -40,14 +40,8 @@ export const ForgotPasswordPage: React.FC<ForgotPasswordProps> = ({
     const { mutate: forgotPassword, isLoading } =
         useForgotPassword<ForgotPasswordFormTypes>();
 
-    const renderLink = (link: React.ReactNode, text?: string) => {
-        if (link) {
-            if (typeof link === "string") {
-                return <ActiveLink to={link}>{text}</ActiveLink>;
-            }
-            return link;
-        }
-        return null;
+    const renderLink = (link: string, text?: string) => {
+        return <ActiveLink to={link}>{text}</ActiveLink>;
     };
 
     const content = (
@@ -73,13 +67,14 @@ export const ForgotPasswordPage: React.FC<ForgotPasswordProps> = ({
                         padding: 25,
                     }}
                 >
-                    <label>
+                    <label htmlFor="email-input">
                         {translate(
                             "pages.forgotPassword.fields.email",
                             "Email",
                         )}
                     </label>
                     <input
+                        id="email-input"
                         name="email"
                         type="mail"
                         autoCorrect="off"

--- a/packages/core/src/components/pages/auth/components/login/index.spec.tsx
+++ b/packages/core/src/components/pages/auth/components/login/index.spec.tsx
@@ -1,0 +1,292 @@
+import React from "react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+
+import { LoginPage } from ".";
+import { TestWrapper, mockLegacyRouterProvider } from "@test/index";
+import { AuthBindings } from "src/interfaces";
+
+const mockAuthProvider: AuthBindings = {
+    login: async () => ({ success: true }),
+    check: async () => ({ authenticated: true }),
+    onError: async () => ({}),
+    logout: async () => ({ success: true }),
+};
+
+describe("Auth Page Login", () => {
+    it("should render card title", async () => {
+        const { getByText } = render(<LoginPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(getByText(/sign in to your account/i)).toBeInTheDocument();
+    });
+
+    it("should render card email and password input", async () => {
+        const { getByLabelText } = render(<LoginPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(getByLabelText(/email/i)).toBeInTheDocument();
+        expect(getByLabelText(/password/i)).toBeInTheDocument();
+    });
+
+    it("should render providers", async () => {
+        const { getByText, queryByText } = render(
+            <LoginPage
+                providers={[
+                    {
+                        name: "Google",
+                        label: "Google",
+                    },
+                    {
+                        name: "Github",
+                    },
+                ]}
+            />,
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        expect(getByText(/google/i)).toBeInTheDocument();
+        expect(queryByText(/github/i)).not.toBeInTheDocument();
+    });
+
+    it("should register link", async () => {
+        const { getByRole } = render(<LoginPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(
+            getByRole("link", {
+                name: /sign up/i,
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it("should not render register link when is false", async () => {
+        const { queryByRole } = render(<LoginPage registerLink={false} />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(
+            queryByRole("link", {
+                name: /sign up/i,
+            }),
+        ).not.toBeInTheDocument();
+    });
+
+    it("should forgotPassword link", async () => {
+        const { getByRole } = render(<LoginPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(
+            getByRole("link", {
+                name: /forgot password?/i,
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it("should not render forgotPassword link when is false", async () => {
+        const { queryByRole } = render(
+            <LoginPage forgotPasswordLink={false} />,
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        expect(
+            queryByRole("link", {
+                name: /forgot password/i,
+            }),
+        ).not.toBeInTheDocument();
+    });
+
+    it("should render remember me", async () => {
+        const { queryByRole } = render(<LoginPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(
+            queryByRole("checkbox", {
+                name: /remember me/i,
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it("should not render remember me when is false", async () => {
+        const { queryByRole } = render(<LoginPage rememberMe={false} />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(
+            queryByRole("checkbox", {
+                name: /remember me/i,
+            }),
+        ).not.toBeInTheDocument();
+    });
+
+    it("should render sign in button", async () => {
+        const { getByRole } = render(<LoginPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(
+            getByRole("button", {
+                name: /sign in/i,
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it("should renderContent only", async () => {
+        const { queryByText, queryByTestId, queryByRole, queryByLabelText } =
+            render(
+                <LoginPage
+                    renderContent={() => <div data-testid="custom-content" />}
+                />,
+                {
+                    wrapper: TestWrapper({}),
+                },
+            );
+
+        expect(queryByLabelText(/email/i)).not.toBeInTheDocument();
+        expect(queryByLabelText(/password/i)).not.toBeInTheDocument();
+        expect(queryByText(/refine project/i)).not.toBeInTheDocument();
+        expect(queryByTestId("refine-logo")).not.toBeInTheDocument();
+        expect(
+            queryByRole("button", {
+                name: /sign in/i,
+            }),
+        ).not.toBeInTheDocument();
+        expect(queryByTestId("custom-content")).toBeInTheDocument();
+    });
+
+    it("should customizable with renderContent", async () => {
+        const { queryByText, queryByTestId, queryByRole, queryByLabelText } =
+            render(
+                <LoginPage
+                    renderContent={(content: any, title: any) => (
+                        <div>
+                            {title}
+                            <div data-testid="custom-content">
+                                <div>Custom Content</div>
+                            </div>
+                            {content}
+                        </div>
+                    )}
+                />,
+                {
+                    wrapper: TestWrapper({}),
+                },
+            );
+
+        expect(queryByText(/custom content/i)).toBeInTheDocument();
+        expect(queryByTestId("custom-content")).toBeInTheDocument();
+        expect(queryByLabelText(/email/i)).toBeInTheDocument();
+        expect(queryByLabelText(/password/i)).toBeInTheDocument();
+        expect(
+            queryByRole("button", {
+                name: /sign in/i,
+            }),
+        ).toBeInTheDocument();
+        expect(queryByTestId("custom-content")).toBeInTheDocument();
+    });
+
+    it("should run login mutation when form is submitted", async () => {
+        const loginMock = jest.fn();
+        const { getByLabelText, getByDisplayValue } = render(<LoginPage />, {
+            wrapper: TestWrapper({
+                authProvider: {
+                    ...mockAuthProvider,
+                    login: loginMock,
+                },
+            }),
+        });
+
+        fireEvent.change(getByLabelText(/email/i), {
+            target: { value: "demo@refine.dev" },
+        });
+
+        fireEvent.change(getByLabelText(/password/i), {
+            target: { value: "demo" },
+        });
+
+        fireEvent.click(getByLabelText(/remember me/i));
+
+        fireEvent.click(getByDisplayValue(/sign in/i));
+
+        await waitFor(() => {
+            expect(loginMock).toBeCalledTimes(1);
+        });
+
+        expect(loginMock).toBeCalledWith({
+            email: "demo@refine.dev",
+            password: "demo",
+            remember: true,
+        });
+    });
+
+    it("should work with legacy router provider Link", async () => {
+        const LinkComponentMock = jest.fn();
+
+        render(<LoginPage />, {
+            wrapper: TestWrapper({
+                legacyRouterProvider: {
+                    ...mockLegacyRouterProvider(),
+                    useLocation: () => jest.fn(),
+                    Link: LinkComponentMock,
+                },
+            }),
+        });
+
+        expect(LinkComponentMock).toBeCalledWith(
+            {
+                to: "/forgot-password",
+                children: "Forgot password?",
+            },
+            {},
+        );
+        expect(LinkComponentMock).toBeCalledWith(
+            {
+                to: "/register",
+                children: "Sign up",
+            },
+            {},
+        );
+    });
+
+    it("should run login mutation when provider button is clicked", async () => {
+        const loginMock = jest.fn();
+        const { getByText } = render(
+            <LoginPage
+                providers={[
+                    {
+                        name: "Google",
+                        label: "Google",
+                    },
+                ]}
+            />,
+            {
+                wrapper: TestWrapper({
+                    authProvider: {
+                        ...mockAuthProvider,
+                        login: loginMock,
+                    },
+                }),
+            },
+        );
+
+        expect(getByText(/google/i)).toBeInTheDocument();
+
+        fireEvent.click(getByText(/google/i));
+
+        await waitFor(() => {
+            expect(loginMock).toBeCalledTimes(1);
+        });
+
+        expect(loginMock).toBeCalledWith({
+            providerName: "Google",
+        });
+    });
+});

--- a/packages/core/src/components/pages/auth/components/login/index.tsx
+++ b/packages/core/src/components/pages/auth/components/login/index.tsx
@@ -37,14 +37,8 @@ export const LoginPage: React.FC<LoginProps> = ({
         v3LegacyAuthProviderCompatible: Boolean(authProvider?.isLegacy),
     });
 
-    const renderLink = (link: React.ReactNode, text?: string) => {
-        if (link) {
-            if (typeof link === "string") {
-                return <ActiveLink to={link}>{text}</ActiveLink>;
-            }
-            return link;
-        }
-        return null;
+    const renderLink = (link: string, text?: string) => {
+        return <ActiveLink to={link}>{text}</ActiveLink>;
     };
 
     const renderProviders = () => {
@@ -100,10 +94,11 @@ export const LoginPage: React.FC<LoginProps> = ({
                         padding: 25,
                     }}
                 >
-                    <label>
+                    <label htmlFor="email-input">
                         {translate("pages.login.fields.email", "Email")}
                     </label>
                     <input
+                        id="email-input"
                         name="email"
                         type="text"
                         size={20}
@@ -114,10 +109,11 @@ export const LoginPage: React.FC<LoginProps> = ({
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
                     />
-                    <label>
+                    <label htmlFor="password-input">
                         {translate("pages.login.fields.password", "Password")}
                     </label>
                     <input
+                        id="password-input"
                         type="password"
                         name="password"
                         required
@@ -127,12 +123,13 @@ export const LoginPage: React.FC<LoginProps> = ({
                     />
                     {rememberMe ?? (
                         <>
-                            <label>
+                            <label htmlFor="remember-me-input">
                                 {translate(
                                     "pages.login.buttons.rememberMe",
                                     "Remember me",
                                 )}
                                 <input
+                                    id="remember-me-input"
                                     name="remember"
                                     type="checkbox"
                                     size={20}

--- a/packages/core/src/components/pages/auth/components/register/index.spec.tsx
+++ b/packages/core/src/components/pages/auth/components/register/index.spec.tsx
@@ -1,0 +1,231 @@
+import React from "react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+
+import { RegisterPage } from ".";
+import { TestWrapper, mockLegacyRouterProvider } from "@test/index";
+import { AuthBindings } from "src/interfaces";
+
+const mockAuthProvider: AuthBindings = {
+    login: async () => ({ success: true }),
+    check: async () => ({ authenticated: true }),
+    onError: async () => ({}),
+    logout: async () => ({ success: true }),
+};
+
+describe("Auth Page Register", () => {
+    it("should render card title", async () => {
+        const { getByText } = render(<RegisterPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(getByText(/sign up for your account/i)).toBeInTheDocument();
+    });
+
+    it("should render card email and password input", async () => {
+        const { getByLabelText } = render(<RegisterPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(getByLabelText(/email/i)).toBeInTheDocument();
+        expect(getByLabelText(/password/i)).toBeInTheDocument();
+    });
+
+    it("should render providers", async () => {
+        const { getByText, queryByText } = render(
+            <RegisterPage
+                providers={[
+                    {
+                        name: "Google",
+                        label: "Google",
+                    },
+                    {
+                        name: "Github",
+                    },
+                ]}
+            />,
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        expect(getByText(/google/i)).toBeInTheDocument();
+        expect(queryByText(/github/i)).not.toBeInTheDocument();
+    });
+
+    it("should login link", async () => {
+        const { getByRole } = render(<RegisterPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(
+            getByRole("link", {
+                name: /sign in/i,
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it("should not render login link when is false", async () => {
+        const { queryByRole } = render(<RegisterPage loginLink={false} />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(
+            queryByRole("link", {
+                name: /sign in/i,
+            }),
+        ).not.toBeInTheDocument();
+    });
+
+    it("should render sign up button", async () => {
+        const { getByRole } = render(<RegisterPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(
+            getByRole("button", {
+                name: /sign up/i,
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it("should renderContent only", async () => {
+        const { queryByText, queryByTestId, queryByRole, queryByLabelText } =
+            render(
+                <RegisterPage
+                    renderContent={() => <div data-testid="custom-content" />}
+                />,
+                {
+                    wrapper: TestWrapper({}),
+                },
+            );
+
+        expect(queryByLabelText(/email/i)).not.toBeInTheDocument();
+        expect(queryByLabelText(/password/i)).not.toBeInTheDocument();
+        expect(queryByText(/refine project/i)).not.toBeInTheDocument();
+        expect(queryByTestId("refine-logo")).not.toBeInTheDocument();
+        expect(
+            queryByRole("button", {
+                name: /sign up/i,
+            }),
+        ).not.toBeInTheDocument();
+        expect(queryByTestId("custom-content")).toBeInTheDocument();
+    });
+
+    it("should customizable with renderContent", async () => {
+        const { queryByText, queryByTestId, queryByRole, queryByLabelText } =
+            render(
+                <RegisterPage
+                    renderContent={(content: any, title: any) => (
+                        <div>
+                            {title}
+                            <div data-testid="custom-content">
+                                <div>Custom Content</div>
+                            </div>
+                            {content}
+                        </div>
+                    )}
+                />,
+                {
+                    wrapper: TestWrapper({}),
+                },
+            );
+
+        expect(queryByText(/custom content/i)).toBeInTheDocument();
+        expect(queryByTestId("custom-content")).toBeInTheDocument();
+        expect(queryByLabelText(/email/i)).toBeInTheDocument();
+        expect(queryByLabelText(/password/i)).toBeInTheDocument();
+        expect(
+            queryByRole("button", {
+                name: /sign up/i,
+            }),
+        ).toBeInTheDocument();
+        expect(queryByTestId("custom-content")).toBeInTheDocument();
+    });
+
+    it("should run register mutation when form is submitted", async () => {
+        const registerMock = jest.fn();
+        const { getByLabelText, getByDisplayValue } = render(<RegisterPage />, {
+            wrapper: TestWrapper({
+                authProvider: {
+                    ...mockAuthProvider,
+                    register: registerMock,
+                },
+            }),
+        });
+
+        fireEvent.change(getByLabelText(/email/i), {
+            target: { value: "demo@refine.dev" },
+        });
+
+        fireEvent.change(getByLabelText(/password/i), {
+            target: { value: "demo" },
+        });
+
+        fireEvent.click(getByDisplayValue(/sign up/i));
+
+        await waitFor(() => {
+            expect(registerMock).toBeCalledTimes(1);
+        });
+
+        expect(registerMock).toBeCalledWith({
+            email: "demo@refine.dev",
+            password: "demo",
+        });
+    });
+
+    it("should work with legacy router provider Link", async () => {
+        const LinkComponentMock = jest.fn();
+
+        render(<RegisterPage />, {
+            wrapper: TestWrapper({
+                legacyRouterProvider: {
+                    ...mockLegacyRouterProvider(),
+                    useLocation: () => jest.fn(),
+                    Link: LinkComponentMock,
+                },
+            }),
+        });
+
+        expect(LinkComponentMock).toBeCalledWith(
+            {
+                to: "/login",
+                children: "Sign in",
+            },
+            {},
+        );
+    });
+
+    it("should run register mutation when provider button is clicked", async () => {
+        const registerMock = jest.fn();
+        const { getByText } = render(
+            <RegisterPage
+                providers={[
+                    {
+                        name: "Google",
+                        label: "Google",
+                    },
+                ]}
+            />,
+            {
+                wrapper: TestWrapper({
+                    authProvider: {
+                        ...mockAuthProvider,
+                        register: registerMock,
+                    },
+                }),
+            },
+        );
+
+        expect(getByText(/google/i)).toBeInTheDocument();
+
+        fireEvent.click(getByText(/google/i));
+
+        await waitFor(() => {
+            expect(registerMock).toBeCalledTimes(1);
+        });
+
+        expect(registerMock).toBeCalledWith({
+            providerName: "Google",
+        });
+    });
+});

--- a/packages/core/src/components/pages/auth/components/register/index.tsx
+++ b/packages/core/src/components/pages/auth/components/register/index.tsx
@@ -43,14 +43,8 @@ export const RegisterPage: React.FC<RegisterProps> = ({
         v3LegacyAuthProviderCompatible: Boolean(authProvider?.isLegacy),
     });
 
-    const renderLink = (link: React.ReactNode, text?: string) => {
-        if (link) {
-            if (typeof link === "string") {
-                return <ActiveLink to={link}>{text}</ActiveLink>;
-            }
-            return link;
-        }
-        return null;
+    const renderLink = (link: string, text?: string) => {
+        return <ActiveLink to={link}>{text}</ActiveLink>;
     };
 
     const renderProviders = () => {
@@ -106,10 +100,11 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                         padding: 25,
                     }}
                 >
-                    <label>
+                    <label htmlFor="email-input">
                         {translate("pages.register.fields.email", "Email")}
                     </label>
                     <input
+                        id="email-input"
                         name="email"
                         type="email"
                         size={20}
@@ -120,13 +115,14 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
                     />
-                    <label>
+                    <label htmlFor="password-input">
                         {translate(
                             "pages.register.fields.password",
                             "Password",
                         )}
                     </label>
                     <input
+                        id="password-input"
                         name="password"
                         type="password"
                         required

--- a/packages/core/src/components/pages/auth/components/updatePassword/index.spec.tsx
+++ b/packages/core/src/components/pages/auth/components/updatePassword/index.spec.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+
+import { UpdatePasswordPage } from ".";
+import { TestWrapper } from "@test/index";
+import { AuthBindings } from "src/interfaces";
+
+const mockAuthProvider: AuthBindings = {
+    login: async () => ({ success: true }),
+    check: async () => ({ authenticated: true }),
+    onError: async () => ({}),
+    logout: async () => ({ success: true }),
+};
+
+describe("Auth Page Update Password", () => {
+    it("should render card title", async () => {
+        const { getByText } = render(<UpdatePasswordPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(getByText(/Update Password?/i)).toBeInTheDocument();
+    });
+
+    it("should render password input", async () => {
+        const { getByLabelText } = render(<UpdatePasswordPage />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(getByLabelText("New Password")).toBeInTheDocument();
+        expect(getByLabelText("Confirm New Password")).toBeInTheDocument();
+    });
+
+    it("should renderContent only", async () => {
+        const { queryByText, queryByTestId, queryByLabelText } = render(
+            <UpdatePasswordPage
+                renderContent={() => <div data-testid="custom-content" />}
+            />,
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        expect(queryByText(/refine project/i)).not.toBeInTheDocument();
+        expect(queryByTestId("refine-logo")).not.toBeInTheDocument();
+        expect(queryByLabelText("New Password")).not.toBeInTheDocument();
+        expect(
+            queryByLabelText("Confirm New Password"),
+        ).not.toBeInTheDocument();
+        expect(queryByTestId("custom-content")).toBeInTheDocument();
+    });
+
+    it("should customizable with renderContent", async () => {
+        const { queryByText, queryByTestId, getByLabelText } = render(
+            <UpdatePasswordPage
+                renderContent={(content: any, title: any) => (
+                    <div>
+                        {title}
+                        <div data-testid="custom-content">
+                            <div>Custom Content</div>
+                        </div>
+                        {content}
+                    </div>
+                )}
+            />,
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        expect(queryByText(/custom content/i)).toBeInTheDocument();
+        expect(queryByTestId("custom-content")).toBeInTheDocument();
+        expect(getByLabelText("New Password")).toBeInTheDocument();
+        expect(getByLabelText("Confirm New Password")).toBeInTheDocument();
+    });
+
+    it("should run updatePassword mutation when form is submitted", async () => {
+        const updatePasswordMock = jest.fn();
+        const { getAllByLabelText, getByLabelText, getByDisplayValue } = render(
+            <UpdatePasswordPage />,
+            {
+                wrapper: TestWrapper({
+                    authProvider: {
+                        ...mockAuthProvider,
+                        updatePassword: updatePasswordMock,
+                    },
+                }),
+            },
+        );
+
+        fireEvent.change(getAllByLabelText(/password/i)[0], {
+            target: { value: "demo" },
+        });
+
+        fireEvent.change(getByLabelText(/confirm new password/i), {
+            target: { value: "demo" },
+        });
+
+        fireEvent.click(getByDisplayValue(/update/i));
+
+        await waitFor(() => {
+            expect(updatePasswordMock).toBeCalledTimes(1);
+        });
+
+        expect(updatePasswordMock).toBeCalledWith({
+            password: "demo",
+            confirmPassword: "demo",
+        });
+    });
+});

--- a/packages/core/src/components/pages/auth/components/updatePassword/index.tsx
+++ b/packages/core/src/components/pages/auth/components/updatePassword/index.tsx
@@ -56,13 +56,14 @@ export const UpdatePasswordPage: React.FC<UpdatePasswordProps> = ({
                         padding: 25,
                     }}
                 >
-                    <label>
+                    <label htmlFor="password-input">
                         {translate(
                             "pages.updatePassword.fields.password",
                             "New Password",
                         )}
                     </label>
                     <input
+                        id="password-input"
                         name="password"
                         type="password"
                         required
@@ -70,13 +71,14 @@ export const UpdatePasswordPage: React.FC<UpdatePasswordProps> = ({
                         value={newPassword}
                         onChange={(e) => setNewPassword(e.target.value)}
                     />
-                    <label>
+                    <label htmlFor="confirm-password-input">
                         {translate(
                             "pages.updatePassword.fields.confirmPassword",
                             "Confirm New Password",
                         )}
                     </label>
                     <input
+                        id="confirm-password-input"
                         name="confirmPassword"
                         type="password"
                         required

--- a/packages/core/src/components/pages/auth/index.spec.tsx
+++ b/packages/core/src/components/pages/auth/index.spec.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { render } from "@testing-library/react";
+
+import { AuthPage } from ".";
+import { TestWrapper } from "@test/index";
+
+describe("Auth Page Index", () => {
+    it.each(["register", "forgotPassword", "updatePassword", "login"] as const)(
+        `should render %s type`,
+        async (type) => {
+            const { getByText } = render(<AuthPage type={type} />, {
+                wrapper: TestWrapper({}),
+            });
+
+            switch (type) {
+                case "register":
+                    expect(
+                        getByText(/sign up for your account/i),
+                    ).toBeInTheDocument();
+                    break;
+                case "forgotPassword":
+                    expect(
+                        getByText(/forgot your password?/i),
+                    ).toBeInTheDocument();
+                    break;
+                case "updatePassword":
+                    expect(getByText(/update password/i)).toBeInTheDocument();
+                    break;
+                default:
+                    expect(
+                        getByText(/Sign in to your account/i),
+                    ).toBeInTheDocument();
+                    break;
+            }
+        },
+    );
+});

--- a/packages/core/src/components/pages/error/index.tsx
+++ b/packages/core/src/components/pages/error/index.tsx
@@ -30,9 +30,9 @@ export const ErrorComponent: React.FC = () => {
                     "pages.error.info",
                     {
                         action: action,
-                        resource: resource?.name,
+                        resource: resource.name,
                     },
-                    `You may have forgotten to add the "${action}" component to "${resource?.name}" resource.`,
+                    `You may have forgotten to add the "${action}" component to "${resource.name}" resource.`,
                 ),
             );
         }

--- a/packages/core/src/definitions/helpers/check-router-prop-misuse/index.spec.ts
+++ b/packages/core/src/definitions/helpers/check-router-prop-misuse/index.spec.ts
@@ -3,14 +3,10 @@ import { checkRouterPropMisuse } from ".";
 
 describe("checkRouterPropMisuse", () => {
     it("should return false when pass routerBindings", () => {
-        expect(
-            checkRouterPropMisuse(mockRouterBindings()),
-        ).toBeFalsy();
+        expect(checkRouterPropMisuse(mockRouterBindings())).toBeFalsy();
     });
 
     it("should return true when pass legacyRouterProvider", () => {
-        expect(
-            checkRouterPropMisuse(mockLegacyRouterProvider()),
-        ).toBeTruthy();
+        expect(checkRouterPropMisuse(mockLegacyRouterProvider())).toBeTruthy();
     });
 });


### PR DESCRIPTION
Added new tests the followings:
- Auth components
- Error page

### Test plan (required)

**Login** and **Welcome** pages are deprecated, therefore skipped.

<img width="1431" alt="image" src="https://github.com/refinedev/refine/assets/41580619/94c6cc7c-cc00-416e-a325-7d8fbe178044">

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
