### PR TITLE
fix: add missing DataGrid operator conversion cases

### DIFF
--- a/.changeset/heavy-cows-happen.md
+++ b/.changeset/heavy-cows-happen.md
@@ -1,0 +1,12 @@
+---
+"@refinedev/mui": patch
+---
+
+fix: add missing DataGrid operator conversion cases
+
+MUI defines the operator for each column types in [here](https://github.com/mui/mui-x/tree/2d09dbc6e5d03c4e66765d225ef93d3984e300fc/packages/grid/x-data-grid/src/colDef). However, there were not enough conversion cases for the following operators, so this changes added them to the mapping.
+
+-   isAnyof: used in Numeric, SingleSelect, String
+-   contains: used in String,
+-   startsWith: used in String
+-   endsWith: used in String

--- a/packages/mui/src/definitions/dataGrid/index.spec.ts
+++ b/packages/mui/src/definitions/dataGrid/index.spec.ts
@@ -201,7 +201,7 @@ describe("transformMuiOperatorToCrudOperators", () => {
     });
 });
 
-describe("transformMuiOperatorToCrudOperator", () => {
+describe("transformCrudOperatorToMuiOperator", () => {
     it("transform crud operator to mui operator with 'number' value", () => {
         expect(transformCrudOperatorToMuiOperator("eq", "number")).toEqual("=");
         expect(transformCrudOperatorToMuiOperator("ne", "number")).toEqual(

--- a/packages/mui/src/definitions/dataGrid/index.spec.ts
+++ b/packages/mui/src/definitions/dataGrid/index.spec.ts
@@ -184,6 +184,7 @@ describe("transformMuiOperatorToCrudOperators", () => {
         expect(transformMuiOperatorToCrudOperator("=")).toEqual("eq");
         expect(transformMuiOperatorToCrudOperator("!=")).toEqual("ne");
         expect(transformMuiOperatorToCrudOperator("not")).toEqual("ne");
+        expect(transformMuiOperatorToCrudOperator("isAnyOf")).toEqual("in");
         expect(transformMuiOperatorToCrudOperator("<")).toEqual("lt");
         expect(transformMuiOperatorToCrudOperator("before")).toEqual("lt");
         expect(transformMuiOperatorToCrudOperator("<=")).toEqual("lte");
@@ -192,6 +193,16 @@ describe("transformMuiOperatorToCrudOperators", () => {
         expect(transformMuiOperatorToCrudOperator("after")).toEqual("gt");
         expect(transformMuiOperatorToCrudOperator(">=")).toEqual("gte");
         expect(transformMuiOperatorToCrudOperator("onOrAfter")).toEqual("gte");
+        expect(transformMuiOperatorToCrudOperator("startsWith")).toEqual(
+            "startswith",
+        );
+        expect(transformMuiOperatorToCrudOperator("endsWith")).toEqual(
+            "endswith",
+        );
+        expect(transformMuiOperatorToCrudOperator("isEmpty")).toEqual("null");
+        expect(transformMuiOperatorToCrudOperator("isNotEmpty")).toEqual(
+            "nnull",
+        );
         expect(transformMuiOperatorToCrudOperator("contains")).toEqual(
             "contains",
         );

--- a/packages/mui/src/definitions/dataGrid/index.ts
+++ b/packages/mui/src/definitions/dataGrid/index.ts
@@ -47,6 +47,10 @@ export const transformMuiOperatorToCrudOperator = (
         case "!=":
         case "not":
             return "ne";
+        case "contains":
+            return "contains";
+        case "isAnyOf":
+            return "in";
         case ">":
         case "after":
             return "gt";
@@ -59,6 +63,10 @@ export const transformMuiOperatorToCrudOperator = (
         case "<=":
         case "onOrBefore":
             return "lte";
+        case "startsWith":
+            return "startswith";
+        case "endsWith":
+            return "endswith";
         case "isEmpty":
             return "null";
         case "isNotEmpty":


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

MUI defines the operator for each column types in [here](https://github.com/mui/mui-x/tree/2d09dbc6e5d03c4e66765d225ef93d3984e300fc/packages/grid/x-data-grid/src/colDef). However, there were not enough conversion cases for the following operators, so I added them to the mapping.

- isAnyof: used in Numeric, SingleSelect, String
- contains: used in String,
- startsWith: used in String
- endsWith: used in String

### Test plan (required)

I updated the tests with the new switch cases I've added.

The test case that was supposed to test the target was actually testing something else, so the describe part of that part has been changed in this PR.

<!-- Make sure tests pass. -->

### Closing issues

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

closes #4970

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
