### PR TITLE
feat(cli): check core package is up to date for devtools

### DIFF
--- a/.changeset/modern-cougars-arrive.md
+++ b/.changeset/modern-cougars-arrive.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/cli": patch
+---
+
+feat: From now on, `npm run refine devtools init` updates `@refinedev/core` to latest version.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,6 +64,7 @@
     "pluralize": "^8.0.0",
     "preferred-pm": "^3.0.3",
     "prettier": "^2.7.1",
+    "semver": "^v5.7.2",
     "semver-diff": "^3.1.1",
     "temp": "^0.9.4",
     "tslib": "^2.3.1"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,7 @@
     "pluralize": "^8.0.0",
     "preferred-pm": "^3.0.3",
     "prettier": "^2.7.1",
-    "semver": "^v5.7.2",
+    "semver": "7.3.8",
     "semver-diff": "^3.1.1",
     "temp": "^0.9.4",
     "tslib": "^2.3.1"

--- a/packages/cli/src/commands/devtools/index.ts
+++ b/packages/cli/src/commands/devtools/index.ts
@@ -75,13 +75,13 @@ const devtoolsInstaller = async () => {
     }
 
     console.log("🌱 Installing refine devtools...");
-    const installPackages = ["@refinedev/devtools@latest"];
+    const packagesToInstall = ["@refinedev/devtools@latest"];
     // we should update core package if it is lower than minRefineCoreVersionForDevtools
     if (isCorePackageOld({ pckg: corePackage })) {
-        installPackages.push("@refinedev/core@latest");
+        packagesToInstall.push("@refinedev/core@latest");
         console.log(`🌱 refine core package is updating for devtools...`);
     }
-    await installPackagesSync(installPackages);
+    await installPackagesSync(packagesToInstall);
 
     // empty line
     console.log("");
@@ -93,7 +93,7 @@ const devtoolsInstaller = async () => {
         "✅ refine devtools package and components added to your project",
     );
     // if core package is updated, we should show the updated version
