### PR TITLE
fix(cli): core version check for devtools

### DIFF
--- a/.changeset/little-beers-greet.md
+++ b/.changeset/little-beers-greet.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/cli": patch
+---
+
+Update `@refinedev/core` version check for devtools runner to do a wider check to locate the package and its version. If the location is not found, it will start devtools without a version check.

--- a/packages/cli/src/commands/devtools/index.ts
+++ b/packages/cli/src/commands/devtools/index.ts
@@ -68,7 +68,10 @@ const devtoolsInstaller = async () => {
         return;
     }
 
-    if (await validateCorePackageIsNotDeprecated({ pkg: corePackage })) {
+    if (
+        corePackage &&
+        (await validateCorePackageIsNotDeprecated({ pkg: corePackage }))
+    ) {
         return;
     }
 

--- a/packages/cli/src/utils/package/index.ts
+++ b/packages/cli/src/utils/package/index.ts
@@ -89,7 +89,11 @@ export const getInstalledRefinePackagesFromNodeModules = async () => {
             }
         });
 
-        const refinePackages: Array<{ name: string; path: string }> = [];
+        const refinePackages: Array<{
+            name: string;
+            path: string;
+            version: string;
+        }> = [];
 
         await Promise.all(
             [...packageDirsFromModules, ...packagesFromGlobbySearch].map(
@@ -104,6 +108,7 @@ export const getInstalledRefinePackagesFromNodeModules = async () => {
 
                         refinePackages.push({
                             name: packageJson.name,
+                            version: packageJson.version,
                             path: packageDir,
                         });
                     }


### PR DESCRIPTION
Update `@refinedev/core` version check for devtools runner to do a wider check to locate the package and its version. If the location is not found, it will start devtools without a version check.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
