### PR TITLE
fix: material-ui `contained` and `primary` button color

### DIFF
--- a/packages/mui/src/theme/index.ts
+++ b/packages/mui/src/theme/index.ts
@@ -85,9 +85,12 @@ const RefineThemes = Object.keys(RefinePalettes).reduce((acc, key) => {
             components: {
                 MuiButton: {
                     styleOverrides: {
-                        root: {
-                            color: "#fff",
-                        },
+                        root: ({ ownerState }) => ({
+                            ...(ownerState.variant === "contained" &&
+                                ownerState.color === "primary" && {
+                                    color: "#fff",
+                                }),
+                        }),
                     },
                 },
             },


### PR DESCRIPTION
Material-ui `contained` and `primary` button color

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
