### PR TITLE
ci(e2e): cache cypress run results

### DIFF
--- a/.github/workflows/e2e-examples.js
+++ b/.github/workflows/e2e-examples.js
@@ -142,7 +142,7 @@ const waitForServer = async (port) => {
                 waitOnFor(`http://127.0.0.1:${port}`),
             ]);
 
-            resolve(resolvedResource)
+            resolve(resolvedResource);
         } catch (error) {
             if (error) console.log(error);
 
@@ -171,7 +171,7 @@ const waitForClose = (resource) => {
             resolve(false);
         }
     });
-}
+};
 
 const runTests = async () => {
     const examplesToRun = await getProjectsWithE2E();
@@ -253,7 +253,7 @@ const runTests = async () => {
                 const params =
                     "" ??
                     `-- --record --key ${KEY} --ci-build-id=${CI_BUILD_ID}-${path} --group ${CI_BUILD_ID}-${path}`;
-                const runner = `npm run lerna run cypress:run -- --scope ${path} ${params}`;
+                const runner = `npm run test:e2e -- --scope ${path} ${params}`;
 
                 prettyLog("blue", `Running tests for ${path}`);
 

--- a/nx.json
+++ b/nx.json
@@ -6,11 +6,21 @@
         "cacheableOperations": [
           "build",
           "lint",
-          "test"
+          "test",
+          "cypress:run"
         ],
         "accessToken": "NGI2NjNiYWItMWNhYi00MDA4LWI1OTMtM2IwYmFmYzRkMjEzfHJlYWQtd3JpdGU="
       }
     }
+  },
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*"],
+    "ignoreE2E": [
+      "!{projectRoot}/cypress/videos",
+      "!{projectRoot}/cypress/screenshots",
+      "!{projectRoot}/cypress/videos/**/*",
+      "!{projectRoot}/cypress/screenshots/**/*"
+    ]
   },
   "targetDefaults": {
     "build": {
@@ -21,6 +31,16 @@
         "{projectRoot}/dist",
         "{projectRoot}/build",
         "{projectRoot}/.next"
+      ]
+    },
+    "cypress:run": {
+      "inputs": [
+        "default",
+        "ignoreE2E"
+      ],
+      "outputs": [
+        "{projectRoot}/cypress/videos",
+        "{projectRoot}/cypress/screenshots"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test": "lerna run test --stream --scope @refinedev/core",
     "test:all": "lerna run test --stream --scope @refinedev/* --scope create-refine-app",
     "test:coverage": "npm run test --stream -- -- --coverage",
-    "test:all:coverage": "npm run test:all --stream -- -- --coverage"
+    "test:all:coverage": "npm run test:all --stream -- -- --coverage",
+    "test:e2e": "lerna run cypress:run"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
Added Nx caching for e2e tests for faster CI runs.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
