### PR TITLE
fix: mantine doc links

### DIFF
--- a/.changeset/tender-toys-yawn.md
+++ b/.changeset/tender-toys-yawn.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mantine": patch
+---
+
+fixed: broken Mantine documentation links on JSDoc.

--- a/documentation/docs/api-reference/mantine/components/buttons/clone.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/clone.md
@@ -56,7 +56,7 @@ const ClonePage = () => {
 };
 ```
 
-`<CloneButton>` uses Mantine's [`<Button>`](https://mantine.dev/core/button/) component. It uses the `clone` method from [useNavigation](/api-reference/core/hooks/navigation/useNavigation.md) under the hood.
+`<CloneButton>` uses Mantine's [`<Button>`](https://mantine.dev/core/button) component. It uses the `clone` method from [useNavigation](/api-reference/core/hooks/navigation/useNavigation.md) under the hood.
 It can be useful when redirecting the app to the create page with the record id route of resource.
 
 :::info-tip Swizzle
@@ -251,9 +251,7 @@ import { Refine } from "@refinedev/core";
 import { CloneButton } from "@refinedev/mantine";
 
 const MyCloneComponent = () => {
-    return (
-        <CloneButton resource="categories" recordItemId="2" />
-    );
+    return <CloneButton resource="categories" recordItemId="2" />;
 };
 // visible-block-end
 
@@ -291,9 +289,7 @@ If the `clone` action route is defined by the pattern: `/posts/:authorId/clone/:
 
 ```tsx
 const MyComponent = () => {
-    return (
-        <CloneButton meta={{ authorId: "10" }} />
-    );
+    return <CloneButton meta={{ authorId: "10" }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/mantine/components/buttons/create.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/create.md
@@ -56,7 +56,7 @@ const CreatePage = () => {
 };
 ```
 
-`<CreateButton>` uses Mantine's [`<Button>`](https://mantine.dev/core/button/) component. It uses the `create` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful to redirect the app to the create page route of resource.
+`<CreateButton>` uses Mantine's [`<Button>`](https://mantine.dev/core/button) component. It uses the `create` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful to redirect the app to the create page route of resource.
 
 :::info-tip Swizzle
 You can swizzle this component with the [**refine CLI**](/docs/packages/documentation/cli) to customize it.
