### PR TITLE
fix: blog-refine-nextui lerna hoisted versions

### DIFF
--- a/examples/blog-refine-nextui/package.json
+++ b/examples/blog-refine-nextui/package.json
@@ -24,21 +24,21 @@
     "react-hook-form": "^7.30.0",
     "react-i18next": "^11.8.11",
     "react-router-dom": "^6.8.1",
-    "recharts": "^2.8.0"
+    "recharts": "^2.1.9"
   },
   "devDependencies": {
     "@types/node": "^18.16.2",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "@typescript-eslint/eslint-plugin": "^5.48.0",
-    "@typescript-eslint/parser": "^5.48.0",
+    "@typescript-eslint/eslint-plugin": "5.48.0",
+    "@typescript-eslint/parser": "5.48.0",
     "@vitejs/plugin-react": "^4.0.0",
-    "autoprefixer": "^10.4.15",
+    "autoprefixer": "^10.4.1",
     "eslint": "^8.24.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.3.4",
     "postcss": "^8.1.4",
-    "tailwindcss": "^3.3.3",
+    "tailwindcss": "^3.0.11",
     "typescript": "^4.7.4",
     "vite": "^4.3.1"
   },


### PR DESCRIPTION
fixed: `blog-refine-nextui` dependency versions

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