-    if (installPackages.includes("@refinedev/core@latest")) {
+    if (packagesToInstall.includes("@refinedev/core@latest")) {
         const corePackageUpdated = await getRefineCorePackage();
         if (!corePackageUpdated) {
             throw new Error("refine core package not found");

--- a/packages/cli/src/commands/devtools/index.ts
+++ b/packages/cli/src/commands/devtools/index.ts
@@ -61,16 +61,16 @@ const devtoolsInstaller = async () => {
         throw new Error("refine core package not found");
     }
 
-    if (await isCorePackageDeprecated({ pckg: corePackage })) {
-        return;
-    }
-
-    const isInstalledDevtools = await spinner(
+    const isInstalled = await spinner(
         isDevtoolsInstalled,
         "Checking if devtools is installed...",
     );
-    if (isInstalledDevtools) {
+    if (isInstalled) {
         console.log("🎉 refine devtools is already installed");
+        return;
+    }
+
+    if (await isCorePackageDeprecated({ pckg: corePackage })) {
         return;
     }
 

--- a/packages/cli/src/commands/devtools/index.ts
+++ b/packages/cli/src/commands/devtools/index.ts
@@ -77,7 +77,7 @@ const devtoolsInstaller = async () => {
     console.log("🌱 Installing refine devtools...");
     const installPackages = ["@refinedev/devtools@latest"];
     // we should update core package if it is lower than minRefineCoreVersionForDevtools
-    if (isCorePackageUpToDate({ pckg: corePackage })) {
+    if (isCorePackageOld({ pckg: corePackage })) {
         installPackages.push("@refinedev/core@latest");
         console.log(`🌱 refine core package is updating for devtools...`);
     }
@@ -172,7 +172,7 @@ export const devtoolsRunner = async () => {
         return;
     }
 
-    if (isCorePackageUpToDate({ pckg: corePackage })) {
+    if (isCorePackageOld({ pckg: corePackage })) {
         console.log(
             `🚨 You're using an old version of refine(${corePackage.version}). refine version should be @4.42.0 or higher to use devtools.`,
         );
@@ -186,7 +186,7 @@ export const devtoolsRunner = async () => {
     server();
 };
 
-export const isCorePackageUpToDate = ({
+export const isCorePackageOld = ({
     pckg,
 }: {
     pckg: { name: string; version: string };

--- a/packages/cli/src/commands/devtools/index.ts
+++ b/packages/cli/src/commands/devtools/index.ts
@@ -178,7 +178,7 @@ export const devtoolsRunner = async () => {
         );
         const pm = await getPreferedPM();
         console.log(
-            `👉 You can update @refinedev/core package by running "${pm.name} run refine refine update"`,
+            `👉 You can update @refinedev/core package by running "${pm.name} run refine update"`,
         );
         return;
     }

--- a/packages/cli/src/commands/devtools/index.ts
+++ b/packages/cli/src/commands/devtools/index.ts
@@ -68,7 +68,7 @@ const devtoolsInstaller = async () => {
         return;
     }
 
-    if (await isCorePackageDeprecated({ pckg: corePackage })) {
+    if (await isCorePackageDeprecated({ pkg: corePackage })) {
         return;
     }
 
@@ -160,7 +160,7 @@ const devtoolsInstaller = async () => {
 export const devtoolsRunner = async () => {
     const corePackage = await getRefineCorePackage();
 
-    if (await isCorePackageDeprecated({ pckg: corePackage })) {
+    if (await isCorePackageDeprecated({ pkg: corePackage })) {
         return;
     }
 
@@ -194,16 +194,13 @@ const getRefineCorePackage = async () => {
 };
 
 export const isCorePackageDeprecated = async ({
-    pckg,
+    pkg,
 }: {
-    pckg: { name: string; version: string };
+    pkg: { name: string; version: string };
 }) => {
-    if (
-        pckg.name === "@pankod/refine-core" ||
-        semver.lt(pckg.version, "4.0.0")
-    ) {
+    if (pkg.name === "@pankod/refine-core" || semver.lt(pkg.version, "4.0.0")) {
         console.log(
-            `🚨 You're using an old version of refine(${pckg.version}). refine version should be @4.42.0 or higher to use devtools.`,
+            `🚨 You're using an old version of refine(${pkg.version}). refine version should be @4.42.0 or higher to use devtools.`,
         );
         console.log("You can follow migration guide to update refine.");
         console.log(

--- a/packages/cli/src/commands/devtools/index.ts
+++ b/packages/cli/src/commands/devtools/index.ts
@@ -68,7 +68,7 @@ const devtoolsInstaller = async () => {
         return;
     }
 
-    if (await isCorePackageDeprecated({ pkg: corePackage })) {
+    if (await validateCorePackageIsNotDeprecated({ pkg: corePackage })) {
         return;
     }
 
@@ -160,7 +160,7 @@ const devtoolsInstaller = async () => {
 export const devtoolsRunner = async () => {
     const corePackage = await getRefineCorePackage();
 
-    if (await isCorePackageDeprecated({ pkg: corePackage })) {
+    if (await validateCorePackageIsNotDeprecated({ pkg: corePackage })) {
         return;
     }
 
@@ -193,7 +193,7 @@ const getRefineCorePackage = async () => {
     return corePackage;
 };
 
-export const isCorePackageDeprecated = async ({
+export const validateCorePackageIsNotDeprecated = async ({
     pkg,
 }: {
     pkg: { name: string; version: string };

--- a/packages/cli/src/components/update-warning-table/utils.tsx
+++ b/packages/cli/src/components/update-warning-table/utils.tsx
@@ -34,5 +34,5 @@ export const getUpdateWarningTable = async (
 ) => {
     const command = await getCommand();
 
-    render(<UpdateWarningTable data={packages} command={command} />);
+    render(<UpdateWarningTable data={packages} command={command} />).unmount();
 };

--- a/packages/cli/src/utils/package/index.ts
+++ b/packages/cli/src/utils/package/index.ts
@@ -42,7 +42,9 @@ export const getInstalledRefinePackages = async () => {
 
         const dependencies = JSON.parse(execution.stdout)?.dependencies || {};
         const refineDependencies = Object.keys(dependencies).filter(
-            (dependency) => dependency.startsWith("@refinedev"),
+            (dependency) =>
+                dependency.startsWith("@refinedev") ||
+                dependency.startsWith("@pankod"),
         );
 
         const normalize: {

--- a/packages/cli/src/utils/package/index.ts
+++ b/packages/cli/src/utils/package/index.ts
@@ -44,7 +44,7 @@ export const getInstalledRefinePackages = async () => {
         const refineDependencies = Object.keys(dependencies).filter(
             (dependency) =>
                 dependency.startsWith("@refinedev") ||
-                dependency.startsWith("@pankod"),
+                dependency.startsWith("@pankod/refine-"),
         );
 
         const normalize: {

--- a/packages/cli/src/utils/refine/index.ts
+++ b/packages/cli/src/utils/refine/index.ts
@@ -1,4 +1,4 @@
-import { getInstalledRefinePackages, getPackageJson } from "@utils/package";
+import { getPackageJson } from "@utils/package";
 
 type ReturnType = {
     dev: boolean;
@@ -19,15 +19,4 @@ export const hasDefaultScript = (): ReturnType => {
     return {
         dev: isDefault,
     };
-};
-
-export const getRefineCorePackage = async () => {
-    const installedRefinePackages = await getInstalledRefinePackages();
-    const corePackage = installedRefinePackages?.find(
-        (pkg) =>
-            pkg.name === "@refinedev/core" ||
-            pkg.name === "@pankod/refine-core",
-    );
-
-    return corePackage;
 };

--- a/packages/cli/src/utils/refine/index.ts
+++ b/packages/cli/src/utils/refine/index.ts
@@ -1,4 +1,4 @@
-import { getPackageJson } from "@utils/package";
+import { getInstalledRefinePackages, getPackageJson } from "@utils/package";
 
 type ReturnType = {
     dev: boolean;
@@ -19,4 +19,15 @@ export const hasDefaultScript = (): ReturnType => {
     return {
         dev: isDefault,
     };
+};
+
+export const getRefineCorePackage = async () => {
+    const installedRefinePackages = await getInstalledRefinePackages();
+    const corePackage = installedRefinePackages?.find(
+        (pkg) =>
+            pkg.name === "@refinedev/core" ||
+            pkg.name === "@pankod/refine-core",
+    );
+
+    return corePackage;
 };


### PR DESCRIPTION
feat: From now on, `npm run refine devtools init` updates `@refinedev/core` to latest version.

<img width="400" alt="added 3 packages, renoved 1 package, changed 1 package, and audited 362 packages in 7s" src="https://github.com/refinedev/refine/assets/23058882/46e98188-b602-48a2-a372-eda157bd9f5c">


<img width="400" alt="Pasted Graphic 1" src="https://github.com/refinedev/refine/assets/23058882/bc46ede4-181c-4181-bc43-d4e439222787">


Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
