### PR TITLE
fix(core): add missing `resource` to `params` in `useCan` calls

### DIFF
--- a/.changeset/great-ducks-pay.md
+++ b/.changeset/great-ducks-pay.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+Added the missing `resource` property in `params` of the `useCan` call, which was leading to missing resource details in the access control checks in the `can` function.
+
+The provided `resource` item is sanitized to remove non-serializable properties such as `icon` etc. If you need such items, you should try to access your `resource` item directly from your defitinions.

--- a/packages/core/src/definitions/helpers/sanitize-resource/index.spec.ts
+++ b/packages/core/src/definitions/helpers/sanitize-resource/index.spec.ts
@@ -43,4 +43,7 @@ describe("sanitizeResource", () => {
             },
         });
     });
+    it("should return undefined if resource is not passed", () => {
+        expect(sanitizeResource()).toEqual(undefined);
+    });
 });

--- a/packages/core/src/definitions/helpers/sanitize-resource/index.ts
+++ b/packages/core/src/definitions/helpers/sanitize-resource/index.ts
@@ -4,8 +4,15 @@ import { IResourceItem } from "../../../interfaces/bindings/resource";
  * Remove all properties that are non-serializable from a resource object.
  */
 export const sanitizeResource = (
-    resource: Partial<IResourceItem> & { children?: unknown },
-): Partial<IResourceItem> => {
+    resource?: Partial<IResourceItem> &
+        Required<Pick<IResourceItem, "name">> & { children?: unknown },
+):
+    | (Partial<IResourceItem> & Required<Pick<IResourceItem, "name">>)
+    | undefined => {
+    if (!resource) {
+        return undefined;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const {
         icon,

--- a/packages/core/src/hooks/accessControl/useCan/index.spec.tsx
+++ b/packages/core/src/hooks/accessControl/useCan/index.spec.tsx
@@ -110,7 +110,10 @@ describe("useCan Hook", () => {
                 useCan({
                     action: "list",
                     resource: "posts",
-                    params: { id: 1, resource: { icon: "test" } as any },
+                    params: {
+                        id: 1,
+                        resource: { icon: "test", name: "posts" } as any,
+                    },
                 }),
             {
                 wrapper: TestWrapper({
@@ -125,6 +128,7 @@ describe("useCan Hook", () => {
             action: "list",
             params: {
                 id: 1,
+                resource: { name: "posts" },
             },
             resource: "posts",
         });

--- a/packages/core/src/hooks/accessControl/useCan/index.ts
+++ b/packages/core/src/hooks/accessControl/useCan/index.ts
@@ -39,7 +39,7 @@ export const useCan = ({
     const { resource: _resource, ...paramsRest } = params ?? {};
 
     /* eslint-disable @typescript-eslint/no-unused-vars */
-    const sanitizedResource = sanitizeResource(_resource ?? {});
+    const sanitizedResource = sanitizeResource(_resource);
 
     /* eslint-enable @typescript-eslint/no-unused-vars */
     const queryResponse = useQuery<CanReturnType>(
@@ -54,8 +54,11 @@ export const useCan = ({
         ],
         // Enabled check for `can` is enough to be sure that it's defined in the query function but TS is not smart enough to know that.
         () =>
-            can?.({ action, resource, params: paramsRest }) ??
-            Promise.resolve({ can: true }),
+            can?.({
+                action,
+                resource,
+                params: { ...paramsRest, resource: sanitizedResource },
+            }) ?? Promise.resolve({ can: true }),
         {
             enabled: typeof can !== "undefined",
             ...queryOptions,

--- a/packages/core/src/hooks/useMeta/index.ts
+++ b/packages/core/src/hooks/useMeta/index.ts
@@ -17,7 +17,7 @@ export const useMeta = () => {
         resource?: IResourceItem;
         meta?: MetaQuery;
     } = {}) => {
-        const { meta } = sanitizeResource(resource ?? {});
+        const { meta } = sanitizeResource(resource) ?? { meta: {} };
 
         // this fields came from the query params and should be removed from the meta because they are not part of the meta.
         const {


### PR DESCRIPTION
Added the missing `resource` value in the `params` of the `useCan` calls. Resource value was sanitized but not passed properly to the `can` function of the `accessControlProvider`.

### Test plan (required)

```sh
Test Suites: 124 passed, 124 total
Tests:       992 passed, 992 total
Snapshots:   18 passed, 18 total
Time:        86.508 s
Ran all test suites.
```

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
