### PR TITLE
build: keep names on build

### DIFF
--- a/.changeset/nine-eagles-flow.md
+++ b/.changeset/nine-eagles-flow.md
@@ -1,0 +1,13 @@
+---
+"@refinedev/antd": patch
+"@refinedev/chakra-ui": patch
+"@refinedev/core": patch
+"@refinedev/inferencer": patch
+"@refinedev/kbar": patch
+"@refinedev/mantine": patch
+"@refinedev/mui": patch
+"@refinedev/react-hook-form": patch
+"@refinedev/react-table": patch
+---
+
+Keep the hook and component names in builds for better debugging.

--- a/packages/antd/tsup.config.ts
+++ b/packages/antd/tsup.config.ts
@@ -103,5 +103,8 @@ export default defineConfig({
     loader: {
         ".svg": "dataurl",
     },
+    esbuildOptions(options) {
+        options.keepNames = true;
+    },
     onSuccess: "tsc --project tsconfig.declarations.json",
 });

--- a/packages/chakra-ui/tsup.config.ts
+++ b/packages/chakra-ui/tsup.config.ts
@@ -95,5 +95,8 @@ export default defineConfig({
     loader: {
         ".svg": "dataurl",
     },
+    esbuildOptions(options) {
+        options.keepNames = true;
+    },
     onSuccess: "tsc --project tsconfig.declarations.json",
 });

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -102,5 +102,8 @@ export default defineConfig({
             },
         }),
     ],
+    esbuildOptions(options) {
+        options.keepNames = true;
+    },
     onSuccess: "tsc --project tsconfig.declarations.json",
 });

--- a/packages/inferencer/tsup.config.ts
+++ b/packages/inferencer/tsup.config.ts
@@ -57,5 +57,8 @@ export default defineConfig({
     loader: {
         ".svg": "dataurl",
     },
+    esbuildOptions(options) {
+        options.keepNames = true;
+    },
     onSuccess: "tsc --project tsconfig.declarations.json",
 });

--- a/packages/kbar/tsup.config.ts
+++ b/packages/kbar/tsup.config.ts
@@ -20,5 +20,8 @@ export default defineConfig({
             },
         }),
     ],
+    esbuildOptions(options) {
+        options.keepNames = true;
+    },
     onSuccess: "tsc --project tsconfig.declarations.json",
 });

--- a/packages/mantine/tsup.config.ts
+++ b/packages/mantine/tsup.config.ts
@@ -49,5 +49,8 @@ export default defineConfig({
     loader: {
         ".svg": "dataurl",
     },
+    esbuildOptions(options) {
+        options.keepNames = true;
+    },
     onSuccess: "tsc --project tsconfig.declarations.json",
 });

--- a/packages/mui/tsup.config.ts
+++ b/packages/mui/tsup.config.ts
@@ -95,5 +95,8 @@ export default defineConfig({
     loader: {
         ".svg": "dataurl",
     },
+    esbuildOptions(options) {
+        options.keepNames = true;
+    },
     onSuccess: "tsc --project tsconfig.declarations.json",
 });

--- a/packages/react-hook-form/tsup.config.ts
+++ b/packages/react-hook-form/tsup.config.ts
@@ -20,5 +20,8 @@ export default defineConfig({
             },
         }),
     ],
+    esbuildOptions(options) {
+        options.keepNames = true;
+    },
     onSuccess: "tsc --project tsconfig.declarations.json",
 });

--- a/packages/react-table/tsup.config.ts
+++ b/packages/react-table/tsup.config.ts
@@ -20,5 +20,8 @@ export default defineConfig({
             },
         }),
     ],
+    esbuildOptions(options) {
+        options.keepNames = true;
+    },
     onSuccess: "tsc --project tsconfig.declarations.json",
 });


### PR DESCRIPTION
Updated our `esbuild` config to keep names of the components and hooks in releases for better debugging experience.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
