### PR TITLE
fix: to fix sticky header issue on Chakra UI use overflow "clip" instead of "auto"

### DIFF
--- a/.changeset/lazy-trainers-boil.md
+++ b/.changeset/lazy-trainers-boil.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/chakra-ui": patch
+---
+
+fix: fixed a bug where the `<ThemedLayoutv2>` component was not worked with sticky header.

--- a/packages/chakra-ui/src/components/themedLayoutV2/index.tsx
+++ b/packages/chakra-ui/src/components/themedLayoutV2/index.tsx
@@ -29,7 +29,7 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
                     flexDirection="column"
                     flex={1}
                     minH="100vh"
-                    overflow="auto"
+                    overflow="clip"
                 >
                     <HeaderToRender />
                     <Box p={[2, 4]}>{children}</Box>


### PR DESCRIPTION
fixes: #4730 

Fixed an issue in the sticky header feature of Chakra UI.