### PR TITLE
chore: bump superplate-cli version for create-refine-app

### DIFF
--- a/.changeset/calm-pens-guess.md
+++ b/.changeset/calm-pens-guess.md
@@ -1,0 +1,5 @@
+---
+"create-refine-app": patch
+---
+
+chore: bump superplate-cli to 1.17.5

--- a/packages/create-refine-app/package.json
+++ b/packages/create-refine-app/package.json
@@ -30,7 +30,7 @@
     "tslib": "^2.3.1",
     "commander": "9.4.1",
     "execa": "^5.1.1",
-    "superplate-cli": "^1.17.4",
+    "superplate-cli": "^1.17.5",
     "got": "^11.8.5",
     "chalk": "^4.1.2",
     "ora": "^5.4.1",


### PR DESCRIPTION
Bumped `superplate-cli` version to 1.17.5 for `create-refine-app`.