### PR TITLE
feat(cli): add dynamic announcements

### DIFF
--- a/.changeset/modern-spies-warn.md
+++ b/.changeset/modern-spies-warn.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/cli": minor
+---
+
+Added dynamic announcements to the CLI to show when a command is executed. Users will be able to receive news and updates about refine without having to update their dependencies.

--- a/packages/cli/ANNOUNCEMENTS.md
+++ b/packages/cli/ANNOUNCEMENTS.md
@@ -8,7 +8,7 @@ test announcement here
 ---
 
 ---announcement
-hidden:false
+hidden:true
 
 ---
 

--- a/packages/cli/ANNOUNCEMENTS.md
+++ b/packages/cli/ANNOUNCEMENTS.md
@@ -1,3 +1,6 @@
 ---announcement
+---
+
 test announcement here
+
 ---

--- a/packages/cli/ANNOUNCEMENTS.md
+++ b/packages/cli/ANNOUNCEMENTS.md
@@ -1,11 +1,16 @@
 ---announcement
+hidden: false
+
 ---
 
 test announcement here
 
 ---
 
-## ---announcement
+---announcement
+hidden:false
+
+---
 
 second **announcement** here test [github](https://github.com) link. raw link: https://github.com
 

--- a/packages/cli/ANNOUNCEMENTS.md
+++ b/packages/cli/ANNOUNCEMENTS.md
@@ -1,0 +1,3 @@
+---announcement
+test announcement here
+---

--- a/packages/cli/ANNOUNCEMENTS.md
+++ b/packages/cli/ANNOUNCEMENTS.md
@@ -8,7 +8,7 @@ refine Devtools beta version has been released, join the waitlist to try it out.
 ---
 
 ---announcement
-hidden: true
+hidden: false
 
 ---
 

--- a/packages/cli/ANNOUNCEMENTS.md
+++ b/packages/cli/ANNOUNCEMENTS.md
@@ -1,5 +1,5 @@
 ---announcement
-hidden: false
+hidden: true
 
 ---
 

--- a/packages/cli/ANNOUNCEMENTS.md
+++ b/packages/cli/ANNOUNCEMENTS.md
@@ -8,10 +8,10 @@ refine Devtools beta version has been released, join the waitlist to try it out.
 ---
 
 ---announcement
-hidden: true
+hidden: false
 
 ---
 
-Hello from refine team! Hope you enjoy! Join our discord server to get help and discuss with other users. https://discord.gg/refine
+Hello from refine team! Hope you enjoy! Join our Discord community to get help and discuss with other users. https://discord.gg/refine
 
 ---

--- a/packages/cli/ANNOUNCEMENTS.md
+++ b/packages/cli/ANNOUNCEMENTS.md
@@ -3,15 +3,15 @@ hidden: false
 
 ---
 
-test announcement here
+refine Devtools beta version has been released, join the waitlist to try it out. https://s.refine.dev/devtools
 
 ---
 
 ---announcement
-hidden: false
+hidden: true
 
 ---
 
-refine Devtools beta version has been released, join the waitlist to try it out. https://s.refine.dev/devtools
+Hello from refine team! Hope you enjoy! Join our discord server to get help and discuss with other users. https://discord.gg/refine
 
 ---

--- a/packages/cli/ANNOUNCEMENTS.md
+++ b/packages/cli/ANNOUNCEMENTS.md
@@ -8,7 +8,7 @@ test announcement here
 ---
 
 ---announcement
-hidden:true
+hidden: true
 
 ---
 

--- a/packages/cli/ANNOUNCEMENTS.md
+++ b/packages/cli/ANNOUNCEMENTS.md
@@ -4,3 +4,9 @@
 test announcement here
 
 ---
+
+## ---announcement
+
+second **announcement** here test [github](https://github.com) link. raw link: https://github.com
+
+---

--- a/packages/cli/ANNOUNCEMENTS.md
+++ b/packages/cli/ANNOUNCEMENTS.md
@@ -8,7 +8,7 @@ refine Devtools beta version has been released, join the waitlist to try it out.
 ---
 
 ---announcement
-hidden: false
+hidden: true
 
 ---
 

--- a/packages/cli/ANNOUNCEMENTS.md
+++ b/packages/cli/ANNOUNCEMENTS.md
@@ -1,5 +1,5 @@
 ---announcement
-hidden: true
+hidden: false
 
 ---
 
@@ -8,10 +8,10 @@ test announcement here
 ---
 
 ---announcement
-hidden: true
+hidden: false
 
 ---
 
-second **announcement** here test [github](https://github.com) link. raw link: https://github.com
+refine Devtools beta version has been released, join the waitlist to try it out. https://s.refine.dev/devtools
 
 ---

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,6 +49,7 @@
     "figlet": "^1.5.2",
     "fs-extra": "^10.1.0",
     "globby": "^11.1.0",
+    "gray-matter": "^4.0.3",
     "handlebars": "^4.7.7",
     "http-proxy-middleware": "^2.0.6",
     "ink": "^3.2.0",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -13,6 +13,7 @@ import whoami from "@commands/whoami";
 import devtools from "@commands/devtools";
 import add from "@commands/add";
 import { telemetryHook } from "@telemetryindex";
+import { handleAnnouncements } from "@utils/announcement";
 import "@utils/env";
 
 // It reads and updates from package.json during build. ref: tsup.config.ts
@@ -51,6 +52,8 @@ const bootstrap = () => {
     proxy(program);
     devtools(program);
     add(program);
+
+    program.hook("preAction", handleAnnouncements);
 
     program.hook("postAction", (thisCommand) => {
         const command = thisCommand.args[0];

--- a/packages/cli/src/commands/runner/dev/index.ts
+++ b/packages/cli/src/commands/runner/dev/index.ts
@@ -48,21 +48,6 @@ const action = async (
 
     if (devtools ?? devtoolsDefault) {
         devtoolsRunner();
-    } else {
-        console.log(
-            `\n${boxen(
-                `refine Devtools beta version has been released, join the waitlist to try it out. https://s.refine.dev/devtools`,
-                {
-                    padding: 1,
-                    title: "refine devtools",
-                    titleAlignment: "center",
-                    textAlignment: "center",
-                    dimBorder: true,
-                    borderColor: "blueBright",
-                    borderStyle: "round",
-                },
-            )}\n`,
-        );
     }
 
     runScript(binPath, command);

--- a/packages/cli/src/components/announcement-message/index.tsx
+++ b/packages/cli/src/components/announcement-message/index.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import Markdown from "ink-markdown";
+import { Box, Text } from "ink";
+import { Announcement } from "@definitions/announcement";
+
+type Props = {
+    announcements: Announcement[];
+};
+
+const AnnouncementMessage: React.FC<Props> = ({ announcements }) => {
+    return (
+        <Box
+            flexDirection="column"
+            alignItems="flex-start"
+            justifyContent="flex-start"
+            borderColor="blueBright"
+            borderStyle="round"
+            paddingLeft={1}
+            paddingRight={1}
+            paddingTop={1}
+            paddingBottom={1}
+        >
+            {announcements.map(({ content }, i, arr) => (
+                <Box display="flex" key={i}>
+                    {arr.length > 1 && <Text>· </Text>}
+                    <Markdown key={i}>{content.trim()}</Markdown>
+                    {i !== arr.length - 1 && arr.length > 1 ? (
+                        <Text>{"\n"}</Text>
+                    ) : null}
+                </Box>
+            ))}
+        </Box>
+    );
+};
+
+export default AnnouncementMessage;

--- a/packages/cli/src/components/announcement-message/index.tsx
+++ b/packages/cli/src/components/announcement-message/index.tsx
@@ -19,16 +19,16 @@ const AnnouncementMessage: React.FC<Props> = ({ announcements }) => {
             paddingRight={1}
             paddingTop={1}
             paddingBottom={1}
+            display="flex"
         >
             {announcements.map(({ content }, i, arr) => (
-                <Box display="flex" key={i}>
-                    {arr.length > 1 && <Text>· </Text>}
-                    <Markdown key={i}>
-                        {content.trim() +
-                            (i === arr.length - 1 && arr.length > 1
-                                ? ""
-                                : "\n")}
-                    </Markdown>
+                <Box
+                    display="flex"
+                    key={i}
+                    paddingBottom={arr.length > 1 && i < arr.length - 1 ? 1 : 0}
+                >
+                    {arr.length > 1 && <Text>- </Text>}
+                    <Markdown key={i}>{content.trim()}</Markdown>
                 </Box>
             ))}
         </Box>

--- a/packages/cli/src/components/announcement-message/index.tsx
+++ b/packages/cli/src/components/announcement-message/index.tsx
@@ -23,10 +23,12 @@ const AnnouncementMessage: React.FC<Props> = ({ announcements }) => {
             {announcements.map(({ content }, i, arr) => (
                 <Box display="flex" key={i}>
                     {arr.length > 1 && <Text>· </Text>}
-                    <Markdown key={i}>{content.trim()}</Markdown>
-                    {i !== arr.length - 1 && arr.length > 1 ? (
-                        <Text>{"\n"}</Text>
-                    ) : null}
+                    <Markdown key={i}>
+                        {content.trim() +
+                            (i === arr.length - 1 && arr.length > 1
+                                ? ""
+                                : "\n")}
+                    </Markdown>
                 </Box>
             ))}
         </Box>

--- a/packages/cli/src/definitions/announcement.ts
+++ b/packages/cli/src/definitions/announcement.ts
@@ -1,0 +1,4 @@
+export type Announcement = {
+    hidden?: boolean;
+    content: string;
+};

--- a/packages/cli/src/utils/announcement/index.tsx
+++ b/packages/cli/src/utils/announcement/index.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { render } from "ink";
+import matter from "gray-matter";
+
+import { Announcement } from "@definitions/announcement";
+import AnnouncementMessage from "@components/announcement-message";
+
+const ANNOUNCEMENT_URL =
+    "https://raw.githubusercontent.com/refinedev/refine/next/packages/cli/ANNOUNCEMENTS.md";
+
+const ANNOUNCEMENT_DELIMITER = "---announcement";
+
+const splitAnnouncements = (feed: string) => {
+    const sections = feed.split(ANNOUNCEMENT_DELIMITER);
+
+    return sections
+        .slice(1)
+        .map((section) => `${ANNOUNCEMENT_DELIMITER}${section}`);
+};
+
+const parseAnnouncement = (raw: string): Announcement => {
+    const fixed = raw.replace(ANNOUNCEMENT_DELIMITER, "---");
+    const parsed = matter(fixed);
+
+    return {
+        ...parsed.data,
+        content:
+            parsed.content.length === 0
+                ? fixed.replace(/---/g, "")
+                : parsed.content.replace(/---/g, ""),
+    } as Announcement;
+};
+
+export const getAnnouncements = async () => {
+    try {
+        const response = await fetch(ANNOUNCEMENT_URL)
+            .then((res) => res.text())
+            .catch(() => "");
+
+        const announcements = splitAnnouncements(response).map((section) =>
+            parseAnnouncement(section),
+        );
+
+        return announcements;
+    } catch (_) {
+        return [];
+    }
+};
+
+export const handleAnnouncements = async () => {
+    const announcements = await getAnnouncements();
+
+    const visibleAnnouncements = announcements.filter(
+        (a) => Boolean(a.hidden) === false,
+    );
+
+    if (visibleAnnouncements.length === 0) {
+        return;
+    }
+
+    const { unmount } = render(
+        <AnnouncementMessage announcements={visibleAnnouncements} />,
+    );
+
+    unmount();
+};


### PR DESCRIPTION
refine CLI will now show announcements dynamically when there's an update from the refine team.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
