### PR TITLE
docs(beta): readable sandpack component

### DIFF
--- a/documentation/src/components/sandpack/index.tsx
+++ b/documentation/src/components/sandpack/index.tsx
@@ -128,142 +128,162 @@ export const Sandpack = ({
     const showHandle = !previewOnly && !layout?.includes("col");
 
     return (
-        <div className={clsx("pb-6", wrapperClassName)}>
-            <div
-                className={clsx(
-                    "absolute",
-                    "left-0",
-                    "right-0",
-                    "w-full",
-                    "px-2",
-                    "md:px-4",
-                    "xl:px-6",
-                    "max-w-screen-xl",
-                    "mx-auto",
-                    className,
-                )}
-            >
-                <SandpackProvider
-                    key={template}
-                    customSetup={{ dependencies, ...customSetup }}
-                    files={files as TemplateFiles<SandpackPredefinedTemplate>}
-                    options={providerOptions}
-                    template={template}
-                    theme={
-                        colorMode === "light"
-                            ? {
-                                  ...defaultLight,
-                                  colors: {
-                                      ...defaultLight.colors,
-                                      surface1: "#F4F8FB",
-                                      surface2: "rgb(222, 229, 237)",
-                                      surface3: "rgb(222, 229, 237)",
-                                  },
-                              }
-                            : {
-                                  ...nightOwl,
-                                  colors: {
-                                      ...nightOwl.colors,
-                                      surface1: "#1D1E30",
-                                      surface2: "#303450",
-                                      surface3: "#303450",
-                                  },
-                              }
-                    }
+        <>
+            <div className={clsx("pb-6", wrapperClassName)}>
+                <div
                     className={clsx(
-                        "not-prose sandpack-container",
+                        "absolute",
+                        "left-0",
+                        "right-0",
+                        "w-full",
+                        "px-2",
+                        "md:px-4",
+                        "xl:px-6",
                         "max-w-screen-xl",
+                        "mx-auto",
+                        className,
                     )}
-                    {...props}
                 >
-                    <SandpackLayout
+                    <SandpackProvider
+                        key={template}
+                        customSetup={{ dependencies, ...customSetup }}
+                        files={
+                            files as TemplateFiles<SandpackPredefinedTemplate>
+                        }
+                        options={providerOptions}
+                        template={template}
+                        theme={
+                            colorMode === "light"
+                                ? {
+                                      ...defaultLight,
+                                      colors: {
+                                          ...defaultLight.colors,
+                                          surface1: "#F4F8FB",
+                                          surface2: "rgb(222, 229, 237)",
+                                          surface3: "rgb(222, 229, 237)",
+                                      },
+                                  }
+                                : {
+                                      ...nightOwl,
+                                      colors: {
+                                          ...nightOwl.colors,
+                                          surface1: "#1D1E30",
+                                          surface2: "#303450",
+                                          surface3: "#303450",
+                                      },
+                                  }
+                        }
                         className={clsx(
-                            layout === "col" && "!flex-col",
-                            layout === "col-reverse" && "!flex-col-reverse",
+                            "not-prose sandpack-container",
+                            "max-w-screen-xl",
                         )}
+                        {...props}
                     >
-                        {!previewOnly && (
-                            <SandpackCodeEditor
-                                {...codeEditorOptions}
-                                style={{
-                                    height: options.editorHeight ?? height,
-                                    ...(layout?.includes("col")
-                                        ? { flex: "initial" }
-                                        : {
-                                              flexGrow: horizontalSize,
-                                              flexShrink: horizontalSize,
-                                              flexBasis: 0,
-                                          }),
-                                    overflow: "hidden",
-                                }}
-                            />
-                        )}
-                        {showHandle ? (
-                            <DragHandle
-                                onMouseDown={onHandleMouseDown}
-                                horizontalSize={horizontalSize}
-                            />
-                        ) : null}
-                        <SandpackPreview
-                            actionsChildren={
-                                <BugReportButton
-                                    onClick={() =>
-                                        setBugReportModalVisible(true)
-                                    }
-                                />
-                            }
-                            startRoute={startRoute}
-                            showNavigator={
-                                showNavigator ?? options.showNavigator
-                            }
-                            showRefreshButton={options.showRefreshButton}
-                            style={{
-                                ...(layout?.includes("col")
-                                    ? { flex: "initial", width: "100%" }
-                                    : {
-                                          flexGrow: 100 - horizontalSize,
-                                          flexShrink: 100 - horizontalSize,
-                                          flexBasis: 0,
-                                          width: previewOnly
-                                              ? "100%"
-                                              : 100 - horizontalSize + "%",
-                                      }),
-                                gap: 0,
-                                height: options.editorHeight ?? height, // use the original editor height
-                            }}
+                        <SandpackLayout
+                            className={clsx(
+                                layout === "col" && "!flex-col",
+                                layout === "col-reverse" && "!flex-col-reverse",
+                            )}
                         >
-                            <div className="sp-custom-loading">
-                                <img
-                                    src="https://refine.ams3.cdn.digitaloceanspaces.com/website/static/assets/spinner.gif"
-                                    className={clsx(
-                                        "w-12",
-                                        "h-12",
-                                        "rounded-full",
-                                    )}
+                            {!previewOnly && (
+                                <SandpackCodeEditor
+                                    {...codeEditorOptions}
+                                    style={{
+                                        height: options.editorHeight ?? height,
+                                        ...(layout?.includes("col")
+                                            ? { flex: "initial" }
+                                            : {
+                                                  flexGrow: horizontalSize,
+                                                  flexShrink: horizontalSize,
+                                                  flexBasis: 0,
+                                              }),
+                                        overflow: "hidden",
+                                    }}
                                 />
-                            </div>
-                        </SandpackPreview>
-                        <BugReportModal
-                            visible={bugReportModalVisible}
-                            onClose={() => setBugReportModalVisible(false)}
-                        />
-                    </SandpackLayout>
-                </SandpackProvider>
+                            )}
+                            {showHandle ? (
+                                <DragHandle
+                                    onMouseDown={onHandleMouseDown}
+                                    horizontalSize={horizontalSize}
+                                />
+                            ) : null}
+                            <SandpackPreview
+                                actionsChildren={
+                                    <BugReportButton
+                                        onClick={() =>
+                                            setBugReportModalVisible(true)
+                                        }
+                                    />
+                                }
+                                startRoute={startRoute}
+                                showNavigator={
+                                    showNavigator ?? options.showNavigator
+                                }
+                                showRefreshButton={options.showRefreshButton}
+                                style={{
+                                    ...(layout?.includes("col")
+                                        ? { flex: "initial", width: "100%" }
+                                        : {
+                                              flexGrow: 100 - horizontalSize,
+                                              flexShrink: 100 - horizontalSize,
+                                              flexBasis: 0,
+                                              width: previewOnly
+                                                  ? "100%"
+                                                  : 100 - horizontalSize + "%",
+                                          }),
+                                    gap: 0,
+                                    height: options.editorHeight ?? height, // use the original editor height
+                                }}
+                            >
+                                <div className="sp-custom-loading">
+                                    <img
+                                        src="https://refine.ams3.cdn.digitaloceanspaces.com/website/static/assets/spinner.gif"
+                                        className={clsx(
+                                            "w-12",
+                                            "h-12",
+                                            "rounded-full",
+                                        )}
+                                    />
+                                </div>
+                            </SandpackPreview>
+                            <BugReportModal
+                                visible={bugReportModalVisible}
+                                onClose={() => setBugReportModalVisible(false)}
+                            />
+                        </SandpackLayout>
+                    </SandpackProvider>
+                </div>
+                <div
+                    className={clsx("")}
+                    style={{
+                        height: Number(options.editorHeight ?? height) + 2,
+                    }}
+                />
+                <div
+                    className={clsx(
+                        layout?.includes("col") ? "block" : "block md:hidden",
+                    )}
+                    style={{
+                        height: Number(options.editorHeight ?? height) + 2,
+                    }}
+                />
             </div>
-            <div
-                className={clsx("")}
-                style={{
-                    height: Number(options.editorHeight ?? height) + 2,
-                }}
-            />
-            <div
-                className={clsx(
-                    layout?.includes("col") ? "block" : "block md:hidden",
-                )}
-                style={{
-                    height: Number(options.editorHeight ?? height) + 2,
-                }}
-            />
-        </div>
+            <section className="hidden max-w-0 max-h-0">
+                <p>{`Dependencies: ${Object.keys(dependencies).map(
+                    (k) => `${k}@${dependencies[k]}`,
+                )}`}</p>
+                <h3>{`Code Files`}</h3>
+                {Object.keys(files).map((f) => (
+                    <div key={f}>
+                        <div>{`File: ${f}`}</div>
+                        <div>
+                            {`Content: ${
+                                "code" in files[f] ? files[f].code : files[f]
+                            }`}
+                        </div>
+                    </div>
+                ))}
+            </section>
+        </>
     );
 };

--- a/documentation/src/refine-theme/changing-text-element.tsx
+++ b/documentation/src/refine-theme/changing-text-element.tsx
@@ -1,0 +1,118 @@
+import clsx from "clsx";
+import React from "react";
+
+type Props = {
+    first: string;
+    second: string;
+    onEnd?: () => void;
+    tick?: number;
+    className?: string;
+    prevClassName?: string;
+    nextClassName?: string;
+    activeClassName?: string;
+};
+
+export type ChangingTextElementRef = {
+    start: () => void;
+    reset: () => void;
+};
+
+export const ChangingTextElement = React.memo(
+    React.forwardRef<ChangingTextElementRef, Props>(function ChangingText(
+        {
+            first,
+            second,
+            onEnd,
+            tick = 75,
+            className,
+            prevClassName,
+            nextClassName,
+            activeClassName,
+        },
+        ref,
+    ) {
+        const maxLen = Math.max(first.length, second.length);
+        const prev = first.padEnd(maxLen, " ");
+        const next = second.padEnd(maxLen, " ");
+        const [pos, setPos] = React.useState(-1);
+        const [status, setStatus] = React.useState<"idle" | "running" | "done">(
+            "idle",
+        );
+
+        React.useImperativeHandle(ref, () => ({
+            start: () => {
+                setPos(-1);
+                setStatus("running");
+            },
+            reset: () => {
+                setPos(-1);
+                setStatus("idle");
+            },
+        }));
+
+        React.useEffect(() => {
+            if (status === "running") {
+                setPos(-1);
+            }
+        }, [status]);
+
+        React.useEffect(() => {
+            if (status === "running") {
+                const timer = setInterval(() => {
+                    setPos((prev) => {
+                        if (prev === maxLen - 1) {
+                            setStatus("done");
+                            return prev;
+                        }
+
+                        return prev + 1;
+                    });
+                }, tick);
+
+                return () => clearInterval(timer);
+            }
+        }, [status, tick, maxLen]);
+
+        React.useEffect(() => {
+            if (status === "done") {
+                onEnd?.();
+            }
+        }, [status]);
+
+        return (
+            <span className={clsx("will-change-contents", "group-", className)}>
+                <span className={clsx("will-change-contents", prevClassName)}>
+                    {next
+                        .split("")
+                        .slice(0, Math.max(pos, 0))
+
+                        .map((letter) => {
+                            return letter;
+                        })}
+                </span>
+                <span className={clsx("will-change-contents", activeClassName)}>
+                    {next.split("")[pos] ?? ""}
+                </span>
+                <span className={clsx("will-change-contents", nextClassName)}>
+                    {prev
+                        .split("")
+                        .slice(pos + 1)
+                        .map((letter) => {
+                            return letter;
+                        })}
+                </span>
+            </span>
+        );
+    }),
+    (prev, next) => {
+        return (
+            prev.first === next.first &&
+            prev.second === next.second &&
+            prev.tick === next.tick &&
+            prev.className === next.className &&
+            prev.prevClassName === next.prevClassName &&
+            prev.nextClassName === next.nextClassName &&
+            prev.activeClassName === next.activeClassName
+        );
+    },
+);


### PR DESCRIPTION
Added section with sandpack content that is hidden for the users but crawlable for AI and bots. This will allow our chatbot to use code written in sandpack examples.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
