### PR TITLE
feat(core): add `dataProviderName` to `liveProvider.subscribe` method

### DIFF
--- a/.changeset/fluffy-beers-drive.md
+++ b/.changeset/fluffy-beers-drive.md
@@ -2,7 +2,7 @@
 "@refinedev/core": patch
 ---
 
-feat: pass `dataPorviderName` to `liveProvider.subscription` method.
+feat: pass `dataProviderName` to `liveProvider.subscribe` method.
 From now on, you can use the `dataProviderName` to distinguish between different data providers.
 
 [Refer to documentation for more info about multiple data providers ->](https://refine.dev/docs/api-reference/core/providers/data-provider/#multiple-data-providers)

--- a/.changeset/fluffy-beers-drive.md
+++ b/.changeset/fluffy-beers-drive.md
@@ -3,7 +3,7 @@
 ---
 
 feat: pass `dataProviderName` to `liveProvider.subscribe` method.
-From now on, you can use the `dataProviderName` to distinguish between different data providers.
+From now on, you can use `dataProviderName` to distinguish between different data providers in live provider.
 
 [Refer to documentation for more info about multiple data providers ->](https://refine.dev/docs/api-reference/core/providers/data-provider/#multiple-data-providers)
 

--- a/.changeset/fluffy-beers-drive.md
+++ b/.changeset/fluffy-beers-drive.md
@@ -1,0 +1,34 @@
+---
+"@refinedev/core": patch
+---
+
+feat: pass `dataPorviderName` to `liveProvider.subscription` method.
+From now on, you can use the `dataProviderName` to distinguish between different data providers.
+
+[Refer to documentation for more info about multiple data providers ->](https://refine.dev/docs/api-reference/core/providers/data-provider/#multiple-data-providers)
+
+#### Usage
+
+```ts
+import { useForm, useList } from "@refinedev/core";
+
+useList({
+    dataProviderName: "first-data-provider",
+});
+
+useForm({
+    dataProviderName: "second-data-provider",
+});
+```
+
+```ts
+import { LiveProvider } from "@refinedev/core";
+
+export const liveProvider = (client: any): LiveProvider => {
+    return {
+        subscribe: ({ channel, types, params, callback, dataProviderName }) => {
+            console.log({ dataProviderName }); //  "second-data-provider"
+        },
+    };
+};
+```

--- a/documentation/docs/api-reference/core/hooks/live/useSubscription.md
+++ b/documentation/docs/api-reference/core/hooks/live/useSubscription.md
@@ -19,6 +19,7 @@ useSubscription({
     channel: "channel-name",
     types: ["event-name", "another-event-name"]
     onLiveEvent: (event) => {},
+    dataProviderName: "default",
 });
 
 ```
@@ -54,6 +55,12 @@ You can pass any additional parameters to the [`liveProvider`][live-provider]'s 
 Hooks that use `useSubscription` internally send the query's parameters' (pagination, meta, sort, filters, etc.) information along with this prop.
 
 > For more information on which hooks use `useSubcription` internally, refer to the [LiveProvider's "Supported Hooks Subscription" section&#8594][supported-hooks-subscription]
+
+### dataProviderName
+
+> Default: `"default"`
+
+You can pass the name of the data provider to use for the subscription.
 
 ## API Reference
 

--- a/documentation/docs/api-reference/core/providers/live-provider.md
+++ b/documentation/docs/api-reference/core/providers/live-provider.md
@@ -12,7 +12,7 @@ A live provider must include following methods:
 
 ```ts
 const liveProvider = {
-    subscribe: ({ channel, params: { ids }, types, callback }) => any,
+    subscribe: ({ channel, params: { ids }, types, callback, dataProviderName }) => any,
     unsubscribe: (subscription) => void,
     publish?: (event) => void,
 };
@@ -55,7 +55,7 @@ interface MessageType extends Types.Message {
 const liveProvider = (client: Ably.Realtime): LiveProvider => {
     return {
         // highlight-start
-        subscribe: ({ channel, types, params, callback }) => {
+        subscribe: ({ channel, types, params, callback, dataProviderName }) => {
             const channelInstance = client.channels.get(channel);
 
             const listener = function (message: MessageType) {
@@ -88,12 +88,13 @@ const liveProvider = (client: Ably.Realtime): LiveProvider => {
 
 #### Parameter Types
 
-| Name     | Type                                                                  | Default |
-| -------- | --------------------------------------------------------------------- | ------- |
-| channel  | `string`                                                              |         |
-| types    | `Array<"deleted"` \| `"updated"` \| `"created"` \| "`*`" \| `string`> | `["*"]` |
-| params   | `{ids?: string[]; [key: string]: any;}`                               |         |
-| callback | `(event: LiveEvent) => void;`                                         |         |
+| Name             | Type                                                                  | Default   |
+| ---------------- | --------------------------------------------------------------------- | --------- |
+| channel          | `string`                                                              |           |
+| types            | `Array<"deleted"` \| `"updated"` \| `"created"` \| "`*`" \| `string`> | `["*"]`   |
+| params           | `{ids?: string[]; [key: string]: any;}`                               |           |
+| callback         | `(event: LiveEvent) => void;`                                         |           |
+| dataProviderName | `string`                                                              | "default" |
 
 > For more information, refer to [`LiveEvent`](/api-reference/core/interfaces.md#liveevent)
 
@@ -282,7 +283,7 @@ const subscriptions = {
 
 export const liveProvider = (client: Client): LiveProvider => {
     return {
-        subscribe: ({ callback, params }) => {
+        subscribe: ({ callback, params, dataProviderName }) => {
             const {
                 resource,
                 meta,

--- a/packages/core/src/contexts/live/ILiveContext.ts
+++ b/packages/core/src/contexts/live/ILiveContext.ts
@@ -36,6 +36,7 @@ export type ILiveContext =
                   [key: string]: any;
               };
               types: LiveEvent["type"][];
+              dataProviderName?: string;
               callback: (event: LiveEvent) => void;
           }) => any;
           unsubscribe: (subscription: any) => void;

--- a/packages/core/src/hooks/data/useInfiniteList.spec.tsx
+++ b/packages/core/src/hooks/data/useInfiniteList.spec.tsx
@@ -108,51 +108,56 @@ describe("useInfiniteList Hook", () => {
     });
 
     describe("useResourceSubscription", () => {
-        it("useSubscription", async () => {
-            const onSubscribeMock = jest.fn();
+        it.each(["default", "categories"])(
+            "useSubscription [dataProviderName: %s]",
+            async (dataProviderName) => {
+                const onSubscribeMock = jest.fn();
 
-            const { result } = renderHook(
-                () =>
-                    useInfiniteList({
-                        resource: "posts",
-                    }),
-                {
-                    wrapper: TestWrapper({
-                        dataProvider: MockJSONServer,
-                        resources: [{ name: "posts" }],
-                        liveProvider: {
-                            unsubscribe: jest.fn(),
-                            subscribe: onSubscribeMock,
-                        },
-                        refineProvider: {
-                            ...mockRefineProvider,
-                            liveMode: "auto",
-                        },
-                    }),
-                },
-            );
-
-            await waitFor(() => {
-                expect(result.current.isSuccess).toBeTruthy();
-            });
-
-            expect(onSubscribeMock).toBeCalled();
-            expect(onSubscribeMock).toHaveBeenCalledWith({
-                channel: "resources/posts",
-                callback: expect.any(Function),
-                params: expect.objectContaining({
-                    hasPagination: true,
-                    pagination: {
-                        current: 1,
-                        pageSize: 10,
-                        mode: "server",
+                const { result } = renderHook(
+                    () =>
+                        useInfiniteList({
+                            resource: "posts",
+                            dataProviderName,
+                        }),
+                    {
+                        wrapper: TestWrapper({
+                            dataProvider: MockJSONServer,
+                            resources: [{ name: "posts" }],
+                            liveProvider: {
+                                unsubscribe: jest.fn(),
+                                subscribe: onSubscribeMock,
+                            },
+                            refineProvider: {
+                                ...mockRefineProvider,
+                                liveMode: "auto",
+                            },
+                        }),
                     },
-                    resource: "posts",
-                    subscriptionType: "useList",
-                }),
-                types: ["*"],
-            });
-        });
+                );
+
+                await waitFor(() => {
+                    expect(result.current.isSuccess).toBeTruthy();
+                });
+
+                expect(onSubscribeMock).toBeCalled();
+                expect(onSubscribeMock).toHaveBeenCalledWith({
+                    channel: "resources/posts",
+                    callback: expect.any(Function),
+                    params: expect.objectContaining({
+                        hasPagination: true,
+                        pagination: {
+                            current: 1,
+                            pageSize: 10,
+                            mode: "server",
+                        },
+                        resource: "posts",
+                        subscriptionType: "useList",
+                    }),
+                    types: ["*"],
+                    dataProviderName,
+                });
+            },
+        );
 
         it("liveMode = Off useSubscription", async () => {
             const onSubscribeMock = jest.fn();

--- a/packages/core/src/hooks/data/useInfiniteList.ts
+++ b/packages/core/src/hooks/data/useInfiniteList.ts
@@ -220,6 +220,7 @@ export const useInfiniteList = <
         enabled: isEnabled,
         liveMode,
         onLiveEvent,
+        dataProviderName: pickedDataProvider,
     });
 
     const queryResponse = useInfiniteQuery<

--- a/packages/core/src/hooks/data/useList.spec.tsx
+++ b/packages/core/src/hooks/data/useList.spec.tsx
@@ -270,53 +270,58 @@ describe("useList Hook", () => {
     });
 
     describe("useResourceSubscription", () => {
-        it("useSubscription", async () => {
-            const onSubscribeMock = jest.fn();
+        it.each(["default", "categories"])(
+            "useSubscription [dataProviderName: %s]",
+            async (dataProviderName) => {
+                const onSubscribeMock = jest.fn();
 
-            const { result } = renderHook(
-                () =>
-                    useList({
-                        resource: "posts",
-                    }),
-                {
-                    wrapper: TestWrapper({
-                        dataProvider: MockJSONServer,
-                        resources: [{ name: "posts" }],
-                        liveProvider: {
-                            unsubscribe: jest.fn(),
-                            subscribe: onSubscribeMock,
-                        },
-                        refineProvider: {
-                            ...mockRefineProvider,
-                            liveMode: "auto",
-                        },
-                    }),
-                },
-            );
+                const { result } = renderHook(
+                    () =>
+                        useList({
+                            resource: "posts",
+                            dataProviderName,
+                        }),
+                    {
+                        wrapper: TestWrapper({
+                            dataProvider: MockJSONServer,
+                            resources: [{ name: "posts" }],
+                            liveProvider: {
+                                unsubscribe: jest.fn(),
+                                subscribe: onSubscribeMock,
+                            },
+                            refineProvider: {
+                                ...mockRefineProvider,
+                                liveMode: "auto",
+                            },
+                        }),
+                    },
+                );
 
-            await waitFor(() => {
-                expect(result.current.isSuccess).toBeTruthy();
-            });
+                await waitFor(() => {
+                    expect(result.current.isSuccess).toBeTruthy();
+                });
 
-            expect(onSubscribeMock).toBeCalled();
-            expect(onSubscribeMock).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    channel: "resources/posts",
-                    callback: expect.any(Function),
-                    params: expect.objectContaining({
-                        hasPagination: true,
-                        pagination: {
-                            current: 1,
-                            mode: "server",
-                            pageSize: 10,
-                        },
-                        resource: "posts",
-                        subscriptionType: "useList",
+                expect(onSubscribeMock).toBeCalled();
+                expect(onSubscribeMock).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        channel: "resources/posts",
+                        callback: expect.any(Function),
+                        params: expect.objectContaining({
+                            hasPagination: true,
+                            pagination: {
+                                current: 1,
+                                mode: "server",
+                                pageSize: 10,
+                            },
+                            resource: "posts",
+                            subscriptionType: "useList",
+                        }),
+                        types: ["*"],
+                        dataProviderName,
                     }),
-                    types: ["*"],
-                }),
-            );
-        });
+                );
+            },
+        );
 
         it("liveMode = Off useSubscription", async () => {
             const onSubscribeMock = jest.fn();

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -217,6 +217,7 @@ export const useList = <
         enabled: isEnabled,
         liveMode,
         onLiveEvent,
+        dataProviderName: pickedDataProvider,
     });
 
     const queryResponse = useQuery<

--- a/packages/core/src/hooks/data/useMany.ts
+++ b/packages/core/src/hooks/data/useMany.ts
@@ -145,6 +145,7 @@ export const useMany = <
         enabled: isEnabled,
         liveMode,
         onLiveEvent,
+        dataProviderName: pickedDataProvider,
     });
 
     const queryResponse = useQuery<

--- a/packages/core/src/hooks/data/useOne.spec.tsx
+++ b/packages/core/src/hooks/data/useOne.spec.tsx
@@ -70,44 +70,53 @@ describe("useOne Hook", () => {
     });
 
     describe("useResourceSubscription", () => {
-        it("useSubscription", async () => {
-            const onSubscribeMock = jest.fn();
+        it.each(["default", "categories"])(
+            "useSubscription [dataProviderName: %s]",
+            async (dataProviderName) => {
+                const onSubscribeMock = jest.fn();
 
-            const { result } = renderHook(
-                () => useOne({ resource: "posts", id: "1" }),
-                {
-                    wrapper: TestWrapper({
-                        dataProvider: MockJSONServer,
-                        resources: [{ name: "posts" }],
-                        liveProvider: {
-                            unsubscribe: jest.fn(),
-                            subscribe: onSubscribeMock,
-                        },
-                        refineProvider: {
-                            ...mockRefineProvider,
-                            liveMode: "auto",
-                        },
+                const { result } = renderHook(
+                    () =>
+                        useOne({
+                            resource: "posts",
+                            id: "1",
+                            dataProviderName,
+                        }),
+                    {
+                        wrapper: TestWrapper({
+                            dataProvider: MockJSONServer,
+                            resources: [{ name: "posts" }],
+                            liveProvider: {
+                                unsubscribe: jest.fn(),
+                                subscribe: onSubscribeMock,
+                            },
+                            refineProvider: {
+                                ...mockRefineProvider,
+                                liveMode: "auto",
+                            },
+                        }),
+                    },
+                );
+
+                await waitFor(() => {
+                    expect(!result.current.isLoading).toBeTruthy();
+                });
+
+                expect(onSubscribeMock).toBeCalled();
+                expect(onSubscribeMock).toHaveBeenCalledWith({
+                    channel: "resources/posts",
+                    callback: expect.any(Function),
+                    params: expect.objectContaining({
+                        ids: ["1"],
+                        id: "1",
+                        resource: "posts",
+                        subscriptionType: "useOne",
                     }),
-                },
-            );
-
-            await waitFor(() => {
-                expect(!result.current.isLoading).toBeTruthy();
-            });
-
-            expect(onSubscribeMock).toBeCalled();
-            expect(onSubscribeMock).toHaveBeenCalledWith({
-                channel: "resources/posts",
-                callback: expect.any(Function),
-                params: expect.objectContaining({
-                    ids: ["1"],
-                    id: "1",
-                    resource: "posts",
-                    subscriptionType: "useOne",
-                }),
-                types: ["*"],
-            });
-        });
+                    types: ["*"],
+                    dataProviderName,
+                });
+            },
+        );
 
         it("liveMode = Off useSubscription", async () => {
             const onSubscribeMock = jest.fn();

--- a/packages/core/src/hooks/data/useOne.ts
+++ b/packages/core/src/hooks/data/useOne.ts
@@ -153,6 +153,7 @@ export const useOne = <
                   typeof id !== "undefined",
         liveMode,
         onLiveEvent,
+        dataProviderName: pickedDataProvider,
     });
 
     const queryResponse = useQuery<

--- a/packages/core/src/hooks/live/useResourceSubscription/index.ts
+++ b/packages/core/src/hooks/live/useResourceSubscription/index.ts
@@ -42,6 +42,7 @@ export type UseResourceSubscriptionProps = {
     types: LiveEvent["type"][];
     resource?: string;
     enabled?: boolean;
+    dataProviderName?: string;
 } & LiveModeProps;
 
 export type PublishType = {
@@ -56,6 +57,7 @@ export const useResourceSubscription = ({
     enabled = true,
     liveMode: liveModeFromProp,
     onLiveEvent,
+    dataProviderName,
 }: UseResourceSubscriptionProps): void => {
     const { resource, identifier } = useResource(resourceFromProp);
 
@@ -99,6 +101,7 @@ export const useResourceSubscription = ({
                 },
                 types,
                 callback,
+                dataProviderName,
             });
         }
 

--- a/packages/core/src/hooks/live/useSubscription/index.spec.ts
+++ b/packages/core/src/hooks/live/useSubscription/index.spec.ts
@@ -18,6 +18,7 @@ describe("useSubscribe Hook", () => {
                 useSubscription({
                     channel: "channel",
                     onLiveEvent: onLiveEventMock,
+                    dataProviderName: "test",
                 }),
             {
                 wrapper: TestWrapper({
@@ -36,6 +37,7 @@ describe("useSubscribe Hook", () => {
             callback: subscriptionParams.onLiveEvent,
             params: undefined,
             types: ["*"],
+            dataProviderName: "test",
         });
     });
 
@@ -76,6 +78,7 @@ describe("useSubscribe Hook", () => {
                     channel: "channel",
                     onLiveEvent: onLiveEventMock,
                     types: ["test", "test2"],
+                    dataProviderName: "default",
                 }),
             {
                 wrapper: TestWrapper({
@@ -94,6 +97,7 @@ describe("useSubscribe Hook", () => {
             callback: subscriptionParams.onLiveEvent,
             params: undefined,
             types: ["test", "test2"],
+            dataProviderName: "default",
         });
     });
 
@@ -128,6 +132,7 @@ describe("useSubscribe Hook", () => {
             callback: subscriptionParams.onLiveEvent,
             params: undefined,
             types: ["*"],
+            dataProviderName: "default",
         });
 
         unmount();

--- a/packages/core/src/hooks/live/useSubscription/index.ts
+++ b/packages/core/src/hooks/live/useSubscription/index.ts
@@ -53,6 +53,11 @@ export type UseSubscriptionProps = {
         resource?: string;
         [key: string]: any;
     };
+    /**
+     * Name of the data provider to subscribe.
+     * @default "default"
+     */
+    dataProviderName?: string;
 };
 
 export const useSubscription = ({
@@ -61,6 +66,7 @@ export const useSubscription = ({
     types = ["*"],
     enabled = true,
     onLiveEvent,
+    dataProviderName = "default",
 }: UseSubscriptionProps): void => {
     const liveDataContext = useContext<ILiveContext>(LiveContext);
 
@@ -73,6 +79,7 @@ export const useSubscription = ({
                 params,
                 types,
                 callback: onLiveEvent,
+                dataProviderName,
             });
         }
 

--- a/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__snapshots__/index.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`MuiInferencer should match the snapshot 1`] = `
                           aria-label="Menu"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall MuiDataGrid-menuIconButton css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
                           data-mui-internal-clone-element="true"
-                          id=":r3:"
+                          id=":r4:"
                           tabindex="-1"
                           type="button"
                         >
@@ -230,7 +230,7 @@ exports[`MuiInferencer should match the snapshot 1`] = `
                           aria-label="Menu"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall MuiDataGrid-menuIconButton css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
                           data-mui-internal-clone-element="true"
-                          id=":r9:"
+                          id=":ra:"
                           tabindex="-1"
                           type="button"
                         >
@@ -334,7 +334,7 @@ exports[`MuiInferencer should match the snapshot 1`] = `
                           aria-label="Menu"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall MuiDataGrid-menuIconButton css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
                           data-mui-internal-clone-element="true"
-                          id=":rf:"
+                          id=":rg:"
                           tabindex="-1"
                           type="button"
                         >
@@ -545,12 +545,13 @@ exports[`MuiInferencer should match the snapshot 1`] = `
                   class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-input css-16c50h-MuiInputBase-root-MuiTablePagination-select"
                 >
                   <div
+                    aria-controls=":r2:"
                     aria-expanded="false"
                     aria-haspopup="listbox"
                     aria-labelledby=":r1: :r0:"
                     class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-194a1fa-MuiSelect-select-MuiInputBase-input"
                     id=":r0:"
-                    role="button"
+                    role="combobox"
                     tabindex="0"
                   >
                     25
@@ -9985,8 +9986,8 @@ exports[`MuiInferencer should match the snapshot 2`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":rk:"
-              id=":rk:-label"
+              for=":rl:"
+              id=":rl:-label"
             >
               Title
             </label>
@@ -9996,7 +9997,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":rk:"
+                id=":rl:"
                 name="title"
                 type="text"
                 value=""
@@ -10021,8 +10022,8 @@ exports[`MuiInferencer should match the snapshot 2`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":rl:"
-              id=":rl:-label"
+              for=":rm:"
+              id=":rm:-label"
             >
               Slug
             </label>
@@ -10032,7 +10033,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":rl:"
+                id=":rm:"
                 name="slug"
                 type="text"
                 value=""
@@ -10057,8 +10058,8 @@ exports[`MuiInferencer should match the snapshot 2`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":rm:"
-              id=":rm:-label"
+              for=":rn:"
+              id=":rn:-label"
             >
               Content
             </label>
@@ -10068,7 +10069,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
               <textarea
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":rm:"
+                id=":rn:"
                 name="content"
                 style="height: 0px; overflow: hidden;"
               />
@@ -10099,8 +10100,8 @@ exports[`MuiInferencer should match the snapshot 2`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":rn:"
-              id=":rn:-label"
+              for=":ro:"
+              id=":ro:-label"
             >
               Hit
             </label>
@@ -10110,7 +10111,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":rn:"
+                id=":ro:"
                 name="hit"
                 type="number"
                 value=""
@@ -10139,8 +10140,8 @@ exports[`MuiInferencer should match the snapshot 2`] = `
               <label
                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="false"
-                for=":ro:"
-                id=":ro:-label"
+                for=":rp:"
+                id=":rp:-label"
               >
                 Category
                 <span
@@ -10160,7 +10161,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
                   autocapitalize="none"
                   autocomplete="off"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
-                  id=":ro:"
+                  id=":rp:"
                   required=""
                   role="combobox"
                   spellcheck="false"
@@ -10218,8 +10219,8 @@ exports[`MuiInferencer should match the snapshot 2`] = `
               <label
                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="false"
-                for=":rq:"
-                id=":rq:-label"
+                for=":rr:"
+                id=":rr:-label"
               >
                 User
                 <span
@@ -10239,7 +10240,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
                   autocapitalize="none"
                   autocomplete="off"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
-                  id=":rq:"
+                  id=":rr:"
                   required=""
                   role="combobox"
                   spellcheck="false"
@@ -10293,8 +10294,8 @@ exports[`MuiInferencer should match the snapshot 2`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":rs:"
-              id=":rs:-label"
+              for=":rt:"
+              id=":rt:-label"
             >
               Status
             </label>
@@ -10304,7 +10305,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":rs:"
+                id=":rt:"
                 name="status"
                 type="text"
                 value=""
@@ -10329,8 +10330,8 @@ exports[`MuiInferencer should match the snapshot 2`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":rt:"
-              id=":rt:-label"
+              for=":ru:"
+              id=":ru:-label"
             >
               Status Color
             </label>
@@ -10340,7 +10341,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":rt:"
+                id=":ru:"
                 name="status_color"
                 type="text"
                 value=""
@@ -10365,8 +10366,8 @@ exports[`MuiInferencer should match the snapshot 2`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":ru:"
-              id=":ru:-label"
+              for=":rv:"
+              id=":rv:-label"
             >
               Created At
             </label>
@@ -10376,7 +10377,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":ru:"
+                id=":rv:"
                 name="createdAt"
                 type="text"
                 value=""
@@ -10401,8 +10402,8 @@ exports[`MuiInferencer should match the snapshot 2`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":rv:"
-              id=":rv:-label"
+              for=":r10:"
+              id=":r10:-label"
             >
               Published At
             </label>
@@ -10412,7 +10413,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":rv:"
+                id=":r10:"
                 name="publishedAt"
                 type="text"
                 value=""
@@ -10441,8 +10442,8 @@ exports[`MuiInferencer should match the snapshot 2`] = `
               <label
                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="false"
-                for=":r10:"
-                id=":r10:-label"
+                for=":r11:"
+                id=":r11:-label"
               >
                 Tags
                 <span
@@ -10462,7 +10463,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
                   autocapitalize="none"
                   autocomplete="off"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
-                  id=":r10:"
+                  id=":r11:"
                   required=""
                   role="combobox"
                   spellcheck="false"
@@ -10516,8 +10517,8 @@ exports[`MuiInferencer should match the snapshot 2`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":r12:"
-              id=":r12:-label"
+              for=":r13:"
+              id=":r13:-label"
             >
               Language
             </label>
@@ -10527,7 +10528,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":r12:"
+                id=":r13:"
                 name="language"
                 type="number"
                 value=""
@@ -10553,7 +10554,7 @@ exports[`MuiInferencer should match the snapshot 2`] = `
       >
         <button
           class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium refine-save-button css-1jmqb42-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
-          id=":r13:"
+          id=":r14:"
           tabindex="0"
           type="button"
         >
@@ -25007,7 +25008,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium refine-refresh-button css-1xanul-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
-                id=":r14:"
+                id=":r15:"
                 tabindex="0"
                 type="button"
               >
@@ -25048,8 +25049,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":r15:"
-              id=":r15:-label"
+              for=":r16:"
+              id=":r16:-label"
             >
               Id
             </label>
@@ -25060,7 +25061,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
                 disabled=""
-                id=":r15:"
+                id=":r16:"
                 name="id"
                 type="number"
                 value=""
@@ -25085,8 +25086,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":r16:"
-              id=":r16:-label"
+              for=":r17:"
+              id=":r17:-label"
             >
               Title
             </label>
@@ -25096,7 +25097,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":r16:"
+                id=":r17:"
                 name="title"
                 type="text"
                 value=""
@@ -25121,8 +25122,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":r17:"
-              id=":r17:-label"
+              for=":r18:"
+              id=":r18:-label"
             >
               Slug
             </label>
@@ -25132,7 +25133,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":r17:"
+                id=":r18:"
                 name="slug"
                 type="text"
                 value=""
@@ -25157,8 +25158,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":r18:"
-              id=":r18:-label"
+              for=":r19:"
+              id=":r19:-label"
             >
               Content
             </label>
@@ -25168,7 +25169,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <textarea
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":r18:"
+                id=":r19:"
                 name="content"
                 style="height: 0px; overflow: hidden;"
               />
@@ -25199,8 +25200,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":r19:"
-              id=":r19:-label"
+              for=":r1a:"
+              id=":r1a:-label"
             >
               Hit
             </label>
@@ -25210,7 +25211,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":r19:"
+                id=":r1a:"
                 name="hit"
                 type="number"
                 value=""
@@ -25239,8 +25240,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <label
                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
-                for=":r1a:"
-                id=":r1a:-label"
+                for=":r1b:"
+                id=":r1b:-label"
               >
                 Category
                 <span
@@ -25260,7 +25261,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
                   autocapitalize="none"
                   autocomplete="off"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
-                  id=":r1a:"
+                  id=":r1b:"
                   required=""
                   role="combobox"
                   spellcheck="false"
@@ -25340,8 +25341,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <label
                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
-                for=":r1c:"
-                id=":r1c:-label"
+                for=":r1d:"
+                id=":r1d:-label"
               >
                 User
                 <span
@@ -25361,7 +25362,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
                   autocapitalize="none"
                   autocomplete="off"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
-                  id=":r1c:"
+                  id=":r1d:"
                   required=""
                   role="combobox"
                   spellcheck="false"
@@ -25437,8 +25438,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":r1e:"
-              id=":r1e:-label"
+              for=":r1f:"
+              id=":r1f:-label"
             >
               Status
             </label>
@@ -25448,7 +25449,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":r1e:"
+                id=":r1f:"
                 name="status"
                 type="text"
                 value=""
@@ -25473,8 +25474,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":r1f:"
-              id=":r1f:-label"
+              for=":r1g:"
+              id=":r1g:-label"
             >
               Status Color
             </label>
@@ -25484,7 +25485,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":r1f:"
+                id=":r1g:"
                 name="status_color"
                 type="text"
                 value=""
@@ -25509,8 +25510,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":r1g:"
-              id=":r1g:-label"
+              for=":r1h:"
+              id=":r1h:-label"
             >
               Created At
             </label>
@@ -25520,7 +25521,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":r1g:"
+                id=":r1h:"
                 name="createdAt"
                 type="text"
                 value=""
@@ -25545,8 +25546,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":r1h:"
-              id=":r1h:-label"
+              for=":r1i:"
+              id=":r1i:-label"
             >
               Published At
             </label>
@@ -25556,7 +25557,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":r1h:"
+                id=":r1i:"
                 name="publishedAt"
                 type="text"
                 value=""
@@ -25585,8 +25586,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <label
                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
-                for=":r1i:"
-                id=":r1i:-label"
+                for=":r1j:"
+                id=":r1j:-label"
               >
                 Tags
                 <span
@@ -25629,7 +25630,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
                   autocapitalize="none"
                   autocomplete="off"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-152mnda-MuiInputBase-input-MuiOutlinedInput-input"
-                  id=":r1i:"
+                  id=":r1j:"
                   required=""
                   role="combobox"
                   spellcheck="false"
@@ -25705,8 +25706,8 @@ exports[`MuiInferencer should match the snapshot 3`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for=":r1k:"
-              id=":r1k:-label"
+              for=":r1l:"
+              id=":r1l:-label"
             >
               Language
             </label>
@@ -25716,7 +25717,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id=":r1k:"
+                id=":r1l:"
                 name="language"
                 type="number"
                 value=""
@@ -25742,7 +25743,7 @@ exports[`MuiInferencer should match the snapshot 3`] = `
       >
         <button
           class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium refine-save-button css-1jmqb42-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
-          id=":r1l:"
+          id=":r1m:"
           tabindex="0"
           type="button"
         >
@@ -41134,7 +41135,7 @@ exports[`MuiInferencer should match the snapshot 4`] = `
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium refine-refresh-button css-1xanul-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
-              id=":r1m:"
+              id=":r1n:"
               tabindex="0"
               type="button"
             >

--- a/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/list.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mui/__tests__/__snapshots__/list.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`MuiListInferencer should match the snapshot 1`] = `
                           aria-label="Menu"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall MuiDataGrid-menuIconButton css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
                           data-mui-internal-clone-element="true"
-                          id=":r3:"
+                          id=":r4:"
                           tabindex="-1"
                           type="button"
                         >
@@ -224,7 +224,7 @@ exports[`MuiListInferencer should match the snapshot 1`] = `
                           aria-label="Menu"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall MuiDataGrid-menuIconButton css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
                           data-mui-internal-clone-element="true"
-                          id=":r9:"
+                          id=":ra:"
                           tabindex="-1"
                           type="button"
                         >
@@ -328,7 +328,7 @@ exports[`MuiListInferencer should match the snapshot 1`] = `
                           aria-label="Menu"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall MuiDataGrid-menuIconButton css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
                           data-mui-internal-clone-element="true"
-                          id=":rf:"
+                          id=":rg:"
                           tabindex="-1"
                           type="button"
                         >
@@ -539,12 +539,13 @@ exports[`MuiListInferencer should match the snapshot 1`] = `
                   class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-input css-16c50h-MuiInputBase-root-MuiTablePagination-select"
                 >
                   <div
+                    aria-controls=":r2:"
                     aria-expanded="false"
                     aria-haspopup="listbox"
                     aria-labelledby=":r1: :r0:"
                     class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-194a1fa-MuiSelect-select-MuiInputBase-input"
                     id=":r0:"
-                    role="button"
+                    role="combobox"
                     tabindex="0"
                   >
                     25


### PR DESCRIPTION
feat: pass `dataPorviderName` to `liveProvider.subscription` method.
From now on, you can use the `dataProviderName` to distinguish between different data providers.

[Refer to documentation for more info about multiple data providers ->](https://refine.dev/docs/api-reference/core/providers/data-provider/#multiple-data-providers)

#### Usage

```ts
import { useForm, useList } from "@refinedev/core";

useList({
    dataProviderName: "first-data-provider",
});

useForm({
    dataProviderName: "second-data-provider",
});
```

```ts
import { LiveProvider } from "@refinedev/core";

export const liveProvider = (client: any): LiveProvider => {
    return {
        subscribe: ({ channel, types, params, callback, dataProviderName }) => {
            console.log({ dataProviderName }); //  "second-data-provider"
        },
    };
};
```

### Test plan (required)

<img width="407" alt="image" src="https://github.com/refinedev/refine/assets/23058882/9a6ca2b6-c83d-4f43-9a27-5a662e2652db">


### Self Check before Merge

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not neededx