### PR TITLE
fix(devtvools): look up to parents on non fiber elements

### DIFF
--- a/.changeset/slimy-singers-explain.md
+++ b/.changeset/slimy-singers-explain.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/devtools": patch
+---
+
+Update `@aliemir/dom-to-fiber-utils` to latest version to fix issue with selecting elements in the DOM tree that are not handled by React Fiber.

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -23,7 +23,7 @@
   "author": "refine",
   "module": "dist/esm/index.js",
   "dependencies": {
-    "@aliemir/dom-to-fiber-utils": "^0.2.0",
+    "@aliemir/dom-to-fiber-utils": "^0.4.0",
     "@refinedev/devtools-shared": "1.1.0",
     "error-stack-parser": "^2.1.4",
     "lodash-es": "^4.17.21",


### PR DESCRIPTION
There was an issue with the DOM selector when it has target of non-fiber elements (in some cases, elements are appended to the DOM outside of React). Now when the target is a non-fiber element, it will look up the parents to find a fiber.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
