### PR TITLE
chore(devtools-server): use `node-fetch` as `fetch` polyfill

### DIFF
--- a/.changeset/sixty-planets-mix.md
+++ b/.changeset/sixty-planets-mix.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/devtools-server": patch
+---
+
+Use `node-fetch` to make feed requests to ensure older versions of Node.js are supported.

--- a/packages/devtools-server/package.json
+++ b/packages/devtools-server/package.json
@@ -46,6 +46,7 @@
     "gray-matter": "^4.0.3",
     "fs-extra": "^10.1.0",
     "marked": "^4.3.0",
+    "node-fetch": "^2.6.7",
     "globby": "^11.1.0",
     "sanitize-html": "^2.11.0",
     "preferred-pm": "^3.0.3",

--- a/packages/devtools-server/src/feed/get-feed.ts
+++ b/packages/devtools-server/src/feed/get-feed.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fetch from "node-fetch";
 import matter from "gray-matter";
 import { marked } from "marked";
 import sanitizeHtml from "sanitize-html";


### PR DESCRIPTION
`fetch` is now built-in with Node v17+ but devtools can currently work with older versions of node without any issues except `fetch` request made in a single endpoint. We've updated it to use `node-fetch` to ensure support for older node versions.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
