### PR TITLE
chore(devtools-ui): persistently store monitor filters in local storage

### DIFF
--- a/.changeset/rude-boxes-tease.md
+++ b/.changeset/rude-boxes-tease.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/devtools-ui": patch
+---
+
+fix filtering monitor from DOM selector

--- a/.changeset/rude-boxes-tease.md
+++ b/.changeset/rude-boxes-tease.md
@@ -2,4 +2,7 @@
 "@refinedev/devtools-ui": patch
 ---
 
-fix filtering monitor from DOM selector
+fix: filtering monitor from DOM selector
+
+feat: persistently store monitor filter in local storage
+From now on, the monitor filter will be stored in local storage and will be restored on page load.

--- a/packages/devtools-ui/jest.config.js
+++ b/packages/devtools-ui/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
     preset: "ts-jest",
     rootDir: "./",
-    displayName: "react-hook-form",
+    displayName: "devtools-ui",
     testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/dist/"],
     testEnvironment: "jsdom",
     transform: {

--- a/packages/devtools-ui/src/components/monitor-applied-filter-group.tsx
+++ b/packages/devtools-ui/src/components/monitor-applied-filter-group.tsx
@@ -34,7 +34,7 @@ export const MonitorAppliedFilterGroup = ({ filters, onClear }: Props) => {
         filters.hook.length > 0 ||
         filters.scope.length > 0 ||
         filters.status.length > 0 ||
-        filters.parent ||
+        filters.parent.length > 0 ||
         filters.resource;
 
     const renderSection = (key: keyof Filters) => {

--- a/packages/devtools-ui/src/hooks/use-local-storage.test.ts
+++ b/packages/devtools-ui/src/hooks/use-local-storage.test.ts
@@ -1,0 +1,42 @@
+import { renderHook, act } from "@testing-library/react-hooks";
+import { useLocalStorage } from "./use-local-storage";
+import { getLocalStorage, setLocalStorage } from "../utils/local-storage";
+
+jest.mock("../utils/local-storage");
+
+describe("useLocalStorage", () => {
+    const name = "test";
+    const defaultValue = "default";
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should return the default value if localStorage is empty", () => {
+        (getLocalStorage as jest.Mock).mockReturnValueOnce(defaultValue);
+        const { result } = renderHook(() =>
+            useLocalStorage({ name, defaultValue }),
+        );
+        expect(result.current[0]).toEqual(defaultValue);
+    });
+
+    it("should return the value from localStorage if available", () => {
+        const value = "value";
+        (getLocalStorage as jest.Mock).mockReturnValueOnce(value);
+        const { result } = renderHook(() =>
+            useLocalStorage({ name, defaultValue }),
+        );
+        expect(result.current[0]).toEqual(value);
+    });
+
+    it("should update the value in localStorage when setValue is called", () => {
+        const value = "value";
+        const { result } = renderHook(() =>
+            useLocalStorage({ name, defaultValue }),
+        );
+        act(() => {
+            result.current[1](value);
+        });
+        expect(setLocalStorage).toHaveBeenCalledWith(name, value);
+    });
+});

--- a/packages/devtools-ui/src/hooks/use-local-storage.ts
+++ b/packages/devtools-ui/src/hooks/use-local-storage.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+import { getLocalStorage, setLocalStorage } from "../utils/local-storage";
+
+type Props<T> = {
+    name: string;
+    defaultValue: T;
+};
+
+export const useLocalStorage = <T>({ name, defaultValue }: Props<T>) => {
+    const [value, setValue] = useState<T>(() => {
+        return getLocalStorage(name, defaultValue);
+    });
+
+    useEffect(() => {
+        setLocalStorage(name, value);
+    }, [value]);
+
+    return [value, setValue] as const;
+};

--- a/packages/devtools-ui/src/pages/monitor.tsx
+++ b/packages/devtools-ui/src/pages/monitor.tsx
@@ -159,7 +159,7 @@ export const Monitor = () => {
                 resource: undefined,
                 scope: [],
                 status: [],
-                parent: [],
+                parent: [highlightParam],
             });
         }
     }, [highlightParam]);

