### PR TITLE
fix(docs): @vitejs/plugin-react was missing for some ant design hooks

### DIFF
--- a/examples/form-antd-use-drawer-form/package.json
+++ b/examples/form-antd-use-drawer-form/package.json
@@ -18,6 +18,7 @@
     "@types/node": "^18.16.2",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
     "typescript": "^4.7.4",
     "vite": "^4.3.1",
     "cypress": "^12.11.0"

--- a/examples/form-antd-use-form/package.json
+++ b/examples/form-antd-use-form/package.json
@@ -18,6 +18,7 @@
     "@types/node": "^18.16.2",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
     "typescript": "^4.7.4",
     "vite": "^4.3.1",
     "cypress": "^12.11.0"

--- a/examples/form-antd-use-modal-form/package.json
+++ b/examples/form-antd-use-modal-form/package.json
@@ -20,6 +20,7 @@
     "@types/node": "^18.16.2",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
     "typescript": "^4.7.4",
     "vite": "^4.3.1",
     "cypress": "^12.11.0"

--- a/examples/form-antd-use-steps-form/package.json
+++ b/examples/form-antd-use-steps-form/package.json
@@ -18,6 +18,7 @@
     "@types/node": "^18.16.2",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
     "typescript": "^4.7.4",
     "vite": "^4.3.1",
     "cypress": "^12.11.0"


### PR DESCRIPTION
### Documentation issue

There are build problems for Codesandbox examples of the hooks below

- [useDrawerForm](https://refine.dev/docs/api-reference/antd/hooks/form/useDrawerForm/#example)
- [useForm](https://refine.dev/docs/api-reference/antd/hooks/form/useForm/#example)
- [useModalForm](https://refine.dev/docs/api-reference/antd/hooks/form/useModalForm/#example)
- [useStepsForm](https://refine.dev/docs/api-reference/antd/hooks/form/useStepsForm/#example)

The error is `Error: Cannot find module '@vitejs/plugin-react'`

### Closing issues

closes #4699 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
