### PR TITLE
chore(docs): update event name for banner events

### DIFF
--- a/documentation/src/components/banner/banner-examples.tsx
+++ b/documentation/src/components/banner/banner-examples.tsx
@@ -29,7 +29,7 @@ export const BannerExamples: FC<Props> = ({
             title &&
             description
         ) {
-            window.gtag("event", "banner_view", {
+            window.gtag("event", "view_banner", {
                 banner_name: "banner-retool-alternative",
                 banner_text: title,
                 banner_description: description,

--- a/documentation/src/components/banner/banner-image-with-text.tsx
+++ b/documentation/src/components/banner/banner-image-with-text.tsx
@@ -40,7 +40,7 @@ export const BannerImageWithText: FC<Props> = ({
             typeof window.gtag !== "undefined" &&
             bannerName
         ) {
-            window.gtag("event", "banner_view", {
+            window.gtag("event", "view_banner", {
                 banner_name: bannerName,
                 banner_text: title,
                 banner_description: description,

--- a/documentation/src/components/banner/banner-sidebar.tsx
+++ b/documentation/src/components/banner/banner-sidebar.tsx
@@ -17,7 +17,7 @@ export const BannerSidebar = ({ shouldShowBanner }) => {
             typeof window.gtag !== "undefined" &&
             shouldShowBanner
         ) {
-            window.gtag("event", "banner_view", {
+            window.gtag("event", "view_banner", {
                 banner_name: "banner-sidebar",
                 banner_text: text,
                 banner_description: description,


### PR DESCRIPTION
We were publishing duplicated events, so we are changing the name of the banner events.