### PR TITLE
fix(core): optional `useList` params

### DIFF
--- a/.changeset/giant-dryers-beg.md
+++ b/.changeset/giant-dryers-beg.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": patch
+---
+
+Fixed the issue of `useList` hook requiring an empty object as prop even if there was no parameter passed to it.

--- a/packages/core/src/hooks/data/useList.spec.tsx
+++ b/packages/core/src/hooks/data/useList.spec.tsx
@@ -1076,4 +1076,46 @@ describe("useList Hook", () => {
             expect(result.current.overtime.elapsedTime).toBeUndefined();
         });
     });
+
+    it("should infer resource from the route", async () => {
+        const getListMock = jest.fn().mockResolvedValue({
+            data: [{ id: 1, title: "foo" }],
+        });
+
+        const { result } = renderHook(() => useList(), {
+            wrapper: TestWrapper({
+                dataProvider: {
+                    default: {
+                        ...MockJSONServer.default,
+                        getList: getListMock,
+                    },
+                },
+                routerProvider: mockRouterBindings({
+                    action: "list",
+                    params: {},
+                    pathname: "/posts",
+                    resource: {
+                        name: "posts",
+                        list: "/posts",
+                    },
+                }),
+                resources: [
+                    {
+                        name: "posts",
+                        list: "/posts",
+                    },
+                ],
+            }),
+        });
+
+        await waitFor(() => {
+            expect(result.current.isSuccess).toBeTruthy();
+        });
+
+        expect(getListMock).toBeCalledWith(
+            expect.objectContaining({
+                resource: "posts",
+            }),
+        );
+    });
 });

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -142,7 +142,7 @@ export const useList = <
     liveParams,
     dataProviderName,
     overtimeOptions,
-}: UseListProps<TQueryFnData, TError, TData>): QueryObserverResult<
+}: UseListProps<TQueryFnData, TError, TData> = {}): QueryObserverResult<
     GetListResponse<TData>,
     TError
 > &


### PR DESCRIPTION
Fixed the issue of `useList` hook requiring an empty object as prop even if there was no parameter passed to it.

### Test plan (required)

Added an additional test for the case with only router inference. Tested with the rest of the scenarios and it worked fine.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
