### PR TITLE
test: fix "antd-use-table" e2e test issues

### DIFF
--- a/examples/table-antd-use-table/cypress/e2e/all.cy.ts
+++ b/examples/table-antd-use-table/cypress/e2e/all.cy.ts
@@ -102,17 +102,10 @@ describe("table-antd-use-table", () => {
     });
 
     it("should work with pagination", () => {
+        cy.interceptGETPosts();
+        cy.wait("@getPosts");
+
         cy.getAntdLoadingOverlay().should("not.exist");
-
-        //clear category filters
-        cy.getAntdFilterTrigger(1).click();
-        cy.contains("Clear").click();
-        cy.contains("Filter").click();
-
-        //clear status filters
-        cy.getAntdFilterTrigger(2).click();
-        cy.get(".ant-btn-dangerous").eq(1).click();
-        cy.get(".ant-btn-primary").eq(1).click();
 
         cy.intercept(
             {
@@ -154,17 +147,10 @@ describe("table-antd-use-table", () => {
     });
 
     it("should set current `1` when filter changed", () => {
+        cy.interceptGETPosts();
+        cy.wait("@getPosts");
+
         cy.getAntdLoadingOverlay().should("not.exist");
-
-        //clear category filters
-        cy.getAntdFilterTrigger(1).click();
-        cy.contains("Clear").click();
-        cy.contains("Filter").click();
-
-        //clear status filters
-        cy.getAntdFilterTrigger(2).click();
-        cy.get(".ant-btn-dangerous").eq(1).click();
-        cy.get(".ant-btn-primary").eq(1).click();
 
         cy.getAntdPaginationItem(2).click();
 
@@ -172,7 +158,7 @@ describe("table-antd-use-table", () => {
 
         cy.get(".ant-input").type("lorem");
 
-        cy.get(".ant-btn-primary").eq(2).click();
+        cy.get(".ant-btn-primary").click();
 
         cy.url().should("include", "current=1");
     });

--- a/examples/table-antd-use-table/cypress/e2e/all.cy.ts
+++ b/examples/table-antd-use-table/cypress/e2e/all.cy.ts
@@ -104,6 +104,16 @@ describe("table-antd-use-table", () => {
     it("should work with pagination", () => {
         cy.getAntdLoadingOverlay().should("not.exist");
 
+        //clear category filters
+        cy.getAntdFilterTrigger(1).click();
+        cy.contains("Clear").click();
+        cy.contains("Filter").click();
+
+        //clear status filters
+        cy.getAntdFilterTrigger(2).click();
+        cy.get(".ant-btn-dangerous").eq(1).click();
+        cy.get(".ant-btn-primary").eq(1).click();
+
         cy.intercept(
             {
                 url: "/posts*",
@@ -146,13 +156,23 @@ describe("table-antd-use-table", () => {
     it("should set current `1` when filter changed", () => {
         cy.getAntdLoadingOverlay().should("not.exist");
 
+        //clear category filters
+        cy.getAntdFilterTrigger(1).click();
+        cy.contains("Clear").click();
+        cy.contains("Filter").click();
+
+        //clear status filters
+        cy.getAntdFilterTrigger(2).click();
+        cy.get(".ant-btn-dangerous").eq(1).click();
+        cy.get(".ant-btn-primary").eq(1).click();
+
         cy.getAntdPaginationItem(2).click();
 
         cy.getAntdFilterTrigger(0).click();
 
         cy.get(".ant-input").type("lorem");
 
-        cy.get(".ant-btn-primary").click();
+        cy.get(".ant-btn-primary").eq(2).click();
 
         cy.url().should("include", "current=1");
     });


### PR DESCRIPTION
Sometimes the test will fail because the table data is not enough to paginate, so I clear the table filter before test cases.