### PR TITLE
chore: update react-router-dom versions

### DIFF
--- a/examples/access-control-casbin/package.json
+++ b/examples/access-control-casbin/package.json
@@ -27,7 +27,7 @@
     "react": "^18.0.0",
     "react-app-rewired": "^2.2.1",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "typescript": "^4.7.4",
     "@uiw/react-md-editor": "^3.19.5",

--- a/examples/access-control-cerbos/package.json
+++ b/examples/access-control-cerbos/package.json
@@ -14,7 +14,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/antd-audit-log/package.json
+++ b/examples/antd-audit-log/package.json
@@ -15,7 +15,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/audit-log-provider/package.json
+++ b/examples/audit-log-provider/package.json
@@ -15,7 +15,7 @@
     "@refinedev/react-hook-form": "^4.4.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/auth-antd/package.json
+++ b/examples/auth-antd/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/auth-auth0/package.json
+++ b/examples/auth-auth0/package.json
@@ -15,7 +15,7 @@
     "axios": "^0.26.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/auth-chakra-ui/package.json
+++ b/examples/auth-chakra-ui/package.json
@@ -21,7 +21,7 @@
     "@chakra-ui/react": "^2.5.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/auth-google-login/package.json
+++ b/examples/auth-google-login/package.json
@@ -14,7 +14,7 @@
     "axios": "^0.26.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/auth-headless/package.json
+++ b/examples/auth-headless/package.json
@@ -18,7 +18,7 @@
     "@refinedev/simple-rest": "^4.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/auth-keycloak/package.json
+++ b/examples/auth-keycloak/package.json
@@ -16,7 +16,7 @@
     "axios": "^0.26.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/auth-mantine/package.json
+++ b/examples/auth-mantine/package.json
@@ -25,7 +25,7 @@
     "@mantine/notifications": "^5.10.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/auth-material-ui/package.json
+++ b/examples/auth-material-ui/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/auth-otp/package.json
+++ b/examples/auth-otp/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/base-antd/package.json
+++ b/examples/base-antd/package.json
@@ -10,7 +10,7 @@
     "@refinedev/simple-rest": "^4.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "antd": "^5.0.5"
   },

--- a/examples/base-chakra-ui/package.json
+++ b/examples/base-chakra-ui/package.json
@@ -22,7 +22,7 @@
     "@chakra-ui/react": "^2.5.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/base-headless/package.json
+++ b/examples/base-headless/package.json
@@ -15,7 +15,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4"

--- a/examples/base-mantine/package.json
+++ b/examples/base-mantine/package.json
@@ -26,7 +26,7 @@
     "@mantine/notifications": "^5.10.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/base-material-ui/package.json
+++ b/examples/base-material-ui/package.json
@@ -16,7 +16,7 @@
     "@mui/x-data-grid": "^6.6.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/blog-hackathonize/package.json
+++ b/examples/blog-hackathonize/package.json
@@ -18,7 +18,7 @@
     "dayjs": "^1.10.7",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/blog-invoice-generator/package.json
+++ b/examples/blog-invoice-generator/package.json
@@ -19,7 +19,7 @@
     "axios": "^0.26.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-pdf": "^5.7.1",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/blog-issue-tracker/package.json
+++ b/examples/blog-issue-tracker/package.json
@@ -18,7 +18,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/blog-job-posting/package.json
+++ b/examples/blog-job-posting/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/blog-mail-subscription/package.json
+++ b/examples/blog-mail-subscription/package.json
@@ -18,7 +18,7 @@
     "axios": "^0.26.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/blog-material-ui-datagrid/package.json
+++ b/examples/blog-material-ui-datagrid/package.json
@@ -21,7 +21,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "styled-components": "^5.3.3",
     "web-vitals": "^1.1.1"

--- a/examples/blog-material-ui/package.json
+++ b/examples/blog-material-ui/package.json
@@ -9,7 +9,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1",
     "@refinedev/core": "^4.20.0",

--- a/examples/blog-ra-chakra-tutorial/package.json
+++ b/examples/blog-ra-chakra-tutorial/package.json
@@ -23,7 +23,7 @@
     "dayzed": "^3.2.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1"
   },

--- a/examples/blog-react-admin-mantine/package.json
+++ b/examples/blog-react-admin-mantine/package.json
@@ -12,7 +12,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1",
     "@refinedev/strapi-v4": "^5.0.2",

