### PR TITLE
fix: convert hasura operator with graphql-default

### DIFF
--- a/.changeset/giant-islands-bathe.md
+++ b/.changeset/giant-islands-bathe.md
@@ -1,0 +1,8 @@
+---
+"@refinedev/hasura": patch
+---
+
+fix: issue with #4972
+
+When using the Hasura provider with the 'graphql-default' naming convention, snake-case graphql operators (e.g. \_is_null) were not converted to the correct case, causing query errors.
+This problem is now fixed. Now the snake_case operator is converted according to the given naming convention (e.g. hasura-default: \_is_null, graphql-default: \_isNull).

--- a/packages/hasura/src/dataProvider/index.ts
+++ b/packages/hasura/src/dataProvider/index.ts
@@ -99,7 +99,7 @@ const dataProvider = (
                 ? generateSorting(sorters)
                 : upperCaseValues(camelizeKeys(generateSorting(sorters)));
 
-            const hasuraFilters = generateFilters(filters);
+            const hasuraFilters = generateFilters(namingConvention, filters);
 
             const operation = defaultNamingConvention
                 ? meta?.operation ?? resource

--- a/packages/hasura/src/dataProvider/index.ts
+++ b/packages/hasura/src/dataProvider/index.ts
@@ -99,7 +99,7 @@ const dataProvider = (
                 ? generateSorting(sorters)
                 : upperCaseValues(camelizeKeys(generateSorting(sorters)));
 
-            const hasuraFilters = generateFilters(namingConvention, filters);
+            const hasuraFilters = generateFilters(filters, namingConvention);
 
             const operation = defaultNamingConvention
                 ? meta?.operation ?? resource

--- a/packages/hasura/src/dataProvider/index.ts
+++ b/packages/hasura/src/dataProvider/index.ts
@@ -11,7 +11,7 @@ import {
 
 type IDType = "uuid" | "Int" | "String" | "Numeric";
 
-type NamingConvention = "hasura-default" | "graphql-default";
+export type NamingConvention = "hasura-default" | "graphql-default";
 
 export type HasuraDataProviderOptions = {
     idType?: IDType | ((resource: string) => IDType);

--- a/packages/hasura/src/utils/generateFilters.ts
+++ b/packages/hasura/src/utils/generateFilters.ts
@@ -91,7 +91,7 @@ const convertHasuraOperatorToGraphqlDefaultNaming = (
 
 export const generateNestedFilterQuery = (
     filter: CrudFilter,
-    namingConvention: NamingConvention,
+    namingConvention: NamingConvention = "hasura-default",
 ): any => {
     const { operator } = filter;
 
@@ -125,8 +125,8 @@ export const generateNestedFilterQuery = (
 };
 
 export const generateFilters: any = (
-    namingConvention: NamingConvention,
     filters?: CrudFilters,
+    namingConvention: NamingConvention = "hasura-default",
 ) => {
     if (!filters) {
         return undefined;

--- a/packages/hasura/src/utils/generateFilters.ts
+++ b/packages/hasura/src/utils/generateFilters.ts
@@ -125,8 +125,8 @@ export const generateNestedFilterQuery = (
 };
 
 export const generateFilters: any = (
+    namingConvention: NamingConvention,
     filters?: CrudFilters,
-    namingConvention?: NamingConvention,
 ) => {
     if (!filters) {
         return undefined;
@@ -137,7 +137,7 @@ export const generateFilters: any = (
             operator: "and",
             value: filters,
         },
-        namingConvention ?? "hasura-default",
+        namingConvention,
     );
 
     return nestedQuery;

--- a/packages/hasura/src/utils/generateUseListSubscription.ts
+++ b/packages/hasura/src/utils/generateUseListSubscription.ts
@@ -1,8 +1,8 @@
 import {
+    CrudFilters,
+    CrudSorting,
     MetaQuery,
     Pagination,
-    CrudSorting,
-    CrudFilters,
 } from "@refinedev/core";
 import * as gql from "gql-query-builder";
 
@@ -37,7 +37,7 @@ export const generateUseListSubscription = ({
     } = pagination ?? {};
 
     const hasuraSorting = generateSorting(sorters);
-    const hasuraFilters = generateFilters(filters);
+    const hasuraFilters = generateFilters("hasura-default", filters);
 
     const operation = meta.operation ?? resource;
 

--- a/packages/hasura/src/utils/generateUseListSubscription.ts
+++ b/packages/hasura/src/utils/generateUseListSubscription.ts
@@ -37,7 +37,7 @@ export const generateUseListSubscription = ({
     } = pagination ?? {};
 
     const hasuraSorting = generateSorting(sorters);
-    const hasuraFilters = generateFilters("hasura-default", filters);
+    const hasuraFilters = generateFilters(filters, "hasura-default");
 
     const operation = meta.operation ?? resource;
 

--- a/packages/hasura/test/utils/generateFilters.spec.ts
+++ b/packages/hasura/test/utils/generateFilters.spec.ts
@@ -10,7 +10,7 @@ describe.each(["hasura-default", "graphql-default"] as const)(
                 { field: "published", operator: "eq", value: true },
             ];
 
-            const result = generateFilters(filters, namingConvention);
+            const result = generateFilters(namingConvention, filters);
 
             expect(result).toEqual({
                 _and: [
@@ -42,7 +42,7 @@ describe.each(["hasura-default", "graphql-default"] as const)(
                 },
             ];
 
-            const result = generateFilters(filters, namingConvention);
+            const result = generateFilters(namingConvention, filters);
 
             expect(result).toEqual({
                 _and: [
@@ -71,7 +71,7 @@ describe.each(["hasura-default", "graphql-default"] as const)(
                 },
             ];
 
-            const result = generateFilters(filters, namingConvention);
+            const result = generateFilters(namingConvention, filters);
             const expected =
                 namingConvention === "hasura-default"
                     ? {

--- a/packages/hasura/test/utils/generateFilters.spec.ts
+++ b/packages/hasura/test/utils/generateFilters.spec.ts
@@ -10,7 +10,7 @@ describe.each(["hasura-default", "graphql-default"] as const)(
                 { field: "published", operator: "eq", value: true },
             ];
 
-            const result = generateFilters(namingConvention, filters);
+            const result = generateFilters(filters, namingConvention);
 
             expect(result).toEqual({
                 _and: [
@@ -42,7 +42,7 @@ describe.each(["hasura-default", "graphql-default"] as const)(
                 },
             ];
 
-            const result = generateFilters(namingConvention, filters);
+            const result = generateFilters(filters, namingConvention);
 
             expect(result).toEqual({
                 _and: [
@@ -71,7 +71,7 @@ describe.each(["hasura-default", "graphql-default"] as const)(
                 },
             ];
 
-            const result = generateFilters(namingConvention, filters);
+            const result = generateFilters(filters, namingConvention);
             const expected =
                 namingConvention === "hasura-default"
                     ? {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **details** for making this change. What existing problem does the pull request solve?

When using the Hasura provider with the 'graphql-default' naming convention, snake-case hasura operators (e.g. _is_null) were not converted to the correct case, causing query errors.
This problem is now fixed. Now the snake_case operator is converted according to the given naming convention (e.g. hasura-default: _is_null, graphql-default: _isNull).

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

### Test plan (required)

- Snake case hasura operator correctly converted to case added.
- The signature of the `generateFilters` function has changed, so existing test cases for this function will now run against the appropriate naming convention (but are backwards compatible in behaviour, as they are optional arguments).

<!-- Make sure tests pass. -->

### Closing issues

closes: #4972

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
