### PR TITLE
chore: update `@tabler/icons` dependency

### DIFF
--- a/.changeset/serious-pens-matter.md
+++ b/.changeset/serious-pens-matter.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/chakra-ui": patch
+"@refinedev/inferencer": patch
+"@refinedev/mantine": patch
+---
+
+Updated dependency of `@tabler/icons` to `v1.119.0` to fix the issue of using misconfigured versions. (Fixes #4921)

--- a/examples/auth-chakra-ui/package.json
+++ b/examples/auth-chakra-ui/package.json
@@ -18,7 +18,7 @@
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
     "@refinedev/react-hook-form": "^4.8.8",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@chakra-ui/react": "^2.5.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/auth-mantine/package.json
+++ b/examples/auth-mantine/package.json
@@ -18,7 +18,7 @@
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/base-chakra-ui/package.json
+++ b/examples/base-chakra-ui/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@refinedev/chakra-ui": "^2.26.8",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/core": "^4.41.0",
     "@refinedev/cli": "^2.12.1",
     "@refinedev/react-router-v6": "^4.5.0",

--- a/examples/base-mantine/package.json
+++ b/examples/base-mantine/package.json
@@ -18,7 +18,7 @@
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/blog-ra-chakra-tutorial/package.json
+++ b/examples/blog-ra-chakra-tutorial/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1",
     "axios": "^0.26.1",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@chakra-ui/react": "^2.5.1",
     "react-hook-form": "^7.30.0"
   },

--- a/examples/blog-refine-mantine-strapi/package.json
+++ b/examples/blog-refine-mantine-strapi/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1",
     "axios": "^0.26.1",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/customization-theme-chakra-ui/package.json
+++ b/examples/customization-theme-chakra-ui/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@refinedev/chakra-ui": "^2.26.8",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/core": "^4.41.0",
     "@refinedev/cli": "^2.12.1",
     "@refinedev/react-router-v6": "^4.5.0",

--- a/examples/customization-theme-mantine/package.json
+++ b/examples/customization-theme-mantine/package.json
@@ -16,7 +16,7 @@
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/form-chakra-ui-mutation-mode/package.json
+++ b/examples/form-chakra-ui-mutation-mode/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@refinedev/chakra-ui": "^2.26.8",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/core": "^4.41.0",
     "@refinedev/cli": "^2.12.1",
     "@refinedev/react-router-v6": "^4.5.0",

--- a/examples/form-chakra-ui-use-drawer-form/package.json
+++ b/examples/form-chakra-ui-use-drawer-form/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@refinedev/chakra-ui": "^2.26.8",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/core": "^4.41.0",
     "@refinedev/cli": "^2.12.1",
     "@refinedev/react-router-v6": "^4.5.0",

--- a/examples/form-chakra-ui-use-form/package.json
+++ b/examples/form-chakra-ui-use-form/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@refinedev/chakra-ui": "^2.26.8",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/core": "^4.41.0",
     "@refinedev/cli": "^2.12.1",
     "@refinedev/react-router-v6": "^4.5.0",

--- a/examples/form-chakra-use-modal-form/package.json
+++ b/examples/form-chakra-use-modal-form/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@refinedev/chakra-ui": "^2.26.8",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/core": "^4.41.0",
     "@refinedev/cli": "^2.12.1",
     "@refinedev/react-router-v6": "^4.5.0",

--- a/examples/form-mantine-mutation-mode/package.json
+++ b/examples/form-mantine-mutation-mode/package.json
@@ -18,7 +18,7 @@
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
     "@mantine/rte": "^5.4.1",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/form-mantine-use-drawer-form/package.json
+++ b/examples/form-mantine-use-drawer-form/package.json
@@ -18,7 +18,7 @@
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/form-mantine-use-form/package.json
+++ b/examples/form-mantine-use-form/package.json
@@ -18,7 +18,7 @@
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
     "@mantine/rte": "^5.4.1",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/form-mantine-use-modal-form/package.json
+++ b/examples/form-mantine-use-modal-form/package.json
@@ -18,7 +18,7 @@
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/form-mantine-use-steps-form/package.json
+++ b/examples/form-mantine-use-steps-form/package.json
@@ -19,7 +19,7 @@
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "@mantine/dates": "^5.4.1",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/import-export-mantine/package.json
+++ b/examples/import-export-mantine/package.json
@@ -15,7 +15,7 @@
     "@refinedev/simple-rest": "^4.5.0",
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/inferencer-chakra-ui/package.json
+++ b/examples/inferencer-chakra-ui/package.json
@@ -15,7 +15,7 @@
     "@refinedev/chakra-ui": "^2.26.8",
     "@refinedev/react-hook-form": "^4.8.8",
     "@refinedev/react-table": "^5.6.2",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@chakra-ui/react": "^2.5.1",
     "react-hook-form": "^7.30.0",
     "@refinedev/react-router-v6": "^4.5.0",

--- a/examples/inferencer-mantine/package.json
+++ b/examples/inferencer-mantine/package.json
@@ -14,7 +14,7 @@
     "@refinedev/simple-rest": "^4.0.0",
     "@refinedev/mantine": "^2.28.10",
     "@refinedev/react-table": "^5.6.2",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/server-side-form-validation-chakra-ui/package.json
+++ b/examples/server-side-form-validation-chakra-ui/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@refinedev/chakra-ui": "^2.26.8",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/core": "^4.41.0",
     "@refinedev/cli": "^2.12.1",
     "@refinedev/react-router-v6": "^4.5.0",

