### PR TITLE
refactor(core): remove `@tanstack/react-query-devtools` dependency

### DIFF
--- a/.changeset/good-bags-explode.md
+++ b/.changeset/good-bags-explode.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": minor
+---
+
+Removed `@tanstack/react-query-devtools` package and its usage from refine's core. This means that you will no longer see the dev tools icon in the bottom right corner of your app by default. If you want to use the dev tools, you can install the package (`@tanstack/react-query-devtools`) and use it in your app. 
+
+`options.reactQuery.devtoolConfig` property has been removed from the `<Refine>` components props. This option will no longer be functional and will be removed in the next major release. If you have any configuration for the dev tools, you can pass it to the `ReactQueryDevtools` component directly.

--- a/documentation/docs/api-reference/core/components/refine-config.md
+++ b/documentation/docs/api-reference/core/components/refine-config.md
@@ -679,7 +679,13 @@ const App: React.FC = () => (
 
 > For more information, refer to the [QueryClient documentation &#8594](https://react-query.tanstack.com/reference/QueryClient#queryclient)
 
-#### `devtoolConfig`
+#### ~~`devtoolConfig`~~
+
+:::caution Deprecated
+
+React Query Devtools are removed from the `@refinedev/core` and this prop is no longer supported for the configuration of the devtools. You can use the `@tanstack/react-query-devtools` in your app directly to use the devtools. For more information, please check out [FAQ - How to use React Query Devtools with refine?](/docs/faq/#how-to-use-react-query-devtools-with-refine)
+
+:::
 
 Config for customizing the React Query Devtools. If you want to disable the Devtools, set `devtoolConfig` to `false`.
 

--- a/documentation/docs/faq.md
+++ b/documentation/docs/faq.md
@@ -769,12 +769,14 @@ Until `@refinedev/core`'s version `4.28.2`, refine had the `@tanstack/react-quer
 
 ```tsx
 import { Refine } from "@refinedev/core";
+// highlight-next-line
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 const App = () => {
     return (
         <Refine>
             ...
+            // highlight-next-line
             <ReactQueryDevtools />
         </Refine>
     );

--- a/documentation/docs/faq.md
+++ b/documentation/docs/faq.md
@@ -763,6 +763,24 @@ Here are a couple of examples of reported errors and their corresponding fix:
 
 By following these steps and updating to the latest module versions, you should be able to resolve the "not exported" error.
 
+## How to use React Query DevTools with refine?
+
+Until `@refinedev/core`'s version `4.28.2`, refine had the `@tanstack/react-query-devtools` package available by default. However, this package has been removed from the core package and is no longer available by default. If you want to use the dev tools, you can install the package (`@tanstack/react-query-devtools`) and use it in your app directly.
+
+```tsx
+import { Refine } from "@refinedev/core";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+const App = () => {
+    return (
+        <Refine>
+            ...
+            <ReactQueryDevtools />
+        </Refine>
+    );
+};
+```
+
 [use-form-core]: /docs/api-reference/core/hooks/useForm/
 [use-form-react-hook-form]: /docs/packages/documentation/react-hook-form/useForm/
 [use-form-antd]: /docs/api-reference/antd/hooks/form/useForm/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,6 @@
     "papaparse": "^5.3.0",
     "pluralize": "^8.0.0",
     "qs": "^6.10.1",
-    "@tanstack/react-query-devtools": "^4.10.1",
     "@tanstack/react-query": "^4.10.1",
     "tslib": "^2.3.1",
     "warn-once": "^0.1.0"

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -1,5 +1,4 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import React from "react";
 
 import { ReadyPage as DefaultReadyPage, RouteChangeHandler } from "@components";
@@ -420,13 +419,6 @@ Interested in any of the new backend features of refine? Join now and get early 
                     </AuthBindingsContextProvider>
                 </LegacyAuthContextProvider>
             </NotificationContextProvider>
-            {reactQueryWithDefaults.devtoolConfig === false ? null : (
-                <ReactQueryDevtools
-                    initialIsOpen={false}
-                    position="bottom-right"
-                    {...reactQueryWithDefaults.devtoolConfig}
-                />
-            )}
         </QueryClientProvider>
     );
 };

--- a/packages/core/src/contexts/refine/IRefineContext.ts
+++ b/packages/core/src/contexts/refine/IRefineContext.ts
@@ -1,7 +1,6 @@
 import { RefineProps } from "@components/containers";
 import React, { ReactNode } from "react";
 import { QueryClientConfig, QueryClient } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 import {
     MutationMode,
@@ -28,7 +27,10 @@ export interface IRefineOptions {
     };
     reactQuery?: {
         clientConfig?: QueryClientConfig | InstanceType<typeof QueryClient>;
-        devtoolConfig?: React.ComponentProps<typeof ReactQueryDevtools> | false;
+        /**
+         * @deprecated `@tanstack/react-query`'s devtools are removed from the core. Please use the `@tanstack/react-query-devtools` package manually in your project. This option will be removed in the next major version and has no effect on the `@tanstack/react-query-devtools` package usage.
+         */
+        devtoolConfig?: any | false;
     };
     overtime?: UseLoadingOvertimeRefineContext;
     textTransformers?: TextTransformers;

--- a/packages/core/src/definitions/helpers/handleRefineOptions/index.ts
+++ b/packages/core/src/definitions/helpers/handleRefineOptions/index.ts
@@ -1,5 +1,4 @@
 import { QueryClient, QueryClientConfig } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 import { defaultRefineOptions } from "@contexts/refine";
 import {
@@ -18,9 +17,7 @@ type HandleRefineOptionsProps = {
     liveMode?: LiveModeProps["liveMode"];
     disableTelemetry?: boolean;
     reactQueryClientConfig?: QueryClientConfig;
-    reactQueryDevtoolConfig?:
-        | React.ComponentProps<typeof ReactQueryDevtools>
-        | false;
+    reactQueryDevtoolConfig?: any | false;
 };
 
 type HandleRefineOptionsReturnValues = {
@@ -28,7 +25,7 @@ type HandleRefineOptionsReturnValues = {
     disableTelemetryWithDefault: boolean;
     reactQueryWithDefaults: {
         clientConfig: QueryClientConfig | InstanceType<typeof QueryClient>;
-        devtoolConfig: false | React.ComponentProps<typeof ReactQueryDevtools>;
+        devtoolConfig: false | any;
     };
 };
 


### PR DESCRIPTION
Removed `@tanstack/react-query-devtools` package and its usage from refine's core. This means that you will no longer see the dev tools icon in the bottom right corner of your app by default. If you want to use the dev tools, you can install the package (`@tanstack/react-query-devtools`) and use it in your app. 

`options.reactQuery.devtoolConfig` property has been removed from the `<Refine>` components props. This option will no longer be functional and will be removed in the next major release. If you have any configuration for the dev tools, you can pass it to the `ReactQueryDevtools` component directly.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
