### PR TITLE
docs: fix live-previews where the `goBack` prop doesn't work

### DIFF
--- a/documentation/docs/api-reference/antd/components/basic-views/create.md
+++ b/documentation/docs/api-reference/antd/components/basic-views/create.md
@@ -253,10 +253,10 @@ To customize the back button or to disable it, you can use the `goBack` property
 
 ```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/create
 const { CreateButton } = RefineAntd;
-import { Button } from "antd";
 
 // visible-block-start
 import { Create } from "@refinedev/antd";
+import { Button } from "antd";
 
 const PostCreate: React.FC = () => {
     const BackButton = () => <Button>←</Button>;
@@ -287,6 +287,32 @@ render(
     />,
 );
 ```
+
+:::caution
+
+If your route has no `:action` parameter or your action is `list`, the back button will not be shown even if you pass a `goBack` property. You can override this behavior by using the `headerProps` property.
+
+```tsx
+/* highlight-next-line */
+import { useBack } from "@refinedev/core";
+import { Create } from "@refinedev/antd";
+import { Button } from "antd";
+
+const PostCreate: React.FC = () => {
+    /* highlight-next-line */
+    const back = useBack();
+    const BackButton = () => <Button>←</Button>;
+
+    return (
+        /* highlight-next-line */
+        <Create goBack={<BackButton />} headerProps={{ onBack: back }}>
+            <p>Rest of your page here</p>
+        </Create>
+    );
+};
+```
+
+:::
 
 ### `isLoading`
 

--- a/documentation/docs/api-reference/antd/components/basic-views/edit.md
+++ b/documentation/docs/api-reference/antd/components/basic-views/edit.md
@@ -619,6 +619,32 @@ render(
 );
 ```
 
+:::caution
+
+If your route has no `:action` parameter or your action is `list`, the back button will not be shown even if you pass a `goBack` property. You can override this behavior by using the `headerProps` property.
+
+```tsx
+/* highlight-next-line */
+import { useBack } from "@refinedev/core";
+import { Edit } from "@refinedev/antd";
+import { Button } from "antd";
+
+const PostEdit: React.FC = () => {
+    /* highlight-next-line */
+    const back = useBack();
+    const BackButton = () => <Button>←</Button>;
+
+    return (
+        /* highlight-next-line */
+        <Edit goBack={<BackButton />} headerProps={{ onBack: back }}>
+            <p>Rest of your page here</p>
+        </Edit>
+    );
+};
+```
+
+:::
+
 ### `isLoading`
 
 To toggle the loading state of the `<Edit/>` component, you can use the `isLoading` property.

--- a/documentation/docs/api-reference/antd/components/basic-views/show.md
+++ b/documentation/docs/api-reference/antd/components/basic-views/show.md
@@ -409,6 +409,32 @@ render(
 );
 ```
 