--- a/examples/blog-react-aria/package.json
+++ b/examples/blog-react-aria/package.json
@@ -19,7 +19,7 @@
     "react": "^18.0.0",
     "react-aria": "^0.1.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "web-vitals": "^1.1.1",

--- a/examples/blog-react-dnd/package.json
+++ b/examples/blog-react-dnd/package.json
@@ -20,7 +20,7 @@
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1",
     "antd": "^5.0.5"

--- a/examples/blog-react-hook-dynamic-form/package.json
+++ b/examples/blog-react-hook-dynamic-form/package.json
@@ -20,7 +20,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "web-vitals": "^1.1.1",

--- a/examples/blog-react-toastify/package.json
+++ b/examples/blog-react-toastify/package.json
@@ -18,7 +18,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-i18next": "^11.8.11",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-toastify": "^9.1.3"
   },
   "devDependencies": {

--- a/examples/blog-refeedback/package.json
+++ b/examples/blog-refeedback/package.json
@@ -18,7 +18,7 @@
     "axios": "^0.26.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/blog-refine-airtable-crud/package.json
+++ b/examples/blog-refine-airtable-crud/package.json
@@ -17,7 +17,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1",
     "cross-env": "^7.0.3"

--- a/examples/blog-refine-antd-dynamic-form/package.json
+++ b/examples/blog-refine-antd-dynamic-form/package.json
@@ -15,7 +15,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "web-vitals": "^1.1.1",

--- a/examples/blog-refine-filtering/package.json
+++ b/examples/blog-refine-filtering/package.json
@@ -14,7 +14,7 @@
     "framer-motion": "^7.5.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "web-vitals": "^1.1.1"

--- a/examples/blog-refine-react-hook-form/package.json
+++ b/examples/blog-refine-react-hook-form/package.json
@@ -11,7 +11,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "web-vitals": "^1.1.1",

--- a/examples/blog-refine-supabase-auth/package.json
+++ b/examples/blog-refine-supabase-auth/package.json
@@ -15,7 +15,7 @@
     "react": "^18.0.0",
     "react-daisyui": "^2.4.1",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "tailwindcss": "^3.0.11",
     "web-vitals": "^1.1.1"

--- a/examples/blog-refineflix/package.json
+++ b/examples/blog-refineflix/package.json
@@ -17,7 +17,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/blog-responsive-navbar/package.json
+++ b/examples/blog-responsive-navbar/package.json
@@ -11,7 +11,7 @@
     "react": "^18.0.0",
     "react-bootstrap": "^2.5.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "web-vitals": "^1.1.1"

--- a/examples/blog-win95/package.json
+++ b/examples/blog-win95/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "react95": "^3.11.1",

--- a/examples/calendar-app/package.json
+++ b/examples/calendar-app/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/command-palette-kbar/package.json
+++ b/examples/command-palette-kbar/package.json
@@ -14,7 +14,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/core-use-import/package.json
+++ b/examples/core-use-import/package.json
@@ -12,7 +12,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4"

--- a/examples/core-use-menu/package.json
+++ b/examples/core-use-menu/package.json
@@ -7,7 +7,7 @@
     "@refinedev/cli": "^2.5.5",
     "@refinedev/react-router-v6": "^4.3.2",
     "@refinedev/simple-rest": "^4.5.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@types/node": "^18.16.2",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",

--- a/examples/core-use-modal/package.json
+++ b/examples/core-use-modal/package.json
@@ -12,7 +12,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4"

--- a/examples/core-use-select/package.json
+++ b/examples/core-use-select/package.json
@@ -12,7 +12,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4"

--- a/examples/customization-footer/package.json
+++ b/examples/customization-footer/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/customization-login/package.json
+++ b/examples/customization-login/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/customization-offlayout-area/package.json
+++ b/examples/customization-offlayout-area/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/customization-rtl/package.json
+++ b/examples/customization-rtl/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/customization-sider/package.json
+++ b/examples/customization-sider/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/customization-theme-antd/package.json
+++ b/examples/customization-theme-antd/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/customization-theme-chakra-ui/package.json
+++ b/examples/customization-theme-chakra-ui/package.json
@@ -20,7 +20,7 @@
     "@chakra-ui/react": "^2.5.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/customization-theme-mantine/package.json
+++ b/examples/customization-theme-mantine/package.json
@@ -24,7 +24,7 @@
     "@mantine/notifications": "^5.10.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/customization-theme-material-ui/package.json
+++ b/examples/customization-theme-material-ui/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/customization-top-menu-layout/package.json
+++ b/examples/customization-top-menu-layout/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/data-provider-airtable/package.json
+++ b/examples/data-provider-airtable/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/data-provider-appwrite/package.json
+++ b/examples/data-provider-appwrite/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/data-provider-hasura/package.json
+++ b/examples/data-provider-hasura/package.json
@@ -14,7 +14,7 @@
     "graphql": "^15.6.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/data-provider-multiple/package.json
+++ b/examples/data-provider-multiple/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/data-provider-nestjsx-crud/package.json
+++ b/examples/data-provider-nestjsx-crud/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/data-provider-nhost/package.json
+++ b/examples/data-provider-nhost/package.json
@@ -16,7 +16,7 @@
     "graphql": "^15.6.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/data-provider-strapi-graphql/package.json
+++ b/examples/data-provider-strapi-graphql/package.json
@@ -15,7 +15,7 @@
     "graphql-request": "^5.2.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/data-provider-strapi-v4/package.json
+++ b/examples/data-provider-strapi-v4/package.json
@@ -14,7 +14,7 @@
     "axios": "^0.26.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/data-provider-strapi/package.json
+++ b/examples/data-provider-strapi/package.json
@@ -18,7 +18,7 @@
     "axios": "^0.26.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/data-provider-supabase/package.json
+++ b/examples/data-provider-supabase/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/field-antd-use-checkbox-group/package.json
+++ b/examples/field-antd-use-checkbox-group/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/field-antd-use-radio-group/package.json
+++ b/examples/field-antd-use-radio-group/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/field-antd-use-select-basic/package.json
+++ b/examples/field-antd-use-select-basic/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/field-antd-use-select-infinite/package.json
+++ b/examples/field-antd-use-select-infinite/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/field-material-ui-use-autocomplete/package.json
+++ b/examples/field-material-ui-use-autocomplete/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/finefoods-antd/package.json
+++ b/examples/finefoods-antd/package.json
@@ -31,7 +31,7 @@
     "lodash": "^4.17.21",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-i18next": "^11.8.11",
     "react-input-mask": "^2.0.4",
     "react-scripts": "^5.0.0",

--- a/examples/finefoods-material-ui/package.json
+++ b/examples/finefoods-material-ui/package.json
@@ -30,7 +30,7 @@
     "i18next-xhr-backend": "^3.2.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-i18next": "^11.8.11",
     "react-input-mask": "^2.0.4",
     "@uiw/react-md-editor": "^3.19.5",

--- a/examples/form-antd-custom-validation/package.json
+++ b/examples/form-antd-custom-validation/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/form-antd-mutation-mode/package.json
+++ b/examples/form-antd-mutation-mode/package.json
@@ -14,7 +14,7 @@
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/form-antd-use-drawer-form/package.json
+++ b/examples/form-antd-use-drawer-form/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/form-antd-use-form/package.json
+++ b/examples/form-antd-use-form/package.json
@@ -14,7 +14,7 @@
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/form-antd-use-modal-form/package.json
+++ b/examples/form-antd-use-modal-form/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/form-antd-use-steps-form/package.json
+++ b/examples/form-antd-use-steps-form/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/form-chakra-ui-mutation-mode/package.json
+++ b/examples/form-chakra-ui-mutation-mode/package.json
@@ -22,7 +22,7 @@
     "@chakra-ui/react": "^2.5.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/form-chakra-ui-use-drawer-form/package.json
+++ b/examples/form-chakra-ui-use-drawer-form/package.json
@@ -22,7 +22,7 @@
     "@chakra-ui/react": "^2.5.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/form-chakra-ui-use-form/package.json
+++ b/examples/form-chakra-ui-use-form/package.json
@@ -22,7 +22,7 @@
     "@chakra-ui/react": "^2.5.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/form-chakra-use-modal-form/package.json
+++ b/examples/form-chakra-use-modal-form/package.json
@@ -22,7 +22,7 @@
     "@chakra-ui/react": "^2.5.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/form-core-use-form/package.json
+++ b/examples/form-core-use-form/package.json
@@ -15,7 +15,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4"

--- a/examples/form-mantine-use-drawer-form/package.json
+++ b/examples/form-mantine-use-drawer-form/package.json
@@ -26,7 +26,7 @@
     "@mantine/notifications": "^5.10.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/form-mantine-use-modal-form/package.json
+++ b/examples/form-mantine-use-modal-form/package.json
@@ -26,7 +26,7 @@
     "@mantine/notifications": "^5.10.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/form-mantine-use-steps-form/package.json
+++ b/examples/form-mantine-use-steps-form/package.json
@@ -27,7 +27,7 @@
     "@mantine/notifications": "^5.10.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/form-material-ui-mutation-mode/package.json
+++ b/examples/form-material-ui-mutation-mode/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/form-material-ui-use-drawer-form/package.json
+++ b/examples/form-material-ui-use-drawer-form/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/form-material-ui-use-form/package.json
+++ b/examples/form-material-ui-use-form/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/form-material-ui-use-modal-form/package.json
+++ b/examples/form-material-ui-use-modal-form/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/form-material-ui-use-steps-form/package.json
+++ b/examples/form-material-ui-use-steps-form/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/form-react-hook-form-use-form/package.json
+++ b/examples/form-react-hook-form-use-form/package.json
@@ -14,7 +14,7 @@
     "axios": "^0.26.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4"

--- a/examples/form-react-hook-form-use-modal-form/package.json
+++ b/examples/form-react-hook-form-use-modal-form/package.json
@@ -14,7 +14,7 @@
     "axios": "^0.26.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4"

--- a/examples/form-react-hook-form-use-steps-form/package.json
+++ b/examples/form-react-hook-form-use-steps-form/package.json
@@ -14,7 +14,7 @@
     "axios": "^0.26.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/form-save-and-continue/package.json
+++ b/examples/form-save-and-continue/package.json
@@ -13,7 +13,7 @@
     "axios": "^0.26.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/i18n-react/package.json
+++ b/examples/i18n-react/package.json
@@ -16,7 +16,7 @@
     "i18next-xhr-backend": "^3.2.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-i18next": "^11.8.11",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",

--- a/examples/import-export-antd/package.json
+++ b/examples/import-export-antd/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/import-export-mantine/package.json
+++ b/examples/import-export-mantine/package.json
@@ -23,7 +23,7 @@
     "@mantine/notifications": "^5.10.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/import-export-material-ui/package.json
+++ b/examples/import-export-material-ui/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4"

--- a/examples/inferencer-antd/package.json
+++ b/examples/inferencer-antd/package.json
@@ -14,7 +14,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4"

--- a/examples/inferencer-chakra-ui/package.json
+++ b/examples/inferencer-chakra-ui/package.json
@@ -21,7 +21,7 @@
     "@chakra-ui/react": "^2.5.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/inferencer-graphql-hasura/package.json
+++ b/examples/inferencer-graphql-hasura/package.json
@@ -15,7 +15,7 @@
     "graphql": "^15.6.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/inferencer-headless/package.json
+++ b/examples/inferencer-headless/package.json
@@ -16,7 +16,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4"

--- a/examples/inferencer-mantine/package.json
+++ b/examples/inferencer-mantine/package.json
@@ -25,7 +25,7 @@
     "@mantine/notifications": "^5.10.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/inferencer-material-ui/package.json
+++ b/examples/inferencer-material-ui/package.json
@@ -20,7 +20,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4"

--- a/examples/input-custom/package.json
+++ b/examples/input-custom/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/input-date-picker/package.json
+++ b/examples/input-date-picker/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/live-provider-ably/package.json
+++ b/examples/live-provider-ably/package.json
@@ -14,7 +14,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/mern-dashboard-client/package.json
+++ b/examples/mern-dashboard-client/package.json
@@ -26,7 +26,7 @@
     "react": "^18.0.0",
     "react-apexcharts": "^1.4.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1",
     "react-hook-form": "^7.30.0"

--- a/examples/monorepo-with-lerna-bootstrap/apps/my-refine-app/package.json
+++ b/examples/monorepo-with-lerna-bootstrap/apps/my-refine-app/package.json
@@ -10,7 +10,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-scripts": "^5.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@refinedev/simple-rest": "^4.5.0",
     "@refinedev/antd": "^5.9.0",
     "antd": "^5.0.5",

--- a/examples/monorepo-with-lerna/apps/my-refine-app/package.json
+++ b/examples/monorepo-with-lerna/apps/my-refine-app/package.json
@@ -10,7 +10,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-scripts": "^5.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@refinedev/simple-rest": "^4.5.0",
     "@refinedev/antd": "^5.9.0",
     "antd": "^5.0.5",

--- a/examples/monorepo-with-turbo/apps/my-refine-app/package.json
+++ b/examples/monorepo-with-turbo/apps/my-refine-app/package.json
@@ -10,7 +10,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-scripts": "^5.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@refinedev/simple-rest": "^4.5.0",
     "@refinedev/antd": "^5.9.0",
     "antd": "^5.0.5",

--- a/examples/multi-level-menu/package.json
+++ b/examples/multi-level-menu/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/multi-tenancy-appwrite/package.json
+++ b/examples/multi-tenancy-appwrite/package.json
@@ -17,7 +17,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/multi-tenancy-strapi/package.json
+++ b/examples/multi-tenancy-strapi/package.json
@@ -14,7 +14,7 @@
     "axios": "^0.26.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/new-routing-example/package.json
+++ b/examples/new-routing-example/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/pixels-admin/package.json
+++ b/examples/pixels-admin/package.json
@@ -22,7 +22,7 @@
     "react": "^18.0.0",
     "react-app-rewired": "^2.2.1",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "stream-browserify": "^3.0.0",
     "util": "^0.12.5",

--- a/examples/pixels/package.json
+++ b/examples/pixels/package.json
@@ -15,7 +15,7 @@
     "dotenv": "^16.0.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "web-vitals": "^1.1.1",

--- a/examples/refine-week-invoice-generator/package.json
+++ b/examples/refine-week-invoice-generator/package.json
@@ -17,7 +17,7 @@
     "cross-env": "^7.0.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0"
   },
   "devDependencies": {

--- a/examples/search/package.json
+++ b/examples/search/package.json
@@ -14,7 +14,7 @@
     "lodash": "^4.17.21",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/table-antd-advanced/package.json
+++ b/examples/table-antd-advanced/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/table-antd-table-filter/package.json
+++ b/examples/table-antd-table-filter/package.json
@@ -14,7 +14,7 @@
     "dayjs": "^1.10.7",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/table-antd-use-delete-many/package.json
+++ b/examples/table-antd-use-delete-many/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/table-antd-use-editable-table/package.json
+++ b/examples/table-antd-use-editable-table/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/table-antd-use-table/package.json
+++ b/examples/table-antd-use-table/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/table-antd-use-update-many/package.json
+++ b/examples/table-antd-use-update-many/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/table-chakra-ui-advanced/package.json
+++ b/examples/table-chakra-ui-advanced/package.json
@@ -21,7 +21,7 @@
     "@chakra-ui/react": "^2.5.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/table-chakra-ui-basic/package.json
+++ b/examples/table-chakra-ui-basic/package.json
@@ -21,7 +21,7 @@
     "@chakra-ui/react": "^2.5.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/table-handson/package.json
+++ b/examples/table-handson/package.json
@@ -18,7 +18,7 @@
     "lodash": "^4.17.21",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/table-mantine-advanced/package.json
+++ b/examples/table-mantine-advanced/package.json
@@ -25,7 +25,7 @@
     "@mantine/notifications": "^5.10.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/table-mantine-basic/package.json
+++ b/examples/table-mantine-basic/package.json
@@ -24,7 +24,7 @@
     "@mantine/notifications": "^5.10.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/table-material-ui-advanced/package.json
+++ b/examples/table-material-ui-advanced/package.json
@@ -21,7 +21,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/table-material-ui-cursor-pagination/package.json
+++ b/examples/table-material-ui-cursor-pagination/package.json
@@ -18,7 +18,7 @@
     "axios": "^0.26.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4"

--- a/examples/table-material-ui-data-grid-pro/package.json
+++ b/examples/table-material-ui-data-grid-pro/package.json
@@ -20,7 +20,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/table-material-ui-table-filter/package.json
+++ b/examples/table-material-ui-table-filter/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/table-material-ui-use-data-grid/package.json
+++ b/examples/table-material-ui-use-data-grid/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/table-material-ui-use-delete-many/package.json
+++ b/examples/table-material-ui-use-delete-many/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/table-material-ui-use-update-many/package.json
+++ b/examples/table-material-ui-use-update-many/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/table-react-table-advanced/package.json
+++ b/examples/table-react-table-advanced/package.json
@@ -16,7 +16,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/table-react-table-basic/package.json
+++ b/examples/table-react-table-basic/package.json
@@ -14,7 +14,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/template-antd/package.json
+++ b/examples/template-antd/package.json
@@ -11,7 +11,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1",
     "@refinedev/simple-rest": "^4.5.0",

--- a/examples/template-chakra-ui/package.json
+++ b/examples/template-chakra-ui/package.json
@@ -11,7 +11,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1",
     "@refinedev/simple-rest": "^4.5.0",

--- a/examples/template-headless/package.json
+++ b/examples/template-headless/package.json
@@ -11,7 +11,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1",
     "@refinedev/simple-rest": "^4.5.0",

--- a/examples/template-mantine/package.json
+++ b/examples/template-mantine/package.json
@@ -11,7 +11,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1",
     "@refinedev/simple-rest": "^4.5.0",

--- a/examples/template-material-ui/package.json
+++ b/examples/template-material-ui/package.json
@@ -11,7 +11,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1",
     "@refinedev/simple-rest": "^4.5.0",

--- a/examples/theme-antd-demo/package.json
+++ b/examples/theme-antd-demo/package.json
@@ -10,7 +10,7 @@
     "@refinedev/simple-rest": "^4.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "antd": "^5.0.5",
     "cross-env": "^7.0.3",

--- a/examples/theme-chakra-ui-demo/package.json
+++ b/examples/theme-chakra-ui-demo/package.json
@@ -20,7 +20,7 @@
     "@chakra-ui/react": "^2.5.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/theme-mantine-demo/package.json
+++ b/examples/theme-mantine-demo/package.json
@@ -24,7 +24,7 @@
     "@mantine/notifications": "^5.10.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/theme-material-ui-demo/package.json
+++ b/examples/theme-material-ui-demo/package.json
@@ -16,7 +16,7 @@
     "@mui/x-data-grid": "^6.6.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "react-hook-form": "^7.30.0"
   },

