### PR TITLE
build: update `esbuild` plugins

### DIFF
--- a/.changeset/early-radios-juggle.md
+++ b/.changeset/early-radios-juggle.md
@@ -1,0 +1,6 @@
+---
+"@refinedev/ui-tests": patch
+"@refinedev/ui-types": patch
+---
+
+Remove redundant lodash plugin for esbuild and use the shared plugins instead

--- a/.changeset/quiet-ladybugs-wonder.md
+++ b/.changeset/quiet-ladybugs-wonder.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/nhost": patch
+---
+
+Add missing `lodash` dependency

--- a/.changeset/ten-dryers-yell.md
+++ b/.changeset/ten-dryers-yell.md
@@ -1,0 +1,13 @@
+---
+"@refinedev/chakra-ui": patch
+"@refinedev/connect": patch
+"@refinedev/core": patch
+"@refinedev/hasura": patch
+"@refinedev/inferencer": patch
+"@refinedev/mui": patch
+"@refinedev/nestjs-query": patch
+"@refinedev/nhost": patch
+---
+
+-   Update build configuration for `esbuild` to use the shared plugins.
+-   Fix the lodash replacement plugin to skip redundant files.

--- a/packages/chakra-ui/tsup.config.ts
+++ b/packages/chakra-ui/tsup.config.ts
@@ -1,10 +1,7 @@
 import { defineConfig } from "tsup";
-import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
 