+:::caution
+
+If your route has no `:action` parameter or your action is `list`, the back button will not be shown even if you pass a `goBack` property. You can override this behavior by using the `headerProps` property.
+
+```tsx
+/* highlight-next-line */
+import { useBack } from "@refinedev/core";
+import { Show } from "@refinedev/antd";
+import { Button } from "antd";
+
+const PostShow: React.FC = () => {
+    /* highlight-next-line */
+    const back = useBack();
+    const BackButton = () => <Button>←</Button>;
+
+    return (
+        /* highlight-next-line */
+        <Show goBack={<BackButton />} headerProps={{ onBack: back }}>
+            <p>Rest of your page here</p>
+        </Show>
+    );
+};
+```
+
+:::
+
 ### `isLoading`
 
 Since `<Show>` uses the Ant Design [`<Card>`](https://ant.design/components/card/) component, the `isLoading` property can be set like the below.

--- a/documentation/docs/api-reference/chakra-ui/components/basic-views/create.md
+++ b/documentation/docs/api-reference/chakra-ui/components/basic-views/create.md
@@ -302,7 +302,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 To customize the back button or to disable it, you can use the `goBack` property. You can pass `false` or `null` to hide the back button.
 
 ```tsx live url=http://localhost:3000/posts/create previewHeight=280px
-setInitialRoutes(["/posts/create"]);
+setInitialRoutes(["/posts", "/posts/create"]);
 import { Refine } from "@refinedev/core";
 import { CreateButton } from "@refinedev/chakra-ui";
 
@@ -310,8 +310,6 @@ import { CreateButton } from "@refinedev/chakra-ui";
 import { Create } from "@refinedev/chakra-ui";
 /* highlight-next-line */
 import { IconMoodSmile } from "@tabler/icons";
-
-console.log("IconMoodSmile", IconMoodSmile);
 
 const PostCreate: React.FC = () => {
     return (

--- a/documentation/docs/api-reference/chakra-ui/components/basic-views/edit.md
+++ b/documentation/docs/api-reference/chakra-ui/components/basic-views/edit.md
@@ -622,7 +622,7 @@ export const App: React.FC = () => {
 To customize the back button or to disable it, you can use the `goBack` property. You can pass `false` or `null` to hide the back button.
 
 ```tsx live url=http://localhost:3000/posts/edit/123 previewHeight=280px
-setInitialRoutes(["/posts/edit/123"]);
+setInitialRoutes(["/posts", "/posts/edit/123"]);
 import { Refine } from "@refinedev/core";
 import { EditButton } from "@refinedev/chakra-ui";
 import routerProvider from "@refinedev/react-router-v6/legacy";

--- a/documentation/docs/api-reference/chakra-ui/components/basic-views/show.md
+++ b/documentation/docs/api-reference/chakra-ui/components/basic-views/show.md
@@ -459,7 +459,7 @@ export const App: React.FC = () => {
 To customize the back button or to disable it, you can use the `goBack` property. You can pass `false` or `null` to hide the back button.
 
 ```tsx live url=http://localhost:3000/posts/show/123 previewHeight=280px
-setInitialRoutes(["/posts", "/posts/edit/123"]);
+setInitialRoutes(["/posts", "/posts/show/123"]);
 import { Refine } from "@refinedev/core";
 import { ShowButton } from "@refinedev/chakra-ui";
 import dataProvider from "@refinedev/simple-rest";

--- a/documentation/docs/api-reference/chakra-ui/components/basic-views/show.md
+++ b/documentation/docs/api-reference/chakra-ui/components/basic-views/show.md
@@ -459,7 +459,7 @@ export const App: React.FC = () => {
 To customize the back button or to disable it, you can use the `goBack` property. You can pass `false` or `null` to hide the back button.
 
 ```tsx live url=http://localhost:3000/posts/show/123 previewHeight=280px
-setInitialRoutes(["/posts/show/123"]);
+setInitialRoutes(["/posts", "/posts/edit/123"]);
 import { Refine } from "@refinedev/core";
 import { ShowButton } from "@refinedev/chakra-ui";
 import dataProvider from "@refinedev/simple-rest";

--- a/documentation/docs/api-reference/mantine/components/basic-views/create.md
+++ b/documentation/docs/api-reference/mantine/components/basic-views/create.md
@@ -309,7 +309,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 To customize the back button or to disable it, you can use the `goBack` property. You can pass `false` or `null` to hide the back button.
 
 ```tsx live url=http://localhost:3000/posts/create previewHeight=280px
-setInitialRoutes(["/posts", "/posts/edit/123"]);
+setInitialRoutes(["/posts", "/posts/create"]);
 import { Refine } from "@refinedev/core";
 import { CreateButton } from "@refinedev/mantine";
 import routerProvider from "@refinedev/react-router-v6/legacy";

--- a/documentation/docs/api-reference/mantine/components/basic-views/create.md
+++ b/documentation/docs/api-reference/mantine/components/basic-views/create.md
@@ -309,7 +309,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 To customize the back button or to disable it, you can use the `goBack` property. You can pass `false` or `null` to hide the back button.
 
 ```tsx live url=http://localhost:3000/posts/create previewHeight=280px
-setInitialRoutes(["/posts/create"]);
+setInitialRoutes(["/posts", "/posts/edit/123"]);
 import { Refine } from "@refinedev/core";
 import { CreateButton } from "@refinedev/mantine";
 import routerProvider from "@refinedev/react-router-v6/legacy";

--- a/documentation/docs/api-reference/mantine/components/basic-views/edit.md
+++ b/documentation/docs/api-reference/mantine/components/basic-views/edit.md
@@ -638,7 +638,7 @@ export const App: React.FC = () => {
 To customize the back button or to disable it, you can use the `goBack` property. You can pass `false` or `null` to hide the back button.
 
 ```tsx live url=http://localhost:3000/posts/edit/123 previewHeight=280px
-setInitialRoutes(["/posts/edit/123"]);
+setInitialRoutes(["/posts", "/posts/edit/123"]);
 import { Refine } from "@refinedev/core";
 import { EditButton } from "@refinedev/mantine";
 import routerProvider from "@refinedev/react-router-v6/legacy";

--- a/documentation/docs/api-reference/mantine/components/basic-views/show.md
+++ b/documentation/docs/api-reference/mantine/components/basic-views/show.md
@@ -461,7 +461,7 @@ export const App: React.FC = () => {
 To customize the back button or to disable it, you can use the `goBack` property. You can pass `false` or `null` to hide the back button.
 
 ```tsx live url=http://localhost:3000/posts/show/123 previewHeight=280px
-setInitialRoutes(["/posts/show/123"]);
+setInitialRoutes(["/posts", "/posts/edit/123"]);
 import { Refine } from "@refinedev/core";
 import { ShowButton } from "@refinedev/mantine";
 import routerProvider from "@refinedev/react-router-v6/legacy";

--- a/documentation/docs/api-reference/mantine/components/basic-views/show.md
+++ b/documentation/docs/api-reference/mantine/components/basic-views/show.md
@@ -461,7 +461,7 @@ export const App: React.FC = () => {
 To customize the back button or to disable it, you can use the `goBack` property. You can pass `false` or `null` to hide the back button.
 
 ```tsx live url=http://localhost:3000/posts/show/123 previewHeight=280px
-setInitialRoutes(["/posts", "/posts/edit/123"]);
+setInitialRoutes(["/posts", "/posts/show/123"]);
 import { Refine } from "@refinedev/core";
 import { ShowButton } from "@refinedev/mantine";
 import routerProvider from "@refinedev/react-router-v6/legacy";

--- a/documentation/docs/api-reference/mui/components/basic-views/create.md
+++ b/documentation/docs/api-reference/mui/components/basic-views/create.md
@@ -271,12 +271,12 @@ To customize the back button or to disable it, you can use the `goBack` property
 // visible-block-start
 import { Create } from "@refinedev/mui";
 import { Button } from "@mui/material";
-import { useBack } from "@refinedev/core";
+import { useNavigation } from "@refinedev/core";
 
 const BackButton = () => {
-    const goBack = useBack();
+    const { goBack } = useNavigation();
 
-    return <Button onClick={() => goBack()}>BACK!</Button>;
+    return <Button onClick={goBack}>BACK!</Button>;
 };
 
 const PostCreate: React.FC = () => {

--- a/documentation/docs/api-reference/mui/components/basic-views/create.md
+++ b/documentation/docs/api-reference/mui/components/basic-views/create.md
@@ -268,13 +268,32 @@ render(
 To customize the back button or to disable it, you can use the `goBack` property.
 
 ```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/create
+import { useNavigation } from "@refinedev/core";
+
+const RealBackButton = () => {
+    const { goBack } = useNavigation();
+
+    return <Button onClick={goBack}>BACK!</Button>;
+};
+
+const RealPostCreate: React.FC = () => {
+    return (
+        <Create
+            // highlight-next-line
+            goBack={<RealBackButton />}
+        >
+            <span>Rest of your page here</span>
+        </Create>
+    );
+};
+
 // visible-block-start
 import { Create } from "@refinedev/mui";
 import { Button } from "@mui/material";
-import { useNavigation } from "@refinedev/core";
+import { useBack } from "@refinedev/core";
 
 const BackButton = () => {
-    const { goBack } = useNavigation();
+    const goBack = useBack();
 
     return <Button onClick={goBack}>BACK!</Button>;
 };
@@ -303,7 +322,7 @@ render(
                         <RefineMui.CreateButton />
                     </div>
                 ),
-                create: PostCreate,
+                create: RealPostCreate,
             },
         ]}
     />,

--- a/documentation/docs/api-reference/mui/components/basic-views/edit.md
+++ b/documentation/docs/api-reference/mui/components/basic-views/edit.md
@@ -596,12 +596,12 @@ To customize the back button or to disable it, you can use the `goBack` property
 // visible-block-start
 import { Edit } from "@refinedev/mui";
 import { Button } from "@mui/material";
-import { useBack } from "@refinedev/core";
+import { useNavigation } from "@refinedev/core";
 
 const BackButton = () => {
-    const goBack = useBack();
+    const { goBack } = useNavigation();
 
-    return <Button onClick={() => goBack()}>BACK!</Button>;
+    return <Button onClick={goBack}>BACK!</Button>;
 };
 
 const PostEdit: React.FC = () => {

--- a/documentation/docs/api-reference/mui/components/basic-views/edit.md
+++ b/documentation/docs/api-reference/mui/components/basic-views/edit.md
@@ -593,13 +593,32 @@ export const App: React.FC = () => {
 To customize the back button or to disable it, you can use the `goBack` property.
 
 ```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/edit/123
+import { useNavigation } from "@refinedev/core";
+
+const RealBackButton = () => {
+    const { goBack } = useNavigation();
+
+    return <Button onClick={goBack}>BACK!</Button>;
+};
+
+const RealPostEdit: React.FC = () => {
+    return (
+        <Edit
+            // highlight-next-line
+            goBack={<RealBackButton />}
+        >
+            <span>Rest of your page here</span>
+        </Edit>
+    );
+};
+
 // visible-block-start
 import { Edit } from "@refinedev/mui";
 import { Button } from "@mui/material";
-import { useNavigation } from "@refinedev/core";
+import { useBack } from "@refinedev/core";
 
 const BackButton = () => {
-    const { goBack } = useNavigation();
+    const goBack = useBack();
 
     return <Button onClick={goBack}>BACK!</Button>;
 };
@@ -628,7 +647,7 @@ render(
                         <RefineMui.EditButton recordItemId={123} />
                     </div>
                 ),
-                edit: PostEdit,
+                edit: RealPostEdit,
             },
         ]}
     />,

--- a/documentation/docs/api-reference/mui/components/basic-views/show.md
+++ b/documentation/docs/api-reference/mui/components/basic-views/show.md
@@ -381,13 +381,33 @@ export const App: React.FC = () => {
 To customize the back button or to disable it, you can use the `goBack` property.
 
 ```tsx live disableScroll previewHeight=280px url=http://localhost:3000/posts/show/123
+import { useNavigation } from "@refinedev/core";
+
+const RealBackButton = () => {
+    const { goBack } = useNavigation();
+
+    return <Button onClick={goBack}>BACK!</Button>;
+};
+
+const RealPostShow: React.FC = () => {
+    return (
+        <Show
+            // highlight-next-line
+            goBack={<RealBackButton />}
+        >
+            <span>Rest of your page here</span>
+        </Show>
+    );
+};
+
+
 // visible-block-start
 import { Show } from "@refinedev/mui";
 import { Button } from "@mui/material";
-import { useNavigation } from "@refinedev/core";
+import { useBack } from "@refinedev/core";
 
 const BackButton = () => {
-    const { goBack } = useNavigation();
+    const goBack = useBack();
 
     return <Button onClick={goBack}>BACK!</Button>;
 };
@@ -416,7 +436,7 @@ render(
                         <RefineMui.ShowButton recordItemId={123} />
                     </div>
                 ),
-                show: PostShow,
+                show: RealPostShow,
             },
         ]}
     />,

--- a/documentation/docs/api-reference/mui/components/basic-views/show.md
+++ b/documentation/docs/api-reference/mui/components/basic-views/show.md
@@ -384,12 +384,12 @@ To customize the back button or to disable it, you can use the `goBack` property
 // visible-block-start
 import { Show } from "@refinedev/mui";
 import { Button } from "@mui/material";
-import { useBack } from "@refinedev/core";
+import { useNavigation } from "@refinedev/core";
 
 const BackButton = () => {
-    const goBack = useBack();
+    const { goBack } = useNavigation();
 
-    return <Button onClick={() => goBack()}>BACK!</Button>;
+    return <Button onClick={goBack}>BACK!</Button>;
 };
 
 const PostShow: React.FC = () => {


### PR DESCRIPTION
Fixed live-previews where the `goBack` prop doesn't work.