--- a/examples/tutorial-antd/package.json
+++ b/examples/tutorial-antd/package.json
@@ -15,7 +15,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1",
     "antd": "^5.0.5",

--- a/examples/tutorial-chakra-ui/package.json
+++ b/examples/tutorial-chakra-ui/package.json
@@ -11,7 +11,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1",
     "@refinedev/simple-rest": "^4.5.0",

--- a/examples/tutorial-headless/package.json
+++ b/examples/tutorial-headless/package.json
@@ -17,7 +17,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "web-vitals": "^1.1.1"

--- a/examples/tutorial-mantine/package.json
+++ b/examples/tutorial-mantine/package.json
@@ -11,7 +11,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1",
     "@refinedev/simple-rest": "^4.5.0",

--- a/examples/tutorial-material-ui/package.json
+++ b/examples/tutorial-material-ui/package.json
@@ -11,7 +11,7 @@
     "@types/jest": "^29.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1",
     "@refinedev/simple-rest": "^4.5.0",

--- a/examples/upload-antd-base64/package.json
+++ b/examples/upload-antd-base64/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/upload-antd-multipart/package.json
+++ b/examples/upload-antd-multipart/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/upload-chakra-ui-basic64/package.json
+++ b/examples/upload-chakra-ui-basic64/package.json
@@ -21,7 +21,7 @@
     "rc-upload": "^4.3.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/upload-chakra-ui-multipart/package.json
