### PR TITLE
fix(docs): about page team members image align

### DIFF
--- a/documentation/src/pages/about/index.tsx
+++ b/documentation/src/pages/about/index.tsx
@@ -320,13 +320,13 @@ const About: React.FC = () => {
                         {team.map(({ name, avatar, role1, role2 }) => (
                             <div
                                 key={name}
-                                className="flex justify-start flex-col text-center"
+                                className="flex justify-start flex-col text-center not-prose"
                             >
                                 <img
                                     srcSet={`${avatar} 1500w`}
                                     src={avatar}
                                     alt={name}
-                                    className="w-full not-prose m-0 mb-6"
+                                    className="w-full m-0 mb-6"
                                 />
                                 <span
                                     className={clsx(
@@ -361,7 +361,10 @@ const About: React.FC = () => {
                         ))}
                         <div
                             className={clsx(
-                                "flex flex-col justify-between text-center lg:justify-start",
+                                "flex",
+                                "flex-col",
+                                "justify-between lg:justify-start",
+                                "text-center",
                             )}
                         >
                             <div className="w-full not-prose m-0">


### PR DESCRIPTION
fixed: `not-prose`class moved to parent otherwise it doesn't work. with that fix child's default classes are removed.

preview: https://64b7efd4dbe8441bc27fdfd8--refine-doc-preview.netlify.app/about/

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
