### PR TITLE
fix(examples): add defaultFitleredValue to base-antd example

### DIFF
--- a/examples/base-antd/src/pages/posts/list.tsx
+++ b/examples/base-antd/src/pages/posts/list.tsx
@@ -88,6 +88,7 @@ export const PostList: React.FC<IResourceComponentsProps> = () => {
                     dataIndex="status"
                     title="Status"
                     render={(value: string) => <TagField value={value} />}
+                    defaultFilteredValue={getDefaultFilter("status", filters)}
                     filterDropdown={(props) => (
                         <FilterDropdown {...props}>
                             <Radio.Group>


### PR DESCRIPTION
without `getDefaultFilter`, `<Table />` can't add a filtered indicator to UI(filtering/fetching logic still works). To resolve that problem, `getDefaultFilter` added to `<Table />`
### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
