### PR TITLE
fix(app-crm) kanban won-lost drop area colors

### DIFF
--- a/examples/app-crm/src/components/deal-kanban-won-lost-drop/index.module.css
+++ b/examples/app-crm/src/components/deal-kanban-won-lost-drop/index.module.css
@@ -12,6 +12,8 @@
 }
 
 .dropArea {
+    transition: color 0.2s ease, border-color 0.2s ease,
+        background-color 0.2s ease;
     height: 100%;
     width: 100%;
     border-radius: 8px;
@@ -24,11 +26,23 @@
         color: #a8071a;
         border: 2px dashed #ff7875;
         background: #ffccc7;
+
+        &.isOver {
+            color: #fff;
+            border: 2px dashed #ffccc7;
+            background: #a8071a;
+        }
     }
 
     &.won {
         color: #237804;
         border: 2px dashed #95de64;
         background: #d9f7be;
+
+        &.isOver {
+            color: #fff;
+            border: 2px dashed #95de64;
+            background: #237804;
+        }
     }
 }

--- a/examples/app-crm/src/components/deal-kanban-won-lost-drop/index.tsx
+++ b/examples/app-crm/src/components/deal-kanban-won-lost-drop/index.tsx
@@ -13,10 +13,6 @@ export const DealKanbanWonLostDrop: FC = () => {
         onDragEnd: () => setShow(false),
     });
 
-    if (!show) {
-        return null;
-    }
-
     return (
         <div className={styles.container}>
             <WonArea />
@@ -26,10 +22,15 @@ export const DealKanbanWonLostDrop: FC = () => {
 };
 
 const WonArea = () => {
-    const { setNodeRef } = useDroppable({ id: "won" });
+    const { setNodeRef, over } = useDroppable({ id: "won" });
 
     return (
-        <div ref={setNodeRef} className={cn(styles.dropArea, styles.won)}>
+        <div
+            ref={setNodeRef}
+            className={cn(styles.dropArea, styles.won, {
+                [styles.isOver]: over?.id === "won",
+            })}
+        >
             <Text
                 style={{
                     color: "inherit",
@@ -43,10 +44,15 @@ const WonArea = () => {
 };
 
 const LostArea = () => {
-    const { setNodeRef } = useDroppable({ id: "lost" });
+    const { setNodeRef, over } = useDroppable({ id: "lost" });
 
     return (
-        <div ref={setNodeRef} className={cn(styles.dropArea, styles.lost)}>
+        <div
+            ref={setNodeRef}
+            className={cn(styles.dropArea, styles.lost, {
+                [styles.isOver]: over?.id === "lost",
+            })}
+        >
             <Text
                 style={{
                     color: "inherit",

--- a/examples/app-crm/src/components/deal-kanban-won-lost-drop/index.tsx
+++ b/examples/app-crm/src/components/deal-kanban-won-lost-drop/index.tsx
@@ -13,6 +13,10 @@ export const DealKanbanWonLostDrop: FC = () => {
         onDragEnd: () => setShow(false),
     });
 
+    if (!show) {
+        return null;
+    }
+
     return (
         <div className={styles.container}>
             <WonArea />


### PR DESCRIPTION
added: when the grabbed card is over on the won-lost drop area, the color should change

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
