### PR TITLE
fix(mui): missing operators and bug with isNull, isNotNull operators

### DIFF
--- a/.changeset/large-beds-cry.md
+++ b/.changeset/large-beds-cry.md
@@ -1,0 +1,14 @@
+---
+"@refinedev/mui": patch
+---
+
+fix: map missing operators for useDataGrid hook.
+
+-   number field, added `isAnyOf` operator.
+-   string field, added `startsWith`, `endsWith` and `isAnyOf` operators.
+
+fix: `isNull` and `isNotNull` doesn't trigger request.
+
+When filter has a value `""`, it's ignored and doesn't trigger request.
+Previously `isNull` and `isNotNull` operators weren't handled correctly and had value `""` by default.
+With this change, these operators has `true` value, so they won't be ignored.

--- a/packages/mui/src/definitions/dataGrid/index.spec.ts
+++ b/packages/mui/src/definitions/dataGrid/index.spec.ts
@@ -226,6 +226,17 @@ describe("transformCrudOperatorToMuiOperator", () => {
         expect(transformCrudOperatorToMuiOperator("lte", "number")).toEqual(
             "<=",
         );
+
+        expect(transformCrudOperatorToMuiOperator("null", "number")).toEqual(
+            "isEmpty",
+        );
+        expect(transformCrudOperatorToMuiOperator("nnull", "number")).toEqual(
+            "isNotEmpty",
+        );
+
+        expect(transformCrudOperatorToMuiOperator("in", "number")).toEqual(
+            "isAnyOf",
+        );
     });
 
     it("transform crud operator to mui operator with 'boolean' value", () => {
@@ -243,6 +254,24 @@ describe("transformCrudOperatorToMuiOperator", () => {
         ).toEqual("contains");
         expect(transformCrudOperatorToMuiOperator("eq", "string")).toEqual(
             "equals",
+        );
+
+        expect(transformCrudOperatorToMuiOperator("null", "string")).toEqual(
+            "isEmpty",
+        );
+        expect(transformCrudOperatorToMuiOperator("nnull", "string")).toEqual(
+            "isNotEmpty",
+        );
+
+        expect(
+            transformCrudOperatorToMuiOperator("startswith", "string"),
+        ).toEqual("startsWith");
+        expect(
+            transformCrudOperatorToMuiOperator("endswith", "string"),
+        ).toEqual("endsWith");
+
+        expect(transformCrudOperatorToMuiOperator("in", "string")).toEqual(
+            "isAnyOf",
         );
     });
 

--- a/packages/mui/src/definitions/dataGrid/index.ts
+++ b/packages/mui/src/definitions/dataGrid/index.ts
@@ -80,11 +80,15 @@ export const transformFilterModelToCrudFilters = ({
     items,
     logicOperator,
 }: GridFilterModel): CrudFilters => {
-    const filters = items.map(({ field, value, operator }) => ({
-        field: field,
-        value: value ?? "",
-        operator: transformMuiOperatorToCrudOperator(operator),
-    }));
+    const filters = items.map(({ field, value, operator }) => {
+        return {
+            field: field,
+            value: ["isEmpty", "isNotEmpty"].includes(operator)
+                ? true
+                : value ?? "",
+            operator: transformMuiOperatorToCrudOperator(operator),
+        };
+    });
 
     if (logicOperator === GridLogicOperator.Or) {
         return [{ operator: "or", value: filters }];
@@ -115,6 +119,8 @@ export const transformCrudOperatorToMuiOperator = (
                     return "isEmpty";
                 case "nnull":
                     return "isNotEmpty";
+                case "in":
+                    return "isAnyOf";
                 default:
                     return operator;
             }
@@ -137,6 +143,12 @@ export const transformCrudOperatorToMuiOperator = (
                     return "isEmpty";
                 case "nnull":
                     return "isNotEmpty";
+                case "startswith":
+                    return "startsWith";
+                case "endswith":
+                    return "endsWith";
+                case "in":
+                    return "isAnyOf";
                 default:
                     return operator;
             }

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -9,7 +9,6 @@ import {
     useTable as useTableCore,
     useTableProps as useTablePropsCore,
     useTableReturnType as useTableReturnTypeCore,
-    useLoadingOvertime,
 } from "@refinedev/core";
 import { useState } from "react";
 


### PR DESCRIPTION
fix: map missing operators for useDataGrid hook.

-   number field, added `isAnyOf` operator.
-   string field, added `startsWith`, `endsWith` and `isAnyOf` operators.

fix: `isNull` and `isNotNull` doesn't trigger request.

When filter has a value `""`, it's ignored and doesn't trigger request.
Previously `isNull` and `isNotNull` operators weren't handled correctly and had value `""` by default.
With this change, these operators has `true` value, so they won't be ignored.