### PR TITLE
fix: use relative path instead of path alias to import FlatTreeItem

### DIFF
--- a/.changeset/neat-ants-perform.md
+++ b/.changeset/neat-ants-perform.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+fix: use relative path instead of path alias to import FlatTreeItem
+
+Using path alias causes imported types being any during build/compilation process which is it should be TreeMenuItem[]

--- a/.changeset/neat-ants-perform.md
+++ b/.changeset/neat-ants-perform.md
@@ -4,4 +4,4 @@
 
 fix: use relative path instead of path alias to import FlatTreeItem
 
-Using path alias causes imported types being any during build/compilation process which is it should be TreeMenuItem[]
+Using path alias causes imported types being any during build/compilation process which should be TreeMenuItem[]

--- a/packages/core/src/definitions/helpers/menu/create-tree.ts
+++ b/packages/core/src/definitions/helpers/menu/create-tree.ts
@@ -1,4 +1,4 @@
-import { IResourceItem } from "@contexts/resource";
+import { IResourceItem } from "../../../contexts/resource";
 import { getParentResource } from "../router";
 import { createResourceKey } from "./create-resource-key";
 

--- a/packages/core/src/hooks/menu/useMenu.tsx
+++ b/packages/core/src/hooks/menu/useMenu.tsx
@@ -8,7 +8,7 @@ import { getParentResource } from "@definitions/helpers/router";
 import {
     FlatTreeItem,
     createTree,
-} from "@definitions/helpers/menu/create-tree";
+} from "../../definitions/helpers/menu/create-tree";
 
 type UseMenuReturnType = {
     defaultOpenKeys: string[];


### PR DESCRIPTION
Explain the **details** for making this change. What existing problem does the pull request solve?

Using relative path insteead of path alias because path alias causes imported types being any during build/compilation process

### Test plan (required)

Demonstrate the code is solid. If not, please add `WIP:` in its title.

<!-- Make sure tests pass. -->

### Closing issues

closes #5179

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
