### PR TITLE
docs(blog): add links to blog post item tags list

### DIFF
--- a/documentation/src/components/blog/featured-blog-post-item/index.js
+++ b/documentation/src/components/blog/featured-blog-post-item/index.js
@@ -38,18 +38,20 @@ export const FeaturedBlogPostItem = () => {
             <div className="py-4 md:px-6">
                 <div className="flex gap-1 mb-2">
                     {tags.map((tag) => (
-                        <label
+                        <Link
                             className={clsx(
                                 "text-xs",
                                 "bg-gray-100 dark:bg-gray-700",
-                                "text-gray-600 dark:text-gray-400",
+                                "text-gray-600 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-400",
+                                "no-underline",
                                 "rounded",
                                 "py-1 px-2",
                             )}
+                            href={tag.permalink}
                             key={tag.permalink}
                         >
                             {tag.label}
-                        </label>
+                        </Link>
                     ))}
                 </div>
                 <div className="mb-3">

--- a/documentation/src/theme/BlogPostItem/index.js
+++ b/documentation/src/theme/BlogPostItem/index.js
@@ -40,18 +40,20 @@ export default function BlogPostItem({ className }) {
             <div className="p-3">
                 <div className="flex gap-1 mb-2">
                     {tags.map((tag) => (
-                        <label
+                        <Link
                             className={clsx(
                                 "text-xs",
                                 "bg-gray-100 dark:bg-gray-700",
-                                "text-gray-600 dark:text-gray-400",
+                                "text-gray-600 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-400",
+                                "no-underline",
                                 "rounded",
                                 "p-1",
                             )}
+                            href={tag.permalink}
                             key={tag.permalink}
                         >
                             {tag.label}
-                        </label>
+                        </Link>
                     ))}
                 </div>
                 <div className="mb-3">


### PR DESCRIPTION
Replaced `<label>`s with `<Link>` components to make tags clickable.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
