### PR TITLE
fix(core): prevent redundant `getIdentity` call in `useLog`

### DIFF
--- a/.changeset/seven-pillows-sneeze.md
+++ b/.changeset/seven-pillows-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": patch
+---
+
+Prevent `authProvider.getIdentity` to be called in `useLog` if `auditLogProvider` is not defined.

--- a/packages/core/src/hooks/auditLog/useLog/index.ts
+++ b/packages/core/src/hooks/auditLog/useLog/index.ts
@@ -82,7 +82,7 @@ export const useLog = <
     } = useGetIdentity({
         v3LegacyAuthProviderCompatible: Boolean(authProvider?.isLegacy),
         queryOptions: {
-            enabled: !!auditLogContext,
+            enabled: !!auditLogContext?.create,
         },
     });
 
@@ -102,7 +102,7 @@ export const useLog = <
             }
 
             let authorData;
-            if (isLoading) {
+            if (isLoading && !!auditLogContext?.create) {
                 authorData = await refetch();
             }
 


### PR DESCRIPTION
Prevent calling `useGetIdentity` if `auditLogProvider.create` is not defined and audit logging is not possible for the case.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
