### PR TITLE
fix(use-select): correct types on `useSelect` options

### DIFF
--- a/.changeset/eight-donkeys-fold.md
+++ b/.changeset/eight-donkeys-fold.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mantine": patch
+---
+
+Updated the return type of the `useSelect` hook to only include properties that actually being returned from the hook. Previously, the return type included all properties of the `Select` component, which was not correct.

--- a/.changeset/flat-oranges-smoke.md
+++ b/.changeset/flat-oranges-smoke.md
@@ -1,0 +1,23 @@
+---
+"@refinedev/antd": patch
+---
+
+Now `useSelect`, `useRadioGroup` and `useCheckboxGroup` hooks accept 4th generic type `TOption` which allows you to change the type of options. By default `TOption` will be equal to `DefaultOption` type which is `{ label: string; value: any; }`. If you want to change the type of options, you can do it like this:
+
+```tsx
+import { useSelect } from "@refinedev/antd";
+import { HttpError } from "@refinedev/core";
+
+type MyData = {
+    id: number;
+    title: string;
+    description: string;
+    category: { id: string };
+};
+
+type Option = { label: MyData["title"]; value: MyData["id"] }; // equals to { label: string; value: number; }
+
+useSelect<MyData, HttpError, MyData, Option>({
+    resource: "posts",
+});
+```

--- a/.changeset/loud-dingos-move.md
+++ b/.changeset/loud-dingos-move.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+Exported `BaseOption` and `DefaultOption` types as successors of the deprecated `Option` type. `BaseOption` is `{ label: any; value: any; }` and `DefaultOption` is `{ label: string; value: any; }`.
+
+Usage of the deprecated `Option` type was correctly assuming that the `value` property of the option is of type `string`. This assumption was wrong and now the types are changed to reflect the correct values of options with the ability to change it via 4th generic type `TOption` of `useSelect` hook.

--- a/.changeset/loud-donkeys-pretend.md
+++ b/.changeset/loud-donkeys-pretend.md
@@ -2,7 +2,7 @@
 "@refinedev/core": patch
 ---
 
