### PR TITLE
chore: bump @ant-design/pro-layout dependency version

### DIFF
--- a/.changeset/eleven-doors-repeat.md
+++ b/.changeset/eleven-doors-repeat.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/antd": patch
+---
+
+chore: bump @ant-design/pro-layout dependency to `v7.17.12`.
+
+Fixes https://github.com/refinedev/refine/issues/5172

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "5.0.1",
-    "@ant-design/pro-layout": "7.8.3",
+    "@ant-design/pro-layout": "7.17.12",
     "@refinedev/ui-types": "^1.22.0",
     "@tanstack/react-query": "^4.10.1",
     "antd": "^5.0.5",


### PR DESCRIPTION
Fixes: https://github.com/refinedev/refine/issues/5172