### PR TITLE
fix(core): telemetry call fallback

### DIFF
--- a/.changeset/beige-pants-speak.md
+++ b/.changeset/beige-pants-speak.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": patch
+---
+
+Use `fetch` for telemetry calls as a fallback for `Image` when it's not available. This fixes an issue where telemetry calls would fail in some environments.

--- a/packages/core/src/components/telemetry/index.spec.tsx
+++ b/packages/core/src/components/telemetry/index.spec.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { render, TestWrapper } from "@test";
+import * as UseTelemetryData from "../../hooks/useTelemetryData";
+
+import { Telemetry } from "./index";
+
+describe("Telemetry", () => {
+    const originalImage = global.Image;
+    const originalFetch = global.fetch;
+
+    const imageMock = jest.fn();
+    global.Image = imageMock;
+
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock;
+
+    beforeEach(() => {
+        global.Image = imageMock;
+        global.fetch = fetchMock;
+
+        jest.spyOn(UseTelemetryData, "useTelemetryData").mockReturnValue({
+            providers: {},
+            version: "1",
+            resourceCount: 1,
+        });
+    });
+
+    afterEach(() => {
+        imageMock.mockClear();
+        fetchMock.mockClear();
+    });
+
+    afterAll(() => {
+        global.Image = originalImage;
+        global.fetch = originalFetch;
+    });
+
+    it("should not crash", async () => {
+        const { container } = render(<Telemetry />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(container).toBeTruthy();
+
+        expect(imageMock).toBeCalledTimes(1);
+        expect(fetchMock).not.toBeCalled();
+    });
+
+    it("should encode payload", async () => {
+        const imageMockInstance = {} as any;
+
+        imageMock.mockImplementation(() => imageMockInstance);
+
+        render(<Telemetry />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(imageMock).toBeCalledTimes(1);
+        expect(fetchMock).not.toBeCalled();
+
+        expect(imageMockInstance.src).toBe(
+            "https://telemetry.refine.dev/telemetry?payload=eyJwcm92aWRlcnMiOnt9LCJ2ZXJzaW9uIjoiMSIsInJlc291cmNlQ291bnQiOjF9",
+        );
+    });
+
+    it("should use fetch when image is undefined", async () => {
+        global.Image = undefined as any;
+
+        render(<Telemetry />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(imageMock).not.toBeCalled();
+        expect(fetchMock).toBeCalledTimes(1);
+    });
+
+    it("should encode payload when using fetch", async () => {
+        global.Image = undefined as any;
+
+        render(<Telemetry />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(imageMock).not.toBeCalled();
+        expect(fetchMock).toBeCalledTimes(1);
+
+        expect(fetchMock).toBeCalledWith(
+            "https://telemetry.refine.dev/telemetry?payload=eyJwcm92aWRlcnMiOnt9LCJ2ZXJzaW9uIjoiMSIsInJlc291cmNlQ291bnQiOjF9",
+        );
+    });
+
+    it("should not call endpoints if encoding fails", async () => {
+        const originalBtoa = global.btoa;
+
+        global.btoa = () => {
+            throw new Error("error");
+        };
+
+        render(<Telemetry />, {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(imageMock).not.toBeCalled();
+        expect(fetchMock).not.toBeCalled();
+
+        global.btoa = originalBtoa;
+    });
+});

--- a/packages/core/src/components/telemetry/index.tsx
+++ b/packages/core/src/components/telemetry/index.tsx
@@ -4,28 +4,49 @@ import { useTelemetryData } from "@hooks/useTelemetryData";
 
 import { ITelemetryData } from "../../interfaces/telemetry";
 
-const encode = (payload: ITelemetryData): string => {
-    const stringifyedPayload = JSON.stringify(payload || {});
+const encode = (payload: ITelemetryData): string | undefined => {
+    try {
+        const stringifiedPayload = JSON.stringify(payload || {});
 
-    if (typeof btoa !== "undefined") {
-        return btoa(stringifyedPayload);
+        if (typeof btoa !== "undefined") {
+            return btoa(stringifiedPayload);
+        }
+
+        return Buffer.from(stringifiedPayload).toString("base64");
+    } catch (err) {
+        return undefined;
     }
+};
 
-    return Buffer.from(stringifyedPayload).toString("base64");
+const throughImage = (src: string) => {
+    const img = new Image();
+
+    img.src = src;
+};
+
+const throughFetch = (src: string) => {
+    fetch(src);
+};
+
+const transport = (src: string) => {
+    if (typeof Image !== "undefined") {
+        throughImage(src);
+    } else if (typeof fetch !== "undefined") {
+        throughFetch(src);
+    }
 };
 
 export const Telemetry: React.FC<{}> = () => {
     const payload = useTelemetryData();
 
     useEffect(() => {
-        if (typeof window === "undefined" && !Image) {
+        const encoded = encode(payload);
+
+        if (!encoded) {
             return;
         }
 
-        const img = new Image();
-        img.src = `https://telemetry.refine.dev/telemetry?payload=${encode(
-            payload,
-        )}`;
+        transport(`https://telemetry.refine.dev/telemetry?payload=${encoded}`);
     }, []);
 
     return null;

--- a/packages/core/src/components/telemetry/index.tsx
+++ b/packages/core/src/components/telemetry/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React from "react";
 
 import { useTelemetryData } from "@hooks/useTelemetryData";
 
@@ -38,8 +38,12 @@ const transport = (src: string) => {
 
 export const Telemetry: React.FC<{}> = () => {
     const payload = useTelemetryData();
+    const sent = React.useRef(false);
 
-    useEffect(() => {
+    React.useEffect(() => {
+        if (sent.current) {
+            return;
+        }
         const encoded = encode(payload);
 
         if (!encoded) {
@@ -47,6 +51,7 @@ export const Telemetry: React.FC<{}> = () => {
         }
 
         transport(`https://telemetry.refine.dev/telemetry?payload=${encoded}`);
+        sent.current = true;
     }, []);
 
     return null;


### PR DESCRIPTION
Use `fetch` for telemetry calls as a fallback for `Image` when it's not available. This fixes an issue where telemetry calls would fail in some environments.

To make sure `fetch` is called only once, added a ref check before the effect.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
