### PR TITLE
fix(mui): list component header buttons not aligned

### DIFF
--- a/.changeset/quiet-tigers-work.md
+++ b/.changeset/quiet-tigers-work.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mui": patch
+---
+
+fixed: Material UI `<List />` component's header buttons not being aligned properly. [#4816](https://github.com/refinedev/refine/issues/4816)

--- a/.changeset/quiet-tigers-work.md
+++ b/.changeset/quiet-tigers-work.md
@@ -2,4 +2,4 @@
 "@refinedev/mui": patch
 ---
 
-fixed: Material UI `<List />`, `<Show />`, `<Edit />` component's header buttons not being aligned properly. [#4816](https://github.com/refinedev/refine/issues/4816)
+fixed: Material UI `<List />`, `<Show />`, `<Edit />`, `<Create />` component's header buttons not being aligned properly. [#4816](https://github.com/refinedev/refine/issues/4816)

--- a/.changeset/quiet-tigers-work.md
+++ b/.changeset/quiet-tigers-work.md
@@ -2,4 +2,4 @@
 "@refinedev/mui": patch
 ---
 
-fixed: Material UI `<List />` component's header buttons not being aligned properly. [#4816](https://github.com/refinedev/refine/issues/4816)
+fixed: Material UI `<List />`, `<Show />`, `<Edit />` component's header buttons not being aligned properly. [#4816](https://github.com/refinedev/refine/issues/4816)

--- a/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`MuiInferencer should match the snapshot 1`] = `
         />
       </nav>
       <div
-        class="MuiCardHeader-root css-12qh39f-MuiCardHeader-root"
+        class="MuiCardHeader-root css-1anz4l6-MuiCardHeader-root"
       >
         <div
           class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"

--- a/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
@@ -9936,7 +9936,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
         />
       </nav>
       <div
-        class="MuiCardHeader-root css-12qh39f-MuiCardHeader-root"
+        class="MuiCardHeader-root css-94f51d-MuiCardHeader-root"
       >
         <div
           class="MuiCardHeader-avatar css-1ssile9-MuiCardHeader-avatar"

--- a/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`MuiInferencer should match the snapshot 1`] = `
         />
       </nav>
       <div
-        class="MuiCardHeader-root css-1anz4l6-MuiCardHeader-root"
+        class="MuiCardHeader-root css-94f51d-MuiCardHeader-root"
       >
         <div
           class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
@@ -24961,7 +24961,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
         />
       </nav>
       <div
-        class="MuiCardHeader-root css-12qh39f-MuiCardHeader-root"
+        class="MuiCardHeader-root css-94f51d-MuiCardHeader-root"
       >
         <div
           class="MuiCardHeader-avatar css-1ssile9-MuiCardHeader-avatar"
@@ -41091,7 +41091,7 @@ exports[`MuiInferencer should match the snapshot 4`] = `
         />
       </nav>
       <div
-        class="MuiCardHeader-root css-12qh39f-MuiCardHeader-root"
+        class="MuiCardHeader-root css-94f51d-MuiCardHeader-root"
       >
         <div
           class="MuiCardHeader-avatar css-1ssile9-MuiCardHeader-avatar"

--- a/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/create.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/create.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`MuiCreateInferencer should match the snapshot 1`] = `
       class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
     >
       <div
-        class="MuiCardHeader-root css-12qh39f-MuiCardHeader-root"
+        class="MuiCardHeader-root css-94f51d-MuiCardHeader-root"
       >
         <div
           class="MuiCardHeader-avatar css-1ssile9-MuiCardHeader-avatar"

--- a/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/edit.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/edit.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`MuiEditInferencer should match the snapshot 1`] = `
       class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
     >
       <div
-        class="MuiCardHeader-root css-12qh39f-MuiCardHeader-root"
+        class="MuiCardHeader-root css-94f51d-MuiCardHeader-root"
       >
         <div
           class="MuiCardHeader-avatar css-1ssile9-MuiCardHeader-avatar"

--- a/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/list.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/list.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`MuiListInferencer should match the snapshot 1`] = `
       class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
     >
       <div
-        class="MuiCardHeader-root css-12qh39f-MuiCardHeader-root"
+        class="MuiCardHeader-root css-1anz4l6-MuiCardHeader-root"
       >
         <div
           class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"

