### PR TITLE
feat: remove deprecated layout components from swizzle

### DIFF
--- a/.changeset/friendly-buttons-sit.md
+++ b/.changeset/friendly-buttons-sit.md
@@ -1,0 +1,11 @@
+---
+"@refinedev/antd": patch
+"@refinedev/chakra-ui": patch
+"@refinedev/mantine": patch
+"@refinedev/mui": patch
+---
+
+feat: deprecated `<ThemedLayout />` and `<Layout />` components removed from `swizzle`.
+From now on, users can swizzle `<ThemedLayoutV2 />` component instead.
+
+feat: swizzled `<ThemedLayoutV2 />` component destination changed to `src/components/layout/` from `src/components/themedLayout`.

--- a/packages/antd/refine.config.js
+++ b/packages/antd/refine.config.js
@@ -464,102 +464,6 @@ module.exports = {
             },
             {
                 group: "Other",
-                label: "Layout",
-                message: `
-                **\`Warning:\`**
-                If you want to change the default layout;
-                You should pass layout related components to the **<Layout/>** component's props.
-
-                \`\`\`
-                // title: App.tsx
-                import { Layout } from "components/layout";
-                import { Header } from "components/layout/header";
-                import { Sider } from "components/layout/sider";
-                import { Title } from "components/layout/title";
-
-                const App = () => {
-                    return (
-                        <Refine
-                            /* ... */
-                        >
-                            <Layout Header={Header} Sider={Sider} Title={Title} />
-                                /* ... */
-                            </Layout>
-                        </Refine>
-                    );
-                }
-                \`\`\`
-                `,
-                files: [
-                    {
-                        src: "./src/components/layout/sider/index.tsx",
-                        dest: "./components/layout/sider.tsx",
-                        transform: (content) => {
-                            let newContent = content;
-                            const imports = getImports(content);
-
-                            imports.map((importItem) => {
-                                // handle @components import replacement
-                                if (importItem.importPath === "@components") {
-                                    const newStatement = `import ${importItem.namedImports} from "@refinedev/antd";`;
-
-                                    newContent = newContent.replace(
-                                        importItem.statement,
-                                        newStatement,
-                                    );
-                                }
-
-                                // add content of ./styles.ts and remove import
-                                if (importItem.importPath === "./styles") {
-                                    newContent = newContent.replace(
-                                        importItem.statement,
-                                        "",
-                                    );
-
-                                    let appending = "";
-
-                                    try {
-                                        const stylesContent = getFileContent(
-                                            join(
-                                                dirname(
-                                                    "./src/components/layout/sider/index.tsx",
-                                                ),
-                                                "/styles.ts",
-                                            ),
-                                            "utf-8",
-                                        ).replace("export const", "const");
-
-                                        appending = stylesContent;
-                                    } catch (err) {
-                                        // console.log(err);
-                                    }
-
-                                    newContent = appendAfterImports(
-                                        newContent,
-                                        appending,
-                                    );
-                                }
-                            });
-
-                            return newContent;
-                        },
-                    },
-                    {
-                        src: "./src/components/layout/header/index.tsx",
-                        dest: "./components/layout/header.tsx",
-                    },
-                    {
-                        src: "./src/components/layout/title/index.tsx",
-                        dest: "./components/layout/title.tsx",
-                    },
-                    {
-                        src: "./src/components/layout/index.tsx",
-                        dest: "./components/layout/index.tsx",
-                    },
-                ],
-            },
-            {
-                group: "Other",
                 label: "ThemedLayoutV2",
                 message: `
                 **\`Warning:\`**
@@ -568,10 +472,10 @@ module.exports = {
 
                 \`\`\`
                 // title: App.tsx
-                import { ThemedLayoutV2 } from "components/themedLayout";
-                import { ThemedHeaderV2 } from "components/themedLayout/header";
-                import { ThemedSiderV2 } from "components/themedLayout/sider";
-                import { ThemedTitleV2 } from "components/themedLayout/title";
+                import { ThemedLayoutV2 } from "components/layout";
+                import { ThemedHeaderV2 } from "components/layout/header";
+                import { ThemedSiderV2 } from "components/layout/sider";
+                import { ThemedTitleV2 } from "components/layout/title";
 
                 const App = () => {
                     return (
@@ -589,7 +493,7 @@ module.exports = {
                 files: [
                     {
                         src: "./src/components/themedLayoutV2/sider/index.tsx",
-                        dest: "./components/themedLayout/sider.tsx",
+                        dest: "./components/layout/sider.tsx",
                         transform: (content) => {
                             let newContent = content;
                             const imports = getImports(content);
@@ -645,15 +549,15 @@ module.exports = {
                     },
                     {
                         src: "./src/components/themedLayoutV2/header/index.tsx",
-                        dest: "./components/themedLayout/header.tsx",
+                        dest: "./components/layout/header.tsx",
                     },
                     {
                         src: "./src/components/themedLayoutV2/title/index.tsx",
-                        dest: "./components/themedLayout/title.tsx",
+                        dest: "./components/layout/title.tsx",
                     },
                     {
                         src: "./src/components/themedLayoutV2/index.tsx",
-                        dest: "./components/themedLayout/index.tsx",
+                        dest: "./components/layout/index.tsx",
                         transform: (content) => {
                             let newContent = content;
                             const imports = getImports(content);
@@ -676,102 +580,6 @@ module.exports = {
 
                             return newContent;
                         },
-                    },
-                ],
-            },
-            {
-                group: "Other",
-                label: "Themed Layout (deprecated use ThemedLayoutV2 instead)",
-                message: `
-                **\`Warning:\`**
-                If you want to change the default layout;
-                You should pass layout related components to the **<ThemedLayout/>** component's props.
-
-                \`\`\`
-                // title: App.tsx
-                import { ThemedLayout } from "components/themedLayout";
-                import { ThemedHeader } from "components/themedLayout/header";
-                import { ThemedSider } from "components/themedLayout/sider";
-                import { ThemedTitle } from "components/themedLayout/title";
-
-                const App = () => {
-                    return (
-                        <Refine
-                            /* ... */
-                        >
-                            <ThemedLayout Header={ThemedHeader} Sider={ThemedSider} Title={ThemedTitle} />
-                                /* ... */
-                            </ThemedLayout>
-                        </Refine>
-                    );
-                }
-                \`\`\`
-                `,
-                files: [
-                    {
-                        src: "./src/components/themedLayout/sider/index.tsx",
-                        dest: "./components/themedLayout/sider.tsx",
-                        transform: (content) => {
-                            let newContent = content;
-                            const imports = getImports(content);
-
-                            imports.map((importItem) => {
-                                // handle @components import replacement
-                                if (importItem.importPath === "@components") {
-                                    const newStatement = `import ${importItem.namedImports} from "@refinedev/antd";`;
-
-                                    newContent = newContent.replace(
-                                        importItem.statement,
-                                        newStatement,
-                                    );
-                                }
-
-                                // add content of ./styles.ts and remove import
-                                if (importItem.importPath === "./styles") {
-                                    newContent = newContent.replace(
-                                        importItem.statement,
-                                        "",
-                                    );
-
-                                    let appending = "";
-
-                                    try {
-                                        const stylesContent = getFileContent(
-                                            join(
-                                                dirname(
-                                                    "./src/components/themedLayout/sider/index.tsx",
-                                                ),
-                                                "/styles.ts",
-                                            ),
-                                            "utf-8",
-                                        ).replace("export const", "const");
-
-                                        appending = stylesContent;
-                                    } catch (err) {
-                                        // console.log(err);
-                                    }
-
-                                    newContent = appendAfterImports(
-                                        newContent,
-                                        appending,
-                                    );
-                                }
-                            });
-
-                            return newContent;
-                        },
-                    },
-                    {
-                        src: "./src/components/themedLayout/header/index.tsx",
-                        dest: "./components/themedLayout/header.tsx",
-                    },
-                    {
-                        src: "./src/components/themedLayout/title/index.tsx",
-                        dest: "./components/themedLayout/title.tsx",
-                    },
-                    {
-                        src: "./src/components/themedLayout/index.tsx",
-                        dest: "./components/themedLayout/index.tsx",
                     },
                 ],
             },

