### PR TITLE
fix(ui-tests): update header layout tests

### DIFF
--- a/.changeset/calm-waves-smile.md
+++ b/.changeset/calm-waves-smile.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/ui-tests": patch
+---
+
+Updated layout header tests to fallback to `img` in case of `presentation` role is not present.c

--- a/packages/ui-tests/src/tests/layout/header.tsx
+++ b/packages/ui-tests/src/tests/layout/header.tsx
@@ -31,28 +31,38 @@ export const layoutHeaderTests = function (
     describe("[@refinedev/ui-tests] Common Tests / Header Element", () => {
         // NOTE : Will be removed in v5
         it("should render successfull user name and avatar in header with legacy authProvider", async () => {
-            const { findByText, getByRole } = render(<HeaderElement />, {
-                wrapper: TestWrapper({
-                    legacyAuthProvider: mockLegacyAuthProvider,
-                }),
-            });
+            const { findByText, queryByRole, queryByAltText } = render(
+                <HeaderElement />,
+                {
+                    wrapper: TestWrapper({
+                        legacyAuthProvider: mockLegacyAuthProvider,
+                    }),
+                },
+            );
 
             await findByText("username");
-            expect(getByRole("presentation")).toHaveAttribute(
+            const imgByRole = queryByRole("img", { queryFallbacks: true });
+            const imgByAltText = queryByAltText("username");
+            expect(imgByRole ?? imgByAltText).toHaveAttribute(
                 "src",
                 "localhost:3000",
             );
         });
 
         it("should render successfull user name and avatar in header with authProvider", async () => {
-            const { findByText, getByRole } = render(<HeaderElement />, {
-                wrapper: TestWrapper({
-                    authProvider: mockAuthProvider,
-                }),
-            });
+            const { findByText, queryByRole, queryByAltText } = render(
+                <HeaderElement />,
+                {
+                    wrapper: TestWrapper({
+                        authProvider: mockAuthProvider,
+                    }),
+                },
+            );
 
             await findByText("username");
-            expect(getByRole("presentation")).toHaveAttribute(
+            const imgByRole = queryByRole("img", { queryFallbacks: true });
+            const imgByAltText = queryByAltText("username");
+            expect(imgByRole ?? imgByAltText).toHaveAttribute(
                 "src",
                 "localhost:3000",
             );


### PR DESCRIPTION
Updated the common header tests to fallback to `img` role if `presentation` does not exists.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
