### PR TITLE
refactor(core): fine-tuning in invalidations

### DIFF
--- a/.changeset/young-months-smash.md
+++ b/.changeset/young-months-smash.md
@@ -1,0 +1,11 @@
+---
+"@refinedev/core": minor
+---
+
+Fine-tuning the invalidation process by setting up additional filters and options for the invalidation.
+
+Now after a successful mutation, refine will invalidate all the queries in the scope but trigger a refetch only for the active queries. If there are any ongoing queries, they will be kept as they are.
+
+After receiving a realtime subscription event, refine will invalidate and refetch only the active queries.
+
+These settings can be changed via `options.invalite` prop of the `<Refine>` component or while using the `useInvalidate` hook.

--- a/documentation/docs/api-reference/antd/hooks/form/useForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useForm.md
@@ -570,6 +570,12 @@ useForm({
 });
 ```
 
+:::tip
+**refine** applies some fine-tuning to the invalidation process. By default, all the queries within the respective scope will be invalidated but only the active/enabled queries will be triggered for a refetch.
+
+If you want to change these behaviors, you can use the `options.invalidate` prop of the `<Refine>` component. For more information, refer to the [`invalidate` section of the `<Refine>` component documentation &#8594](/docs/api-reference/core/components/refine-config.md#invalidate)
+:::
+
 ### `dataProviderName`
 
 If there is more than one `dataProvider`, you should pass the name of the `dataProvider` you are going to use to `dataProviderName`.
@@ -838,8 +844,11 @@ const { overtime } = useForm({
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 
 // You can use it like this:
-{elapsedTime >= 4000 && <div>this takes a bit longer than expected</div>}
+{
+    elapsedTime >= 4000 && <div>this takes a bit longer than expected</div>;
+}
 ```
+
 ### `autoSave`
 
 If you want to save the form automatically after some delay when user edits the form, you can pass true to `autoSave.enabled` prop.

--- a/documentation/docs/api-reference/core/components/refine-config.md
+++ b/documentation/docs/api-reference/core/components/refine-config.md
@@ -620,6 +620,52 @@ If you don't have a show page and you redirect to the show page, the user will b
 
 :::
 
+### `invalidate`
+
+By default, **refine** invalidates the respective query cache after a successful mutation or by a realtime event subscription. To make the invalidation behaviour smoother and more precise, **refine** applies some fine-tuning to the invalidation process. You can change the default configuration by setting the `invalidate` option as follows:
+
+```tsx title="App.tsx"
+const App: React.FC = () => {
+    return (
+        <Refine
+            ...
+            // highlight-start
+            options={{
+                invalidate: {
+                    filters: {
+                        type: "all",
+                        refetchType: "active",
+                    },
+                    options: {
+                        cancelRefetch: false,
+                    },
+                    liveUpdates: {
+                        filters: {
+                            type: "active",
+                            refetchType: "active",
+                        },
+                        options: {
+                            cancelRefetch: false,
+                        },
+                    },
+                },
+            }}
+            // highlight-end
+        />
+    );
+};
+```
+
+After a successful mutation, **refine** invalidates all the queries of the defined scope of the resource but refetches only the active queries. If there are already on-going refetches, they are kept as they are.
+
+After a realtime event is captured in a subscription, **refine** invalidates and refetches all the active queries of the target resource while keeping the ongoing refetches as they are.
+
+While these are the default options and filters for the invalidation action, you can override them while using the [`useInvalidate`](/docs/api-reference/core/hooks/invalidate/useInvalidate/) hook.
+
+:::tip
+The scope of the invalidation is determined by the mutation, you can always use the `invalidates` property of the mutation hook to override the scope of the invalidation.
+:::
+
 ### `reactQuery`
 
 #### `clientConfig`

--- a/documentation/docs/api-reference/core/hooks/data/useCreate/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCreate/index.md
@@ -98,7 +98,7 @@ mutate(
 ### `overtimeOptions`
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
-`interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval. 
+`interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
 
 Return `overtime` object from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 
@@ -110,14 +110,17 @@ const { overtime } = useCreate({
         onInterval(elapsedInterval) {
             console.log(elapsedInterval);
         },
-    }
+    },
 });
 
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 
 // You can use it like this:
-{elapsedTime >= 4000 && <div>this takes a bit longer than expected</div>}
+{
+    elapsedTime >= 4000 && <div>this takes a bit longer than expected</div>;
+}
 ```
+
 ## Mutation Parameters
 
 ### `resource` <PropTag required />
@@ -271,6 +274,12 @@ mutate({
 });
 ```
 
