### PR TITLE
fix(devtools): conflicting `port` variable when using with `dev` command

### DIFF
--- a/.changeset/purple-fireants-collect.md
+++ b/.changeset/purple-fireants-collect.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/devtools-server": patch
+---
+
+Fixed the issue with conflicting devtools port when `PORT` environment variable is set.

--- a/.changeset/thin-dryers-hear.md
+++ b/.changeset/thin-dryers-hear.md
@@ -2,4 +2,4 @@
 "@refinedev/devtools": patch
 ---
 
-Use the proper devtools url coming from the websocket handshare rather than using the hardcoded port.
+Use the proper devtools url coming from the websocket handshake rather than using the hardcoded port.

--- a/.changeset/thin-dryers-hear.md
+++ b/.changeset/thin-dryers-hear.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/devtools": patch
+---
+
+Use the proper devtools url coming from the websocket handshare rather than using the hardcoded port.

--- a/packages/devtools-server/src/constants.ts
+++ b/packages/devtools-server/src/constants.ts
@@ -1,8 +1,8 @@
 export const DEFAULT_WS_PORT = 5002;
 export const DEFAULT_SERVER_PORT = 5001;
 
-export const WS_PORT = Number(process.env.WS_PORT || DEFAULT_WS_PORT);
-export const SERVER_PORT = Number(process.env.PORT || DEFAULT_SERVER_PORT);
+export const WS_PORT = DEFAULT_WS_PORT;
+export const SERVER_PORT = DEFAULT_SERVER_PORT;
 
 export const REFINE_API_URL = __DEVELOPMENT__
     ? "https://develop.cloud.refine.dev"

--- a/packages/devtools-server/src/serve-proxy.ts
+++ b/packages/devtools-server/src/serve-proxy.ts
@@ -1,6 +1,6 @@
 import { type Express } from "express";
 import { createProxyMiddleware, Options } from "http-proxy-middleware";
-import { REFINE_API_URL } from "./constants";
+import { REFINE_API_URL, SERVER_PORT } from "./constants";
 
 const onProxyRes: Options["onProxyRes"] | undefined = (proxyRes) => {
     if (proxyRes.headers["set-cookie"]) {
@@ -41,7 +41,7 @@ export const serveProxy = (app: Express) => {
         },
         logLevel: __DEVELOPMENT__ ? "debug" : "silent",
         headers: {
-            "auth-base-url-rewrite": `http://localhost:5001/api/.auth`,
+            "auth-base-url-rewrite": `http://localhost:${SERVER_PORT}/api/.auth`,
         },
         onProxyRes,
     });

--- a/packages/devtools-server/src/setup-server.ts
+++ b/packages/devtools-server/src/setup-server.ts
@@ -1,9 +1,10 @@
 import type { Express } from "express";
+import { SERVER_PORT } from "./constants";
 
 export const setupServer = (app: Express) => {
-    const server = app.listen(5001, () => {
+    const server = app.listen(SERVER_PORT, () => {
         if (__DEVELOPMENT__) {
-            console.log("Server started on PORT 5001");
+            console.log(`Server started on PORT ${SERVER_PORT}`);
         }
     });
 

--- a/packages/devtools/src/utilities/use-selector.tsx
+++ b/packages/devtools/src/utilities/use-selector.tsx
@@ -8,15 +8,21 @@ import {
     getNameFromFiber,
     getParentOfFiber,
 } from "@aliemir/dom-to-fiber-utils";
+import { DevToolsContext } from "@refinedev/devtools-shared";
 
 type Fiber = Exclude<ReturnType<typeof getFiberFromElement>, null>;
 
 export const useSelector = (active: boolean) => {
+    const { devtoolsUrl } = React.useContext(DevToolsContext);
     const [traceItems, setTraceItems] = React.useState<string[]>([]);
 
     React.useEffect(() => {
         if (active) {
-            fetch("http://localhost:5001/api/unique-trace-items").then((res) =>
+            fetch(
+                `${
+                    devtoolsUrl ?? "http://localhost:5001"
+                }/api/unique-trace-items`,
+            ).then((res) =>
                 res
                     .json()
                     .then((data: { data: string[] }) =>
@@ -24,7 +30,7 @@ export const useSelector = (active: boolean) => {
                     ),
             );
         }
-    }, [active]);
+    }, [active, devtoolsUrl]);
 
     const [selectedFiber, setSelectedFiber] = React.useState<{
         stateNode: Fiber | null;


### PR DESCRIPTION
Devtools server was picking up the wrong port to run when there's a `PORT` environment variable. This causes showing the wrong page content in the devtools panel.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
