### PR TITLE
chore: bump peer dependency versions

### DIFF
--- a/.changeset/hip-cougars-appear.md
+++ b/.changeset/hip-cougars-appear.md
@@ -1,0 +1,10 @@
+---
+"@refinedev/antd": patch
+"@refinedev/chakra-ui": patch
+"@refinedev/inferencer": patch
+"@refinedev/mantine": patch
+"@refinedev/mui": patch
+"@refinedev/react-hook-form": patch
+---
+
+chore: update @refinedev/core peer dependency versions.

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -17,7 +17,7 @@
     "generate-theme": "npx @emeks/antd-custom-theme-generator -w --antd ../../node_modules/antd ./src/assets/styles/custom-theme.less ./src/assets/styles/styles.min.css"
   },
   "peerDependencies": {
-    "@refinedev/core": "^4.0.0",
+    "@refinedev/core": "^4.40.0",
     "@types/react": "^17.0.0 || ^18.0.0",
     "@types/react-dom": "^17.0.0 || ^18.0.0",
     "antd": "^5.0.5",
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@refinedev/cli": "^2.10.0",
     "@refinedev/ui-tests": "^1.13.0",
-    "@refinedev/core": "^4.39.0",
+    "@refinedev/core": "^4.40.0",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "@refinedev/cli": "^2.0.0",
-    "@refinedev/core": "^4.0.0",
+    "@refinedev/core": "^4.40.0",
     "@chakra-ui/react": "^2.5.1",
     "react-hook-form": "^7.30.0",
     "dayjs": "^1.10.7",
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@refinedev/cli": "^2.7.6",
     "@refinedev/ui-tests": "^1.13.2",
-    "@refinedev/core": "^4.38.4",
+    "@refinedev/core": "^4.40.0",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",

--- a/packages/inferencer/package.json
+++ b/packages/inferencer/package.json
@@ -64,7 +64,7 @@
   "peerDependencies": {
     "@refinedev/antd": "^5.0.0",
     "@refinedev/chakra-ui": "^2.0.0",
-    "@refinedev/core": "^4.0.0",
+    "@refinedev/core": "^4.40.0",
     "@refinedev/mantine": "^2.0.0",
     "@refinedev/mui": "^5.0.0",
     "@refinedev/react-hook-form": "^4.0.0",
@@ -154,7 +154,7 @@
   "devDependencies": {
     "@refinedev/antd": "^5.34.2",
     "@refinedev/chakra-ui": "^2.26.6",
-    "@refinedev/core": "^4.38.4",
+    "@refinedev/core": "^4.40.0",
     "@refinedev/mantine": "^2.28.6",
     "@refinedev/mui": "^5.13.8",
     "@types/lodash": "^4.14.171",
@@ -185,7 +185,7 @@
   },
   "dependencies": {
     "@tabler/icons": "^1.1.0",
-    "@refinedev/core": "^4.38.4",
+    "@refinedev/core": "^4.40.0",
     "dayjs": "^1.10.7",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",

--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "@refinedev/cli": "^2.0.0",
-    "@refinedev/core": "^4.0.0",
+    "@refinedev/core": "^4.40.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "@refinedev/cli": "^2.10.0",
-    "@refinedev/core": "^4.39.0",
+    "@refinedev/core": "^4.40.0",
     "@refinedev/ui-tests": "^1.13.2",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -14,7 +14,7 @@
     "prepare": "npm run build"
   },
   "peerDependencies": {
-    "@refinedev/core": "^4.0.0",
+    "@refinedev/core": "^4.40.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "dayjs": "^1.10.7",
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@refinedev/cli": "^2.7.6",
     "@refinedev/ui-tests": "^1.13.2",
-    "@refinedev/core": "^4.38.4",
+    "@refinedev/core": "^4.40.0",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -23,7 +23,7 @@
   "author": "refine",
   "module": "dist/esm/index.js",
   "peerDependencies": {
-    "@refinedev/core": "^4.0.0",
+    "@refinedev/core": "^4.40.0",
     "react-hook-form": "^7.30.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.4",
-    "@refinedev/core": "^4.39.0",
+    "@refinedev/core": "^4.40.0",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "@types/jest": "^29.2.4",
     "jest": "^29.3.1",


### PR DESCRIPTION
Updated `@refinedev/core` version in peer dependencies for following packages:

- `@refinedev/antd`
- `@refinedev/chakra-ui`
- `@refinedev/inferencer`
- `@refinedev/mantine`
- `@refinedev/mui`
- `@refinedev/react-hook-form`