### PR TITLE
docs: correct symbol for date picker

### DIFF
--- a/documentation/blog/2023-05-03-react-date-picker.md
+++ b/documentation/blog/2023-05-03-react-date-picker.md
@@ -46,7 +46,7 @@ import DatePicker from 'react-datepicker'
 You also need to import CSS styles to display elements in all their beauty.
 
 ```tsx
-import 'react-datepicker/dist/react-datepicker.css’
+import 'react-datepicker/dist/react-datepicker.css'
 ```
 
 ### Create a basic date picker


### PR DESCRIPTION
 fixed the following:
 
![image](https://github.com/refinedev/refine/assets/91601706/eefde19c-184c-4115-b544-cabf1017810c)

To: 

![image](https://github.com/refinedev/refine/assets/91601706/472c73b5-78e7-442e-80f4-800ce75f5652)



### Closing issues

Closes issue #4702 

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
