### PR TITLE
fix(examples): form-antd-mutation-mode e2e test

### DIFF
--- a/examples/form-antd-mutation-mode/cypress/e2e/all.cy.ts
+++ b/examples/form-antd-mutation-mode/cypress/e2e/all.cy.ts
@@ -72,7 +72,7 @@ describe("form-antd-mutation-mode", () => {
     it("should edit record when mutation mode is pessimistic", () => {
         waitForListPageLoading();
 
-        cy.get("input[value=pessimistic]").check();
+        cy.get("input[value=pessimistic]").check({ force: true });
         cy.getEditButton().first().should("not.be.disabled");
         cy.getEditButton().first().click();
         // wait loading state and render to be finished
@@ -94,7 +94,7 @@ describe("form-antd-mutation-mode", () => {
 
     it("should edit a record when mutation mode is undoable", () => {
         waitForListPageLoading();
-        cy.get("input[value=undoable]").check();
+        cy.get("input[value=undoable]").check({ force: true });
         cy.getEditButton().first().click();
 
         // wait loading state and render to be finished
@@ -125,7 +125,7 @@ describe("form-antd-mutation-mode", () => {
     it("should undo editing when mutation mode is undoable", () => {
         waitForListPageLoading();
 
-        cy.get("input[value=undoable]").check();
+        cy.get("input[value=undoable]").check({ force: true });
         cy.getEditButton().first().click();
 
         waitForEditPageLoading();
@@ -143,7 +143,7 @@ describe("form-antd-mutation-mode", () => {
     it("should create a record when mutation mode is optimistic", () => {
         waitForListPageLoading();
 
-        cy.get("input[value=optimistic]").check();
+        cy.get("input[value=optimistic]").check({ force: true });
         cy.getCreateButton().click();
 
         cy.wait("@getCategories");
@@ -166,7 +166,7 @@ describe("form-antd-mutation-mode", () => {
     it("should edit a record when mutation mode is optimistic", () => {
         waitForListPageLoading();
 
-        cy.get("input[value=optimistic]").check();
+        cy.get("input[value=optimistic]").check({ force: true });
         cy.getEditButton().first().click();
 
         waitForEditPageLoading();
@@ -188,7 +188,7 @@ describe("form-antd-mutation-mode", () => {
     it("should delete record when mutation mode is pessimistic", () => {
         waitForListPageLoading();
 
-        cy.get("input[value=pessimistic]").check();
+        cy.get("input[value=pessimistic]").check({ force: true });
         cy.getEditButton().first().click();
 
         waitForEditPageLoading();
@@ -210,7 +210,7 @@ describe("form-antd-mutation-mode", () => {
     it("should delete a record when mutation mode is undoable", () => {
         waitForListPageLoading();
 
-        cy.get("input[value=undoable]").check();
+        cy.get("input[value=undoable]").check({ force: true });
         cy.getEditButton().first().click();
 
         waitForEditPageLoading();


### PR DESCRIPTION
added `check({ force: true })` because inputs are absolute and on small viewports, inputs can be covered by another element. (z-index does not solves the cypress error)

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
