### PR TITLE
fix(inferencer): `show code` button isn't visible on tutorials.

### DIFF
--- a/.changeset/lucky-seals-yell.md
+++ b/.changeset/lucky-seals-yell.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/inferencer": patch
+---
+
+fix: show code button for inferencer isn't visible on tutorials.

--- a/.changeset/lucky-seals-yell.md
+++ b/.changeset/lucky-seals-yell.md
@@ -2,4 +2,4 @@
 "@refinedev/inferencer": patch
 ---
 
-fix: show code button for inferencer isn't visible on tutorials.
+fix: show code button for inferencers was not visible in smaller screens.

--- a/packages/inferencer/src/components/shared-code-viewer/index.tsx
+++ b/packages/inferencer/src/components/shared-code-viewer/index.tsx
@@ -36,7 +36,7 @@ export const SharedCodeViewer: CreateInferencerConfig["codeViewerComponent"] =
         // Visibility Check
         React.useEffect(() => {
             if (typeof window !== "undefined") {
-                const mediaQuery = window.matchMedia("(max-width: 1024px)");
+                const mediaQuery = window.matchMedia("(max-width: 449px)");
                 if (mediaQuery.matches) {
                     setIsVisible(false);
                 } else {


### PR DESCRIPTION
Updated media query condition to 449px.