--- a/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/list.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/list.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`MuiListInferencer should match the snapshot 1`] = `
       class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
     >
       <div
-        class="MuiCardHeader-root css-1anz4l6-MuiCardHeader-root"
+        class="MuiCardHeader-root css-94f51d-MuiCardHeader-root"
       >
         <div
           class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"

--- a/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/show.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/show.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`MuiShowInferencer should match the snapshot 1`] = `
       class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
     >
       <div
-        class="MuiCardHeader-root css-12qh39f-MuiCardHeader-root"
+        class="MuiCardHeader-root css-94f51d-MuiCardHeader-root"
       >
         <div
           class="MuiCardHeader-avatar css-1ssile9-MuiCardHeader-avatar"

--- a/packages/mui/src/components/crud/create/index.tsx
+++ b/packages/mui/src/components/crud/create/index.tsx
@@ -80,7 +80,14 @@ export const Create: React.FC<CreateProps> = ({
         <Card {...(wrapperProps ?? {})}>
             {breadcrumbComponent}
             <CardHeader
-                sx={{ display: "flex", flexWrap: "wrap" }}
+                sx={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    ".MuiCardHeader-action": {
+                        margin: 0,
+                        alignSelf: "center",
+                    },
+                }}
                 title={
                     title ?? (
                         <Typography

--- a/packages/mui/src/components/crud/edit/index.tsx
+++ b/packages/mui/src/components/crud/edit/index.tsx
@@ -169,7 +169,14 @@ export const Edit: React.FC<EditProps> = ({
         <Card {...(wrapperProps ?? {})}>
             {breadcrumbComponent}
             <CardHeader
-                sx={{ display: "flex", flexWrap: "wrap" }}
+                sx={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    ".MuiCardHeader-action": {
+                        margin: 0,
+                        alignSelf: "center",
+                    },
+                }}
                 title={
                     title ?? (
                         <Typography

--- a/packages/mui/src/components/crud/list/index.tsx
+++ b/packages/mui/src/components/crud/list/index.tsx
@@ -81,7 +81,13 @@ export const List: React.FC<ListProps> = ({
         <Card {...(wrapperProps ?? {})}>
             {breadcrumbComponent}
             <CardHeader
-                sx={{ display: "flex", flexWrap: "wrap" }}
+                sx={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    ".MuiCardHeader-action": {
+                        margin: 0,
+                    },
+                }}
                 title={
                     title ?? (
                         <Typography

--- a/packages/mui/src/components/crud/list/index.tsx
+++ b/packages/mui/src/components/crud/list/index.tsx
@@ -86,6 +86,7 @@ export const List: React.FC<ListProps> = ({
                     flexWrap: "wrap",
                     ".MuiCardHeader-action": {
                         margin: 0,
+                        alignSelf: "center",
                     },
                 }}
                 title={

--- a/packages/mui/src/components/crud/show/index.tsx
+++ b/packages/mui/src/components/crud/show/index.tsx
@@ -153,7 +153,14 @@ export const Show: React.FC<ShowProps> = ({
         <Card {...(wrapperProps ?? {})}>
             {breadcrumbComponent}
             <CardHeader
-                sx={{ display: "flex", flexWrap: "wrap" }}
+                sx={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    ".MuiCardHeader-action": {
+                        margin: 0,
+                        alignSelf: "center",
+                    },
+                }}
                 title={
                     title ?? (
                         <Typography


### PR DESCRIPTION
This class has a negative margin:
```css
MuiCardHeader-action {
-webkit-flex: 0 0 auto;
-ms-flex: 0 0 auto;
flex: 0 0 auto;
-webkit-align-self: flex-start;
-ms-flex-item-align: flex-start;
align-self: flex-start;
margin-top: -4px;
margin-right: -8px;
margin-bottom: -4px;
}
```
Because of that, header buttons are not aligned properly along the header title.
![Pasted Graphic](https://github.com/refinedev/refine/assets/23058882/ed82b49b-122a-4215-ab88-7567c68ad0d0)

To fix that, the margin property is set to 0.

### after the fix:
![image](https://github.com/refinedev/refine/assets/23058882/1d212d2f-dda9-40fa-9044-e1bd044d79b7)
![Pasted Graphic](https://github.com/refinedev/refine/assets/23058882/99dc36dc-f891-4807-b3ad-12a42e44b577)
![Pasted Graphic 1](https://github.com/refinedev/refine/assets/23058882/d33785b2-39b8-4600-aeab-646c5fa382b5)

￼

closes #4816 

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
