### PR TITLE
fix(inferencer): skip relation when field has fieldable properties

### DIFF
--- a/.changeset/loud-bears-yell.md
+++ b/.changeset/loud-bears-yell.md
@@ -1,0 +1,26 @@
+---
+"@refinedev/inferencer": patch
+---
+
+Updated inferencer functions to check for relational fields with representable values. If the inferencer type is `show` or `list`, the inferencer will use the available properties to show the field instead of trying to fetch the relational data.
+
+```tsx
+// posts/1
+{
+    id: 1,
+    name: "Post 1",
+    tags: [
+        {
+            id: 5,
+            name: "Tag 5"
+        },
+        {
+            id: 6,
+            name: "Tag 6"
+        }
+    ],
+    content: "...",
+}
+```
+
+Above structure will show the `tags` field in list and show inferencers using the `name` property instead of trying to fetch the relational data. But `edit` and `create` inferencers will still work with the relational data.

--- a/packages/inferencer/src/compose-inferencers/index.test.ts
+++ b/packages/inferencer/src/compose-inferencers/index.test.ts
@@ -12,7 +12,7 @@ describe("composeInferencers", () => {
             inferencer3,
         ]);
 
-        composedInferencer("key", "value", {}, composedInferencer);
+        composedInferencer("key", "value", {}, composedInferencer, "list");
 
         expect(inferencer1).toHaveBeenCalled();
         expect(inferencer2).toHaveBeenCalled();
@@ -23,18 +23,21 @@ describe("composeInferencers", () => {
             "value",
             {},
             composedInferencer,
+            "list",
         );
         expect(inferencer2).toHaveBeenCalledWith(
             "key",
             "value",
             {},
             composedInferencer,
+            "list",
         );
         expect(inferencer3).toHaveBeenCalledWith(
             "key",
             "value",
             {},
             composedInferencer,
+            "list",
         );
     });
 });

