### PR TITLE
chore: add changeset for packages with README update

### DIFF
--- a/.changeset/grumpy-cameras-wonder.md
+++ b/.changeset/grumpy-cameras-wonder.md
@@ -1,0 +1,41 @@
+---
+"@refinedev/ably": patch
+"@refinedev/airtable": patch
+"@refinedev/altogic": patch
+"@refinedev/antd": patch
+"@refinedev/antd-audit-log": patch
+"@refinedev/appwrite": patch
+"@refinedev/chakra-ui": patch
+"@refinedev/cli": patch
+"create-refine-app": patch
+"@refinedev/devtools-internal": patch
+"@refinedev/devtools-server": patch
+"@refinedev/devtools-shared": patch
+"@refinedev/devtools-ui": patch
+"@refinedev/graphql": patch
+"@refinedev/hasura": patch
+"@refinedev/inferencer": patch
+"@refinedev/kbar": patch
+"@refinedev/mantine": patch
+"@refinedev/medusa": patch
+"@refinedev/mui": patch
+"@refinedev/nestjs-query": patch
+"@refinedev/nestjsx-crud": patch
+"@refinedev/nextjs-router": patch
+"@refinedev/nhost": patch
+"@refinedev/react-hook-form": patch
+"@refinedev/react-router-v6": patch
+"@refinedev/react-table": patch
+"@refinedev/sdk": patch
+"@refinedev/simple-rest": patch
+"@refinedev/strapi": patch
+"@refinedev/strapi-graphql": patch
+"@refinedev/strapi-v4": patch
+"@refinedev/supabase": patch
+---
+
+chore: update README.md
+
+-   fix grammar errors.
+-   make all README.md files consistent.
+-   add code example code snippets.

--- a/.changeset/grumpy-cameras-wonder.md
+++ b/.changeset/grumpy-cameras-wonder.md
@@ -26,7 +26,6 @@
 "@refinedev/react-hook-form": patch
 "@refinedev/react-router-v6": patch
 "@refinedev/react-table": patch
-"@refinedev/sdk": patch
 "@refinedev/simple-rest": patch
 "@refinedev/strapi": patch
 "@refinedev/strapi-graphql": patch


### PR DESCRIPTION
Recently, [we've updated README.md in most of the packages](https://github.com/refinedev/refine/pull/4989/files#diff-5b847048ab9829c8231dbb3630de903065ed83f63f693cb4f73454801a318919) but didn't do a patch release. This PR adds patch changeset for all relevant packages.

