### PR TITLE
fix(antd): undoableNotification doesn't work with useNotificationProvider

### DIFF
--- a/.changeset/rude-terms-turn.md
+++ b/.changeset/rude-terms-turn.md
@@ -2,4 +2,4 @@
 "@refinedev/antd": patch
 ---
 
-fix: `undoableNotification` not work when using `useNotificationProvider` due to different `notification` instance.
+fix: `undoableNotification` does not work when using `useNotificationProvider` due to a different `notification` instance.

--- a/.changeset/rude-terms-turn.md
+++ b/.changeset/rude-terms-turn.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/antd": patch
+---
+
+fix: `undoableNotification` not work when using `useNotificationProvider` due to different `notification` instance.

--- a/packages/antd/src/components/undoableNotification/index.tsx
+++ b/packages/antd/src/components/undoableNotification/index.tsx
@@ -12,8 +12,8 @@ export type UndoableNotificationProps = {
 
 export const UndoableNotification: React.FC<UndoableNotificationProps> = ({
     message,
-    undoableTimeout,
     cancelMutation,
+    undoableTimeout,
 }) => (
     <div
         style={{

--- a/packages/antd/src/components/undoableNotification/index.tsx
+++ b/packages/antd/src/components/undoableNotification/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, notification, Progress } from "antd";
+import { Button, Progress } from "antd";
 import { OpenNotificationParams } from "@refinedev/core";
 import { UndoOutlined } from "@ant-design/icons";
 
@@ -8,13 +8,13 @@ export type UndoableNotificationProps = {
     message: OpenNotificationParams["message"];
     cancelMutation: OpenNotificationParams["cancelMutation"];
     undoableTimeout: OpenNotificationParams["undoableTimeout"];
+    onUndo?: () => void;
 };
 
 export const UndoableNotification: React.FC<UndoableNotificationProps> = ({
-    notificationKey,
     message,
-    cancelMutation,
     undoableTimeout,
+    onUndo,
 }) => (
     <div
         style={{
@@ -35,10 +35,7 @@ export const UndoableNotification: React.FC<UndoableNotificationProps> = ({
         <span style={{ marginLeft: 8, width: "100%" }}>{message}</span>
         <Button
             style={{ flexShrink: 0 }}
-            onClick={() => {
-                cancelMutation?.();
-                notification.destroy(notificationKey ?? "");
-            }}
+            onClick={onUndo}
             disabled={undoableTimeout === 0}
             icon={<UndoOutlined />}
         ></Button>

--- a/packages/antd/src/components/undoableNotification/index.tsx
+++ b/packages/antd/src/components/undoableNotification/index.tsx
@@ -8,13 +8,12 @@ export type UndoableNotificationProps = {
     message: OpenNotificationParams["message"];
     cancelMutation: OpenNotificationParams["cancelMutation"];
     undoableTimeout: OpenNotificationParams["undoableTimeout"];
-    onUndo?: () => void;
 };
 
 export const UndoableNotification: React.FC<UndoableNotificationProps> = ({
     message,
     undoableTimeout,
-    onUndo,
+    cancelMutation,
 }) => (
     <div
         style={{
@@ -35,7 +34,7 @@ export const UndoableNotification: React.FC<UndoableNotificationProps> = ({
         <span style={{ marginLeft: 8, width: "100%" }}>{message}</span>
         <Button
             style={{ flexShrink: 0 }}
-            onClick={onUndo}
+            onClick={cancelMutation}
             disabled={undoableTimeout === 0}
             icon={<UndoOutlined />}
         ></Button>

--- a/packages/antd/src/providers/notificationProvider/index.spec.tsx
+++ b/packages/antd/src/providers/notificationProvider/index.spec.tsx
@@ -79,7 +79,7 @@ describe("Antd notificationProvider", () => {
                 <UndoableNotification
                     message="Test Notification Message"
                     notificationKey="test-notification"
-                    cancelMutation={cancelMutation}
+                    cancelMutation={expect.any(Function)}
                     undoableTimeout={5}
                 />
             ),
@@ -169,7 +169,7 @@ describe("Antd useNotificationProvider", () => {
                     <UndoableNotification
                         message="Test Notification Message"
                         notificationKey="test-notification"
-                        cancelMutation={cancelMutation}
+                        cancelMutation={expect.any(Function)}
                         undoableTimeout={5}
                     />
                 ),
@@ -284,7 +284,7 @@ describe("Antd useNotificationProvider", () => {
                         <UndoableNotification
                             message="Test Notification Message"
                             notificationKey="test-notification"
-                            cancelMutation={cancelMutation}
+                            cancelMutation={expect.any(Function)}
                             undoableTimeout={5}
                         />
                     ),

--- a/packages/antd/src/providers/notificationProvider/index.tsx
+++ b/packages/antd/src/providers/notificationProvider/index.tsx
@@ -25,12 +25,11 @@ export const notificationProvider: NotificationProvider = {
                     <UndoableNotification
                         notificationKey={key}
                         message={message}
-                        cancelMutation={cancelMutation}
-                        undoableTimeout={undoableTimeout}
-                        onUndo={() => {
+                        cancelMutation={() => {
                             cancelMutation?.();
                             staticNotification.destroy(key ?? "");
                         }}
+                        undoableTimeout={undoableTimeout}
                     />
                 ),
                 message: null,
@@ -72,12 +71,11 @@ export const useNotificationProvider = (): NotificationProvider => {
                         <UndoableNotification
                             notificationKey={key}
                             message={message}
-                            cancelMutation={cancelMutation}
-                            undoableTimeout={undoableTimeout}
-                            onUndo={() => {
+                            cancelMutation={() => {
                                 cancelMutation?.();
                                 notification.destroy(key ?? "");
                             }}
+                            undoableTimeout={undoableTimeout}
                         />
                     ),
                     message: null,

--- a/packages/antd/src/providers/notificationProvider/index.tsx
+++ b/packages/antd/src/providers/notificationProvider/index.tsx
@@ -27,6 +27,10 @@ export const notificationProvider: NotificationProvider = {
                         message={message}
                         cancelMutation={cancelMutation}
                         undoableTimeout={undoableTimeout}
+                        onUndo={() => {
+                            cancelMutation?.();
+                            staticNotification.destroy(key ?? "");
+                        }}
                     />
                 ),
                 message: null,
@@ -70,6 +74,10 @@ export const useNotificationProvider = (): NotificationProvider => {
                             message={message}
                             cancelMutation={cancelMutation}
                             undoableTimeout={undoableTimeout}
+                            onUndo={() => {
+                                cancelMutation?.();
+                                notification.destroy(key ?? "");
+                            }}
                         />
                     ),
                     message: null,


### PR DESCRIPTION
fix: `undoableNotification` does not work when using `useNotificationProvider` due to a different `notification` instance.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
