### PR TITLE
chore: update mantine installation command

### DIFF
--- a/.changeset/fifty-forks-melt.md
+++ b/.changeset/fifty-forks-melt.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mantine": patch
+---
+
+chore: update README installation command

--- a/packages/mantine/README.md
+++ b/packages/mantine/README.md
@@ -57,7 +57,7 @@ It eliminates repetitive tasks in CRUD operations and provides industry-standard
 ## Installation & Usage
 
 ```
-npm install @refinedev/mantine @refinedev/react-table @mantine/core @mantine/hooks @mantine/form @mantine/notifications @emotion/react @tabler/icons
+npm install @refinedev/mantine @refinedev/react-table @mantine/core@5 @mantine/hooks@5 @mantine/form@5 @mantine/notifications@5 @emotion/react @tabler/icons
 ```
 
 


### PR DESCRIPTION
Since we are supporting `mantine@5` for now, installation command in the readme installs latest version 7 and it creates confusion.

Updated mantine package readme to explicitly install version 5 for all mantine dependencies.