### PR TITLE
feat(docs): add devtools link to sidebar

### DIFF
--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -16,6 +16,12 @@ module.exports = {
             className: "category-as-header",
         },
         {
+            type: "link",
+            href: "https://s.refine.dev/devtools-beta",
+            label: "refine Developer Tools",
+            className: "sidebar-item-shiny mt-6 -ml-2",
+        },
+        {
             type: "category",
             collapsible: false,
             label: "API Reference",

--- a/documentation/src/refine-theme/doc-sidebar.tsx
+++ b/documentation/src/refine-theme/doc-sidebar.tsx
@@ -12,6 +12,8 @@ import Link from "@docusaurus/Link";
 import { DashIcon } from "./icons/dash";
 import { ChevronDownIcon } from "./icons/chevron-down";
 import { HEADER_HEIGHT } from "./doc-header";
+import { NewBadgeShiny } from "./icons/new-badge-shiny";
+import { RefineLogoShiny } from "./icons/refine-logo-shiny";
 
 type Variant = "desktop" | "mobile";
 
@@ -30,6 +32,7 @@ type SidebarLinkItem = {
     label: string;
     href: string;
     docId: string;
+    className?: string;
 };
 
 type SidebarHtmlItem = {
@@ -223,8 +226,8 @@ const SidebarLink = ({
 }) => {
     const ref = React.useRef<HTMLAnchorElement>(null);
     const isActive = isActiveSidebarItem(item, path);
-
     const isSame = isSamePath(item.href, path);
+    const isShiny = item.className?.includes("sidebar-item-shiny") || false;
 
     // React.useEffect(() => {
     //     if (isActive) {
@@ -244,12 +247,17 @@ const SidebarLink = ({
             className={clsx(
                 "relative",
                 "min-h-[40px]",
-                isActive
+                isShiny &&
+                    "bg-sidebar-item-shiny-light dark:bg-sidebar-item-shiny-dark rounded-xl",
+                isShiny
+                    ? "text-refine-blue dark:text-refine-cyan-alt"
+                    : isActive
                     ? "dark:text-gray-0 text-gray-900"
                     : "text-gray-500 dark:text-gray-400",
+                !isShiny && "hover:dark:text-gray-0 hover:text-gray-900",
+                isShiny ? "px-4 py-3" : "p-2",
                 "text-sm font-normal leading-6",
                 "flex items-start justify-start",
-                "p-2",
                 dashed && !line && "pl-0",
                 line && !dashed && "pl-5",
                 line && dashed && "pl-5",
@@ -257,33 +265,39 @@ const SidebarLink = ({
                 line && "border-l-2 border-l-gray-200 dark:border-l-gray-600",
                 "group",
                 "transition-colors duration-200 ease-in-out",
-                "hover:dark:text-gray-0 hover:text-gray-900",
                 "no-underline",
+                item.className,
             )}
         >
             {dashed && (
                 <DashIcon className="z-[1] h-6 w-6 flex-shrink-0 opacity-70" />
             )}
-            <span className="z-[1]">{item.label}</span>
-            <div
-                className={clsx(
-                    "absolute",
-                    "rounded-lg",
-                    "transition-opacity",
-                    "duration-200 ease-in-out",
-                    "group-hover:bg-gray-200/40 dark:group-hover:bg-gray-700/80",
-                    {
-                        "bg-gray-100/50 dark:bg-gray-700/50":
-                            isActive && isSame,
-                        "right-0": variant === "desktop",
-                        "-right-2": variant === "mobile",
-                        "w-[calc(280px-24px)]": variant === "desktop",
-                        "w-[calc(480px-16px)]": variant === "mobile",
-                    },
-                    "top-0",
-                    "h-full",
-                )}
-            />
+            <div className={"flex items-center"}>
+                {isShiny && <RefineLogoShiny className="mr-2 flex-shrink-0" />}
+                <span className="z-[1] flex-shrink-0">{item.label}</span>
+                {isShiny && <NewBadgeShiny className="ml-2 flex-shrink-0" />}
+            </div>
+            {!isShiny && (
+                <div
+                    className={clsx(
+                        "absolute",
+                        "rounded-lg",
+                        "transition-opacity",
+                        "duration-200 ease-in-out",
+                        "group-hover:bg-gray-200/40 dark:group-hover:bg-gray-700/80",
+                        {
+                            "bg-gray-100/50 dark:bg-gray-700/50":
+                                isActive && isSame,
+                            "right-0": variant === "desktop",
+                            "-right-2": variant === "mobile",
+                            "w-[calc(280px-24px)]": variant === "desktop",
+                            "w-[calc(480px-16px)]": variant === "mobile",
+                        },
+                        "top-0",
+                        "h-full",
+                    )}
+                />
+            )}
         </Link>
     );
 };

--- a/documentation/src/refine-theme/icons/new-badge-shiny-blue.tsx
+++ b/documentation/src/refine-theme/icons/new-badge-shiny-blue.tsx
@@ -1,0 +1,70 @@
+import * as React from "react";
+import { SVGProps } from "react";
+
+export const NewBadgeShinyBlue = (props: SVGProps<SVGSVGElement>) => {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={31}
+            height={14}
+            viewBox="0 0 31 14"
+            fill="none"
+            {...props}
+        >
+            <rect
+                width={30}
+                height={13}
+                x={0.5}
+                y={0.5}
+                fill="#007FFF"
+                fillOpacity={0.1}
+                rx={6.5}
+            />
+            <path
+                fill="#0080FF"
+                d="M11.433 4.182V10h-.937L7.754 6.037h-.048V10H6.652V4.182h.943l2.739 3.966h.05V4.182h1.05ZM12.582 10V4.182h3.784v.883h-2.73v1.58h2.534v.883h-2.534v1.588h2.753V10h-3.807Zm6.084 0-1.643-5.818h1.134l1.048 4.275h.054l1.12-4.275h1.03l1.123 4.278h.051l1.048-4.278h1.134L23.123 10h-1.04l-1.165-4.082h-.045L19.705 10h-1.04Z"
+            />
+            <rect
+                width={30}
+                height={13}
+                x={0.5}
+                y={0.5}
+                stroke="#0080FF"
+                strokeOpacity={0.2}
+                rx={6.5}
+            />
+            <rect
+                width={30}
+                height={13}
+                x={0.5}
+                y={0.5}
+                stroke="url(#new-badge-shiny-blue-a)"
+                rx={6.5}
+            />
+            <defs>
+                <radialGradient
+                    id="new-badge-shiny-blue-a"
+                    cx={0}
+                    cy={0}
+                    r={1}
+                    gradientTransform="matrix(0 7 -15.5 0 15.5 7)"
+                    gradientUnits="userSpaceOnUse"
+                >
+                    <stop stopColor="#0080FF" stopOpacity={0} />
+                    <stop
+                        offset={0.125}
+                        stopColor="#0080FF"
+                        stopOpacity={0.5}
+                    />
+                    <stop offset={0.25} stopColor="#0080FF" stopOpacity={0} />
+                    <stop offset={0.375} stopColor="#0080FF" stopOpacity={0} />
+                    <stop offset={0.5} stopColor="#0080FF" stopOpacity={0} />
+                    <stop offset={0.625} stopColor="#0080FF" />
+                    <stop offset={0.75} stopColor="#0080FF" stopOpacity={0} />
+                    <stop offset={0.875} stopColor="#0080FF" stopOpacity={0} />
+                    <stop offset={1} stopColor="#0080FF" stopOpacity={0} />
+                </radialGradient>
+            </defs>
+        </svg>
+    );
+};

--- a/documentation/src/refine-theme/icons/new-badge-shiny-cyan.tsx
+++ b/documentation/src/refine-theme/icons/new-badge-shiny-cyan.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import { SVGProps } from "react";
+
+export const NewBadgeShinyCyan = (props: SVGProps<SVGSVGElement>) => {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={31}
+            height={14}
+            fill="none"
+            {...props}
+        >
+            <rect
+                width={30}
+                height={13}
+                x={0.5}
+                y={0.5}
+                fill="#47EBEB"
+                fillOpacity={0.1}
+                rx={6.5}
+            />
+            <path
+                fill="#47EBEB"
+                d="M11.433 4.182V10h-.937L7.754 6.037h-.048V10H6.652V4.182h.943l2.739 3.966h.05V4.182h1.05ZM12.582 10V4.182h3.784v.883h-2.73v1.58h2.534v.883h-2.534v1.588h2.753V10h-3.807Zm6.084 0-1.643-5.818h1.134l1.048 4.275h.054l1.12-4.275h1.03l1.123 4.278h.051l1.048-4.278h1.134L23.123 10h-1.04l-1.165-4.082h-.045L19.705 10h-1.04Z"
+            />
+            <rect
+                width={30}
+                height={13}
+                x={0.5}
+                y={0.5}
+                stroke="#47EBEB"
+                strokeOpacity={0.2}
+                rx={6.5}
+            />
+            <rect
+                width={30}
+                height={13}
+                x={0.5}
+                y={0.5}
+                stroke="url(#new-badge-shiny-cyan-a)"
+                rx={6.5}
+            />
+            <defs>
+                <radialGradient
+                    id="new-badge-shiny-cyan-a"
+                    cx={0}
+                    cy={0}
+                    r={1}
+                    gradientTransform="matrix(0 7 -15.5 0 15.5 7)"
+                    gradientUnits="userSpaceOnUse"
+                >
+                    <stop stopColor="#47EBEB" stopOpacity={0} />
+                    <stop
+                        offset={0.125}
+                        stopColor="#47EBEB"
+                        stopOpacity={0.5}
+                    />
+                    <stop offset={0.25} stopColor="#47EBEB" stopOpacity={0} />
+                    <stop offset={0.375} stopColor="#47EBEB" stopOpacity={0} />
+                    <stop offset={0.5} stopColor="#47EBEB" stopOpacity={0} />
+                    <stop offset={0.625} stopColor="#47EBEB" />
+                    <stop offset={0.75} stopColor="#47EBEB" stopOpacity={0} />
+                    <stop offset={0.875} stopColor="#47EBEB" stopOpacity={0} />
+                    <stop offset={1} stopColor="#47EBEB" stopOpacity={0} />
+                </radialGradient>
+            </defs>
+        </svg>
+    );
+};

--- a/documentation/src/refine-theme/icons/new-badge-shiny.tsx
+++ b/documentation/src/refine-theme/icons/new-badge-shiny.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { SVGProps } from "react";
+import { useColorMode } from "@docusaurus/theme-common";
+import { NewBadgeShinyCyan } from "./new-badge-shiny-cyan";
+import { NewBadgeShinyBlue } from "./new-badge-shiny-blue";
+
+export const NewBadgeShiny = (props: SVGProps<SVGSVGElement>) => {
+    const { colorMode } = useColorMode();
+
+    if (colorMode === "dark") {
+        return <NewBadgeShinyCyan {...props} />;
+    }
+
+    return <NewBadgeShinyBlue {...props} />;
+};

--- a/documentation/src/refine-theme/icons/refine-logo-shiny-blue.tsx
+++ b/documentation/src/refine-theme/icons/refine-logo-shiny-blue.tsx
@@ -1,0 +1,84 @@
+import * as React from "react";
+import { SVGProps } from "react";
+
+export const RefineLogoShinyBlue = (props: SVGProps<SVGSVGElement>) => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={24}
+        height={24}
+        viewBox="0 0 24 24"
+        fill="none"
+        {...props}
+    >
+        <path
+            fill="url(#a)"
+            fillRule="evenodd"
+            d="M14.399 7.4a2.4 2.4 0 1 1-4.8 0 2.4 2.4 0 0 1 4.8 0Z"
+            clipRule="evenodd"
+        />
+        <path
+            fill="url(#b)"
+            fillRule="evenodd"
+            d="M8.278 7.32a3.72 3.72 0 1 1 7.44 0v9.36a3.72 3.72 0 1 1-7.44 0V7.32Zm3.72-3.12a3.12 3.12 0 0 0-3.12 3.12v9.36a3.12 3.12 0 0 0 6.24 0V7.32a3.12 3.12 0 0 0-3.12-3.12Z"
+            clipRule="evenodd"
+        />
+        <path
+            fill="url(#c)"
+            fillRule="evenodd"
+            d="M9.317.633a6 6 0 0 1 5.366 0l6 3A6 6 0 0 1 24 9v6a6 6 0 0 1-3.317 5.367l-6 3a6 6 0 0 1-5.366 0l-6-3A6 6 0 0 1 0 15V9a6 6 0 0 1 3.317-5.367l6-3Zm.268.537a5.4 5.4 0 0 1 4.83 0l6 3A5.4 5.4 0 0 1 23.4 9v6a5.4 5.4 0 0 1-2.985 4.83l-6 3a5.4 5.4 0 0 1-4.83 0l-6-3A5.4 5.4 0 0 1 .6 15V9a5.4 5.4 0 0 1 2.985-4.83l6-3Z"
+            clipRule="evenodd"
+        />
+        <path
+            fill="url(#d)"
+            fillRule="evenodd"
+            d="M9.585 1.17a5.4 5.4 0 0 1 4.83 0l6 3A5.4 5.4 0 0 1 23.4 9v6a5.4 5.4 0 0 1-2.985 4.83l-6 3a5.4 5.4 0 0 1-4.83 0l-6-3A5.4 5.4 0 0 1 .6 15V9a5.4 5.4 0 0 1 2.985-4.83l6-3Zm2.413 2.43a3.72 3.72 0 0 0-3.72 3.72v9.36a3.72 3.72 0 1 0 7.44 0V7.32a3.72 3.72 0 0 0-3.72-3.72Z"
+            clipRule="evenodd"
+        />
+        <defs>
+            <linearGradient
+                id="a"
+                x1={12}
+                x2={12}
+                y1={5.1}
+                y2={9.9}
+                gradientUnits="userSpaceOnUse"
+            >
+                <stop stopColor="#6EB3F7" />
+                <stop offset={1} stopColor="#0080FF" />
+            </linearGradient>
+            <linearGradient
+                id="b"
+                x1={12}
+                x2={12}
+                y1={3.6}
+                y2={20.4}
+                gradientUnits="userSpaceOnUse"
+            >
+                <stop stopColor="#33F" />
+                <stop offset={1} stopColor="#0080FF" />
+            </linearGradient>
+            <linearGradient
+                id="c"
+                x1={12}
+                x2={12}
+                y1={0}
+                y2={24}
+                gradientUnits="userSpaceOnUse"
+            >
+                <stop stopColor="#6EB3F7" />
+                <stop offset={1} stopColor="#0080FF" />
+            </linearGradient>
+            <radialGradient
+                id="d"
+                cx={0}
+                cy={0}
+                r={1}
+                gradientTransform="matrix(0 24 -24 0 12 0)"
+                gradientUnits="userSpaceOnUse"
+            >
+                <stop stopColor="#0080FF" />
+                <stop offset={1} stopColor="#6EB3F7" />
+            </radialGradient>
+        </defs>
+    </svg>
+);

--- a/documentation/src/refine-theme/icons/refine-logo-shiny-cyan.tsx
+++ b/documentation/src/refine-theme/icons/refine-logo-shiny-cyan.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
 import { SVGProps } from "react";
 
-export const RefineLogoCyan = (props: SVGProps<SVGSVGElement>) => (
+export const RefineLogoShinyCyan = (props: SVGProps<SVGSVGElement>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width={24}
         height={24}
+        viewBox="0 0 24 24"
         fill="none"
         {...props}
     >

--- a/documentation/src/refine-theme/icons/refine-logo-shiny.tsx
+++ b/documentation/src/refine-theme/icons/refine-logo-shiny.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { SVGProps } from "react";
+import { useColorMode } from "@docusaurus/theme-common";
+import { RefineLogoShinyCyan } from "./refine-logo-shiny-cyan";
+import { RefineLogoShinyBlue } from "./refine-logo-shiny-blue";
+
+export const RefineLogoShiny = (props: SVGProps<SVGSVGElement>) => {
+    const { colorMode } = useColorMode();
+
+    if (colorMode === "dark") {
+        return <RefineLogoShinyCyan {...props} />;
+    }
+
+    return <RefineLogoShinyBlue {...props} />;
+};

--- a/documentation/src/refine-theme/top-announcement.tsx
+++ b/documentation/src/refine-theme/top-announcement.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import React, { SVGProps } from "react";
-import { RefineLogoCyan } from "./icons/refine-logo-cyan";
+import { RefineLogoShinyCyan } from "./icons/refine-logo-shiny-cyan";
 
 export const TopAnnouncement = () => {
     return (
@@ -119,7 +119,7 @@ const Text = () => {
                 "hover:no-underline",
             )}
         >
-            <RefineLogoCyan className="flex-shrink-0" />
+            <RefineLogoShinyCyan className="flex-shrink-0" />
             <div className={clsx("ml-2")}>
                 Unlock the power of{" "}
                 <span className={clsx("font-semibold")}>refine Devtools</span>,

--- a/documentation/tailwind.config.js
+++ b/documentation/tailwind.config.js
@@ -18,6 +18,7 @@ module.exports = {
                     yellow: "#FFBF00",
                     green: "#1FAD66",
                     cyan: "#0FBDBD",
+                    "cyan-alt": "#47EBEB",
                     blue: "#0080FF",
                     indigo: "#3333FF",
                     purple: "#8000FF",
@@ -213,6 +214,10 @@ module.exports = {
                     "linear-gradient(180deg, #FFF 0%, rgba(255, 255, 255, 0.50) 100%)",
                 "top-announcement-text":
                     "linear-gradient(90deg, rgba(31, 63, 72, 0.00) 0%, #1F3F48 10%, #1F3F48 90%, rgba(31, 63, 72, 0.00) 100%)",
+                "sidebar-item-shiny-dark":
+                    "radial-gradient(457.67% 141.42% at 0% 0%, rgba(71, 235, 235, 0.10) 0%, rgba(71, 235, 235, 0.20) 100%)",
+                "sidebar-item-shiny-light":
+                    "radial-gradient(457.67% 141.42% at 0% 0%, rgba(0, 128, 255, 0.20) 0%, rgba(0, 128, 255, 0.10) 100%)",
             },
             animation: {
                 "spin-slow": "spin 3s linear infinite",


### PR DESCRIPTION
feat: devtools link added to sidebar

<img width="300" alt="image" src="https://github.com/refinedev/refine/assets/23058882/e4977a98-3584-4ee2-9623-4b600c277b3b">>

<img width="300" alt="image" src="https://github.com/refinedev/refine/assets/23058882/efea6d27-6a37-4abe-a81e-59cea92cde3d">


Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
