### PR TITLE
docs: Correct auth-page.md missing closing tag

### DIFF
--- a/documentation/docs/api-reference/antd/components/auth-page.md
+++ b/documentation/docs/api-reference/antd/components/auth-page.md
@@ -657,6 +657,7 @@ The `rememberMe` property defines to render your custom `<RememberMe>` component
 
 :::info
 You have to wrap your custom `<RememberMe>` component with the `Form.Item` component from **Ant Design** and pass the `name` prop to it then you can access its value from the `formProps` `onFinish` function with `formValues`.
+:::
 
 ```tsx
 const MyLoginPage = () => {


### PR DESCRIPTION
Updated auth-page.md in ant design doc for a missing tag

### Closing issues

closes #4768

### Self Check before Merge

Please check all items below before review.

-   [X] Corresponding issues are created/updated or not needed
-   [X] Docs are updated/provided or not needed
-   [X] Examples are updated/provided or not needed
-   [X] TypeScript definitions are updated/provided or not needed
-   [X] Tests are updated/provided or not needed
-   [X] Changesets are provided or not needed