--- a/packages/devtools-ui/src/pages/monitor.tsx
+++ b/packages/devtools-ui/src/pages/monitor.tsx
@@ -30,6 +30,7 @@ import { Filters, MonitorFilters } from "src/components/monitor-filters";
 import { useSearchParams } from "react-router-dom";
 import { getResourceValue } from "src/utils/get-resource-value";
 import { ResourceValue } from "src/components/resource-value";
+import { useLocalStorage } from "src/hooks/use-local-storage";
 
 export const Monitor = () => {
     const { ws } = React.useContext(DevToolsContext);
@@ -144,12 +145,15 @@ export const Monitor = () => {
         [],
     );
 
-    const [filters, setFilters] = React.useState<Filters>({
-        hook: [],
-        parent: [],
-        resource: undefined,
-        scope: ["data"],
-        status: [],
+    const [filters, setFilters] = useLocalStorage<Filters>({
+        name: "monitor-filters",
+        defaultValue: {
+            hook: [],
+            parent: [],
+            resource: undefined,
+            scope: ["data"],
+            status: [],
+        },
     });
 
     React.useEffect(() => {

--- a/packages/devtools-ui/src/utils/local-storage.test.ts
+++ b/packages/devtools-ui/src/utils/local-storage.test.ts
@@ -1,0 +1,48 @@
+import { getLocalStorage } from "./local-storage";
+
+describe("getLocalStorage", () => {
+    const mockLocalStorage = {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+        removeItem: jest.fn(),
+    };
+
+    beforeEach(() => {
+        Object.defineProperty(window, "localStorage", {
+            value: mockLocalStorage,
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should return default value if localStorage is not available", () => {
+        mockLocalStorage.getItem.mockImplementation(() => {
+            throw new Error("test error");
+        });
+        const defaultValue = "default";
+        const value = getLocalStorage("test", defaultValue);
+        expect(value).toEqual(defaultValue);
+    });
+
+    it("should return the value from localStorage if available", () => {
+        const name = "test";
+        const value = "value";
+        mockLocalStorage.getItem.mockReturnValueOnce(JSON.stringify(value));
+        const result = getLocalStorage(name, "default");
+        expect(result).toEqual(value);
+        expect(mockLocalStorage.getItem).toHaveBeenCalledWith(name);
+    });
+
+    it("should return default value if localStorage throws an error", () => {
+        const defaultValue = "default";
+        const name = "test";
+        mockLocalStorage.getItem.mockImplementation(() => {
+            throw new Error("test error");
+        });
+        const result = getLocalStorage(name, defaultValue);
+        expect(result).toEqual(defaultValue);
+        expect(mockLocalStorage.getItem).toHaveBeenCalledWith(name);
+    });
+});

--- a/packages/devtools-ui/src/utils/local-storage.ts
+++ b/packages/devtools-ui/src/utils/local-storage.ts
@@ -1,0 +1,22 @@
+export const getLocalStorage = <T>(name: string, defaultValue: T): T => {
+    if (typeof window === "undefined") {
+        return defaultValue;
+    }
+
+    try {
+        const value = window.localStorage.getItem(name);
+        return value ? JSON.parse(value) : defaultValue;
+    } catch (error) {
+        return defaultValue;
+    }
+};
+
+export const setLocalStorage = <T>(name: string, newValue: T) => {
+    if (typeof window === "undefined") {
+        return;
+    }
+
+    try {
+        window.localStorage.setItem(name, JSON.stringify(newValue));
+    } catch (error) {}
+};


### PR DESCRIPTION
fix: filtering monitor from DOM selector

feat: persistently store monitor filter in local storage
From now on, the monitor filter will be stored in local storage and will be restored on page load.


### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
