### PR TITLE
fix: Remove redundant return statement after try-catch block

### DIFF
--- a/documentation/docs/advanced-tutorials/auth/auth0.md
+++ b/documentation/docs/advanced-tutorials/auth/auth0.md
@@ -188,16 +188,6 @@ const App = () => {
                     redirectTo: "/login",
                     logout: true,
                 };
-            }
-
-            return {
-                authenticated: false,
-                error: {
-                    message: "Check failed",
-                    name: "Token not found",
-                },
-                redirectTo: "/login",
-                logout: true,
             };
         },
         getPermissions: async () => null,


### PR DESCRIPTION
The code for the auth0 example in the documentation has an unreachable return after a try-catch block. No change is being made to the actual code of the project, just the markdown documentation.

### Self Check before Merge

Please check all items below before review.

-   [ ] Corresponding issues are created/updated or not needed
-   [ ] Docs are updated/provided or not needed
-   [ ] Examples are updated/provided or not needed
-   [ ] TypeScript definitions are updated/provided or not needed
-   [ ] Tests are updated/provided or not needed
-   [ ] Changesets are provided or not needed
