### PR TITLE
fix(react-hook-form): unhandled error on submit

### DIFF
--- a/.changeset/tame-parents-behave.md
+++ b/.changeset/tame-parents-behave.md
@@ -1,0 +1,6 @@
+---
+"@refinedev/react-hook-form": patch
+---
+
+fixed: `handleSubmitReactHookForm` now returns a Promise without awaiting it.
+With this change, unhandled errors will propagate to the caller.

--- a/packages/react-hook-form/src/useForm/index.ts
+++ b/packages/react-hook-form/src/useForm/index.ts
@@ -160,7 +160,7 @@ export const useForm = <
     const handleSubmit: UseFormHandleSubmit<TVariables> =
         (onValid, onInvalid) => async (e) => {
             setWarnWhen(false);
-            return await handleSubmitReactHookForm(onValid, onInvalid)(e);
+            return handleSubmitReactHookForm(onValid, onInvalid)(e);
         };
 
     const saveButtonProps = {


### PR DESCRIPTION
fixed: `handleSubmitReactHookForm` now returns a Promise without awaiting it.
With this change, unhandled errors will propagate to the caller.

### Test plan (required)

![image](https://github.com/refinedev/refine/assets/23058882/ef6f8d3e-f0dd-4e8c-9181-fa884d76274e)

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
