### PR TITLE
fix: build error for `with-nextjs-next-auth` example

### DIFF
--- a/examples/with-nextjs-next-auth/pages/_app.tsx
+++ b/examples/with-nextjs-next-auth/pages/_app.tsx
@@ -76,7 +76,7 @@ const App = (props: React.PropsWithChildren) => {
 
             return {
                 success: false,
-                error: new Error(error),
+                error: new Error(error?.toString()),
             };
         },
         register: async ({ providerName, email, password }) => {
@@ -115,7 +115,7 @@ const App = (props: React.PropsWithChildren) => {
 
             return {
                 success: false,
-                error: new Error(error),
+                error: new Error(error?.toString()),
             };
         },
         updatePassword: async (params) => {


### PR DESCRIPTION
Fix build error for `with-nextjs-next-auth` example

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