@@ -229,9 +229,7 @@ If the `create` action route is defined by the pattern: `/posts/:authorId/create
 
 ```tsx
 const MyComponent = () => {
-    return (
-        <CreateButton meta={{ authorId: "10" }} />
-    );
+    return <CreateButton meta={{ authorId: "10" }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/mantine/components/buttons/delete.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/delete.md
@@ -32,7 +32,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-`<DeleteButton>` uses Mantine's [`<Button>`](https://mantine.dev/core/button/) and [`<Popconfirm>`](https://mantine.dev/core/popover/) components.
+`<DeleteButton>` uses Mantine's [`<Button>`](https://mantine.dev/core/button) and [`<Popconfirm>`](https://mantine.dev/core/popover/) components.
 When you try to delete something, a pop-up shows up and asks for confirmation. When confirmed it executes the [`useDelete`](/docs/api-reference/core/hooks/data/useDelete/) method provided by your [`dataProvider`](/api-reference/core/providers/data-provider.md).
 
 :::info-tip Swizzle
@@ -238,9 +238,7 @@ import dataProvider from "@refinedev/simple-rest";
 import { DeleteButton } from "@refinedev/mantine";
 
 const MyDeleteComponent = () => {
-    return (
-        <DeleteButton resource="categories" recordItemId="2" />
-    );
+    return <DeleteButton resource="categories" recordItemId="2" />;
 };
 // visible-block-end
 

--- a/documentation/docs/api-reference/mantine/components/buttons/edit.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/edit.md
@@ -56,7 +56,7 @@ const EditPage = () => {
 };
 ```
 
-`<EditButton>` uses Mantine's [`<Button>`](https://mantine.dev/core/button/) component. It uses the `edit` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful when redirecting the app to the edit page with the record id route of resource.
+`<EditButton>` uses Mantine's [`<Button>`](https://mantine.dev/core/button) component. It uses the `edit` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful when redirecting the app to the edit page with the record id route of resource.
 
 :::info-tip Swizzle
 You can swizzle this component to customize it with the [**refine CLI**](/docs/packages/documentation/cli)

--- a/documentation/docs/api-reference/mantine/components/buttons/export.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/export.md
@@ -34,7 +34,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-`<ExportButton>` is an Mantine [`<Button>`](https://mantine.dev/core/button/) with a default export icon and a default text with "Export". It only has presentational value.
+`<ExportButton>` is an Mantine [`<Button>`](https://mantine.dev/core/button) with a default export icon and a default text with "Export". It only has presentational value.
 
 ```tsx live url=http://localhost:3000 previewHeight=420px hideCode
 setInitialRoutes(["/posts"]);

--- a/documentation/docs/api-reference/mantine/components/buttons/import.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/import.md
@@ -217,5 +217,5 @@ render(
 <PropsTable module="@refinedev/mantine/ImportButton" />
 
 [useimport]: /api-reference/core/hooks/import-export/useImport.md
-[button]: https://mantine.dev/core/button/
+[button]: https://mantine.dev/core/button
 [input]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input

--- a/documentation/docs/api-reference/mantine/components/buttons/list.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/list.md
@@ -34,7 +34,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-`<ListButton>` is uses Mantine's [`<Button>`](https://mantine.dev/core/button/) component. It uses the `list` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful when redirecting the app to the list page route of resource.
+`<ListButton>` is uses Mantine's [`<Button>`](https://mantine.dev/core/button) component. It uses the `list` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful when redirecting the app to the list page route of resource.
 
 :::info-tip Swizzle
 You can swizzle this component with the [**refine CLI**](/docs/packages/documentation/cli) to customize it.

--- a/documentation/docs/api-reference/mantine/components/buttons/refresh.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/refresh.md
@@ -34,7 +34,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-`<RefreshButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button/) omponent to update the data shown on the page via the [`useInvalidate`][use-invalidate] hook.
+`<RefreshButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button) omponent to update the data shown on the page via the [`useInvalidate`][use-invalidate] hook.
 
 :::info-tip Swizzle
 You can swizzle this component with the [**refine CLI**](/docs/packages/documentation/cli) to customize it.

--- a/documentation/docs/api-reference/mantine/components/buttons/save.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/save.md
@@ -34,7 +34,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-`<SaveButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button/) component. It uses it for presantation purposes only. Some of the hooks that **refine** has adds features to this button.
+`<SaveButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button) component. It uses it for presantation purposes only. Some of the hooks that **refine** has adds features to this button.
 
 :::info-tip Swizzle
 You can swizzle this component with the [**refine CLI**](/docs/packages/documentation/cli) to customize it.

--- a/documentation/docs/api-reference/mantine/components/buttons/show.md
+++ b/documentation/docs/api-reference/mantine/components/buttons/show.md
@@ -56,7 +56,7 @@ const ShowPage = () => {
 };
 ```
 
-`<ShowButton>` uses Mantine's [`<Button>`](https://mantine.dev/core/button/) component. It uses the `show` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful when redirecting the app to the show page with the record id route of resource.
+`<ShowButton>` uses Mantine's [`<Button>`](https://mantine.dev/core/button) component. It uses the `show` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful when redirecting the app to the show page with the record id route of resource.
 
 :::info-tip Swizzle
 You can swizzle this component with the [**refine CLI**](/docs/packages/documentation/cli) to customize it.
@@ -285,9 +285,7 @@ If the `show` action route is defined by the pattern: `/posts/:authorId/show/:id
 
 ```tsx
 const MyComponent = () => {
-    return (
-        <ShowButton meta={{ authorId: "10" }} />
-    );
+    return <ShowButton meta={{ authorId: "10" }} />;
 };
 ```
 

--- a/documentation/docs/api-reference/mantine/components/fields/boolean.md
+++ b/documentation/docs/api-reference/mantine/components/fields/boolean.md
@@ -33,7 +33,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-This field is used to display boolean values. It uses the [`<Tooltip>`](https://mantine.dev/core/tooltip/) values from Mantine.
+This field is used to display boolean values. It uses the [`<Tooltip>`](https://mantine.dev/core/tooltip) values from Mantine.
 
 :::info-tip Swizzle
 You can swizzle this component to customize it with the [**refine CLI**](/docs/packages/documentation/cli)
@@ -167,5 +167,5 @@ render(
 <PropsTable module="@refinedev/mantine/BooleanField" title-description="The text shown in the tooltip" title-default="`value` ? `valueLabelTrue` : `valueLabelFalse`" trueIcon-default="[`<IconCheck />`](https://tabler-icons.io/i/check)" falseIcon-default="[`<IconX />`](https://tabler-icons.io/i/x)" />
 
 :::tip External Props
-It also accepts all props of Mantine [Tooltip](https://mantine.dev/core/tooltip/?t=props).
+It also accepts all props of Mantine [Tooltip](https://mantine.dev/core/tooltip?t=props).
 :::

--- a/documentation/docs/api-reference/mantine/components/fields/email.md
+++ b/documentation/docs/api-reference/mantine/components/fields/email.md
@@ -33,7 +33,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-This field is used to display email values. It uses the [`<Anchor>`](https://mantine.dev/core/anchor/) component of Mantine.
+This field is used to display email values. It uses the [`<Anchor>`](https://mantine.dev/core/anchor) component of Mantine.
 
 :::info-tip Swizzle
 You can swizzle this component to customize it with the [**refine CLI**](/docs/packages/documentation/cli)
@@ -159,7 +159,7 @@ render(
 ```
 
 :::tip
-`<EmailField>` uses "mailto:" in the href prop of the [`<Anchor>`](https://mantine.dev/core/anchor/) component. For this reason, clicking `<EmailField>` opens your device's default mail application.
+`<EmailField>` uses "mailto:" in the href prop of the [`<Anchor>`](https://mantine.dev/core/anchor) component. For this reason, clicking `<EmailField>` opens your device's default mail application.
 :::
 
 ## API Reference
@@ -168,4 +168,4 @@ render(
 
 <PropsTable module="@refinedev/mantine/EmailField" />
 
-[Refer to the documentation for the rest of Anchor properties. &#8594](https://mantine.dev/core/anchor/?t=props)
+[Refer to the documentation for the rest of Anchor properties. &#8594](https://mantine.dev/core/anchor?t=props)

--- a/documentation/docs/api-reference/mantine/components/fields/file.md
+++ b/documentation/docs/api-reference/mantine/components/fields/file.md
@@ -33,7 +33,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-This field is used to display files and it uses the [`<Anchor>`](https://mantine.dev/core/anchor/) component of Mantine.
+This field is used to display files and it uses the [`<Anchor>`](https://mantine.dev/core/anchor) component of Mantine.
 
 :::info-tip Swizzle
 You can swizzle this component to customize it with the [**refine CLI**](/docs/packages/documentation/cli)

--- a/documentation/docs/api-reference/mantine/components/fields/tag.md
+++ b/documentation/docs/api-reference/mantine/components/fields/tag.md
@@ -33,7 +33,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-This field lets you display a value in a tag. It uses Mantine [`<Chip>`](https://mantine.dev/core/chip/) component.
+This field lets you display a value in a tag. It uses Mantine [`<Chip>`](https://mantine.dev/core/chip) component.
 
 :::info-tip Swizzle
 You can swizzle this component to customize it with the [**refine CLI**](/docs/packages/documentation/cli)
@@ -159,5 +159,5 @@ render(
 <PropsTable module="@refinedev/mantine/TagField" value-description="Tag content" />
 
 :::tip External Props
-It also accepts all props of Mantine [Chip](https://mantine.dev/core/chip/?t=props).
+It also accepts all props of Mantine [Chip](https://mantine.dev/core/chip?t=props).
 :::

--- a/documentation/docs/api-reference/mantine/components/fields/url.md
+++ b/documentation/docs/api-reference/mantine/components/fields/url.md
@@ -159,5 +159,5 @@ render(
 <PropsTable module="@refinedev/mantine/UrlField" value-description="URL for link to reference to"/>
 
 :::tip External Props
-It also accepts all props of Mantine [Anchor](https://mantine.dev/core/anchor/?t=props).
+It also accepts all props of Mantine [Anchor](https://mantine.dev/core/anchor?t=props).
 :::

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/clone.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/clone.md
@@ -56,7 +56,7 @@ const ClonePage = () => {
 };
 ```
 
-`<CloneButton>` uses Mantine's [`<Button>`](https://mantine.dev/core/button/) component. It uses the `clone` method from [useNavigation](/api-reference/core/hooks/navigation/useNavigation.md) under the hood.
+`<CloneButton>` uses Mantine's [`<Button>`](https://mantine.dev/core/button) component. It uses the `clone` method from [useNavigation](/api-reference/core/hooks/navigation/useNavigation.md) under the hood.
 It can be useful when redirecting the app to the create page with the record id route of resource.
 
 :::info-tip Swizzle
@@ -326,7 +326,11 @@ This prop can be used to skip access control check with its `enabled` property o
 import { CloneButton } from "@pankod/refine-mantine";
 
 export const MyListComponent = () => {
-    return <CloneButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
+    return (
+        <CloneButton
+            accessControl={{ enabled: true, hideIfUnauthorized: true }}
+        />
+    );
 };
 ```
 

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/create.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/create.md
@@ -56,7 +56,7 @@ const CreatePage = () => {
 };
 ```
 
-`<CreateButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button/) component. It uses the `create` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful to redirect the app to the create page route of resource.
+`<CreateButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button) component. It uses the `create` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful to redirect the app to the create page route of resource.
 
 :::info-tip Swizzle
 You can swizzle this component to customize it with the [**refine CLI**](/docs/packages/documentation/cli)
@@ -262,7 +262,11 @@ This prop can be used to skip access control check with its `enabled` property o
 import { CreateButton } from "@pankod/refine-mantine";
 
 export const MyListComponent = () => {
-    return <CreateButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
+    return (
+        <CreateButton
+            accessControl={{ enabled: true, hideIfUnauthorized: true }}
+        />
+    );
 };
 ```
 

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/delete.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/delete.md
@@ -32,7 +32,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-`<DeleteButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button/) and [`<Popconfirm>`](https://mantine.dev/core/popover/) components.
+`<DeleteButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button) and [`<Popconfirm>`](https://mantine.dev/core/popover/) components.
 When you try to delete something, a pop-up shows up and asks for confirmation. When confirmed it executes the [`useDelete`](/docs/api-reference/core/hooks/data/useDelete/) method provided by your [`dataProvider`](/api-reference/core/providers/data-provider.md).
 
 :::info-tip Swizzle
@@ -466,7 +466,11 @@ This prop can be used to skip access control check with its `enabled` property o
 import { DeleteButton } from "@pankod/refine-mantine";
 
 export const MyListComponent = () => {
-    return <DeleteButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
+    return (
+        <DeleteButton
+            accessControl={{ enabled: true, hideIfUnauthorized: true }}
+        />
+    );
 };
 ```
 

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/edit.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/edit.md
@@ -56,7 +56,7 @@ const EditPage = () => {
 };
 ```
 
-`<EditButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button/) component. It uses the `edit` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful when redirecting the app to the edit page with the record id route of resource.
+`<EditButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button) component. It uses the `edit` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful when redirecting the app to the edit page with the record id route of resource.
 
 :::info-tip Swizzle
 You can swizzle this component to customize it with the [**refine CLI**](/docs/packages/documentation/cli)
@@ -312,7 +312,11 @@ This prop can be used to skip access control check with its `enabled` property o
 import { EditButton } from "@pankod/refine-mantine";
 
 export const MyListComponent = () => {
-    return <EditButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
+    return (
+        <EditButton
+            accessControl={{ enabled: true, hideIfUnauthorized: true }}
+        />
+    );
 };
 ```
 

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/export.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/export.md
@@ -34,7 +34,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-`<ExportButton>` is an Mantine [`<Button>`](https://mantine.dev/core/button/) with a default export icon and a default text with "Export". It only has presentational value.
+`<ExportButton>` is an Mantine [`<Button>`](https://mantine.dev/core/button) with a default export icon and a default text with "Export". It only has presentational value.
 
 ```tsx live url=http://localhost:3000 previewHeight=420px hideCode
 setInitialRoutes(["/posts"]);

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/import.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/import.md
@@ -217,5 +217,5 @@ render(
 <PropsTable module="@pankod/refine-mantine/ImportButton" />
 
 [useimport]: /api-reference/core/hooks/import-export/useImport.md
-[button]: https://mantine.dev/core/button/
+[button]: https://mantine.dev/core/button
 [input]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/list.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/list.md
@@ -34,7 +34,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-`<ListButton>` is using Mantine [`<Button>`](https://mantine.dev/core/button/) component. It uses the `list` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful when redirecting the app to the list page route of resource.
+`<ListButton>` is using Mantine [`<Button>`](https://mantine.dev/core/button) component. It uses the `list` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful when redirecting the app to the list page route of resource.
 
 :::info-tip Swizzle
 You can swizzle this component to customize it with the [**refine CLI**](/docs/packages/documentation/cli)
@@ -223,7 +223,11 @@ This prop can be used to skip access control check with its `enabled` property o
 import { ListButton } from "@pankod/refine-mantine";
 
 export const MyListComponent = () => {
-    return <ListButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
+    return (
+        <ListButton
+            accessControl={{ enabled: true, hideIfUnauthorized: true }}
+        />
+    );
 };
 ```
 

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/refresh.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/refresh.md
@@ -34,7 +34,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-`<RefreshButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button/) component to update the data shown on the page via the [`useOne`](/docs/api-reference/core/hooks/data/useOne/) method provided by your [`dataProvider`](/api-reference/core/providers/data-provider.md).
+`<RefreshButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button) component to update the data shown on the page via the [`useOne`](/docs/api-reference/core/hooks/data/useOne/) method provided by your [`dataProvider`](/api-reference/core/providers/data-provider.md).
 
 :::info-tip Swizzle
 You can swizzle this component to customize it with the [**refine CLI**](/docs/packages/documentation/cli)

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/save.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/save.md
@@ -34,7 +34,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-`<SaveButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button/) component. It uses it for presantation purposes only. Some of the hooks that **refine** has adds features to this button.
+`<SaveButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button) component. It uses it for presantation purposes only. Some of the hooks that **refine** has adds features to this button.
 
 :::info-tip Swizzle
 You can swizzle this component to customize it with the [**refine CLI**](/docs/packages/documentation/cli)

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/show.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/buttons/show.md
@@ -56,7 +56,7 @@ const ShowPage = () => {
 };
 ```
 
-`<ShowButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button/) component. It uses the `show` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful when redirecting the app to the show page with the record id route of resource.
+`<ShowButton>` uses Mantine [`<Button>`](https://mantine.dev/core/button) component. It uses the `show` method from [`useNavigation`](/api-reference/core/hooks/navigation/useNavigation.md) under the hood. It can be useful when redirecting the app to the show page with the record id route of resource.
 
 :::info-tip Swizzle
 You can swizzle this component to customize it with the [**refine CLI**](/docs/packages/documentation/cli)
@@ -317,7 +317,11 @@ This prop can be used to skip access control check with its `enabled` property o
 import { ShowButton } from "@pankod/refine-mantine";
 
 export const MyListComponent = () => {
-    return <ShowButton accessControl={{ enabled: true, hideIfUnauthorized: true }} />;
+    return (
+        <ShowButton
+            accessControl={{ enabled: true, hideIfUnauthorized: true }}
+        />
+    );
 };
 ```
 

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/fields/boolean.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/fields/boolean.md
@@ -70,7 +70,7 @@ const IconCheck = (
 );
 ```
 
-This field is used to display boolean values. It uses the [`<Tooltip>`](https://mantine.dev/core/tooltip/) values from Mantine.
+This field is used to display boolean values. It uses the [`<Tooltip>`](https://mantine.dev/core/tooltip) values from Mantine.
 
 :::info-tip Swizzle
 You can swizzle this component to customize it with the [**refine CLI**](/docs/packages/documentation/cli)
@@ -202,5 +202,5 @@ render(
 <PropsTable module="@pankod/refine-mantine/BooleanField" title-description="The text shown in the tooltip" title-default="`value` ? `valueLabelTrue` : `valueLabelFalse`" trueIcon-default="[`<IconCheck />`](https://tabler-icons.io/i/check)" falseIcon-default="[`<IconX />`](https://tabler-icons.io/i/x)" />
 
 :::tip External Props
-It also accepts all props of Mantine [Tooltip](https://mantine.dev/core/tooltip/?t=props).
+It also accepts all props of Mantine [Tooltip](https://mantine.dev/core/tooltip?t=props).
 :::

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/fields/email.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/fields/email.md
@@ -33,7 +33,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-This field is used to display email values. It uses the [`<Anchor>`](https://mantine.dev/core/anchor/) component of Mantine.
+This field is used to display email values. It uses the [`<Anchor>`](https://mantine.dev/core/anchor) component of Mantine.
 
 :::info-tip Swizzle
 You can swizzle this component to customize it with the [**refine CLI**](/docs/packages/documentation/cli)
@@ -157,7 +157,7 @@ render(
 ```
 
 :::tip
-`<EmailField>` uses "mailto:" in the href prop of the [`<Anchor>`](https://mantine.dev/core/anchor/) component. For this reason, clicking `<EmailField>` opens your device's default mail application.
+`<EmailField>` uses "mailto:" in the href prop of the [`<Anchor>`](https://mantine.dev/core/anchor) component. For this reason, clicking `<EmailField>` opens your device's default mail application.
 :::
 
 ## API Reference
@@ -166,4 +166,4 @@ render(
 
 <PropsTable module="@pankod/refine-mantine/EmailField" />
 
-[Refer to the documentation for the rest of Anchor properties. &#8594](https://mantine.dev/core/anchor/?t=props)
+[Refer to the documentation for the rest of Anchor properties. &#8594](https://mantine.dev/core/anchor?t=props)

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/fields/file.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/fields/file.md
@@ -33,7 +33,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-This field is used to display files and it uses the [`<Anchor>`](https://mantine.dev/core/anchor/) component of Mantine.
+This field is used to display files and it uses the [`<Anchor>`](https://mantine.dev/core/anchor) component of Mantine.
 
 :::info-tip Swizzle
 You can swizzle this component to customize it with the [**refine CLI**](/docs/packages/documentation/cli)

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/fields/tag.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/fields/tag.md
@@ -33,7 +33,7 @@ const Wrapper = ({ children }) => {
 };
 ```
 
-This field lets you display a value in a tag. It uses Mantine [`<Chip>`](https://mantine.dev/core/chip/) component.
+This field lets you display a value in a tag. It uses Mantine [`<Chip>`](https://mantine.dev/core/chip) component.
 
 :::info-tip Swizzle
 You can swizzle this component to customize it with the [**refine CLI**](/docs/packages/documentation/cli)
@@ -157,5 +157,5 @@ render(
 <PropsTable module="@pankod/refine-mantine/TagField" value-description="Tag content" />
 
 :::tip External Props
-It also accepts all props of Mantine [Chip](https://mantine.dev/core/chip/?t=props).
+It also accepts all props of Mantine [Chip](https://mantine.dev/core/chip?t=props).
 :::

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/fields/url.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/components/fields/url.md
@@ -157,5 +157,5 @@ render(
 <PropsTable module="@pankod/refine-mantine/UrlField" value-description="URL for link to reference to"/>
 
 :::tip External Props
-It also accepts all props of Mantine [Anchor](https://mantine.dev/core/anchor/?t=props).
+It also accepts all props of Mantine [Anchor](https://mantine.dev/core/anchor?t=props).
 :::

--- a/packages/mantine/src/components/buttons/clone/index.tsx
+++ b/packages/mantine/src/components/buttons/clone/index.tsx
@@ -20,7 +20,7 @@ import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { CloneButtonProps } from "../types";
 
 /**
- * `<CloneButton>` uses Mantine {@link https://mantine.dev/core/button/ `<Button> component`}.
+ * `<CloneButton>` uses Mantine {@link https://mantine.dev/core/button `<Button> component`}.
  * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#clone `clone`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation useNavigation} under the hood.
  * It can be useful when redirecting the app to the create page with the record id route of resource.
  *

--- a/packages/mantine/src/components/buttons/delete/index.tsx
+++ b/packages/mantine/src/components/buttons/delete/index.tsx
@@ -20,7 +20,7 @@ import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { DeleteButtonProps } from "../types";
 
 /**
- * `<DeleteButton>` uses Mantine {@link https://mantine.dev/core/button/ `<Button>`} and {@link https://mantine.dev/core/modal/ `<Modal>`} components.
+ * `<DeleteButton>` uses Mantine {@link https://mantine.dev/core/button `<Button>`} and {@link https://mantine.dev/core/modal `<Modal>`} components.
  * When you try to delete something, a dialog modal shows up and asks for confirmation. When confirmed it executes the `useDelete` method provided by your `dataProvider`.
  *
  * @see {@link https://refine.dev/docs/api-reference/mantine/components/buttons/delete-button} for more details.

--- a/packages/mantine/src/components/buttons/edit/index.tsx
+++ b/packages/mantine/src/components/buttons/edit/index.tsx
@@ -20,7 +20,7 @@ import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { EditButtonProps } from "../types";
 
 /**
- * `<EditButton>` uses Mantine {@link https://mantine.dev/core/button/ `<Button> component`}.
+ * `<EditButton>` uses Mantine {@link https://mantine.dev/core/button `<Button> component`}.
  * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#edit `edit`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful when redirecting the app to the edit page with the record id route of resource}.
  *

--- a/packages/mantine/src/components/buttons/export/index.tsx
+++ b/packages/mantine/src/components/buttons/export/index.tsx
@@ -11,7 +11,7 @@ import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { ExportButtonProps } from "../types";
 
 /**
- * `<ExportButton>` uses Mantine {@link https://mantine.dev/core/button/ `<Button> `} component with a default export icon and a default text with "Export".
+ * `<ExportButton>` uses Mantine {@link https://mantine.dev/core/button `<Button> `} component with a default export icon and a default text with "Export".
  * It only has presentational value.
  *
  * @see {@link https://refine.dev/docs/api-reference/mantine/components/buttons/export-button} for more details.

--- a/packages/mantine/src/components/buttons/import/index.tsx
+++ b/packages/mantine/src/components/buttons/import/index.tsx
@@ -12,7 +12,7 @@ import { ImportButtonProps } from "../types";
 
 /**
  * `<ImportButton>` is compatible with the {@link https://refine.dev/docs/api-reference/core/hooks/import-export/useImport/ `useImport`} core hook.
- * It uses uses Mantine {@link https://mantine.dev/core/button/ `<Button> component`} and native html {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input  `<input>`} element.
+ * It uses uses Mantine {@link https://mantine.dev/core/button `<Button> component`} and native html {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input  `<input>`} element.
  *
  * @see {@link https://refine.dev/docs/api-reference/mantine/components/buttons/import-button} for more details.
  */

--- a/packages/mantine/src/components/buttons/list/index.tsx
+++ b/packages/mantine/src/components/buttons/list/index.tsx
@@ -22,7 +22,7 @@ import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { ListButtonProps } from "../types";
 
 /**
- * `<ListButton>` is using uses Mantine {@link https://mantine.dev/core/button/ `<Button> `} component.
+ * `<ListButton>` is using uses Mantine {@link https://mantine.dev/core/button `<Button> `} component.
  * It uses the  {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#list `list`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful when redirecting the app to the list page route of resource}.
  *

--- a/packages/mantine/src/components/buttons/refresh/index.tsx
+++ b/packages/mantine/src/components/buttons/refresh/index.tsx
@@ -19,7 +19,7 @@ import { RefreshButtonProps } from "../types";
 import { useQueryClient } from "@tanstack/react-query";
 
 /**
- * `<RefreshButton>` uses Mantine {@link https://mantine.dev/core/button/ `<Button> `} component.
+ * `<RefreshButton>` uses Mantine {@link https://mantine.dev/core/button `<Button> `} component.
  * to update the data shown on the page via the {@link https://refine.dev/docs/api-reference/core/hooks/invalidate/useInvalidate `useInvalidate`} hook.
  *
  * @see {@link https://refine.dev/docs/api-reference/mantine/components/buttons/refresh-button} for more details.

--- a/packages/mantine/src/components/buttons/save/index.tsx
+++ b/packages/mantine/src/components/buttons/save/index.tsx
@@ -11,7 +11,7 @@ import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { SaveButtonProps } from "../types";
 
 /**
- * `<SaveButton>` uses Mantine {@link https://mantine.dev/core/button/ `<Button> `}.
+ * `<SaveButton>` uses Mantine {@link https://mantine.dev/core/button `<Button> `}.
  * It uses it for presantation purposes only. Some of the hooks that refine has adds features to this button.
  *
  * @see {@link https://refine.dev/docs/api-reference/mantine/components/buttons/save-button} for more details.

--- a/packages/mantine/src/components/buttons/show/index.tsx
+++ b/packages/mantine/src/components/buttons/show/index.tsx
@@ -20,7 +20,7 @@ import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { ShowButtonProps } from "../types";
 
 /**
- * `<ShowButton>` uses Mantine {@link https://mantine.dev/core/button/ `<Button> `} component.
+ * `<ShowButton>` uses Mantine {@link https://mantine.dev/core/button `<Button> `} component.
  * It uses the {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation#show `show`} method from {@link https://refine.dev/docs/api-reference/core/hooks/navigation/useNavigation `useNavigation`} under the hood.
  * It can be useful when red sirecting the app to the show page with the record id route of resource.
  *

--- a/packages/mantine/src/components/fields/boolean/index.tsx
+++ b/packages/mantine/src/components/fields/boolean/index.tsx
@@ -5,7 +5,7 @@ import { IconX, IconCheck } from "@tabler/icons";
 import { BooleanFieldProps } from "../types";
 
 /**
- * This field is used to display boolean values. It uses the {@link https://mantine.dev/core/tooltip/ `<Tooltip>`} values from Mantine.
+ * This field is used to display boolean values. It uses the {@link https://mantine.dev/core/tooltip `<Tooltip>`} values from Mantine.
  *
  * @see {@link https://refine.dev/docs/api-reference/mantine/components/fields/boolean} for more details.
  */

--- a/packages/mantine/src/components/fields/date/index.tsx
+++ b/packages/mantine/src/components/fields/date/index.tsx
@@ -13,7 +13,7 @@ import { DateFieldProps } from "../types";
 
 /**
  * This field is used to display dates. It uses {@link https://day.js.org/docs/en/display/format `Day.js`} to display date format and
- * Mantine {@link https://mantine.dev/core/text/ `<Text>`} component
+ * Mantine {@link https://mantine.dev/core/text`<Text>`} component
  *
  * @see {@link https://refine.dev/docs/api-reference/mantine/components/fields/date} for more details.
  */

--- a/packages/mantine/src/components/fields/date/index.tsx
+++ b/packages/mantine/src/components/fields/date/index.tsx
@@ -13,7 +13,7 @@ import { DateFieldProps } from "../types";
 
 /**
  * This field is used to display dates. It uses {@link https://day.js.org/docs/en/display/format `Day.js`} to display date format and
- * Mantine {@link https://mantine.dev/core/text`<Text>`} component
+ * Mantine {@link https://mantine.dev/core/text `<Text>`} component
  *
  * @see {@link https://refine.dev/docs/api-reference/mantine/components/fields/date} for more details.
  */

--- a/packages/mantine/src/components/fields/email/index.tsx
+++ b/packages/mantine/src/components/fields/email/index.tsx
@@ -4,8 +4,8 @@ import { Anchor } from "@mantine/core";
 import { EmailFieldProps } from "../types";
 
 /**
- * This field is used to display email values. It uses the {@link https://mantine.dev/core/text/  `<Text>` }
- * and {@link https://mantine.dev/core/anchor/ <Anchor>`} components from Mantine.
+ * This field is used to display email values. It uses the {@link https://mantine.dev/core/text `<Text>` }
+ * and {@link https://mantine.dev/core/anchor <Anchor>`} components from Mantine.
  *
  * @see {@link https://refine.dev/docs/api-reference/mantine/components/fields/email} for more details.
  */

--- a/packages/mantine/src/components/fields/number/index.tsx
+++ b/packages/mantine/src/components/fields/number/index.tsx
@@ -12,7 +12,7 @@ function toLocaleStringSupportsOptions() {
 }
 /**
  * This field is used to display a number formatted according to the browser locale, right aligned. and uses {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl `Intl`} to display date format
- * and Mantine {@link https://mantine.dev/core/text/  `<Text>`} component.
+ * and Mantine {@link https://mantine.dev/core/text `<Text>`} component.
  * @see {@link https://refine.dev/docs/api-reference/mantine/components/fields/number/} for more details.
  */
 export const NumberField: React.FC<NumberFieldProps> = ({

--- a/packages/mantine/src/components/fields/tag/index.tsx
+++ b/packages/mantine/src/components/fields/tag/index.tsx
@@ -4,7 +4,7 @@ import { Chip } from "@mantine/core";
 import { TagFieldProps } from "../types";
 
 /**
- * This field lets you display a value in a tag. It uses Mantine {@link https://mantine.dev/core/chip/ `<Chip>`} component.
+ * This field lets you display a value in a tag. It uses Mantine {@link https://mantine.dev/core/chip `<Chip>`} component.
  *
  * @see {@link https://refine.dev/docs/api-reference/mantine/components/fields/tag} for more details.
  */

--- a/packages/mantine/src/components/fields/text/index.tsx
+++ b/packages/mantine/src/components/fields/text/index.tsx
@@ -4,7 +4,7 @@ import { Text } from "@mantine/core";
 import { TextFieldProps } from "../types";
 
 /**
- * This field lets you show basic text. It uses Mantine {@link https://mantine.dev/core/text/  `<Text>`} component.
+ * This field lets you show basic text. It uses Mantine {@link https://mantine.dev/core/text `<Text>`} component.
  *
  * @see {@link https://refine.dev/docs/api-reference/mantine/components/fields/text} for more details.
  */

--- a/packages/mantine/src/components/fields/url/index.tsx
+++ b/packages/mantine/src/components/fields/url/index.tsx
@@ -4,8 +4,8 @@ import { Anchor } from "@mantine/core";
 import { UrlFieldProps } from "../types";
 
 /**
- * This field is used to display email values. It uses the {@link https://mantine.dev/core/text/  `<Text>` }
- * and {@link https://mantine.dev/core/anchor/ <Anchor>`} components from Mantine.
+ * This field is used to display email values. It uses the {@link https://mantine.dev/core/text `<Text>` }
+ * and {@link https://mantine.dev/core/anchor <Anchor>`} components from Mantine.
  * You can pass a URL in its `value` property and you can show a text in its place by passing any `children`.
  *
  * @see {@link https://refine.dev/docs/api-reference/mantine/components/fields/url} for more details.


### PR DESCRIPTION
fixed: Mantine documentation links on JSDoc 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
