### PR TITLE
fix(core): pass resource from props to useExport

### DIFF
--- a/.changeset/perfect-students-knock.md
+++ b/.changeset/perfect-students-knock.md
@@ -1,0 +1,12 @@
+---
+"@refinedev/core": patch
+---
+
+fixed: `useExport`'s `resource` props is not working.
+With this fix, `useExport` will now work with `resource` props.
+
+```ts
+useExport({
+    resource: "users",
+});
+```

--- a/packages/core/src/hooks/export/index.spec.ts
+++ b/packages/core/src/hooks/export/index.spec.ts
@@ -40,25 +40,59 @@ describe("useExport Hook", () => {
         expect(generateCsvMock).toBeCalledWith(posts);
     });
 
-    it("should trigger export correctly with explicit resource configuration", async () => {
-        const { result } = renderHook(
-            () =>
-                useExport({
-                    resource: "posts",
+    it.each(["categories", "posts"])(
+        "should call getList with '%s' resource",
+        async (testCase) => {
+            const getListMock = jest.fn();
+
+            const { result } = renderHook(
+                () =>
+                    useExport({
+                        resource: testCase,
+                    }),
+                {
+                    wrapper: TestWrapper({
+                        dataProvider: {
+                            ...MockJSONServer.default,
+                            getList: (props) => getListMock(props.resource),
+                        },
+                        resources: [{ name: "posts" }, { name: "categories" }],
+                    }),
+                },
+            );
+
+            await act(async () => {
+                await result.current.triggerExport();
+            });
+
+            expect(getListMock).toBeCalledWith(testCase);
+        },
+    );
+
+    it("should call getList with resource from router provider", async () => {
+        const getListMock = jest.fn();
+
+        const { result } = renderHook(() => useExport(), {
+            wrapper: TestWrapper({
+                routerProvider: mockRouterBindings({
+                    resource: {
+                        name: "posts",
+                        list: "/posts",
+                    },
                 }),
-            {
-                wrapper: TestWrapper({
-                    dataProvider: MockJSONServer,
-                    resources: [{ name: "posts" }],
-                }),
-            },
-        );
+                dataProvider: {
+                    ...MockJSONServer.default,
+                    getList: (props) => getListMock(props.resource),
+                },
+                resources: [{ name: "posts" }, { name: "categories" }],
+            }),
+        });
 
         await act(async () => {
             await result.current.triggerExport();
         });
 
-        expect(generateCsvMock).toBeCalledWith(posts);
+        expect(getListMock).toBeCalledWith("posts");
     });
 
     it("should cut the amount of data to be exported when given maxItemCount", async () => {

--- a/packages/core/src/hooks/export/index.ts
+++ b/packages/core/src/hooks/export/index.ts
@@ -111,7 +111,9 @@ export const useExport = <
 
     const dataProvider = useDataProvider();
 
-    const { resource, resources } = useResource();
+    const { resource, resources } = useResource(
+        pickNotDeprecated(resourceFromProps, resourceName),
+    );
 
     const filename = `${userFriendlyResourceName(
         resource?.name,


### PR DESCRIPTION
fixed: `useExport`'s `resource` props is not working.
With this fix, `useExport` will now work with `resource` props.

```ts
useExport({
    resource: "users",
});
```

### Test plan (required)

![image](https://github.com/refinedev/refine/assets/23058882/9c1d9953-5f9d-4c62-9cfa-6ee7b60a894a)

### Closing issues

#4479 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
