### PR TITLE
fix(nextjs): unhandled `null` in `pathname` for `appdir`

### DIFF
--- a/.changeset/fast-squids-kiss.md
+++ b/.changeset/fast-squids-kiss.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/nextjs-router": patch
+---
+
+Fixed the unhandled nullable `pathname` issue returning from `usePathname` hook for the `appDir` router.

--- a/packages/nextjs-router/src/app/bindings.tsx
+++ b/packages/nextjs-router/src/app/bindings.tsx
@@ -57,7 +57,8 @@ export const routerBindings: RouterBindings = {
                     urlQuery.to = encodeURIComponent(`${urlQuery.to}`);
                 }
 
-                const cleanPathname = pathname.split("?")[0].split("#")[0];
+                const cleanPathname =
+                    pathname?.split("?")[0].split("#")[0] ?? "";
 
                 const urlTo = to || cleanPathname;
 


### PR DESCRIPTION
There was an unhandled case for `pathname` returned from `usePathname` hook in `appDir` router of `@refinedev/nextjs-router`. The `usePathname` hook can return `string` or `null`. Only `string` was handled. Now added proper handling for `null` value as well.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
