### PR TITLE
fix(examples): fix layout of field-material-ui-use-autocomplete

### DIFF
--- a/examples/field-material-ui-use-autocomplete/src/App.tsx
+++ b/examples/field-material-ui-use-autocomplete/src/App.tsx
@@ -13,6 +13,8 @@ import routerProvider, {
     DocumentTitleHandler,
 } from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
+import CssBaseline from "@mui/material/CssBaseline";
+import GlobalStyles from "@mui/material/GlobalStyles";
 import { ThemeProvider } from "@mui/material/styles";
 
 import { PostList, PostCreate, PostEdit } from "./pages/posts";
@@ -24,6 +26,10 @@ const App: React.FC = () => {
         <BrowserRouter>
             <GitHubBanner />
             <ThemeProvider theme={RefineThemes.Blue}>
+                <CssBaseline />
+                <GlobalStyles
+                    styles={{ html: { WebkitFontSmoothing: "auto" } }}
+                />
                 <SnackbarProvider>
                     <Refine
                         routerProvider={routerProvider}


### PR DESCRIPTION
fixed: Material UI styles added to `field-material-ui-use-autocomplete` example.

before: 
![image](https://github.com/refinedev/refine/assets/23058882/5c9687e8-ae05-461b-a331-336d7f1a1568)

after:
![image](https://github.com/refinedev/refine/assets/23058882/3c96eb49-af6e-4f7a-b680-7ef2363e0a2e)


### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