--- a/examples/server-side-form-validation-mantine/package.json
+++ b/examples/server-side-form-validation-mantine/package.json
@@ -18,7 +18,7 @@
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/table-chakra-ui-advanced/package.json
+++ b/examples/table-chakra-ui-advanced/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@refinedev/chakra-ui": "^2.26.8",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/core": "^4.41.0",
     "@refinedev/cli": "^2.12.1",
     "@refinedev/react-router-v6": "^4.5.0",

--- a/examples/table-chakra-ui-basic/package.json
+++ b/examples/table-chakra-ui-basic/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@refinedev/chakra-ui": "^2.26.8",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/core": "^4.41.0",
     "@refinedev/cli": "^2.12.1",
     "@refinedev/react-router-v6": "^4.5.0",

--- a/examples/table-mantine-advanced/package.json
+++ b/examples/table-mantine-advanced/package.json
@@ -18,7 +18,7 @@
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/table-mantine-basic/package.json
+++ b/examples/table-mantine-basic/package.json
@@ -17,7 +17,7 @@
     "@refinedev/simple-rest": "^4.5.0",
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/template-chakra-ui/package.json
+++ b/examples/template-chakra-ui/package.json
@@ -14,7 +14,7 @@
     "@refinedev/react-hook-form": "^4.8.8",
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/react-router-v6": "^4.5.0",
     "@chakra-ui/react": "^2.5.1"
   },

--- a/examples/template-mantine/package.json
+++ b/examples/template-mantine/package.json
@@ -13,7 +13,7 @@
     "@refinedev/mantine": "^2.28.10",
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/react-router-v6": "^4.5.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",

--- a/examples/theme-chakra-ui-demo/package.json
+++ b/examples/theme-chakra-ui-demo/package.json
@@ -16,7 +16,7 @@
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
     "@refinedev/react-hook-form": "^4.8.8",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@chakra-ui/react": "^2.5.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/theme-mantine-demo/package.json
+++ b/examples/theme-mantine-demo/package.json
@@ -16,7 +16,7 @@
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/tutorial-chakra-ui/package.json
+++ b/examples/tutorial-chakra-ui/package.json
@@ -14,7 +14,7 @@
     "@refinedev/react-hook-form": "^4.8.8",
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/react-router-v6": "^4.5.0",
     "@refinedev/inferencer": "^4.5.10",
     "@chakra-ui/react": "^2.5.1"

--- a/examples/tutorial-mantine/package.json
+++ b/examples/tutorial-mantine/package.json
@@ -13,7 +13,7 @@
     "@refinedev/mantine": "^2.28.10",
     "@refinedev/react-table": "^5.6.2",
     "@tanstack/react-table": "^8.2.6",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/react-router-v6": "^4.5.0",
     "@refinedev/inferencer": "^4.5.10",
     "@emotion/react": "^11.8.2",

--- a/examples/upload-chakra-ui-basic64/package.json
+++ b/examples/upload-chakra-ui-basic64/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@refinedev/chakra-ui": "^2.26.8",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/core": "^4.41.0",
     "@refinedev/cli": "^2.12.1",
     "@refinedev/react-router-v6": "^4.5.0",

--- a/examples/upload-chakra-ui-multipart/package.json
+++ b/examples/upload-chakra-ui-multipart/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@refinedev/chakra-ui": "^2.26.8",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/core": "^4.41.0",
     "@refinedev/cli": "^2.12.1",
     "@refinedev/react-router-v6": "^4.5.0",

--- a/examples/upload-mantine-base64/package.json
+++ b/examples/upload-mantine-base64/package.json
@@ -17,7 +17,7 @@
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "@mantine/dropzone": "^5.4.1",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/examples/upload-mantine-multipart/package.json
+++ b/examples/upload-mantine-multipart/package.json
@@ -17,7 +17,7 @@
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "@mantine/dropzone": "^5.4.1",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@mantine/core": "^5.10.4",
     "@mantine/hooks": "^5.10.4",

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -50,7 +50,7 @@
     "@refinedev/react-hook-form": "^4.8.8",
     "react-hook-form": "^7.30.0",
     "@chakra-ui/react": "^2.5.1",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
     "framer-motion": "^7.5.3",

--- a/packages/inferencer/package.json
+++ b/packages/inferencer/package.json
@@ -184,7 +184,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "@refinedev/core": "^4.40.0",
     "dayjs": "^1.10.7",
     "lodash": "^4.17.21",

--- a/packages/live-previews/package.json
+++ b/packages/live-previews/package.json
@@ -50,7 +50,7 @@
         "@mui/material": "^5.14.2",
         "@mui/x-data-grid": "^6.6.0",
         "@mui/icons-material": "^5.8.3",
-        "@tabler/icons": "^1.1.0",
+        "@tabler/icons": "^1.119.0",
         "@chakra-ui/react": "^2.5.1",
         "react-hook-form": "^7.30.0",
         "base64url": "^3.0.1",

--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -60,7 +60,7 @@
     "dayjs": "^1.10.7",
     "react-markdown": "^6.0.1",
     "remark-gfm": "^1.0.0",
-    "@tabler/icons": "^1.1.0",
+    "@tabler/icons": "^1.119.0",
     "tslib": "^2.3.1"
   },
   "author": "refine",


### PR DESCRIPTION
There are some versions between the defined version (`v1.1.0`) and the latest in the range (`v1.119.0`) which are not fully compatible with our usage by missing icons or due to changes in the configuration. Recently had this issue reported at #4921 

We're updating our `@tabler/icons` dependency to `v1.119.0` to make sure the package managers are installing a properly working version with our packages. 

In the future, we're planning to move to `v2` of `@tabler/icons` to follow the latest version.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
