### PR TITLE
chore(devtools): click to highlight with selector

### DIFF
--- a/.changeset/forty-kangaroos-remember.md
+++ b/.changeset/forty-kangaroos-remember.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/devtools": patch
+---
+
+Updated DOM selector to pick elements to highlight by `click` instead of `space`

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -34,8 +34,8 @@
     "react-dom": "^17.0.0 || ^18.0.0",
     "@types/react": "^17.0.0 || ^18.0.0",
     "@types/react-dom": "^17.0.0 || ^18.0.0",
-    "@refinedev/devtools-server": "^1.0.2",
-    "@refinedev/cli": "^2.12.2",
+    "@refinedev/devtools-server": "^1.1.1",
+    "@refinedev/cli": "^2.15.1",
     "@refinedev/core": "^4.41.0"
   },
   "devDependencies": {

--- a/packages/devtools/src/components/devtools-selector.tsx
+++ b/packages/devtools/src/components/devtools-selector.tsx
@@ -43,22 +43,30 @@ export const DevtoolsSelector = ({
     }, [active]);
 
     React.useEffect(() => {
-        const onKeyDown = (e: KeyboardEvent) => {
+        const onMouseClick = (e: MouseEvent) => {
             if (!active) return;
             if (!name) return;
-            if (e.code === "Space") {
-                e?.preventDefault();
-                e?.stopPropagation();
-                onHighlight(name);
-                setActive(false);
-            }
+
+            e?.preventDefault();
+            e?.stopPropagation();
+            e.stopImmediatePropagation();
+            onHighlight(name);
+            setActive(false);
         };
 
-        document.addEventListener("keydown", onKeyDown);
+        if (active) {
+            document.addEventListener("click", onMouseClick, {
+                capture: true,
+            });
 
-        return () => {
-            document.removeEventListener("keydown", onKeyDown);
-        };
+            return () => {
+                document.removeEventListener("click", onMouseClick, {
+                    capture: true,
+                });
+            };
+        }
+
+        return () => 0;
     }, [name, onHighlight, active]);
 
     React.useEffect(() => {

--- a/packages/devtools/src/components/selector-hint.tsx
+++ b/packages/devtools/src/components/selector-hint.tsx
@@ -55,7 +55,7 @@ export const SelectorHint = ({
                     textShadow: "none",
                 }}
             >
-                space
+                click
             </kbd>{" "}
             to highlight in monitor.
         </div>

--- a/packages/devtools/src/panel.tsx
+++ b/packages/devtools/src/panel.tsx
@@ -65,6 +65,7 @@ export const DevtoolsPanel =
                       <ResizablePane visible={visible} placement={placement}>
                           {({ resizing }) => (
                               <iframe
+                                  allow="clipboard-write;"
                                   src={devtoolsUrl}
                                   srcDoc={
                                       devtoolsUrl


### PR DESCRIPTION
Added the ability to highlight in monitor with `click` instead of `space`

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
