### PR TITLE
fix: `useForm` warn condition

### DIFF
--- a/.changeset/serious-kids-tell.md
+++ b/.changeset/serious-kids-tell.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": patch
+---
+
+fix: update `useForm` warn condition

--- a/packages/core/src/hooks/form/useForm.ts
+++ b/packages/core/src/hooks/form/useForm.ts
@@ -332,7 +332,8 @@ export const useForm = <
     warnOnce(
         (isClone || isEdit) &&
             Boolean(resourceFromProps) &&
-            !Boolean(idFromProps),
+            !Boolean(idFromProps) &&
+            queryOptions?.enabled !== false,
         `[useForm]: action: "${action}", resource: "${identifier}", id: ${id} \n\n` +
             `If you don't use the \`setId\` method to set the \`id\`, you should pass the \`id\` prop to \`useForm\`. Otherwise, \`useForm\` will not be able to infer the \`id\` from the current URL. \n\n` +
             `See https://refine.dev/docs/api-reference/core/hooks/useForm/#resource`,


### PR DESCRIPTION
Updated `useForm` warn condition. If the user passes the `queryOption.enabled: false` to the hook, the `useForm` will not throw a warning anymore.