### PR TITLE
fix(docs): blog page tag overflow

### DIFF
--- a/documentation/src/components/blog/featured-blog-post-item/index.js
+++ b/documentation/src/components/blog/featured-blog-post-item/index.js
@@ -36,7 +36,12 @@ export const FeaturedBlogPostItem = () => {
                 </div>
             </Link>
             <div className="px-4 py-4 md:px-6  md:py-6">
-                <div className="mb-2 flex gap-1 md:mb-4 2xl:mb-6">
+                <div
+                    className={clsx(
+                        "mb-2 gap-1 md:mb-4 2xl:mb-6",
+                        "flex items-center flex-wrap",
+                    )}
+                >
                     {tags.map((tag) => (
                         <Link
                             className={clsx(

--- a/documentation/src/theme/BlogPostItem/index.js
+++ b/documentation/src/theme/BlogPostItem/index.js
@@ -38,7 +38,12 @@ export default function BlogPostItem({ className }) {
                 </Link>
             </div>
             <div className="p-4">
-                <div className="mb-2 flex gap-1 md:mb-4">
+                <div
+                    className={clsx(
+                        "mb-2 flex gap-1 md:mb-4",
+                        "flex items-center flex-wrap",
+                    )}
+                >
                     {tags.map((tag) => (
                         <Link
                             className={clsx(


### PR DESCRIPTION
before:
![Pasted Graphic 1](https://github.com/refinedev/refine/assets/23058882/a8f8bf8f-cd0e-4952-a39c-1d27d0ca15e0)

after:
![Pasted Graphic](https://github.com/refinedev/refine/assets/23058882/4e902096-12e7-41b8-8b6c-d067d9538ec4)


Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
