### PR TITLE
fix(antd): sider not collapsing

### DIFF
--- a/.changeset/calm-drinks-happen.md
+++ b/.changeset/calm-drinks-happen.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/antd": patch
+---
+
+fixed: antd default `<ThemedSiderV2 />` is not collapsing.

--- a/packages/antd/src/components/themedLayoutV2/index.tsx
+++ b/packages/antd/src/components/themedLayoutV2/index.tsx
@@ -17,7 +17,7 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
 }) => {
     const breakpoint = Grid.useBreakpoint();
     const SiderToRender = Sider ?? DefaultSider;
-    const sider = SiderToRender({ Title });
+    const hasSider = SiderToRender({ Title });
     const HeaderToRender = Header ?? DefaultHeader;
     const isSmall = typeof breakpoint.sm === "undefined" ? true : breakpoint.sm;
 
@@ -25,8 +25,8 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
         <ThemedLayoutContextProvider
             initialSiderCollapsed={initialSiderCollapsed}
         >
-            <AntdLayout style={{ minHeight: "100vh" }} hasSider={!!sider}>
-                {sider}
+            <AntdLayout style={{ minHeight: "100vh" }} hasSider={!!hasSider}>
+                <SiderToRender Title={Title} />
                 <AntdLayout>
                     <HeaderToRender />
                     <AntdLayout.Content>

--- a/packages/antd/src/components/themedLayoutV2/index.tsx
+++ b/packages/antd/src/components/themedLayoutV2/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Grid, Layout as AntdLayout } from "antd";
 
 import { ThemedSiderV2 as DefaultSider } from "./sider";
@@ -17,15 +17,18 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
 }) => {
     const breakpoint = Grid.useBreakpoint();
     const SiderToRender = Sider ?? DefaultSider;
-    const hasSider = SiderToRender({ Title });
     const HeaderToRender = Header ?? DefaultHeader;
     const isSmall = typeof breakpoint.sm === "undefined" ? true : breakpoint.sm;
+
+    const hasSider = useMemo(() => {
+        return !!SiderToRender({ Title });
+    }, [SiderToRender, Title]);
 
     return (
         <ThemedLayoutContextProvider
             initialSiderCollapsed={initialSiderCollapsed}
         >
-            <AntdLayout style={{ minHeight: "100vh" }} hasSider={!!hasSider}>
+            <AntdLayout style={{ minHeight: "100vh" }} hasSider={hasSider}>
                 <SiderToRender Title={Title} />
                 <AntdLayout>
                     <HeaderToRender />

--- a/packages/antd/src/components/themedLayoutV2/index.tsx
+++ b/packages/antd/src/components/themedLayoutV2/index.tsx
@@ -19,10 +19,7 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
     const SiderToRender = Sider ?? DefaultSider;
     const HeaderToRender = Header ?? DefaultHeader;
     const isSmall = typeof breakpoint.sm === "undefined" ? true : breakpoint.sm;
-
-    const hasSider = useMemo(() => {
-        return !!SiderToRender({ Title });
-    }, [SiderToRender, Title]);
+    const hasSider = !!SiderToRender({ Title });
 
     return (
         <ThemedLayoutContextProvider


### PR DESCRIPTION
fixed: antd default `<ThemedSiderV2 />` is not collapsing.

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
