### PR TITLE
fix(docs): top announcement responsive

### DIFF
--- a/documentation/src/refine-theme/top-announcement.tsx
+++ b/documentation/src/refine-theme/top-announcement.tsx
@@ -113,7 +113,7 @@ const Text = () => {
                 "h-full w-full lg:w-[780px]",
                 "flex items-center justify-center",
                 "text-white",
-                "text-sm",
+                "text-xs sm:text-sm",
                 "text-center",
                 "no-underline",
                 "hover:no-underline",


### PR DESCRIPTION
fixed: set font-size to xs on mobile 

<img width="400" alt="image" src="https://github.com/refinedev/refine/assets/23058882/ade9a646-656d-4086-9546-64ebe5ec40dc">


### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
