### PR TITLE
fix(data-provider-sanity): downgraded refine-sanity

### DIFF
--- a/examples/data-provider-sanity/package.json
+++ b/examples/data-provider-sanity/package.json
@@ -12,7 +12,6 @@
     "@sanity/client": "^6.6.0",
     "@uiw/react-md-editor": "^3.19.5",
     "antd": "^5.0.5",
-    "groqd": "0.15.9",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1",

--- a/examples/data-provider-sanity/package.json
+++ b/examples/data-provider-sanity/package.json
@@ -12,11 +12,11 @@
     "@sanity/client": "^6.6.0",
     "@uiw/react-md-editor": "^3.19.5",
     "antd": "^5.0.5",
+    "groqd": "0.15.9",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1",
-    "refine-sanity": "^1.2.0",
-    "groqd": "0.15.9"
+    "refine-sanity": "^1.1.1"
   },
   "scripts": {
     "start": "refine dev",


### PR DESCRIPTION
Fixes current example, without `liveProvider`. 
As `refine-sanity` is with `1.1.0` currently, it can't use `1.2.0`. Which was left to be reverted, and is fixed with this PR.

### Self Check before Merge

Please check all items below before review.

-  * [x] Corresponding issues are not needed
-  * [x] Docs are not needed
-  * [x] Examples are not needed
-  * [x] TypeScript definitions are not needed
-  * [x] Tests are not needed
-  * [x] Changesets are not needed
