### PR TITLE
fix(docs): light mode announcement text color is wrong

### DIFF
--- a/documentation/src/refine-theme/top-announcement.tsx
+++ b/documentation/src/refine-theme/top-announcement.tsx
@@ -117,7 +117,7 @@ const Text = () => {
                 "text-center",
                 "no-underline",
                 "hover:no-underline",
-                "hover:text-inherit",
+                "hover:text-white",
             )}
         >
             <RefineLogoShinyCyan className="flex-shrink-0" />


### PR DESCRIPTION
fixed: light mode announcement text color is wrong

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
