### PR TITLE
fix(mantine): notification description does not work

### DIFF
--- a/.changeset/long-zoos-decide.md
+++ b/.changeset/long-zoos-decide.md
@@ -1,0 +1,18 @@
+---
+"@refinedev/mantine": patch
+---
+
+fixed: `description` prop does not show up in Mantine notification.
+With this fix, you can now use `description` prop to show a description in the notification.
+
+```tsx
+import { useNotification } from "@refinedev/core";
+
+const { open } = useNotification();
+
+open?.({
+    description: "This is a description",
+    message: "This is a message",
+    type: "progress",
+});
+```

--- a/packages/mantine/src/providers/notificationProvider.tsx
+++ b/packages/mantine/src/providers/notificationProvider.tsx
@@ -5,7 +5,7 @@ import {
     updateNotification,
     hideNotification,
 } from "@mantine/notifications";
-import { ActionIcon, Group, Text } from "@mantine/core";
+import { ActionIcon, Box, Group, Text } from "@mantine/core";
 import { IconCheck, IconRotate2, IconX } from "@tabler/icons";
 
 import { RingCountdown } from "@components";
@@ -36,7 +36,14 @@ export const notificationProvider = (): NotificationProvider => {
     };
 
     const notificationProvider: NotificationProvider = {
-        open: ({ message, type, undoableTimeout, key, cancelMutation }) => {
+        open: ({
+            message,
+            description,
+            type,
+            undoableTimeout,
+            key,
+            cancelMutation,
+        }) => {
             if (type === "progress") {
                 if (isNotificationActive(key)) {
                     updateNotification({
@@ -47,7 +54,12 @@ export const notificationProvider = (): NotificationProvider => {
                                     <RingCountdown
                                         undoableTimeout={undoableTimeout ?? 0}
                                     />
-                                    <Text>{message}</Text>
+                                    <Box>
+                                        <Text>{message}</Text>
+                                        {description && (
+                                            <Text>{description}</Text>
+                                        )}
+                                    </Box>
                                 </Group>
                                 <ActionIcon
                                     variant="default"
@@ -84,7 +96,12 @@ export const notificationProvider = (): NotificationProvider => {
                                     <RingCountdown
                                         undoableTimeout={undoableTimeout ?? 0}
                                     />
-                                    <Text>{message}</Text>
+                                    <Box>
+                                        <Text>{message}</Text>
+                                        {description && (
+                                            <Text>{description}</Text>
+                                        )}
+                                    </Box>
                                 </Group>
                                 <ActionIcon
                                     variant="default"
@@ -100,6 +117,7 @@ export const notificationProvider = (): NotificationProvider => {
                                 </ActionIcon>
                             </Group>
                         ),
+
                         styles: {
                             root: {
                                 paddingLeft: "8px",
@@ -124,6 +142,7 @@ export const notificationProvider = (): NotificationProvider => {
                                 <IconX size={18} />
                             ),
                         message,
+                        title: description,
                         autoClose: 5000,
                     });
                 } else {
@@ -137,6 +156,7 @@ export const notificationProvider = (): NotificationProvider => {
                                 <IconX size={18} />
                             ),
                         message,
+                        title: description,
                         onClose: () => {
                             removeNotification(key);
                         },


### PR DESCRIPTION
fixed: `description` prop does not show up in Mantine notification.
With this fix, you can now use `description` prop to show a description in the notification.

```tsx
import { useNotification } from "@refinedev/core";

const { open } = useNotification();

open?.({
    description: "This is a description",
    message: "This is a message",
    type: "progress",
});
```

![image](https://github.com/refinedev/refine/assets/23058882/374e528a-e5a5-4925-a134-0fa7da79b1ee)

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