+:::tip
+**refine** applies some fine-tuning to the invalidation process. By default, all the queries within the respective scope will be invalidated but only the active/enabled queries will be triggered for a refetch.
+
+If you want to change these behaviors, you can use the `options.invalidate` prop of the `<Refine>` component. For more information, refer to the [`invalidate` section of the `<Refine>` component documentation &#8594](/docs/api-reference/core/components/refine-config.md#invalidate)
+:::
+
 ## Return Values
 
 Returns an object with TanStack Query's `useMutation` return values.
@@ -278,6 +287,7 @@ Returns an object with TanStack Query's `useMutation` return values.
 > For more information, refer to the [`useMutation` documentation &#8594](https://tanstack.com/query/v4/docs/react/reference/useMutation)
 
 ### Additional Values
+
 #### `overtime`
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
@@ -287,6 +297,7 @@ const { overtime } = useCreate();
 
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
+
 ## API
 
 ### Mutation Parameters

--- a/documentation/docs/api-reference/core/hooks/data/useCreateMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCreateMany/index.md
@@ -118,7 +118,7 @@ mutate(
 ### `overtimeOptions`
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
-`interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval. 
+`interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
 
 Return `overtime` object from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 
@@ -130,14 +130,17 @@ const { overtime } = useCreateMany({
         onInterval(elapsedInterval) {
             console.log(elapsedInterval);
         },
-    }
+    },
 });
 
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 
 // You can use it like this:
-{elapsedTime >= 4000 && <div>this takes a bit longer than expected</div>}
+{
+    elapsedTime >= 4000 && <div>this takes a bit longer than expected</div>;
+}
 ```
+
 ## Mutation Parameters
 
 ### `resource` <PropTag required />
@@ -297,6 +300,12 @@ mutate({
 });
 ```
 
+:::tip
+**refine** applies some fine-tuning to the invalidation process. By default, all the queries within the respective scope will be invalidated but only the active/enabled queries will be triggered for a refetch.
+
+If you want to change these behaviors, you can use the `options.invalidate` prop of the `<Refine>` component. For more information, refer to the [`invalidate` section of the `<Refine>` component documentation &#8594](/docs/api-reference/core/components/refine-config.md#invalidate)
+:::
+
 ## Return Values
 
 Returns an object with TanStack Query's `useMutation` return values.
@@ -304,6 +313,7 @@ Returns an object with TanStack Query's `useMutation` return values.
 > For more information, refer to the [`useMutation` documentation &#8594](https://tanstack.com/query/v4/docs/react/reference/useMutation)
 
 ### Additional Values
+
 #### `overtime`
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
@@ -313,6 +323,7 @@ const { overtime } = useCreateMany();
 
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
+
 ## API
 
 ### Mutation Parameters

--- a/documentation/docs/api-reference/core/hooks/data/useDelete/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useDelete/index.md
@@ -111,7 +111,9 @@ const { overtime } = useDelete({
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 
 // You can use it like this:
-{elapsedTime >= 4000 && <div>this takes a bit longer than expected</div>}
+{
+    elapsedTime >= 4000 && <div>this takes a bit longer than expected</div>;
+}
 ```
 
 ## Mutation Parameters
@@ -328,6 +330,12 @@ mutate({
     invalidates: ["list", "many"],
 });
 ```
+
+:::tip
+**refine** applies some fine-tuning to the invalidation process. By default, all the queries within the respective scope will be invalidated but only the active/enabled queries will be triggered for a refetch.
+
+If you want to change these behaviors, you can use the `options.invalidate` prop of the `<Refine>` component. For more information, refer to the [`invalidate` section of the `<Refine>` component documentation &#8594](/docs/api-reference/core/components/refine-config.md#invalidate)
+:::
 
 ## Return Values
 

--- a/documentation/docs/api-reference/core/hooks/data/useDeleteMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useDeleteMany/index.md
@@ -107,7 +107,9 @@ const { overtime } = useDeleteMany({
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 
 // You can use it like this:
-{elapsedTime >= 4000 && <div>this takes a bit longer than expected</div>}
+{
+    elapsedTime >= 4000 && <div>this takes a bit longer than expected</div>;
+}
 ```
 
 ## Mutation Parameters
@@ -325,6 +327,12 @@ mutate({
     invalidates: ["list", "many", "detail"],
 });
 ```
+
+:::tip
+**refine** applies some fine-tuning to the invalidation process. By default, all the queries within the respective scope will be invalidated but only the active/enabled queries will be triggered for a refetch.
+
+If you want to change these behaviors, you can use the `options.invalidate` prop of the `<Refine>` component. For more information, refer to the [`invalidate` section of the `<Refine>` component documentation &#8594](/docs/api-reference/core/components/refine-config.md#invalidate)
+:::
 
 ## Return Values
 

--- a/documentation/docs/api-reference/core/hooks/data/useUpdate/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useUpdate/index.md
@@ -328,6 +328,12 @@ mutate({
 });
 ```
 
+:::tip
+**refine** applies some fine-tuning to the invalidation process. By default, all the queries within the respective scope will be invalidated but only the active/enabled queries will be triggered for a refetch.
+
+If you want to change these behaviors, you can use the `options.invalidate` prop of the `<Refine>` component. For more information, refer to the [`invalidate` section of the `<Refine>` component documentation &#8594](/docs/api-reference/core/components/refine-config.md#invalidate)
+:::
+
 ### `overtimeOptions`
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
@@ -349,7 +355,9 @@ const { overtime } = useUpdate({
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 
 // You can use it like this:
-{elapsedTime >= 4000 && <div>this takes a bit longer than expected</div>}
+{
+    elapsedTime >= 4000 && <div>this takes a bit longer than expected</div>;
+}
 ```
 
 ## Return Values

--- a/documentation/docs/api-reference/core/hooks/data/useUpdateMany/index.md
+++ b/documentation/docs/api-reference/core/hooks/data/useUpdateMany/index.md
@@ -348,6 +348,12 @@ mutate({
 });
 ```
 
+:::tip
+**refine** applies some fine-tuning to the invalidation process. By default, all the queries within the respective scope will be invalidated but only the active/enabled queries will be triggered for a refetch.
+
+If you want to change these behaviors, you can use the `options.invalidate` prop of the `<Refine>` component. For more information, refer to the [`invalidate` section of the `<Refine>` component documentation &#8594](/docs/api-reference/core/components/refine-config.md#invalidate)
+:::
+
 ## Return Values
 
 Returns an object with TanStack Query's `useMutation` return values.

--- a/documentation/docs/api-reference/core/hooks/invalidate/useInvalidate.md
+++ b/documentation/docs/api-reference/core/hooks/invalidate/useInvalidate.md
@@ -108,15 +108,27 @@ The states you want to invalidate. You can use the following values:
 -   `"detail"`: Invalidates the `"detail"` state of the given `resource` and `id`.
 -   `"many"`: Invalidates the `"many"` state of the given `resource`.
 
+### `invalidationFilters` and `invalidationOptions`
+
+> Type: [`InvalidateQueryFilters`](https://tanstack.com/query/latest/docs/react/reference/QueryClient#queryclientinvalidatequeries)
+
+The filters and options applied to the invalidation process when picking which queries to invalidate. By default **refine** applies some filters and options to fine-tune the invalidation process.
+
+By default settings, all the targeted queries are invalidated and the active ones are triggered for a refetch. If there are any ongoing queries, they are kept as they are.
+
+If you want to set filters globally, you can use the `options.invalidate` prop of the `<Refine>` component. For more information, refer to the [`invalidate` section of the `<Refine>` component documentation &#8594](/docs/api-reference/core/components/refine-config.md#invalidate)
+
 ## API Reference
 
 ### Invalidation Parameters
 
-| Property                                                                                              | Description                                                       | Type                                                    | Default   |
-| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------- | --------- |
-| <div className="required-block"><div>invalidates</div> <div className="required">Required</div></div> | The states you want to invalidate.                                | `all`, `resourceAll`, `list`, `many`, `detail`, `false` |           |
-| resource                                                                                              | Resource name for State invalidation.                             | `string`                                                |           |
-| id                                                                                                    | The `id` to use when invalidating the "detail" state.             | [`BaseKey`](/api-reference/core/interfaces.md#basekey)  |           |
-| dataProviderName                                                                                      | The name of the data provider whose state you want to invalidate. | `string`                                                | `default` |
+| Property                                                                                              | Description                                                       | Type                                                                                                                        | Default                                  |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| <div className="required-block"><div>invalidates</div> <div className="required">Required</div></div> | The states you want to invalidate.                                | `all`, `resourceAll`, `list`, `many`, `detail`, `false`                                                                     |                                          |
+| resource                                                                                              | Resource name for State invalidation.                             | `string`                                                                                                                    |                                          |
+| id                                                                                                    | The `id` to use when invalidating the "detail" state.             | [`BaseKey`](/api-reference/core/interfaces.md#basekey)                                                                      |                                          |
+| dataProviderName                                                                                      | The name of the data provider whose state you want to invalidate. | `string`                                                                                                                    | `default`                                |
+| invalidationFilters                                                                                   | The filters to use when invalidating the "list" state.            | [`InvalidateQueryFilters`](https://tanstack.com/query/latest/docs/react/reference/QueryClient#queryclientinvalidatequeries) | `{ type: "all", refetchType: "active" }` |
+| invalidationOptions                                                                                   |                                                                   | [`InvalidateOptions`](https://tanstack.com/query/latest/docs/react/reference/QueryClient#queryclientinvalidatequeries)      | `{ cancelRefetch: false }`               |
 
 [data-provider]: /docs/api-reference/core/providers/data-provider/

--- a/documentation/docs/api-reference/core/hooks/useForm.md
+++ b/documentation/docs/api-reference/core/hooks/useForm.md
@@ -897,6 +897,12 @@ useForm({
 });
 ```
 
+:::tip
+**refine** applies some fine-tuning to the invalidation process. By default, all the queries within the respective scope will be invalidated but only the active/enabled queries will be triggered for a refetch.
+
+If you want to change these behaviors, you can use the `options.invalidate` prop of the `<Refine>` component. For more information, refer to the [`invalidate` section of the `<Refine>` component documentation &#8594](/docs/api-reference/core/components/refine-config.md#invalidate)
+:::
+
 ### `dataProviderName`
 
 If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.

--- a/documentation/docs/api-reference/core/providers/live-provider.md
+++ b/documentation/docs/api-reference/core/providers/live-provider.md
@@ -461,6 +461,12 @@ const { data } = useList({ liveMode: "auto" });
 Queries of related resource are invalidated in Realtime as new events from subscription arrive.
 For example data from a `useTable` hook will be automatically updated when data is changed.
 
+:::tip
+
+By default, the invalidation and refetches are only triggered for the active queries. If you want to change these settings, you can use the `options.invalidate` prop of the `<Refine>` component. For more information, refer to the [`invalidate.liveUpdates` section of the `<Refine>` component documentation &#8594](/docs/api-reference/core/components/refine-config.md#invalidate)
+
+:::
+
 ### `manual`
 
 Queries of related resource are **not invalidated** in Realtime, instead [`onLiveEvent`](#onliveevent) is run with the `event` as new events from subscription arrive.

--- a/documentation/docs/api-reference/mantine/hooks/form/useForm.md
+++ b/documentation/docs/api-reference/mantine/hooks/form/useForm.md
@@ -527,7 +527,7 @@ render(<RefineMantineDemo />);
 
 ### `resource`
 
-`resource`, read from the current URL by default, will be passed to the [`dataProvider`][data-provider]'s method as a params. This parameter is usually used to as a API endpoint path. It all depends on how to handle the `resource` in your [`dataProvider`][data-provider]. 
+`resource`, read from the current URL by default, will be passed to the [`dataProvider`][data-provider]'s method as a params. This parameter is usually used to as a API endpoint path. It all depends on how to handle the `resource` in your [`dataProvider`][data-provider].
 
 See the [`creating a data provider`](/api-reference/core/providers/data-provider.md#creating-a-data-provider) section for an example of how `resource` are handled.
 
@@ -590,7 +590,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 It is useful when you want to `edit` or `clone` a `resource` from a different page.
 
 :::note
- `id` is required when `action: "edit"` or `action: "clone"`.
+`id` is required when `action: "edit"` or `action: "clone"`.
 :::
 
 ```tsx
@@ -675,6 +675,12 @@ useForm({
     },
 });
 ```
+
+:::tip
+**refine** applies some fine-tuning to the invalidation process. By default, all the queries within the respective scope will be invalidated but only the active/enabled queries will be triggered for a refetch.
+
+If you want to change these behaviors, you can use the `options.invalidate` prop of the `<Refine>` component. For more information, refer to the [`invalidate` section of the `<Refine>` component documentation &#8594](/docs/api-reference/core/components/refine-config.md#invalidate)
+:::
 
 ### `dataProviderName`
 
@@ -970,7 +976,6 @@ If you want to save the form automatically after some delay when user edits the 
 
 It also supports the [`onMutationSuccess`](#onmutationsuccess) and [`onMutationError`](#onmutationerror) callback functions. You can use the `isAutoSave` parameter to determine whether the mutation is triggered by `autoSave` or not.
 
-
 `onMutationSuccess` and `onMutationError` callbacks will be called after the mutation is successful or failed.
 
 #### `enabled`
@@ -1091,7 +1096,6 @@ const { overtime } = useForm();
 
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
-
 
 ### `autoSaveProps`
 

--- a/documentation/docs/packages/documentation/react-hook-form/useForm.md
+++ b/documentation/docs/packages/documentation/react-hook-form/useForm.md
@@ -679,6 +679,12 @@ useForm({
 });
 ```
 
+:::tip
+**refine** applies some fine-tuning to the invalidation process. By default, all the queries within the respective scope will be invalidated but only the active/enabled queries will be triggered for a refetch.
+
+If you want to change these behaviors, you can use the `options.invalidate` prop of the `<Refine>` component. For more information, refer to the [`invalidate` section of the `<Refine>` component documentation &#8594](/docs/api-reference/core/components/refine-config.md#invalidate)
+:::
+
 ### `dataProviderName`
 
 If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.
@@ -939,6 +945,7 @@ Works only in `action: "edit"` mode.
 :::
 
 `onMutationSuccess` and `onMutationError` callbacks will be called after the mutation is successful or failed.
+
 #### `enabled`
 
 To enable the `autoSave` feature, set the `enabled` parameter to `true`.
@@ -949,8 +956,8 @@ useForm({
         autoSave: {
             enabled: true,
         },
-    }
-})
+    },
+});
 ```
 
 #### `debounce`
@@ -965,9 +972,10 @@ useForm({
             // highlight-next-line
             debounce: 2000,
         },
-    }
-})
+    },
+});
 ```
+
 #### `onFinish`
 
 If you want to modify the data before sending it to the server, you can use `onFinish` callback function.
@@ -987,8 +995,9 @@ useForm({
             // highlight-end
         },
     },
-})
+});
 ```
+
 ## Return Values
 
 ### `queryResult`
@@ -1200,7 +1209,6 @@ const {
 | --------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | saveButtonProps | Props for a submit button | `{ disabled: boolean; onClick: (e: React.BaseSyntheticEvent) => void; }`                                                                |
 | autoSaveProps   | Auto save props           | `{ data: UpdateResponse<TData>` \| `undefined, error: HttpError` \| `null, status: "loading"` \| `"error"` \| `"idle"` \| `"success" }` |
-
 
 ### Type Parameters
 

--- a/packages/core/src/contexts/refine/IRefineContext.ts
+++ b/packages/core/src/contexts/refine/IRefineContext.ts
@@ -1,6 +1,11 @@
 import { RefineProps } from "@components/containers";
 import React, { ReactNode } from "react";
-import { QueryClientConfig, QueryClient } from "@tanstack/react-query";
+import {
+    QueryClientConfig,
+    QueryClient,
+    InvalidateQueryFilters,
+    InvalidateOptions,
+} from "@tanstack/react-query";
 
 import {
     MutationMode,
@@ -24,6 +29,14 @@ export interface IRefineOptions {
         afterCreate?: RedirectAction;
         afterClone?: RedirectAction;
         afterEdit?: RedirectAction;
+    };
+    invalidate?: {
+        filters?: InvalidateQueryFilters;
+        options?: InvalidateOptions;
+        liveUpdates?: {
+            filters?: InvalidateQueryFilters;
+            options?: InvalidateOptions;
+        };
     };
     reactQuery?: {
         clientConfig?: QueryClientConfig | InstanceType<typeof QueryClient>;
@@ -58,6 +71,14 @@ export interface IRefineContextOptions {
         afterCreate: RedirectAction;
         afterClone: RedirectAction;
         afterEdit: RedirectAction;
+    };
+    invalidate: {
+        filters: InvalidateQueryFilters;
+        options: InvalidateOptions;
+        liveUpdates: {
+            filters: InvalidateQueryFilters;
+            options: InvalidateOptions;
+        };
     };
     overtime: UseLoadingOvertimeRefineContext;
     textTransformers: Required<TextTransformers>;

--- a/packages/core/src/contexts/refine/index.tsx
+++ b/packages/core/src/contexts/refine/index.tsx
@@ -25,6 +25,24 @@ export const defaultRefineOptions: IRefineContextOptions = {
     overtime: {
         interval: 1000,
     },
+    invalidate: {
+        filters: {
+            type: "all",
+            refetchType: "active",
+        },
+        options: {
+            cancelRefetch: false,
+        },
+        liveUpdates: {
+            filters: {
+                type: "active",
+                refetchType: "active",
+            },
+            options: {
+                cancelRefetch: false,
+            },
+        },
+    },
     textTransformers: {
         humanize: humanizeString,
         plural: pluralize.plural,

--- a/packages/core/src/definitions/helpers/handleRefineOptions/index.ts
+++ b/packages/core/src/definitions/helpers/handleRefineOptions/index.ts
@@ -71,6 +71,22 @@ export const handleRefineOptions = ({
                 options?.redirect?.afterEdit ??
                 defaultRefineOptions.redirect.afterEdit,
         },
+        invalidate: {
+            filters:
+                options?.invalidate?.filters ??
+                defaultRefineOptions.invalidate.filters,
+            options:
+                options?.invalidate?.options ??
+                defaultRefineOptions.invalidate.options,
+            liveUpdates: {
+                filters:
+                    options?.invalidate?.liveUpdates?.filters ??
+                    defaultRefineOptions.invalidate.liveUpdates.filters,
+                options:
+                    options?.invalidate?.liveUpdates?.options ??
+                    defaultRefineOptions.invalidate.liveUpdates.options,
+            },
+        },
         overtime: options?.overtime ?? defaultRefineOptions.overtime,
         textTransformers: {
             humanize:

--- a/packages/core/src/hooks/live/useResourceSubscription/index.ts
+++ b/packages/core/src/hooks/live/useResourceSubscription/index.ts
@@ -1,5 +1,4 @@
 import { useContext, useEffect } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 import {
     BaseKey,
     CrudFilters,
@@ -14,7 +13,7 @@ import {
 import { LiveContext } from "@contexts/live";
 import { RefineContext } from "@contexts/refine";
 import { useResource } from "@hooks/resource";
-import { useKeys } from "@hooks/useKeys";
+import { useInvalidate } from "@hooks/invalidate";
 
 export type UseResourceSubscriptionProps = {
     channel: string;
@@ -58,21 +57,38 @@ export const useResourceSubscription = ({
     liveMode: liveModeFromProp,
     onLiveEvent,
 }: UseResourceSubscriptionProps): void => {
-    const queryClient = useQueryClient();
-
     const { resource, identifier } = useResource(resourceFromProp);
-    const { keys, preferLegacyKeys } = useKeys();
 
     const liveDataContext = useContext<ILiveContext>(LiveContext);
     const {
         liveMode: liveModeFromContext,
         onLiveEvent: onLiveEventContextCallback,
+        options: {
+            invalidate: { liveUpdates },
+        },
     } = useContext<IRefineContext>(RefineContext);
 
     const liveMode = liveModeFromProp ?? liveModeFromContext;
 
+    const invalidate = useInvalidate();
+
     useEffect(() => {
         let subscription: any;
+
+        const callback = (event: LiveEvent) => {
+            if (liveMode === "auto") {
+                invalidate({
+                    resource: identifier,
+                    dataProviderName: resource?.meta?.dataProviderName,
+                    invalidates: ["resourceAll"],
+                    invalidationFilters: liveUpdates.filters,
+                    invalidationOptions: liveUpdates.options,
+                });
+            }
+
+            onLiveEvent?.(event);
+            onLiveEventContextCallback?.(event);
+        };
 
         if (liveMode && liveMode !== "off" && enabled) {
             subscription = liveDataContext?.subscribe({
@@ -82,19 +98,7 @@ export const useResourceSubscription = ({
                     ...params,
                 },
                 types,
-                callback: (event) => {
-                    if (liveMode === "auto") {
-                        queryClient.invalidateQueries(
-                            keys()
-                                .data(resource?.meta?.dataProviderName)
-                                .resource(identifier)
-                                .get(preferLegacyKeys),
-                        );
-                    }
-
-                    onLiveEvent?.(event);
-                    onLiveEventContextCallback?.(event);
-                },
+                callback,
             });
         }
 


### PR DESCRIPTION
Fine-tuning the invalidation process by setting up additional filters and options for the invalidation.

Now after a successful mutation, refine will invalidate all the queries in the scope but trigger a refetch only for the active queries. If there are any ongoing queries, they will be kept as they are.

After receiving a realtime subscription event, refine will invalidate and refetch only the active queries.

These settings can be changed via `options.invalidate` prop of the `<Refine>` component or while using the `useInvalidate` hook.

These changes will resolve the conflicting invalidation calls when using `"auto"` live updates and `"pessimistic"` mutations.

### Test plan (required)

Tests are on the way.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [ ] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
