### PR TITLE
fix(examples): inferencer e2e wait category intercept

### DIFF
--- a/examples/inferencer-antd/cypress/e2e/all.cy.ts
+++ b/examples/inferencer-antd/cypress/e2e/all.cy.ts
@@ -24,6 +24,7 @@ describe("inferencer-antd", () => {
         cy.clearAllLocalStorage();
         cy.clearAllSessionStorage();
 
+        cy.interceptGETCategory();
         cy.interceptGETCategories();
         cy.interceptGETBlogPosts();
         cy.visit(BASE_URL);
@@ -33,7 +34,6 @@ describe("inferencer-antd", () => {
 
     it("should list resource", () => {
         cy.wait("@getBlogPosts");
-        cy.wait("@getCategories");
         cy.getAntdLoadingOverlay().should("not.exist");
 
         cy.url().should("include", "/blog-posts");
@@ -44,7 +44,6 @@ describe("inferencer-antd", () => {
 
     it("should show resource", () => {
         cy.interceptGETBlogPost();
-        cy.interceptGETCategory();
 
         cy.wait("@getBlogPosts");
         cy.wait("@getCategories");

--- a/examples/inferencer-chakra-ui/cypress/e2e/all.cy.ts
+++ b/examples/inferencer-chakra-ui/cypress/e2e/all.cy.ts
@@ -25,6 +25,7 @@ describe("inferencer-chakra-ui", () => {
         cy.clearAllSessionStorage();
 
         cy.interceptGETCategories();
+        cy.interceptGETCategory();
         cy.interceptGETBlogPosts();
         cy.visit(BASE_URL);
 
@@ -33,7 +34,6 @@ describe("inferencer-chakra-ui", () => {
 
     it("should list resource", () => {
         cy.wait("@getBlogPosts");
-        cy.wait("@getCategories");
         cy.getChakraUILoadingOverlay().should("not.exist");
 
         cy.url().should("include", "/blog-posts");

--- a/examples/inferencer-headless/cypress/e2e/all.cy.ts
+++ b/examples/inferencer-headless/cypress/e2e/all.cy.ts
@@ -28,6 +28,7 @@ describe("inferencer-headless", () => {
         cy.clearAllLocalStorage();
         cy.clearAllSessionStorage();
 
+        cy.interceptGETCategory();
         cy.interceptGETCategories();
         cy.interceptGETBlogPosts();
         cy.visit(BASE_URL);
@@ -37,10 +38,8 @@ describe("inferencer-headless", () => {
 
     it("should list resource", () => {
         cy.interceptGETBlogPost();
-        cy.interceptGETCategory();
 
         cy.wait("@getBlogPosts");
-        cy.wait("@getCategories");
         waitForLoading();
 
         cy.url().should("include", "/blog-posts");
@@ -50,7 +49,6 @@ describe("inferencer-headless", () => {
 
     it("should show resource", () => {
         cy.interceptGETBlogPost();
-        cy.interceptGETCategory();
         waitForLoading();
 
         cy.get("td > div > button").contains("Show").first().click();
@@ -78,7 +76,6 @@ describe("inferencer-headless", () => {
 
     it("should create resource", () => {
         cy.interceptPOSTBlogPost();
-        cy.interceptGETCategory();
 
         cy.wait("@getBlogPosts");
         cy.wait("@getCategories");
@@ -122,8 +119,8 @@ describe("inferencer-headless", () => {
         cy.interceptGETBlogPost();
 
         cy.wait("@getBlogPosts");
-        cy.wait("@getCategories");
         waitForLoading();
+        cy.wait("@getCategories");
 
         cy.get("button").contains("Edit").click();
         waitForLoading();

--- a/examples/inferencer-mantine/cypress/e2e/all.cy.ts
+++ b/examples/inferencer-mantine/cypress/e2e/all.cy.ts
@@ -24,6 +24,7 @@ describe("inferencer-mantine", () => {
         cy.clearAllLocalStorage();
         cy.clearAllSessionStorage();
 
+        cy.interceptGETCategory();
         cy.interceptGETCategories();
         cy.interceptGETBlogPosts();
         cy.visit(BASE_URL);
@@ -33,7 +34,6 @@ describe("inferencer-mantine", () => {
 
     it("should list resource", () => {
         cy.wait("@getBlogPosts");
-        cy.wait("@getCategories");
         cy.getMantineLoadingOverlay().should("not.exist");
 
         cy.url().should("include", "/blog-posts");
@@ -44,7 +44,6 @@ describe("inferencer-mantine", () => {
 
     it("should show resource", () => {
         cy.interceptGETBlogPost();
-        cy.interceptGETCategory();
 
         cy.wait("@getBlogPosts");
         cy.wait("@getCategories");

--- a/examples/inferencer-material-ui/cypress/e2e/all.cy.ts
+++ b/examples/inferencer-material-ui/cypress/e2e/all.cy.ts
@@ -24,6 +24,7 @@ describe("inferencer-material-ui", () => {
         cy.clearAllLocalStorage();
         cy.clearAllSessionStorage();
 
+        cy.interceptGETCategory();
         cy.interceptGETCategories();
         cy.interceptGETBlogPosts();
         cy.visit(BASE_URL);
@@ -33,7 +34,6 @@ describe("inferencer-material-ui", () => {
 
     it("should list resource", () => {
         cy.wait("@getBlogPosts");
-        cy.wait("@getCategories");
         cy.getMaterialUILoadingCircular().should("not.exist");
 
         cy.url().should("include", "/blog-posts");
@@ -44,7 +44,6 @@ describe("inferencer-material-ui", () => {
 
     it("should show resource", () => {
         cy.interceptGETBlogPost();
-        cy.interceptGETCategory();
 
         cy.wait("@getBlogPosts");
         cy.wait("@getCategories");


### PR DESCRIPTION
The inferencer tests were not passing because it couldn't find the getCategories intercept. getCategories intercept deleted because it is not needed

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
