### PR TITLE
fix: lint staged command

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "eslint -c ./.eslintrc --quiet --fix --cache packages examples"
+      "eslint -c ./.eslintrc --quiet --fix --cache"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
Updated the `lint-staged` command to use only staged files

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