-import * as fs from "fs";
-import path from "path";
-
-const JS_EXTENSIONS = new Set(["js", "cjs", "mjs"]);
+import { markAsExternalPlugin } from "../shared/mark-as-external-plugin";
+import { removeTestIdsPlugin } from "../shared/remove-test-ids-plugin";
 
 export default defineConfig({
     entry: ["src/index.tsx"],
@@ -12,86 +9,7 @@ export default defineConfig({
     sourcemap: true,
     clean: false,
     platform: "browser",
-    esbuildPlugins: [
-        {
-            name: "react-remove-testids",
-            setup(build) {
-                build.onEnd(async (args) => {
-                    // data-testid regexp
-                    const regexp = /("data-testid":)(.*?)(?:(,)|(}))/gi;
-
-                    // output files with `*.js`
-                    const jsOutputFiles =
-                        args.outputFiles?.filter((el) =>
-                            el.path.endsWith(".js"),
-                        ) ?? [];
-
-                    // replace data-testid in output files
-                    for (const jsOutputFile of jsOutputFiles) {
-                        const str = new TextDecoder("utf-8").decode(
-                            jsOutputFile.contents,
-                        );
-                        const newStr = str.replace(regexp, "$4");
-                        jsOutputFile.contents = new TextEncoder().encode(
-                            newStr,
-                        );
-                    }
-                });
-            },
-        },
-        {
-            name: "textReplace",
-            setup: (build) => {
-                // original code: https://github.com/josteph/esbuild-plugin-lodash
-                if (build.initialOptions.format === "cjs") {
-                    return;
-                }
-                build.onLoad({ filter: /.(ts|tsx)$/ }, async (args) => {
-                    const contents = await fs.promises.readFile(
-                        args.path,
-                        "utf8",
-                    );
-
-                    const lodashImportRegex =
-                        /import\s+?(?:(?:(?:[\w*\s{},]*)\s+from\s+?)|)[\'\"](?:(?:lodash\/?.*?))[\'\"][\s]*?(?:;|$|)/g;
-                    const extension = path.extname(args.path).replace(".", "");
-
-                    const loader = JS_EXTENSIONS.has(extension)
-                        ? "jsx"
-                        : (extension as any);
-
-                    const lodashImports = contents.match(lodashImportRegex);
-                    if (!lodashImports) {
-                        return {
-                            loader,
-                            contents,
-                        };
-                    }
-
-                    const finalContents = contents.replaceAll(
-                        "lodash",
-                        "lodash-es",
-                    );
-
-                    return {
-                        loader,
-                        contents: finalContents,
-                    };
-                });
-            },
-        },
-        NodeResolvePlugin({
-            extensions: [".js", "ts", "tsx", "jsx"],
-            onResolved: (resolved) => {
-                if (resolved.includes("node_modules")) {
-                    return {
-                        external: true,
-                    };
-                }
-                return resolved;
-            },
-        }),
-    ],
+    esbuildPlugins: [removeTestIdsPlugin, markAsExternalPlugin],
     loader: {
         ".svg": "dataurl",
     },

--- a/packages/connect/tsup.config.ts
+++ b/packages/connect/tsup.config.ts
@@ -1,10 +1,7 @@
 import { defineConfig } from "tsup";
-import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
 
-import * as fs from "fs";
-import path from "path";
-
-const JS_EXTENSIONS = new Set(["js", "cjs", "mjs"]);
+import { lodashReplacePlugin } from "../shared/lodash-replace-plugin";
+import { markAsExternalPlugin } from "../shared/mark-as-external-plugin";
 
 export default defineConfig({
     entry: ["src/index.ts"],
@@ -12,59 +9,6 @@ export default defineConfig({
     sourcemap: true,
     clean: false,
     platform: "browser",
-    esbuildPlugins: [
-        {
-            name: "textReplace",
-            setup: (build) => {
-                // original code: https://github.com/josteph/esbuild-plugin-lodash
-                if (build.initialOptions.format === "cjs") {
-                    return;
-                }
-                build.onLoad({ filter: /.*/ }, async (args) => {
-                    const contents = await fs.promises.readFile(
-                        args.path,
-                        "utf8",
-                    );
-
-                    const lodashImportRegex =
-                        /import\s+?(?:(?:(?:[\w*\s{},]*)\s+from\s+?)|)[\'\"](?:(?:lodash\/?.*?))[\'\"][\s]*?(?:;|$|)/g;
-                    const extension = path.extname(args.path).replace(".", "");
-
-                    const loader = JS_EXTENSIONS.has(extension)
-                        ? "jsx"
-                        : (extension as any);
-
-                    const lodashImports = contents.match(lodashImportRegex);
-                    if (!lodashImports) {
-                        return {
-                            loader,
-                            contents,
-                        };
-                    }
-
-                    const finalContents = contents.replaceAll(
-                        "lodash",
-                        "lodash-es",
-                    );
-
-                    return {
-                        loader,
-                        contents: finalContents,
-                    };
-                });
-            },
-        },
-        NodeResolvePlugin({
-            extensions: [".js", "ts", "tsx", "jsx"],
-            onResolved: (resolved) => {
-                if (resolved.includes("node_modules")) {
-                    return {
-                        external: true,
-                    };
-                }
-                return resolved;
-            },
-        }),
-    ],
+    esbuildPlugins: [lodashReplacePlugin, markAsExternalPlugin],
     onSuccess: "tsc --project tsconfig.declarations.json",
 });

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,16 +1,8 @@
 import { defineConfig } from "tsup";
-import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
 
-import * as fs from "fs";
-import path from "path";
-
-const JS_EXTENSIONS = new Set(["js", "cjs", "mjs"]);
-
-const getRefineCoreVersion = async () => {
-    const packages = await fs.promises.readFile("./package.json", "utf8");
-    const { version } = JSON.parse(packages);
-    return version;
-};
+import { lodashReplacePlugin } from "../shared/lodash-replace-plugin";
+import { markAsExternalPlugin } from "../shared/mark-as-external-plugin";
+import { replaceCoreVersionPlugin } from "../shared/replace-core-version-plugin";
 
 export default defineConfig({
     entry: ["src/index.tsx"],
@@ -19,88 +11,9 @@ export default defineConfig({
     clean: false,
     platform: "browser",
     esbuildPlugins: [
-        {
-            name: "textReplace",
-            setup: (build) => {
-                build.onLoad({ filter: /\.ts$/ }, async (args) => {
-                    const contents = await fs.promises.readFile(
-                        args.path,
-                        "utf8",
-                    );
-
-                    const extension = path.extname(args.path).replace(".", "");
-                    const loader = JS_EXTENSIONS.has(extension)
-                        ? "jsx"
-                        : (extension as any);
-
-                    const versionRegex = /const REFINE_VERSION = "\d.\d.\d";/gm;
-                    const hasVersion = contents.match(versionRegex);
-
-                    if (!hasVersion) {
-                        return {
-                            loader,
-                            contents,
-                        };
-                    }
-
-                    const version = await getRefineCoreVersion();
-                    return {
-                        loader,
-                        contents: contents.replace(
-                            versionRegex,
-                            `const REFINE_VERSION = "${version}";`,
-                        ),
-                    };
-                });
-            },
-        },
-        {
-            name: "textReplace",
-            setup: (build) => {
-                // original code: https://github.com/josteph/esbuild-plugin-lodash
-                if (build.initialOptions.format === "cjs") {
-                    return;
-                }
-                build.onLoad({ filter: /.*/ }, async (args) => {
-                    const contents = await fs.promises.readFile(
-                        args.path,
-                        "utf8",
-                    );
-
-                    const extension = path.extname(args.path).replace(".", "");
-                    const loader = JS_EXTENSIONS.has(extension)
-                        ? "jsx"
-                        : (extension as any);
-
-                    const lodashImportRegex =
-                        /import\s+?(?:(?:(?:[\w*\s{},]*)\s+from\s+?)|)[\'\"](?:(?:lodash\/?.*?))[\'\"][\s]*?(?:;|$|)/g;
-
-                    const lodashImports = contents.match(lodashImportRegex);
-                    if (!lodashImports) {
-                        return {
-                            loader,
-                            contents,
-                        };
-                    }
-
-                    return {
-                        loader,
-                        contents: contents.replaceAll("lodash", "lodash-es"),
-                    };
-                });
-            },
-        },
-        NodeResolvePlugin({
-            extensions: [".js", "ts", "tsx", "jsx"],
-            onResolved: (resolved) => {
-                if (resolved.includes("node_modules")) {
-                    return {
-                        external: true,
-                    };
-                }
-                return resolved;
-            },
-        }),
+        replaceCoreVersionPlugin,
+        lodashReplacePlugin,
+        markAsExternalPlugin,
     ],
     esbuildOptions(options) {
         options.keepNames = true;

--- a/packages/hasura/tsup.config.ts
+++ b/packages/hasura/tsup.config.ts
@@ -1,9 +1,7 @@
 import { defineConfig } from "tsup";
-import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
-import * as fs from "fs";
-import path from "path";
 
-const JS_EXTENSIONS = new Set(["js", "cjs", "mjs"]);
+import { lodashReplacePlugin } from "../shared/lodash-replace-plugin";
+import { markAsExternalPlugin } from "../shared/mark-as-external-plugin";
 
 export default defineConfig({
     entry: ["src/index.ts"],
@@ -11,59 +9,6 @@ export default defineConfig({
     sourcemap: true,
     clean: false,
     platform: "browser",
-    esbuildPlugins: [
-        {
-            name: "textReplace",
-            setup: (build) => {
-                // original code: https://github.com/josteph/esbuild-plugin-lodash
-                if (build.initialOptions.format === "cjs") {
-                    return;
-                }
-                build.onLoad({ filter: /.*/ }, async (args) => {
-                    const contents = await fs.promises.readFile(
-                        args.path,
-                        "utf8",
-                    );
-
-                    const lodashImportRegex =
-                        /import\s+?(?:(?:(?:[\w*\s{},]*)\s+from\s+?)|)[\'\"](?:(?:lodash\/?.*?))[\'\"][\s]*?(?:;|$|)/g;
-                    const extension = path.extname(args.path).replace(".", "");
-
-                    const loader = JS_EXTENSIONS.has(extension)
-                        ? "jsx"
-                        : (extension as any);
-
-                    const lodashImports = contents.match(lodashImportRegex);
-                    if (!lodashImports) {
-                        return {
-                            loader,
-                            contents,
-                        };
-                    }
-
-                    const finalContents = contents.replaceAll(
-                        "lodash",
-                        "lodash-es",
-                    );
-
-                    return {
-                        loader,
-                        contents: finalContents,
-                    };
-                });
-            },
-        },
-        NodeResolvePlugin({
-            extensions: [".js", "ts", "tsx", "jsx"],
-            onResolved: (resolved) => {
-                if (resolved.includes("node_modules")) {
-                    return {
-                        external: true,
-                    };
-                }
-                return resolved;
-            },
-        }),
-    ],
+    esbuildPlugins: [lodashReplacePlugin, markAsExternalPlugin],
     onSuccess: "tsc --project tsconfig.declarations.json",
 });

--- a/packages/inferencer/tsup.config.ts
+++ b/packages/inferencer/tsup.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from "tsup";
-import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
+
+import { lodashReplacePlugin } from "../shared/lodash-replace-plugin";
+import { markAsExternalPlugin } from "../shared/mark-as-external-plugin";
+import { removeTestIdsPlugin } from "../shared/remove-test-ids-plugin";
 
 export default defineConfig({
     entry: {
@@ -16,43 +19,9 @@ export default defineConfig({
     clean: false,
     platform: "browser",
     esbuildPlugins: [
-        {
-            name: "react-remove-testids",
-            setup(build) {
-                build.onEnd(async (args) => {
-                    // data-testid regexp
-                    const regexp = /("data-testid":)(.*?)(?:(,)|(}))/gi;
-
-                    // output files with `*.js`
-                    const jsOutputFiles =
-                        args.outputFiles?.filter((el) =>
-                            el.path.endsWith(".js"),
-                        ) ?? [];
-
-                    // replace data-testid in output files
-                    for (const jsOutputFile of jsOutputFiles) {
-                        const str = new TextDecoder("utf-8").decode(
-                            jsOutputFile.contents,
-                        );
-                        const newStr = str.replace(regexp, "$4");
-                        jsOutputFile.contents = new TextEncoder().encode(
-                            newStr,
-                        );
-                    }
-                });
-            },
-        },
-        NodeResolvePlugin({
-            extensions: [".js", "ts", "tsx", "jsx"],
-            onResolved: (resolved) => {
-                if (resolved.includes("node_modules")) {
-                    return {
-                        external: true,
-                    };
-                }
-                return resolved;
-            },
-        }),
+        removeTestIdsPlugin,
+        lodashReplacePlugin,
+        markAsExternalPlugin,
     ],
     loader: {
         ".svg": "dataurl",

--- a/packages/mui/tsup.config.ts
+++ b/packages/mui/tsup.config.ts
@@ -1,10 +1,8 @@
 import { defineConfig } from "tsup";
-import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
 
-import * as fs from "fs";
-import path from "path";
-
-const JS_EXTENSIONS = new Set(["js", "cjs", "mjs"]);
+import { lodashReplacePlugin } from "../shared/lodash-replace-plugin";
+import { markAsExternalPlugin } from "../shared/mark-as-external-plugin";
+import { removeTestIdsPlugin } from "../shared/remove-test-ids-plugin";
 
 export default defineConfig({
     entry: ["src/index.tsx"],
@@ -13,84 +11,9 @@ export default defineConfig({
     clean: false,
     platform: "browser",
     esbuildPlugins: [
-        {
-            name: "react-remove-testids",
-            setup(build) {
-                build.onEnd(async (args) => {
-                    // data-testid regexp
-                    const regexp = /("data-testid":)(.*?)(?:(,)|(}))/gi;
-
-                    // output files with `*.js`
-                    const jsOutputFiles =
-                        args.outputFiles?.filter((el) =>
-                            el.path.endsWith(".js"),
-                        ) ?? [];
-
-                    // replace data-testid in output files
-                    for (const jsOutputFile of jsOutputFiles) {
-                        const str = new TextDecoder("utf-8").decode(
-                            jsOutputFile.contents,
-                        );
-                        const newStr = str.replace(regexp, "$4");
-                        jsOutputFile.contents = new TextEncoder().encode(
-                            newStr,
-                        );
-                    }
-                });
-            },
-        },
-        {
-            name: "textReplace",
-            setup: (build) => {
-                // original code: https://github.com/josteph/esbuild-plugin-lodash
-                if (build.initialOptions.format === "cjs") {
-                    return;
-                }
-                build.onLoad({ filter: /.(ts|tsx)$/ }, async (args) => {
-                    const contents = await fs.promises.readFile(
-                        args.path,
-                        "utf8",
-                    );
-
-                    const lodashImportRegex =
-                        /import\s+?(?:(?:(?:[\w*\s{},]*)\s+from\s+?)|)[\'\"](?:(?:lodash\/?.*?))[\'\"][\s]*?(?:;|$|)/g;
-                    const extension = path.extname(args.path).replace(".", "");
-
-                    const loader = JS_EXTENSIONS.has(extension)
-                        ? "jsx"
-                        : (extension as any);
-
-                    const lodashImports = contents.match(lodashImportRegex);
-                    if (!lodashImports) {
-                        return {
-                            loader,
-                            contents,
-                        };
-                    }
-
-                    const finalContents = contents.replaceAll(
-                        "lodash",
-                        "lodash-es",
-                    );
-
-                    return {
-                        loader,
-                        contents: finalContents,
-                    };
-                });
-            },
-        },
-        NodeResolvePlugin({
-            extensions: [".js", "ts", "tsx", "jsx"],
-            onResolved: (resolved) => {
-                if (resolved.includes("node_modules")) {
-                    return {
-                        external: true,
-                    };
-                }
-                return resolved;
-            },
-        }),
+        removeTestIdsPlugin,
+        lodashReplacePlugin,
+        markAsExternalPlugin,
     ],
     loader: {
         ".svg": "dataurl",

--- a/packages/nestjs-query/tsup.config.ts
+++ b/packages/nestjs-query/tsup.config.ts
@@ -1,7 +1,7 @@
-import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
 import { defineConfig } from "tsup";
 
-const JS_EXTENSIONS = new Set(["js", "cjs", "mjs"]);
+import { lodashReplacePlugin } from "../shared/lodash-replace-plugin";
+import { markAsExternalPlugin } from "../shared/mark-as-external-plugin";
 
 export default defineConfig({
     entry: ["src/index.ts"],
@@ -9,54 +9,6 @@ export default defineConfig({
     sourcemap: true,
     clean: false,
     platform: "browser",
-    esbuildPlugins: [
-        NodeResolvePlugin({
-            extensions: [".js", "ts", "tsx", "jsx"],
-            onResolved: (resolved) => {
-                if (resolved.includes("node_modules")) {
-                    return {
-                        external: true,
-                    };
-                }
-                return resolved;
-            },
-        }),
-        {
-            name: "textReplace",
-            setup: (build) => {
-                // original code: https://github.com/josteph/esbuild-plugin-lodash
-                if (build.initialOptions.format === "cjs") {
-                    return;
-                }
-                build.onLoad({ filter: /.*/ }, async (args) => {
-                    const contents = await fs.promises.readFile(
-                        args.path,
-                        "utf8",
-                    );
-
-                    const extension = path.extname(args.path).replace(".", "");
-                    const loader = JS_EXTENSIONS.has(extension)
-                        ? "jsx"
-                        : (extension as any);
-
-                    const lodashImportRegex =
-                        /import\s+?(?:(?:(?:[\w*\s{},]*)\s+from\s+?)|)[\'\"](?:(?:lodash\/?.*?))[\'\"][\s]*?(?:;|$|)/g;
-
-                    const lodashImports = contents.match(lodashImportRegex);
-                    if (!lodashImports) {
-                        return {
-                            loader,
-                            contents,
-                        };
-                    }
-
-                    return {
-                        loader,
-                        contents: contents.replaceAll("lodash", "lodash-es"),
-                    };
-                });
-            },
-        },
-    ],
+    esbuildPlugins: [markAsExternalPlugin, lodashReplacePlugin],
     onSuccess: "tsc --project tsconfig.declarations.json",
 });

--- a/packages/nhost/package.json
+++ b/packages/nhost/package.json
@@ -27,7 +27,6 @@
     "@types/jest": "^29.2.4",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
-    "lodash": "^4.17.21",
     "nock": "^13.1.3",
     "ts-jest": "^29.0.3",
     "tslib": "^2.3.1",
@@ -39,6 +38,7 @@
     "gql-query-builder": "^3.5.5",
     "graphql": "^15.6.1",
     "graphql-ws": "^5.9.1",
+    "lodash": "^4.17.21",
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {

--- a/packages/nhost/tsup.config.ts
+++ b/packages/nhost/tsup.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "tsup";
-import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
+
+import { lodashReplacePlugin } from "../shared/lodash-replace-plugin";
+import { markAsExternalPlugin } from "../shared/mark-as-external-plugin";
 
 export default defineConfig({
     entry: ["src/index.ts"],
@@ -7,18 +9,6 @@ export default defineConfig({
     sourcemap: true,
     clean: false,
     platform: "browser",
-    esbuildPlugins: [
-        NodeResolvePlugin({
-            extensions: [".js", "ts", "tsx", "jsx"],
-            onResolved: (resolved) => {
-                if (resolved.includes("node_modules")) {
-                    return {
-                        external: true,
-                    };
-                }
-                return resolved;
-            },
-        }),
-    ],
+    esbuildPlugins: [lodashReplacePlugin, markAsExternalPlugin],
     onSuccess: "tsc --project tsconfig.declarations.json",
 });

--- a/packages/shared/get-refine-core-version.ts
+++ b/packages/shared/get-refine-core-version.ts
@@ -1,0 +1,11 @@
+import fs from "fs";
+import path from "path";
+
+export const getRefineCoreVersion = async () => {
+    const packages = await fs.promises.readFile(
+        path.join("..", "core", "package.json"),
+        "utf8",
+    );
+    const { version } = JSON.parse(packages);
+    return version;
+};

--- a/packages/shared/lodash-replace-plugin.ts
+++ b/packages/shared/lodash-replace-plugin.ts
@@ -1,0 +1,39 @@
+import { Plugin } from "esbuild";
+import * as fs from "fs";
+import path from "path";
+
+const JS_EXTENSIONS = new Set(["js", "cjs", "mjs"]);
+
+export const lodashReplacePlugin: Plugin = {
+    name: "replaceLodashWithLodashEsForEsm",
+    setup: (build) => {
+        // original code: https://github.com/josteph/esbuild-plugin-lodash
+        if (build.initialOptions.format === "cjs") {
+            return;
+        }
+
+        build.onLoad({ filter: /.*/ }, async (args) => {
+            const contents = await fs.promises.readFile(args.path, "utf8");
+
+            const extension = path.extname(args.path).replace(".", "");
+            const loader = JS_EXTENSIONS.has(extension)
+                ? "jsx"
+                : (extension as any);
+
+            const lodashImportRegex =
+                /import\s+?(?:(?:(?:[\w*\s{},]*)\s+from\s+?)|)[\'\"](?:(?:lodash\/?.*?))[\'\"][\s]*?(?:;|$|)/g;
+
+            const isExternal = !args.path.startsWith(process.cwd());
+
+            const lodashImports = contents.match(lodashImportRegex);
+            if (!lodashImports || isExternal) {
+                return;
+            }
+
+            return {
+                loader,
+                contents: contents.replace(/lodash/g, "lodash-es"),
+            };
+        });
+    },
+};

--- a/packages/shared/mark-as-external-plugin.ts
+++ b/packages/shared/mark-as-external-plugin.ts
@@ -1,0 +1,13 @@
+import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
+
+export const markAsExternalPlugin = NodeResolvePlugin({
+    extensions: [".js", "ts", "tsx", "jsx"],
+    onResolved: (resolved) => {
+        if (resolved.includes("node_modules")) {
+            return {
+                external: true,
+            };
+        }
+        return resolved;
+    },
+});

--- a/packages/shared/remove-test-ids-plugin.ts
+++ b/packages/shared/remove-test-ids-plugin.ts
@@ -1,0 +1,24 @@
+import { Plugin } from "esbuild";
+
+export const removeTestIdsPlugin: Plugin = {
+    name: "react-remove-testids",
+    setup(build) {
+        build.onEnd(async (args) => {
+            // data-testid regexp
+            const regexp = /("data-testid":)(.*?)(?:(,)|(}))/gi;
+
+            // output files with `*.js`
+            const jsOutputFiles =
+                args.outputFiles?.filter((el) => el.path.endsWith(".js")) ?? [];
+
+            // replace data-testid in output files
+            for (const jsOutputFile of jsOutputFiles) {
+                const str = new TextDecoder("utf-8").decode(
+                    jsOutputFile.contents,
+                );
+                const newStr = str.replace(regexp, "$4");
+                jsOutputFile.contents = new TextEncoder().encode(newStr);
+            }
+        });
+    },
+};

--- a/packages/shared/replace-core-version-plugin.ts
+++ b/packages/shared/replace-core-version-plugin.ts
@@ -1,0 +1,36 @@
+import { Plugin } from "esbuild";
+import * as fs from "fs";
+import path from "path";
+
+import { getRefineCoreVersion } from "./get-refine-core-version";
+
+export const replaceCoreVersionPlugin: Plugin = {
+    name: "replaceCoreVersion",
+    setup: (build) => {
+        build.onLoad({ filter: /\.ts$/ }, async (args) => {
+            const contents = await fs.promises.readFile(args.path, "utf8");
+
+            const extension = path.extname(args.path).replace(".", "");
+            const loader = ["js", "cjs", "mjs"].includes(extension)
+                ? "jsx"
+                : (extension as any);
+
+            const versionRegex = /const REFINE_VERSION = "\d.\d.\d";/gm;
+            const hasVersion = contents.match(versionRegex);
+
+            if (!hasVersion) {
+                return;
+            }
+
+            const version = await getRefineCoreVersion();
+
+            return {
+                loader,
+                contents: contents.replace(
+                    versionRegex,
+                    `const REFINE_VERSION = "${version}";`,
+                ),
+            };
+        });
+    },
+};

--- a/packages/ui-tests/tsup.config.ts
+++ b/packages/ui-tests/tsup.config.ts
@@ -1,10 +1,5 @@
 import { defineConfig } from "tsup";
-import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
-
-import * as fs from "fs";
-import path from "path";
-
-const JS_EXTENSIONS = new Set(["js", "cjs", "mjs"]);
+import { markAsExternalPlugin } from "../shared/mark-as-external-plugin";
 
 export default defineConfig({
     entry: ["src/index.tsx"],
@@ -12,60 +7,7 @@ export default defineConfig({
     sourcemap: true,
     clean: false,
     platform: "browser",
-    esbuildPlugins: [
-        {
-            name: "textReplace",
-            setup: (build) => {
-                // original code: https://github.com/josteph/esbuild-plugin-lodash
-                if (build.initialOptions.format === "cjs") {
-                    return;
-                }
-                build.onLoad({ filter: /.(ts|tsx)$/ }, async (args) => {
-                    const contents = await fs.promises.readFile(
-                        args.path,
-                        "utf8",
-                    );
-
-                    const lodashImportRegex =
-                        /import\s+?(?:(?:(?:[\w*\s{},]*)\s+from\s+?)|)[\'\"](?:(?:lodash\/?.*?))[\'\"][\s]*?(?:;|$|)/g;
-                    const extension = path.extname(args.path).replace(".", "");
-
-                    const loader = JS_EXTENSIONS.has(extension)
-                        ? "jsx"
-                        : (extension as any);
-
-                    const lodashImports = contents.match(lodashImportRegex);
-                    if (!lodashImports) {
-                        return {
-                            loader,
-                            contents,
-                        };
-                    }
-
-                    const finalContents = contents.replaceAll(
-                        "lodash",
-                        "lodash-es",
-                    );
-
-                    return {
-                        loader,
-                        contents: finalContents,
-                    };
-                });
-            },
-        },
-        NodeResolvePlugin({
-            extensions: [".js", "ts", "tsx", "jsx"],
-            onResolved: (resolved) => {
-                if (resolved.includes("node_modules")) {
-                    return {
-                        external: true,
-                    };
-                }
-                return resolved;
-            },
-        }),
-    ],
+    esbuildPlugins: [markAsExternalPlugin],
     loader: {
         ".svg": "dataurl",
     },

--- a/packages/ui-types/tsup.config.ts
+++ b/packages/ui-types/tsup.config.ts
@@ -1,10 +1,6 @@
 import { defineConfig } from "tsup";
-import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
 
-import * as fs from "fs";
-import path from "path";
-
-const JS_EXTENSIONS = new Set(["js", "cjs", "mjs"]);
+import { markAsExternalPlugin } from "../shared/mark-as-external-plugin";
 
 export default defineConfig({
     entry: ["src/index.tsx"],
@@ -12,60 +8,7 @@ export default defineConfig({
     sourcemap: true,
     clean: false,
     platform: "browser",
-    esbuildPlugins: [
-        {
-            name: "textReplace",
-            setup: (build) => {
-                // original code: https://github.com/josteph/esbuild-plugin-lodash
-                if (build.initialOptions.format === "cjs") {
-                    return;
-                }
-                build.onLoad({ filter: /.(ts|tsx)$/ }, async (args) => {
-                    const contents = await fs.promises.readFile(
-                        args.path,
-                        "utf8",
-                    );
-
-                    const lodashImportRegex =
-                        /import\s+?(?:(?:(?:[\w*\s{},]*)\s+from\s+?)|)[\'\"](?:(?:lodash\/?.*?))[\'\"][\s]*?(?:;|$|)/g;
-                    const extension = path.extname(args.path).replace(".", "");
-
-                    const loader = JS_EXTENSIONS.has(extension)
-                        ? "jsx"
-                        : (extension as any);
-
-                    const lodashImports = contents.match(lodashImportRegex);
-                    if (!lodashImports) {
-                        return {
-                            loader,
-                            contents,
-                        };
-                    }
-
-                    const finalContents = contents.replaceAll(
-                        "lodash",
-                        "lodash-es",
-                    );
-
-                    return {
-                        loader,
-                        contents: finalContents,
-                    };
-                });
-            },
-        },
-        NodeResolvePlugin({
-            extensions: [".js", "ts", "tsx", "jsx"],
-            onResolved: (resolved) => {
-                if (resolved.includes("node_modules")) {
-                    return {
-                        external: true,
-                    };
-                }
-                return resolved;
-            },
-        }),
-    ],
+    esbuildPlugins: [markAsExternalPlugin],
     loader: {
         ".svg": "dataurl",
     },


### PR DESCRIPTION
Moved the `esbuild` plugins to `packages/shared` for shared usage and fixed the `lodash` replacement plugin to skip unwanted files.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