--- a/packages/antd/src/components/themedLayoutV2/sider/index.tsx
+++ b/packages/antd/src/components/themedLayoutV2/sider/index.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from "react";
+import React from "react";
 import { Layout, Menu, Grid, Drawer, Button, theme } from "antd";
 import {
     DashboardOutlined,
@@ -109,7 +109,7 @@ export const ThemedSiderV2: React.FC<RefineThemedLayoutV2SiderProps> = ({
                     undefined && children.length === 0
             );
 
-            const linkStyle: CSSProperties =
+            const linkStyle: React.CSSProperties =
                 activeItemDisabled && isSelected
                     ? { pointerEvents: "none" }
                     : {};

--- a/packages/chakra-ui/refine.config.js
+++ b/packages/chakra-ui/refine.config.js
@@ -440,53 +440,6 @@ module.exports = {
             },
             {
                 group: "Other",
-                label: "Layout",
-                message: `
-                **\`Warning:\`**
-                If you want to change the default layout;
-                You should pass layout related components to the **<Layout/>** component's props.
-
-                \`\`\`
-                // title: App.tsx
-                import { Layout } from "components/layout";
-                import { Header } from "components/layout/header";
-                import { Sider } from "components/layout/sider";
-                import { Title } from "components/layout/title";
-
-                const App = () => {
-                    return (
-                        <Refine
-                            /* ... */
-                        >
-                            <Layout Header={Header} Sider={Sider} Title={Title} />
-                                /* ... */
-                            </Layout>
-                        </Refine>
-                    );
-                }
-                \`\`\`
-                `,
-                files: [
-                    {
-                        src: "./src/components/layout/sider/index.tsx",
-                        dest: "./components/layout/sider.tsx",
-                    },
-                    {
-                        src: "./src/components/layout/header/index.tsx",
-                        dest: "./components/layout/header.tsx",
-                    },
-                    {
-                        src: "./src/components/layout/title/index.tsx",
-                        dest: "./components/layout/title.tsx",
-                    },
-                    {
-                        src: "./src/components/layout/index.tsx",
-                        dest: "./components/layout/index.tsx",
-                    },
-                ],
-            },
-            {
-                group: "Other",
                 label: "ThemedLayoutV2",
                 message: `
                 **\`Warning:\`**
@@ -495,10 +448,10 @@ module.exports = {
 
                 \`\`\`
                 // title: App.tsx
-                import { ThemedLayoutV2 } from "components/themedLayout";
-                import { ThemedHeaderV2 } from "components/themedLayout/header";
-                import { ThemedSiderV2 } from "components/themedLayout/sider";
-                import { ThemedTitleV2 } from "components/themedLayout/title";
+                import { ThemedLayoutV2 } from "components/layout";
+                import { ThemedHeaderV2 } from "components/layout/header";
+                import { ThemedSiderV2 } from "components/layout/sider";
+                import { ThemedTitleV2 } from "components/layout/title";
 
                 const App = () => {
                     return (
@@ -516,7 +469,7 @@ module.exports = {
                 files: [
                     {
                         src: "./src/components/themedLayoutV2/sider/index.tsx",
-                        dest: "./components/themedLayout/sider.tsx",
+                        dest: "./components/layout/sider.tsx",
                         transform: (content) => {
                             let newContent = content;
                             const imports = getImports(content);
@@ -544,7 +497,7 @@ module.exports = {
                     },
                     {
                         src: "./src/components/themedLayoutV2/header/index.tsx",
-                        dest: "./components/themedLayout/header.tsx",
+                        dest: "./components/layout/header.tsx",
                         transform: (content) => {
                             let newContent = content;
 
@@ -560,11 +513,11 @@ module.exports = {
                     },
                     {
                         src: "./src/components/themedLayoutV2/title/index.tsx",
-                        dest: "./components/themedLayout/title.tsx",
+                        dest: "./components/layout/title.tsx",
                     },
                     {
                         src: "./src/components/themedLayoutV2/index.tsx",
-                        dest: "./components/themedLayout/index.tsx",
+                        dest: "./components/layout/index.tsx",
                         transform: (content) => {
                             let newContent = content;
                             const imports = getImports(content);
@@ -588,7 +541,7 @@ module.exports = {
                     },
                     {
                         src: "./src/components/themedLayoutV2/hamburgerMenu/index.tsx",
-                        dest: "./components/themedLayout/hamburgerMenu.tsx",
+                        dest: "./components/layout/hamburgerMenu.tsx",
                         transform: (content) => {
                             let newContent = content;
                             const imports = getImports(content);
@@ -607,53 +560,6 @@ module.exports = {
 
                             return newContent;
                         },
-                    },
-                ],
-            },
-            {
-                group: "Other",
-                label: "ThemedLayout",
-                message: `
-                **\`Warning:\`**
-                If you want to change the default themed layout;
-                You should pass layout related components to the **<ThemedLayout/>** component's props.
-
-                \`\`\`
-                // title: App.tsx
-                import { ThemedLayout } from "components/themedLayout";
-                import { ThemedHeader } from "components/themedLayout/header";
-                import { ThemedSider } from "components/themedLayout/sider";
-                import { ThemedTitle } from "components/themedLayout/title";
-
-                const App = () => {
-                    return (
-                        <Refine
-                            /* ... */
-                        >
-                            <ThemedLayout Header={ThemedHeader} Sider={ThemedSider} Title={ThemedTitle}>
-                                /* ... */
-                            </ThemedLayout>
-                        </Refine>
-                    );
-                }
-                \`\`\`
-                `,
-                files: [
-                    {
-                        src: "./src/components/themedLayout/sider/index.tsx",
-                        dest: "./components/themedLayout/sider.tsx",
-                    },
-                    {
-                        src: "./src/components/themedLayout/header/index.tsx",
-                        dest: "./components/themedLayout/header.tsx",
-                    },
-                    {
-                        src: "./src/components/themedLayout/title/index.tsx",
-                        dest: "./components/themedLayout/title.tsx",
-                    },
-                    {
-                        src: "./src/components/themedLayout/index.tsx",
-                        dest: "./components/themedLayout/index.tsx",
                     },
                 ],
             },

--- a/packages/mantine/refine.config.js
+++ b/packages/mantine/refine.config.js
@@ -440,53 +440,6 @@ module.exports = {
                 ],
             },
             {
-                group: "Other",
-                label: "Layout",
-                message: `
-                **\`Warning:\`**
-                If you want to change the default layout;
-                You should pass layout related components to the **<Layout/>** component's props.
-
-                \`\`\`
-                // title: App.tsx
-                import { Layout } from "components/layout";
-                import { Header } from "components/layout/header";
-                import { Sider } from "components/layout/sider";
-                import { Title } from "components/layout/title";
-
-                const App = () => {
-                    return (
-                        <Refine
-                            /* ... */
-                        >
-                            <Layout Header={Header} Sider={Sider} Title={Title} />
-                                /* ... */
-                            </Layout>
-                        </Refine>
-                    );
-                }
-                \`\`\`
-                `,
-                files: [
-                    {
-                        src: "./src/components/layout/sider/index.tsx",
-                        dest: "./components/layout/sider.tsx",
-                    },
-                    {
-                        src: "./src/components/layout/header/index.tsx",
-                        dest: "./components/layout/header.tsx",
-                    },
-                    {
-                        src: "./src/components/layout/title/index.tsx",
-                        dest: "./components/layout/title.tsx",
-                    },
-                    {
-                        src: "./src/components/layout/index.tsx",
-                        dest: "./components/layout/index.tsx",
-                    },
-                ],
-            },
-            {
                 group: "Basic Views",
                 label: "Create",
                 files: [
@@ -535,10 +488,10 @@ module.exports = {
                 You should pass layout related components to the **<ThemedLayoutV2 />** component's props.
                 \`\`\`
                 // title: App.tsx
-                import { ThemedLayoutV2 } from "components/themedLayout";
-                import { ThemedHeaderV2 } from "components/themedLayout/header";
-                import { ThemedSiderV2 } from "components/themedLayout/sider";
-                import { ThemedTitleV2 } from "components/themedLayout/title";
+                import { ThemedLayoutV2 } from "components/layout";
+                import { ThemedHeaderV2 } from "components/layout/header";
+                import { ThemedSiderV2 } from "components/layout/sider";
+                import { ThemedTitleV2 } from "components/layout/title";
                 const App = () => {
                     return (
                         <Refine
@@ -555,7 +508,7 @@ module.exports = {
                 files: [
                     {
                         src: "./src/components/themedLayoutV2/sider/index.tsx",
-                        dest: "./components/themedLayout/sider.tsx",
+                        dest: "./components/layout/sider.tsx",
                         transform: (content) => {
                             let newContent = content;
                             const imports = getImports(content);
@@ -583,7 +536,7 @@ module.exports = {
                     },
                     {
                         src: "./src/components/themedLayoutV2/header/index.tsx",
-                        dest: "./components/themedLayout/header.tsx",
+                        dest: "./components/layout/header.tsx",
                         transform: (content) => {
                             let newContent = content;
 
@@ -599,11 +552,11 @@ module.exports = {
                     },
                     {
                         src: "./src/components/themedLayoutV2/title/index.tsx",
-                        dest: "./components/themedLayout/title.tsx",
+                        dest: "./components/layout/title.tsx",
                     },
                     {
                         src: "./src/components/themedLayoutV2/index.tsx",
-                        dest: "./components/themedLayout/index.tsx",
+                        dest: "./components/layout/index.tsx",
                         transform: (content) => {
                             let newContent = content;
                             const imports = getImports(content);
@@ -627,7 +580,7 @@ module.exports = {
                     },
                     {
                         src: "./src/components/themedLayoutV2/hamburgerMenu/index.tsx",
-                        dest: "./components/themedLayout/hamburgerMenu.tsx",
+                        dest: "./components/layout/hamburgerMenu.tsx",
                         transform: (content) => {
                             let newContent = content;
                             const imports = getImports(content);

--- a/packages/mui/refine.config.js
+++ b/packages/mui/refine.config.js
@@ -441,71 +441,6 @@ module.exports = {
             },
             {
                 group: "Other",
-                label: "Layout",
-                message: `
-                **\`Warning:\`**
-                If you want to change the default layout;
-                You should pass layout related components to the **<Layout/>** component's props.
-
-                \`\`\`
-                // title: App.tsx
-                import { Layout } from "components/layout";
-                import { Header } from "components/layout/header";
-                import { Sider } from "components/layout/sider";
-                import { Title } from "components/layout/title";
-
-                const App = () => {
-                    return (
-                        <Refine
-                            /* ... */
-                        >
-                            <Layout Header={Header} Sider={Sider} Title={Title} />
-                                /* ... */
-                            </Layout>
-                        </Refine>
-                    );
-                }
-                \`\`\`
-                `,
-                files: [
-                    {
-                        src: "./src/components/layout/sider/index.tsx",
-                        dest: "./components/layout/sider.tsx",
-                        transform: (content) => {
-                            let newContent = content;
-                            const imports = getImports(content);
-
-                            imports.map((importItem) => {
-                                // handle @components import replacement
-                                if (importItem.importPath === "@components") {
-                                    const newStatement = `import ${importItem.namedImports} from "@refinedev/mui";`;
-
-                                    newContent = newContent.replace(
-                                        importItem.statement,
-                                        newStatement,
-                                    );
-                                }
-                            });
-
-                            return newContent;
-                        },
-                    },
-                    {
-                        src: "./src/components/layout/header/index.tsx",
-                        dest: "./components/layout/header.tsx",
-                    },
-                    {
-                        src: "./src/components/layout/title/index.tsx",
-                        dest: "./components/layout/title.tsx",
-                    },
-                    {
-                        src: "./src/components/layout/index.tsx",
-                        dest: "./components/layout/index.tsx",
-                    },
-                ],
-            },
-            {
-                group: "Other",
                 label: "ThemedLayoutV2",
                 message: `
                 **\`Warning:\`**
@@ -514,10 +449,10 @@ module.exports = {
 
                 \`\`\`
                 // title: App.tsx
-                import { ThemedLayoutV2 } from "components/themedLayout";
-                import { ThemedHeaderV2 } from "components/themedLayout/header";
-                import { ThemedSiderV2 } from "components/themedLayout/sider";
-                import { ThemedTitleV2 } from "components/themedLayout/title";
+                import { ThemedLayoutV2 } from "components/layout";
+                import { ThemedHeaderV2 } from "components/layout/header";
+                import { ThemedSiderV2 } from "components/layout/sider";
+                import { ThemedTitleV2 } from "components/layout/title";
 
                 const App = () => {
                     return (
@@ -535,7 +470,7 @@ module.exports = {
                 files: [
                     {
                         src: "./src/components/themedLayoutV2/sider/index.tsx",
-                        dest: "./components/themedLayout/sider.tsx",
+                        dest: "./components/layout/sider.tsx",
                         transform: (content) => {
                             let newContent = content;
                             const imports = getImports(content);
@@ -560,7 +495,7 @@ module.exports = {
                     },
                     {
                         src: "./src/components/themedLayoutV2/header/index.tsx",
-                        dest: "./components/themedLayout/header.tsx",
+                        dest: "./components/layout/header.tsx",
                         transform: (content) => {
                             let newContent = content;
 
@@ -576,11 +511,11 @@ module.exports = {
                     },
                     {
                         src: "./src/components/themedLayoutV2/title/index.tsx",
-                        dest: "./components/themedLayout/title.tsx",
+                        dest: "./components/layout/title.tsx",
                     },
                     {
                         src: "./src/components/themedLayoutV2/index.tsx",
-                        dest: "./components/themedLayout/index.tsx",
+                        dest: "./components/layout/index.tsx",
                         transform: (content) => {
                             let newContent = content;
                             const imports = getImports(content);
@@ -602,7 +537,7 @@ module.exports = {
                     },
                     {
                         src: "./src/components/themedLayoutV2/hamburgerMenu/index.tsx",
-                        dest: "./components/themedLayout/hamburgerMenu.tsx",
+                        dest: "./components/layout/hamburgerMenu.tsx",
                         transform: (content) => {
                             let newContent = content;
                             const imports = getImports(content);
@@ -621,71 +556,6 @@ module.exports = {
 
                             return newContent;
                         },
-                    },
-                ],
-            },
-            {
-                group: "Other",
-                label: "ThemedLayout (deprecated use ThemedLayoutV2 instead)",
-                message: `
-                **\`Warning:\`**
-                If you want to change the default themed layout;
-                You should pass layout related components to the **<ThemedLayout/>** component's props.
-
-                \`\`\`
-                // title: App.tsx
-                import { ThemedLayout } from "components/themedLayout";
-                import { ThemedHeader } from "components/themedLayout/header";
-                import { ThemedSider } from "components/themedLayout/sider";
-                import { ThemedTitle } from "components/themedLayout/title";
-
-                const App = () => {
-                    return (
-                        <Refine
-                            /* ... */
-                        >
-                            <ThemedLayout Header={ThemedHeader} Sider={ThemedSider} Title={ThemedTitle}>
-                                /* ... */
-                            </ThemedLayout>
-                        </Refine>
-                    );
-                }
-                \`\`\`
-                `,
-                files: [
-                    {
-                        src: "./src/components/themedLayout/sider/index.tsx",
-                        dest: "./components/themedLayout/sider.tsx",
-                        transform: (content) => {
-                            let newContent = content;
-                            const imports = getImports(content);
-
-                            imports.map((importItem) => {
-                                // handle @components import replacement
-                                if (importItem.importPath === "@components") {
-                                    const newStatement = `import ${importItem.namedImports} from "@refinedev/mui";`;
-
-                                    newContent = newContent.replace(
-                                        importItem.statement,
-                                        newStatement,
-                                    );
-                                }
-                            });
-
-                            return newContent;
-                        },
-                    },
-                    {
-                        src: "./src/components/themedLayout/header/index.tsx",
-                        dest: "./components/themedLayout/header.tsx",
-                    },
-                    {
-                        src: "./src/components/themedLayout/title/index.tsx",
-                        dest: "./components/themedLayout/title.tsx",
-                    },
-                    {
-                        src: "./src/components/themedLayout/index.tsx",
-                        dest: "./components/themedLayout/index.tsx",
                     },
                 ],
             },


### PR DESCRIPTION
feat: deprecated `<ThemedLayout />` and `<Layout />` components removed from `swizzle`.
From now on, users can swizzle `<ThemedLayoutV2 />` component instead.

feat: swizzled `<ThemedLayoutV2 />` component destination changed to `src/components/layout/` from `src/components/themedLayout`.

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