+++ b/examples/upload-chakra-ui-multipart/package.json
@@ -21,7 +21,7 @@
     "rc-upload": "^4.3.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/upload-mantine-base64/package.json
+++ b/examples/upload-mantine-base64/package.json
@@ -25,7 +25,7 @@
     "@mantine/notifications": "^5.10.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/upload-mantine-multipart/package.json
+++ b/examples/upload-mantine-multipart/package.json
@@ -25,7 +25,7 @@
     "@mantine/notifications": "^5.10.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/examples/upload-material-ui-base64/package.json
+++ b/examples/upload-material-ui-base64/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/upload-material-ui-multipart/package.json
+++ b/examples/upload-material-ui-multipart/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/use-infinite-list/package.json
+++ b/examples/use-infinite-list/package.json
@@ -15,7 +15,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4"

--- a/examples/use-modal-antd/package.json
+++ b/examples/use-modal-antd/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/use-simple-list-antd/package.json
+++ b/examples/use-simple-list-antd/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/with-connect/package.json
+++ b/examples/with-connect/package.json
@@ -15,7 +15,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/with-custom-pages/package.json
+++ b/examples/with-custom-pages/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/with-javascript/package.json
+++ b/examples/with-javascript/package.json
@@ -11,7 +11,7 @@
     "cross-env": "^7.0.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "antd": "^5.0.5"

