### PR TITLE
[FEAT] supabase getList count option

### DIFF
--- a/.changeset/silly-pumas-vanish.md
+++ b/.changeset/silly-pumas-vanish.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/supabase": minor
+---
+
+feat: added `count` property to meta for `getList` method

--- a/documentation/docs/packages/documentation/data-providers/supabase.md
+++ b/documentation/docs/packages/documentation/data-providers/supabase.md
@@ -1621,6 +1621,26 @@ const { tableProps, sorter } = useTable({
 If you filter based on a table from an inner join, you will need to use `.select('*, mytable!inner(*)')` within Supabase.
 :::
 
+### `getList` - performance
+
+By default, the data provider `getList` method returns the exact count of rows. Depending on the table size, this can slow down the request. You can request estimations of the total count by passing the `count` property in the `meta` as shown below:
+
+```tsx
+useList({
+    resource: "posts",
+    //highlight-start
+    meta: {
+        count: "estimated",
+    },
+    // highlight-end
+});
+```
+
+By default the `exact` count is used.
+
+[Refer to the PostgREST docs for more information about the count property &#8594](https://postgrest.org/en/stable/references/api/tables_views.html#exact-count)
+
+
 ## Example
 
 <CodeSandboxExample path="data-provider-supabase" />

--- a/packages/supabase/src/dataProvider/index.ts
+++ b/packages/supabase/src/dataProvider/index.ts
@@ -16,7 +16,7 @@ export const dataProvider = (
             const query = supabaseClient
                 .from(resource)
                 .select(meta?.select ?? "*", {
-                    count: "exact",
+                    count: meta?.count ?? "exact",
                 });
 
             if (mode === "server") {

--- a/packages/supabase/test/getList/index.mock.ts
+++ b/packages/supabase/test/getList/index.mock.ts
@@ -745,3 +745,61 @@ nock("https://iwdfzvfqbtokqetmbmbp.supabase.co:443", {
             "kong/2.2.1",
         ],
     );
+
+nock("https://iwdfzvfqbtokqetmbmbp.supabase.co:443", {
+    encodedQueryParams: true,
+})
+    .get("/rest/v1/posts")
+    .query({ select: "%2A", offset: "0", limit: "10" })
+    .matchHeader("prefer", "count=estimated")
+    .reply(
+        200,
+        [
+            {
+                id: 2,
+                title: "test title",
+                slug: "test-slug",
+                createdAt: "2021-09-03T07:36:42+00:00",
+                content: "test content",
+                categoryId: 1,
+                image: {},
+            },
+            {
+                id: 3,
+                title: "What a library, sayın seyirciler",
+                slug: "refine-nokta-kom",
+                createdAt: "2021-09-03T09:17:51+00:00",
+                content: "Hello lorem ipsum pala baba",
+                categoryId: 1,
+                image: {},
+            },
+        ],
+        [
+            "Content-Type",
+            "application/json; charset=utf-8",
+            "Transfer-Encoding",
+            "chunked",
+            "Connection",
+            "close",
+            "Date",
+            "Mon, 06 Sep 2021 08:23:41 GMT",
+            "Server",
+            "postgrest/8.0.0",
+            "Content-Range",
+            "0-1/2",
+            "Content-Location",
+            "/posts?limit=10&offset=0&select=%2A",
+            "Content-Profile",
+            "public",
+            "vary",
+            "Origin",
+            "Access-Control-Allow-Origin",
+            "*",
+            "X-Kong-Upstream-Latency",
+            "23",
+            "X-Kong-Proxy-Latency",
+            "1",
+            "Via",
+            "kong/2.2.1",
+        ],
+    );

--- a/packages/supabase/test/getList/index.spec.ts
+++ b/packages/supabase/test/getList/index.spec.ts
@@ -27,6 +27,19 @@ describe("getList", () => {
         expect(total).toBe(71);
     });
 
+    it("correct response with metadata count", async () => {
+        const { data, total } = await dataProvider(supabaseClient).getList({
+            resource: "posts",
+            meta: {
+                count: "estimated",
+            },
+        });
+
+        expect(data[0]["id"]).toBe(2);
+        expect(data[0]["title"]).toBe("test title");
+        expect(total).toBe(2);
+    });
+
     it("correct sorting response", async () => {
         const { data, total } = await dataProvider(supabaseClient).getList({
             resource: "posts",


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

The supabase `getList` provider method uses the `count=exact` parameter. This makes the query very slow on large tables. As described [here](https://postgrest.org/en/stable/references/api/tables_views.html#exact-count).

Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Exposing the `count` property  of the `getList` method.

### Test plan (required)

Demonstrate the code is solid. If not, please add `WIP:` in its title.

A test has been added, testing the header is set correctly.

<!-- Make sure tests pass. -->

### Closing issues

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
closes #4779

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