-Reverted the faulty assumption on option values of `useSelect` hook to be of type `string`. Now changed the types and the logic to reflect the correct values of options with the ability to change it via 4th generic type `TOption` of `useSelect` hook.
+Reverted the faulty assumption on option values of `useSelect` hook to be of type `string`. Now changed the types and the logic to reflect the correct values of options with the ability to change it via 4th generic type `TOption` of `useSelect` hook. (Reverted PR #5160)
 
 By default `TOption` will be equal to `DefaultOption` type which is `{ label: string; value: any; }`. If you want to change the type of options, you can do it like this:
 

--- a/.changeset/loud-donkeys-pretend.md
+++ b/.changeset/loud-donkeys-pretend.md
@@ -1,0 +1,24 @@
+---
+"@refinedev/core": patch
+---
+
+Reverted the faulty assumption on option values of `useSelect` hook to be of type `string`. Now changed the types and the logic to reflect the correct values of options with the ability to change it via 4th generic type `TOption` of `useSelect` hook.
+
+By default `TOption` will be equal to `DefaultOption` type which is `{ label: string; value: any; }`. If you want to change the type of options, you can do it like this:
+
+```tsx
+import { useSelect, HttpError } from "@refinedev/core";
+
+type MyData = {
+    id: number;
+    title: string;
+    description: string;
+    category: { id: string };
+};
+
+type Option = { label: MyData["title"]; value: MyData["id"] }; // equals to { label: string; value: number; }
+
+useSelect<MyData, HttpError, MyData, Option>({
+    resource: "posts",
+});
+```

--- a/.changeset/new-cups-beg.md
+++ b/.changeset/new-cups-beg.md
@@ -1,0 +1,46 @@
+---
+"@refinedev/mantine": patch
+---
+
+Now `useSelect` hook accepts 4th generic type `TOption` which allows you to change the type of options. By default `TOption` will be equal to `DefaultOption` type which is `{ label: string; value: any; }`. If you want to change the type of options, you can do it like this:
+
+In PR #5160 the type convertion of the options are tried to be resolved by string conversion. This is not correct due to the fact that the `value` property of the option can be of any type. This was breaking the connection between the forms and the select inputs.
+
+This change is reverted in the `@refinedev/core`, now changed the types and the logic to reflect the correct values of options with the ability to change it via 4th generic type `TOption` of `useSelect` hook.
+
+Mantine's `<Select />` component only allows values to be `string`. In a case of a `value` not being `string`, you'll be able to manipulate the options via mapping the options before using them.
+
+Here's how to get the proper types for the options and fix the value type issue:
+
+```tsx
+import { HttpError } from "@refinedev/core";
+import { useSelect } from "@refinedev/mantine";
+import { Select } from "@mantine/core";
+
+type IPost = {
+    id: number;
+    title: string;
+    description: string;
+};
+
+type IOption = { value: IPost["id"]; label: IPost["title"] };
+
+const MyComponent = () => {
+    const { selectProps } = useSelect<IPost, HttpError, IPost, IOption>({
+        resource: "posts",
+    });
+
+    // This will result in `selectProps.data` to be of type `IOption[]`.
+    // <Select /> will not accept `value` as `number` so you'll have to map the options.
+
+    return (
+        <Select
+            {...selectProps}
+            data={selectProps.data.map((option) => ({
+                ...option,
+                value: option.value.toString(),
+            }))}
+        />
+    );
+};
+```

--- a/.changeset/shiny-cooks-trade.md
+++ b/.changeset/shiny-cooks-trade.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/antd": patch
+---
+
+Updated return types of `useSelect`, `useRadioGroup` and `useCheckboxGroup` hooks to only include properties that actually being returned from the hook. Previously, the return types included all properties of the respective components, which was not correct.

--- a/packages/antd/src/hooks/fields/useCheckboxGroup/index.ts
+++ b/packages/antd/src/hooks/fields/useCheckboxGroup/index.ts
@@ -1,6 +1,6 @@
 import { QueryObserverResult } from "@tanstack/react-query";
+import type { Checkbox } from "antd";
 
-import { CheckboxGroupProps } from "antd/lib/checkbox";
 import {
     BaseRecord,
     GetListResponse,
@@ -9,13 +9,22 @@ import {
     useSelect,
     BaseKey,
     pickNotDeprecated,
+    Prettify,
+    BaseOption,
+    DefaultOption,
 } from "@refinedev/core";
 
-export type UseCheckboxGroupReturnType<TData extends BaseRecord = BaseRecord> =
-    {
-        checkboxGroupProps: CheckboxGroupProps;
-        queryResult: QueryObserverResult<GetListResponse<TData>>;
-    };
+export type UseCheckboxGroupReturnType<
+    TData extends BaseRecord = BaseRecord,
+    TOption extends BaseOption = DefaultOption,
+> = {
+    checkboxGroupProps: Prettify<
+        Pick<React.ComponentProps<typeof Checkbox.Group>, "defaultValue"> & {
+            options: TOption[];
+        }
+    >;
+    queryResult: QueryObserverResult<GetListResponse<TData>>;
+};
 
 type UseCheckboxGroupProps<TQueryFnData, TError, TData> = Omit<
     UseSelectProps<TQueryFnData, TError, TData>,
@@ -42,6 +51,7 @@ export const useCheckboxGroup = <
     TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TData extends BaseRecord = TQueryFnData,
+    TOption extends BaseOption = DefaultOption,
 >({
     resource,
     sort,
@@ -63,8 +73,13 @@ export const useCheckboxGroup = <
     TQueryFnData,
     TError,
     TData
->): UseCheckboxGroupReturnType<TData> => {
-    const { queryResult, options } = useSelect({
+>): UseCheckboxGroupReturnType<TData, TOption> => {
+    const { queryResult, options } = useSelect<
+        TQueryFnData,
+        TError,
+        TData,
+        TOption
+    >({
         resource,
         sort,
         sorters,

--- a/packages/antd/src/hooks/fields/useRadioGroup/index.ts
+++ b/packages/antd/src/hooks/fields/useRadioGroup/index.ts
@@ -1,18 +1,28 @@
 import { QueryObserverResult } from "@tanstack/react-query";
+import type { Radio } from "antd";
 
-import { RadioGroupProps } from "antd/lib/radio";
 import {
     BaseKey,
+    BaseOption,
     BaseRecord,
+    DefaultOption,
     GetListResponse,
     HttpError,
     pickNotDeprecated,
+    Prettify,
     useSelect,
     UseSelectProps,
 } from "@refinedev/core";
 
-export type UseRadioGroupReturnType<TData extends BaseRecord = BaseRecord> = {
-    radioGroupProps: RadioGroupProps;
+export type UseRadioGroupReturnType<
+    TData extends BaseRecord = BaseRecord,
+    TOption extends BaseOption = DefaultOption,
+> = {
+    radioGroupProps: Prettify<
+        Pick<React.ComponentProps<typeof Radio.Group>, "defaultValue"> & {
+            options: TOption[];
+        }
+    >;
     queryResult: QueryObserverResult<GetListResponse<TData>>;
 };
 
@@ -41,6 +51,7 @@ export const useRadioGroup = <
     TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TData extends BaseRecord = TQueryFnData,
+    TOption extends BaseOption = DefaultOption,
 >({
     resource,
     sort,
@@ -58,12 +69,16 @@ export const useRadioGroup = <
     meta,
     metaData,
     dataProviderName,
-}: UseRadioGroupProps<
-    TQueryFnData,
-    TError,
-    TData
->): UseRadioGroupReturnType<TData> => {
-    const { queryResult, options } = useSelect({
+}: UseRadioGroupProps<TQueryFnData, TError, TData>): UseRadioGroupReturnType<
+    TData,
+    TOption
+> => {
+    const { queryResult, options } = useSelect<
+        TQueryFnData,
+        TError,
+        TData,
+        TOption
+    >({
         resource,
         sort,
         sorters,

--- a/packages/antd/src/hooks/fields/useSelect/index.ts
+++ b/packages/antd/src/hooks/fields/useSelect/index.ts
@@ -8,10 +8,21 @@ import {
     GetListResponse,
     HttpError,
     UseSelectProps,
+    BaseOption,
+    DefaultOption,
+    Prettify,
 } from "@refinedev/core";
 
-export type UseSelectReturnType<TData extends BaseRecord = BaseRecord> = {
-    selectProps: SelectProps<{ value: string; label: string }>;
+export type UseSelectReturnType<
+    TData extends BaseRecord = BaseRecord,
+    TOption extends BaseOption = DefaultOption,
+> = {
+    selectProps: Prettify<
+        Pick<
+            SelectProps<TOption, TOption>,
+            "options" | "onSearch" | "loading" | "showSearch" | "filterOption"
+        >
+    >;
     queryResult: QueryObserverResult<GetListResponse<TData>>;
     defaultValueQueryResult: QueryObserverResult<GetManyResponse<TData>>;
 };
@@ -31,11 +42,12 @@ export const useSelect = <
     TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TData extends BaseRecord = TQueryFnData,
+    TOption extends BaseOption = DefaultOption,
 >(
     props: UseSelectProps<TQueryFnData, TError, TData>,
-): UseSelectReturnType<TData> => {
+): UseSelectReturnType<TData, TOption> => {
     const { queryResult, defaultValueQueryResult, onSearch, options } =
-        useSelectCore(props);
+        useSelectCore<TQueryFnData, TError, TData, TOption>(props);
 
     return {
         selectProps: {

--- a/packages/core/src/hooks/useSelect/index.spec.ts
+++ b/packages/core/src/hooks/useSelect/index.spec.ts
@@ -1035,44 +1035,4 @@ describe("useSelect Hook", () => {
             expect(result.current.overtime.elapsedTime).toBeUndefined();
         });
     });
-
-    it("an option should have both value and label converted to string", async () => {
-        const { result } = renderHook(
-            () =>
-                useSelect({
-                    resource: "posts",
-                    optionValue: "userId",
-                }),
-            {
-                wrapper: TestWrapper({
-                    dataProvider: MockJSONServer,
-                    resources: [{ name: "posts" }],
-                }),
-            },
-        );
-
-        await waitFor(() => {
-            expect(result.current.queryResult.isSuccess).toBeTruthy();
-        });
-
-        const { options } = result.current;
-
-        await waitFor(() => expect(options).toHaveLength(2), { timeout: 2000 });
-        /*
-            Original data in dataMocks.ts:
-            const posts = [
-                { userId: 5, title: "Necessitatibus necessitatibus id et cupiditate provident est qui amet." },
-                { userId: 36, name: "Recusandae consectetur aut atque est." },
-            ];
-        */
-        expect(options).toEqual([
-            {
-                value: "5",
-                label: "Necessitatibus necessitatibus id et cupiditate provident est qui amet.",
-            },
-            { value: "36", label: "Recusandae consectetur aut atque est." },
-        ]);
-        expect(typeof options[0].value).toBe("string");
-        expect(typeof options[0].label).toBe("string");
-    });
 });

--- a/packages/core/src/hooks/useSelect/index.ts
+++ b/packages/core/src/hooks/useSelect/index.ts
@@ -7,7 +7,8 @@ import get from "lodash/get";
 import { useList, useMany, useMeta } from "@hooks";
 import {
     CrudSorting,
-    Option,
+    DefaultOption,
+    BaseOption,
     BaseRecord,
     GetManyResponse,
     GetListResponse,
@@ -38,16 +39,13 @@ export type UseSelectProps<TQueryFnData, TError, TData> = {
      * Set the option's value
      * @default `"title"`
      */
-    optionLabel?: keyof TData extends string
-        ? keyof TData
-        : never;
+    optionLabel?: keyof TData extends string ? keyof TData : never;
+    // optionLabel?: String | keyof TData;
     /**
      * Set the option's label value
      * @default `"id"`
      */
-    optionValue?: keyof TData extends string
-        ? keyof TData
-        : never;
+    optionValue?: keyof TData extends string ? keyof TData : never;
     /**
      * Allow us to sort the options
      * @deprecated Use `sorters` instead
@@ -139,11 +137,14 @@ export type UseSelectProps<TQueryFnData, TError, TData> = {
     LiveModeProps &
     UseLoadingOvertimeOptionsProps;
 
-export type UseSelectReturnType<TData extends BaseRecord = BaseRecord> = {
+export type UseSelectReturnType<
+    TData extends BaseRecord = BaseRecord,
+    TOption extends BaseOption = DefaultOption,
+> = {
     queryResult: QueryObserverResult<GetListResponse<TData>>;
     defaultValueQueryResult: QueryObserverResult<GetManyResponse<TData>>;
     onSearch: (value: string) => void;
-    options: Option[];
+    options: TOption[];
 } & UseLoadingOvertimeReturnType;
 
 /**
@@ -164,12 +165,13 @@ export const useSelect = <
     TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TData extends BaseRecord = TQueryFnData,
+    TOption extends BaseOption = DefaultOption,
 >(
     props: UseSelectProps<TQueryFnData, TError, TData>,
-): UseSelectReturnType<TData> => {
+): UseSelectReturnType<TData, TOption> => {
     const [search, setSearch] = useState<CrudFilters>([]);
-    const [options, setOptions] = useState<Option[]>([]);
-    const [selectedOptions, setSelectedOptions] = useState<Option[]>([]);
+    const [options, setOptions] = useState<TOption[]>([]);
+    const [selectedOptions, setSelectedOptions] = useState<TOption[]>([]);
 
     const {
         resource: resourceFromProps,
@@ -213,10 +215,13 @@ export const useSelect = <
     const defaultValueQueryOnSuccess = useCallback(
         (data: GetManyResponse<TData>) => {
             setSelectedOptions(
-                data.data.map((item) => ({
-                    label: String(get(item, optionLabel)),
-                    value: String(get(item, optionValue)),
-                })),
+                data.data.map(
+                    (item) =>
+                        ({
+                            label: get(item, optionLabel),
+                            value: get(item, optionValue),
+                        } as TOption),
+                ),
             );
         },
         [optionLabel, optionValue],
@@ -248,10 +253,13 @@ export const useSelect = <
         (data: GetListResponse<TData>) => {
             {
                 setOptions(
-                    data.data.map((item) => ({
-                        label: String(get(item, optionLabel)),
-                        value: String(get(item, optionValue)),
-                    })),
+                    data.data.map(
+                        (item) =>
+                            ({
+                                label: get(item, optionLabel),
+                                value: get(item, optionValue),
+                            } as TOption),
+                    ),
                 );
             }
         },
@@ -311,13 +319,15 @@ export const useSelect = <
         onInterval: overtimeOptions?.onInterval,
     });
 
+    const combinedOptions = useMemo(
+        () => uniqBy([...options, ...selectedOptions], "value"),
+        [options, selectedOptions],
+    );
+
     return {
         queryResult,
         defaultValueQueryResult,
-        options: useMemo(
-            () => uniqBy([...options, ...selectedOptions], "value"),
-            [options, selectedOptions],
-        ),
+        options: combinedOptions,
         onSearch: debounce(onSearch, debounceValue),
         overtime: { elapsedTime },
     };

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -40,6 +40,8 @@ export {
     NotificationProvider,
     OpenNotificationParams,
     Option,
+    BaseOption,
+    DefaultOption,
     Pagination,
     PromptProps,
     RedirectionTypes,

--- a/packages/core/src/interfaces/index.ts
+++ b/packages/core/src/interfaces/index.ts
@@ -61,10 +61,21 @@ export type BaseRecord = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any;
 };
-export interface Option {
+export type BaseOption = {
+    label: any;
+    value: any;
+};
+
+export type DefaultOption = {
     label: string;
-    value: string;
-}
+    value: any;
+};
+
+/**
+ * @deprecated Use `DefaultOption` or `BaseOption` instead.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Option extends DefaultOption {}
 
 /* Backward compatible version of 'TreeMenuItem' */
 export type ITreeMenu = IResourceItem & {

--- a/packages/mantine/src/hooks/useSelect/index.ts
+++ b/packages/mantine/src/hooks/useSelect/index.ts
@@ -8,10 +8,26 @@ import {
     GetListResponse,
     HttpError,
     UseSelectProps,
+    BaseOption,
+    DefaultOption,
+    Prettify,
 } from "@refinedev/core";
 
-export type UseSelectReturnType<TData extends BaseRecord = BaseRecord> = {
-    selectProps: SelectProps;
+export type UseSelectReturnType<
+    TData extends BaseRecord = BaseRecord,
+    TOption extends BaseOption = DefaultOption,
+> = {
+    selectProps: Prettify<
+        Pick<
+            SelectProps,
+            | "onSearchChange"
+            | "searchable"
+            | "filterDataOnExactSearchMatch"
+            | "clearable"
+        > & {
+            data: TOption[];
+        }
+    >;
     queryResult: QueryObserverResult<GetListResponse<TData>>;
     defaultValueQueryResult: QueryObserverResult<GetManyResponse<TData>>;
 };
@@ -34,11 +50,12 @@ export const useSelect = <
     TQueryFnData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TData extends BaseRecord = TQueryFnData,
+    TOption extends BaseOption = DefaultOption,
 >(
     props: UseSelectProps<TQueryFnData, TError, TData>,
-): UseSelectReturnType<TData> => {
+): UseSelectReturnType<TData, TOption> => {
     const { queryResult, defaultValueQueryResult, onSearch, options } =
-        useSelectCore<TQueryFnData, TError, TData>(props);
+        useSelectCore<TQueryFnData, TError, TData, TOption>(props);
 
     return {
         selectProps: {


### PR DESCRIPTION
Exported `BaseOption` and `DefaultOption` types as successors of the deprecated `Option` type. `BaseOption` is `{ label: any; value: any; }` and `DefaultOption` is `{ label: string; value: any; }`.

Usage of the deprecated `Option` type was correctly assuming that the `value` property of the option is of type `string`. This assumption was wrong and now the types are changed to reflect the correct values of options with the ability to change it via 4th generic type `TOption` of `useSelect` hook.

---

Reverted the faulty assumption on option values of `useSelect` hook to be of type `string`. Now changed the types and the logic to reflect the correct values of options with the ability to change it via 4th generic type `TOption` of `useSelect` hook. (Reverted PR #5160)

By default `TOption` will be equal to `DefaultOption` type which is `{ label: string; value: any; }`. If you want to change the type of options, you can do it like this:

```tsx
import { useSelect, HttpError } from "@refinedev/core";

type MyData = {
    id: number;
    title: string;
    description: string;
    category: { id: string };
};

type Option = { label: MyData["title"]; value: MyData["id"] }; // equals to { label: string; value: number; }

useSelect<MyData, HttpError, MyData, Option>({
    resource: "posts",
});
```

### Closing issues

Fixes #5192

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [ ] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
