### PR TITLE
fix(docs): blog post image overflow

### DIFF
--- a/documentation/src/components/blog/featured-blog-post-item/index.js
+++ b/documentation/src/components/blog/featured-blog-post-item/index.js
@@ -23,14 +23,14 @@ export const FeaturedBlogPostItem = () => {
     return (
         <BlogPostItemContainer>
             <Link itemProp="url" to={permalink}>
-                <div className="relative m-0 h-40 md:h-64 hover:brightness-90">
+                <div className="not-prose relative m-0 h-40 hover:brightness-90 md:h-64">
                     <img
                         src={`https://refine-web.imgix.net${frontMatter.image?.replace(
                             "https://refine.ams3.cdn.digitaloceanspaces.com",
                             "",
                         )}?h=256`}
                         alt={title}
-                        className="absolute inset-0 h-full w-full rounded-[10px] object-cover mt-0"
+                        className="absolute inset-0 mt-0 h-full w-full rounded-[10px] object-cover"
                         loading="lazy"
                     />
                 </div>
@@ -39,7 +39,7 @@ export const FeaturedBlogPostItem = () => {
                 <div
                     className={clsx(
                         "mb-2 gap-1 md:mb-4 2xl:mb-6",
-                        "flex items-center flex-wrap",
+                        "flex flex-wrap items-center",
                     )}
                 >
                     {tags.map((tag) => (
@@ -104,7 +104,7 @@ export const FeaturedBlogPostItem = () => {
                     </Link>
                     <span
                         className={clsx(
-                            "w-[4px] h-[4px] rounded-full",
+                            "h-[4px] w-[4px] rounded-full",
                             "bg-gray-600 dark:bg-gray-500",
                         )}
                     ></span>

--- a/documentation/src/theme/BlogPostItem/index.js
+++ b/documentation/src/theme/BlogPostItem/index.js
@@ -24,14 +24,14 @@ export default function BlogPostItem({ className }) {
         <BlogPostItemContainer className={className}>
             <div>
                 <Link itemProp="url" to={permalink}>
-                    <div className="relative m-0 h-40 hover:brightness-90">
+                    <div className="not-prose relative m-0 h-40 hover:brightness-90">
                         <img
                             src={`https://refine-web.imgix.net${frontMatter.image?.replace(
                                 "https://refine.ams3.cdn.digitaloceanspaces.com",
                                 "",
                             )}?h=160`}
                             alt={title}
-                            className="absolute inset-0 h-full w-full rounded-[10px] object-cover transition duration-150 mt-0"
+                            className="absolute inset-0 mt-0 h-full w-full rounded-[10px] object-cover transition duration-150"
                             loading="lazy"
                         />
                     </div>
@@ -41,7 +41,7 @@ export default function BlogPostItem({ className }) {
                 <div
                     className={clsx(
                         "mb-2 flex gap-1 md:mb-4",
-                        "flex items-center flex-wrap",
+                        "flex flex-wrap items-center",
                     )}
                 >
                     {tags.map((tag) => (


### PR DESCRIPTION
`refine-prose` class giving default margin to img elements. (it works only in production).
This causes an overflow problem on a blog item. 

```css
@media (min-width: 1536px)
.refine-prose :where(img):not(:where([class~=not-prose] *)) {
    margin-bottom: 2em;
    margin-top: 2em;
}
```

To remove `refine-prose` class, `not-prose` class added to the parent.


before:
<img width="200px" alt="image" src="https://github.com/refinedev/refine/assets/23058882/3b242445-f9a2-47ad-b308-a420a5142eaf">

after:
<img width="200px" alt="image" src="https://github.com/refinedev/refine/assets/23058882/26d62867-5c1e-406c-b794-7d7004eced00">




### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