--- a/packages/inferencer/src/compose-inferencers/index.ts
+++ b/packages/inferencer/src/compose-inferencers/index.ts
@@ -13,9 +13,10 @@ export const composeInferencers = (
         value,
         record,
         infer = fieldInferencer,
+        type,
     ) => {
         const inferences = inferencers.map((inferencer) =>
-            inferencer(key, value, record, infer),
+            inferencer(key, value, record, infer, type),
         );
         const picked = pickInferredField(inferences);
 

--- a/packages/inferencer/src/compose-transformers/index.test.ts
+++ b/packages/inferencer/src/compose-transformers/index.test.ts
@@ -14,7 +14,7 @@ describe("composeTransformers", () => {
             transformer3,
         ]);
 
-        composedTransformer([], [], { name: "test" }, {}, inferencer);
+        composedTransformer([], [], { name: "test" }, {}, inferencer, "list");
 
         expect(transformer1).toHaveBeenCalled();
         expect(transformer2).toHaveBeenCalled();

--- a/packages/inferencer/src/compose-transformers/index.ts
+++ b/packages/inferencer/src/compose-transformers/index.ts
@@ -13,9 +13,10 @@ export const composeTransformers = (
         resource,
         record,
         infer,
+        type,
     ) => {
         return transformers.reduce((acc, transformer) => {
-            return transformer(acc, resources, resource, record, infer);
+            return transformer(acc, resources, resource, record, infer, type);
         }, fields);
     };
 

--- a/packages/inferencer/src/create-inferencer/index.tsx
+++ b/packages/inferencer/src/create-inferencer/index.tsx
@@ -84,7 +84,7 @@ export const createInferencer: CreateInferencer = ({
             value: any,
             record: Record<string, unknown>,
         ) => {
-            const inferResult = infer(key, value, record, infer);
+            const inferResult = infer(key, value, record, infer, type);
 
             if (inferResult) {
                 if (resource) {
@@ -94,6 +94,7 @@ export const createInferencer: CreateInferencer = ({
                         resource,
                         record,
                         infer,
+                        type,
                     );
 
                     const customTransformedFields = fieldTransformer
@@ -200,7 +201,13 @@ export const createInferencer: CreateInferencer = ({
                     .map((key) => {
                         const value = record[key];
 
-                        const inferResult = infer(key, value, record, infer);
+                        const inferResult = infer(
+                            key,
+                            value,
+                            record,
+                            infer,
+                            type,
+                        );
 
                         return inferResult;
                     })
@@ -213,6 +220,7 @@ export const createInferencer: CreateInferencer = ({
                         resource,
                         record,
                         infer,
+                        type,
                     );
 
                     const customTransformedFields = fieldTransformer

--- a/packages/inferencer/src/field-inferencers/array.ts
+++ b/packages/inferencer/src/field-inferencers/array.ts
@@ -1,6 +1,12 @@
 import { FieldInferencer, InferType } from "../types";
 
-export const arrayInfer: FieldInferencer = (key, value, record, infer) => {
+export const arrayInfer: FieldInferencer = (
+    key,
+    value,
+    record,
+    infer,
+    type,
+) => {
     const isArray = Array.isArray(value);
     const isBasicArray =
         Array.isArray(value) &&
@@ -8,7 +14,7 @@ export const arrayInfer: FieldInferencer = (key, value, record, infer) => {
 
     if (isArray) {
         if (!isBasicArray) {
-            const inferredInnerType = infer(key, value[0], record, infer);
+            const inferredInnerType = infer(key, value[0], record, infer, type);
             if (inferredInnerType) {
                 return {
                     ...inferredInnerType,
@@ -20,7 +26,7 @@ export const arrayInfer: FieldInferencer = (key, value, record, infer) => {
                 return false;
             }
         }
-        const basicType = infer(key, value[0], record, infer) || {
+        const basicType = infer(key, value[0], record, infer, type) || {
             type: "string" as InferType,
         };
 

--- a/packages/inferencer/src/field-inferencers/object.ts
+++ b/packages/inferencer/src/field-inferencers/object.ts
@@ -3,7 +3,13 @@ import { FieldInferencer } from "../types";
 
 const idPropertyRegexp = /id$/i;
 
-export const objectInfer: FieldInferencer = (key, value, record, infer) => {
+export const objectInfer: FieldInferencer = (
+    key,
+    value,
+    record,
+    infer,
+    type,
+) => {
     const isNotNull = value !== null;
     const isNotArray = !Array.isArray(value);
     const isObject = typeof value === "object";
@@ -13,7 +19,11 @@ export const objectInfer: FieldInferencer = (key, value, record, infer) => {
             Object.keys(value).length === 1 &&
             idPropertyRegexp.test(Object.keys(value)[0]);
 
-        if (onlyHasId) {
+        const hasAnyId = Object.keys(value).some((k) =>
+            idPropertyRegexp.test(k),
+        );
+
+        if (onlyHasId || ((type === "create" || type === "edit") && hasAnyId)) {
             return {
                 key,
                 type: "relation",
@@ -43,6 +53,7 @@ export const objectInfer: FieldInferencer = (key, value, record, infer) => {
                 (value as Record<string, unknown>)[innerFieldKey],
                 value as Record<string, unknown>,
                 infer,
+                type,
             );
 
             if (innerFieldType) {

--- a/packages/inferencer/src/field-inferencers/object.ts
+++ b/packages/inferencer/src/field-inferencers/object.ts
@@ -19,11 +19,9 @@ export const objectInfer: FieldInferencer = (
             Object.keys(value).length === 1 &&
             idPropertyRegexp.test(Object.keys(value)[0]);
 
-        const hasAnyId = Object.keys(value).some((k) =>
-            idPropertyRegexp.test(k),
-        );
+        const hasId = Object.keys(value).some((k) => idPropertyRegexp.test(k));
 
-        if (onlyHasId || ((type === "create" || type === "edit") && hasAnyId)) {
+        if (onlyHasId) {
             return {
                 key,
                 type: "relation",
@@ -74,6 +72,20 @@ export const objectInfer: FieldInferencer = (
                         ? `${fieldableKeys}.${innerFieldType.accessor[0]}`
                         : `${fieldableKeys}.${innerFieldType.accessor}`
                     : fieldableKeys;
+
+                if (
+                    innerFieldType?.type === "text" &&
+                    (type === "create" || type === "edit") &&
+                    hasId
+                ) {
+                    return {
+                        key,
+                        type: "relation",
+                        relation: true,
+                        accessor: "id",
+                        priority: 1,
+                    };
+                }
 
                 return {
                     ...innerFieldType,

--- a/packages/inferencer/src/field-transformers/relation-to-fieldable.ts
+++ b/packages/inferencer/src/field-transformers/relation-to-fieldable.ts
@@ -6,6 +6,7 @@ export const relationToFieldable: FieldTransformer = (
     resource,
     record,
     infer,
+    type,
 ) => {
     const mapped: Array<InferField> = fields.map((field) => {
         if (field.relation && field.type === "relation" && !field.resource) {
@@ -13,7 +14,7 @@ export const relationToFieldable: FieldTransformer = (
                 ? (record[field.key] as any)[field.accessor as string]
                 : record[field.key];
 
-            const inferredType = infer(field.key, value, record, infer);
+            const inferredType = infer(field.key, value, record, infer, type);
 
             if (inferredType && inferredType.type !== "relation") {
                 return {

--- a/packages/inferencer/src/types/index.ts
+++ b/packages/inferencer/src/types/index.ts
@@ -44,6 +44,7 @@ export type FieldInferencer = (
     value: unknown,
     record: Record<string, unknown>,
     infer: FieldInferencer,
+    type?: "list" | "show" | "edit" | "create",
 ) => InferField | null | false;
 
 export type FieldTransformer = (
@@ -52,6 +53,7 @@ export type FieldTransformer = (
     resource: IResourceItem,
     record: Record<string, unknown>,
     infer: FieldInferencer,
+    type: "list" | "show" | "edit" | "create",
 ) => Array<InferField>;
 
 export type RecordField = {


### PR DESCRIPTION
Updated inferencer functions to check for relational fields with representable values. If the inferencer type is `show` or `list`, the inferencer will use the available properties to show the field instead of trying to fetch the relational data.

```tsx
// posts/1
{
    id: 1,
    name: "Post 1",
    tags: [
        {
            id: 5,
            name: "Tag 5"
        },
        {
            id: 6,
            name: "Tag 6"
        }
    ],
    content: "...",
}
```

Above structure will show the `tags` field in list and show inferencers using the `name` property instead of trying to fetch the relational data. But `edit` and `create` inferencers will still work with the relational data.

### Closing issues

Resolves #4575 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
