### PR TITLE
chore(devtools-server): update running log

### DIFF
--- a/.changeset/mighty-beds-glow.md
+++ b/.changeset/mighty-beds-glow.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/devtools-server": patch
+---
+
+Updated the devtools running log on terminal to a less attractive one.

--- a/packages/devtools-server/src/index.ts
+++ b/packages/devtools-server/src/index.ts
@@ -1,7 +1,6 @@
 import express from "express";
 
-import boxen from "boxen";
-import chalk from "chalk";
+import { cyanBright, bold } from "chalk";
 
 import { DevtoolsEvent, receive, send } from "@refinedev/devtools-shared";
 
@@ -133,19 +132,8 @@ export const server = async ({ projectPath = process.cwd() }: Options = {}) => {
     serveOpenInEditor(app, projectPath);
 
     console.log(
-        `\n${boxen(
-            `refine devtools is running on ${chalk.blueBright.bold(
-                `http://localhost:${SERVER_PORT}`,
-            )}`,
-            {
-                padding: 1,
-                title: "refine devtools",
-                titleAlignment: "center",
-                textAlignment: "center",
-                dimBorder: true,
-                borderColor: "blueBright",
-                borderStyle: "round",
-            },
-        )}\n`,
+        `\n${cyanBright.bold("\u2713 ")}${bold(
+            "refine devtools",
+        )} is running at port ${cyanBright.bold(SERVER_PORT)}\n`,
     );
 };


### PR DESCRIPTION
Updated the devtools running log after a successful start to a less eye-catching and distractive one to avoid taking focus from the actual development server logs.

Old:

<img width="682" alt="old" src="https://github.com/refinedev/refine/assets/11361964/45faf784-3c87-4f05-bb4d-32aa32856a1b">

New:

<img width="682" alt="new" src="https://github.com/refinedev/refine/assets/11361964/c82af60d-1a3a-4828-af37-bffd5460a8ad">

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
