### PR TITLE
fix: correct types for optionLabel and optionValue for useSelect hook

### DIFF
--- a/packages/core/src/hooks/useSelect/index.ts
+++ b/packages/core/src/hooks/useSelect/index.ts
@@ -38,15 +38,15 @@ export type UseSelectProps<TQueryFnData, TError, TData> = {
      * Set the option's value
      * @default `"title"`
      */
-    optionLabel?: keyof TQueryFnData extends string
-        ? keyof TQueryFnData
+    optionLabel?: keyof TData extends string
+        ? keyof TData
         : never;
     /**
      * Set the option's label value
      * @default `"id"`
      */
-    optionValue?: keyof TQueryFnData extends string
-        ? keyof TQueryFnData
+    optionValue?: keyof TData extends string
+        ? keyof TData
         : never;
     /**
      * Allow us to sort the options


### PR DESCRIPTION
When transforming data using `queryOptions.select` option types were broken.  
For more context see: https://github.com/TanStack/query/discussions/1477

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

### Test plan (required)

Demonstrate the code is solid. If not, please add `WIP:` in its title.

<!-- Make sure tests pass. -->

### Closing issues

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

### Self Check before Merge

Please check all items below before review.

-   [ ] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