--- a/examples/with-meta-properties/package.json
+++ b/examples/with-meta-properties/package.json
@@ -15,7 +15,7 @@
     "@refinedev/simple-rest": "^4.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "antd": "^5.0.5"
   },
   "devDependencies": {

--- a/examples/with-nx/package.json
+++ b/examples/with-nx/package.json
@@ -16,7 +16,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-scripts": "^5.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@refinedev/simple-rest": "^4.5.0",
     "@refinedev/antd": "^5.22.0",
     "antd": "^5.0.5",

--- a/examples/with-persist-query/package.json
+++ b/examples/with-persist-query/package.json
@@ -17,7 +17,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4",

--- a/examples/with-react-toastify/package.json
+++ b/examples/with-react-toastify/package.json
@@ -15,7 +15,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "react-toastify": "^8.1.0",

--- a/examples/with-storybook-antd/package.json
+++ b/examples/with-storybook-antd/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/examples/with-storybook-material-ui/package.json
+++ b/examples/with-storybook-material-ui/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-scripts": "^5.0.0",
     "cross-env": "^7.0.3",
     "typescript": "^4.7.4"

--- a/examples/with-web3/package.json
+++ b/examples/with-web3/package.json
@@ -16,7 +16,7 @@
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@types/node": "^18.16.2",
     "@uiw/react-md-editor": "^3.19.5",
     "react-scripts": "^5.0.0",

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -41,7 +41,7 @@
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "postcss": "^8.1.4",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "ts-jest": "^29.0.3",
     "tsup": "^6.7.0",
     "typescript": "^4.7.4"

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -39,7 +39,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "ts-jest": "^29.0.3",
     "tsup": "^6.7.0",
     "typescript": "^4.7.4"

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -38,7 +38,7 @@
     "@types/jest": "^29.2.4",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "ts-jest": "^29.0.3",
     "tslib": "^2.3.1",
     "tsup": "^6.7.0"

--- a/packages/inferencer/package.json
+++ b/packages/inferencer/package.json
@@ -176,7 +176,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react-test-renderer": "^18.2.0",
     "ts-jest": "^29.0.3",
     "tsup": "^6.7.0",

--- a/packages/kbar/package.json
+++ b/packages/kbar/package.json
@@ -33,7 +33,7 @@
     "@testing-library/react": "^13.1.1",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "@types/jest": "^29.2.4",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",

--- a/packages/live-previews/package.json
+++ b/packages/live-previews/package.json
@@ -59,7 +59,7 @@
         "next": "13.0.6",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
-        "react-router-dom": "^6.8.1",
+        "react-router-dom": "6.11.2",
         "@aliemir/react-live": "^4.0.0"
     },
     "devDependencies": {

--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -44,7 +44,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "ts-jest": "^29.0.3",
     "tsup": "^6.7.0",
     "typescript": "^4.7.4"

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -45,7 +45,7 @@
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "postcss": "^8.1.4",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "ts-jest": "^29.0.3",
     "tsup": "^6.7.0",
     "typescript": "^4.7.4"

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -35,7 +35,7 @@
     "@types/jest": "^29.2.4",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "ts-jest": "^29.0.3",
     "tslib": "^2.3.1",
     "tsup": "^6.7.0"

--- a/packages/react-router-v6/package.json
+++ b/packages/react-router-v6/package.json
@@ -52,12 +52,12 @@
     "tsup": "^6.7.0"
   },
   "dependencies": {
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "qs": "^6.10.1"
   },
   "peerDependencies": {
     "@refinedev/core": "^4.0.0",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "@types/react": "^17.0.0 || ^18.0.0",

--- a/packages/react-table/package.json
+++ b/packages/react-table/package.json
@@ -33,7 +33,7 @@
     "@types/jest": "^29.2.4",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "ts-jest": "^29.0.3",
     "tslib": "^2.3.1",
     "tsup": "^6.7.0"

--- a/packages/ui-tests/package.json
+++ b/packages/ui-tests/package.json
@@ -28,7 +28,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/testing-library__jest-dom": "^5.14.3",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.11.2",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "ts-jest": "^29.0.3",


### PR DESCRIPTION
Updated `react-router-dom` package versions due to the production breaking issue occurring in `^6.12.0`. This is a temporary fix for live previews therefore there's no changesets included.