### PR TITLE
fix: `@refinedev/mui` Button text color

### DIFF
--- a/.changeset/pink-pugs-walk.md
+++ b/.changeset/pink-pugs-walk.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mui": patch
+---
+
+fix: `Button` text color on [`RefineThemes`](https://refine.dev/docs/api-reference/mui/theming/#predefined-themes)

--- a/packages/mui/src/theme/index.ts
+++ b/packages/mui/src/theme/index.ts
@@ -82,6 +82,15 @@ const RefineThemes = Object.keys(RefinePalettes).reduce((acc, key) => {
             palette: {
                 ...RefinePalettes[paletteName],
             },
+            components: {
+                MuiButton: {
+                    styleOverrides: {
+                        root: {
+                            color: "#fff",
+                        },
+                    },
+                },
+            },
         }),
     };
 }, {}) as Record<keyof typeof RefinePalettes, Theme>;


### PR DESCRIPTION
Fix `Button` text color on [`RefineThemes`](https://refine.dev/docs/api-reference/mui/theming/#predefined-themes)

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
