### PR TITLE
feat(docs): do not render sidebar item if its collapsed

### DIFF
--- a/documentation/src/refine-theme/doc-sidebar.tsx
+++ b/documentation/src/refine-theme/doc-sidebar.tsx
@@ -186,14 +186,18 @@ const SidebarCategory = ({
                     !collapsed && settled && "max-h-[2500px]",
                 )}
             >
-                {renderItems({
-                    items: item?.items ?? [],
-                    path: path,
-                    line: !isHeader,
-                    fromHeader: isHeader,
-                    variant,
-                    onLinkClick,
-                })}
+                {
+                    // if category is collapsed, don't render items for performance reasons
+                    !collapsed &&
+                        renderItems({
+                            items: item?.items ?? [],
+                            path: path,
+                            line: !isHeader,
+                            fromHeader: isHeader,
+                            variant,
+                            onLinkClick,
+                        })
+                }
             </div>
         </div>
     );


### PR DESCRIPTION
On mobile devices, the sidebar tree renders slowly. to fix this issue we disable collapsed items rendering

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
