### PR TITLE
Fix Astro.js iteration expression in blog post on Astro.js

### DIFF
--- a/documentation/blog/2023-06-12-astro-js.md
+++ b/documentation/blog/2023-06-12-astro-js.md
@@ -473,14 +473,15 @@ Another approach to fetching data in Astro.js involves using serverless function
 ```tsx
 ---
 import { getPosts } from '../lib/posts';
+const posts = getPosts();
 ---
 
-{#each getPosts() as post}
+{posts.map((post) => (
   <div>
     <h2>{post.title}</h2>
     <p>{post.body}</p>
   </div>
-{/each}
+))}
 ```
 
 Once we have fetched the required data, Astro.js empowers us to seamlessly integrate it into your templates and components, enabling dynamic rendering and data-driven UIs.


### PR DESCRIPTION
[The blog post ](https://refine.dev/blog/astro-js-guide/#installation-and-setup)provides incorrect syntax, not related to Astrojs.