### PR TITLE
chore: bump superplate-cli version for create-refine-app

### DIFF
--- a/.changeset/empty-icons-battle.md
+++ b/.changeset/empty-icons-battle.md
@@ -1,0 +1,5 @@
+---
+"create-refine-app": patch
+---
+
+chore: bump superplate-cli version to 1.17.3

--- a/packages/create-refine-app/package.json
+++ b/packages/create-refine-app/package.json
@@ -30,7 +30,7 @@
     "tslib": "^2.3.1",
     "commander": "9.4.1",
     "execa": "^5.1.1",
-    "superplate-cli": "^1.17.2",
+    "superplate-cli": "^1.17.3",
     "got": "^11.8.5",
     "chalk": "^4.1.2",
     "ora": "^5.4.1",


### PR DESCRIPTION
bump `superplate-cli` version to `1.17.3`