### PR TITLE
Docs/update testimonial links

### DIFF
--- a/documentation/src/refine-theme/common-circle-chevron-down.tsx
+++ b/documentation/src/refine-theme/common-circle-chevron-down.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import { SVGProps } from "react";
+
+export const CommonCircleChevronDown = (props: SVGProps<SVGSVGElement>) => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={25}
+        height={24}
+        viewBox="0 0 25 24"
+        fill="none"
+        {...props}
+    >
+        <path
+            fill="currentColor"
+            d="M10.354 10.646a.5.5 0 0 0-.708.708l2.5 2.5a.5.5 0 0 0 .708 0l2.5-2.5a.5.5 0 0 0-.708-.708L12.5 12.793l-2.146-2.147Z"
+        />
+        <path
+            fill="currentColor"
+            fillRule="evenodd"
+            d="M20.5 12a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-1 0a7 7 0 1 1-14 0 7 7 0 0 1 14 0Z"
+            clipRule="evenodd"
+        />
+    </svg>
+);

--- a/documentation/src/refine-theme/common-circle-chevron-up.tsx
+++ b/documentation/src/refine-theme/common-circle-chevron-up.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import { SVGProps } from "react";
+
+export const CommonCircleChevronUp = (props: SVGProps<SVGSVGElement>) => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={25}
+        height={24}
+        viewBox="0 0 25 24"
+        fill="none"
+        {...props}
+    >
+        <path
+            fill="currentColor"
+            d="M14.646 13.354a.5.5 0 0 0 .708-.708l-2.5-2.5a.5.5 0 0 0-.708 0l-2.5 2.5a.5.5 0 0 0 .708.708l2.146-2.147 2.146 2.147Z"
+        />
+        <path
+            fill="currentColor"
+            fillRule="evenodd"
+            d="M4.5 12a8 8 0 1 1 16 0 8 8 0 0 1-16 0Zm1 0a7 7 0 1 1 14 0 7 7 0 0 1-14 0Z"
+            clipRule="evenodd"
+        />
+    </svg>
+);

--- a/documentation/src/refine-theme/landing-section-cta-button.tsx
+++ b/documentation/src/refine-theme/landing-section-cta-button.tsx
@@ -14,6 +14,7 @@ export const LandingSectionCtaButton: FC<PropsWithChildren<Props>> = ({
     className,
     to,
     onClick,
+    icon,
 }) => {
     return (
         <Link
@@ -23,6 +24,7 @@ export const LandingSectionCtaButton: FC<PropsWithChildren<Props>> = ({
             onClick={onClick}
             className={clsx(
                 className,
+                "select-none",
                 "group/cta-button",
                 "relative",
                 "no-underline",
@@ -41,8 +43,7 @@ export const LandingSectionCtaButton: FC<PropsWithChildren<Props>> = ({
             )}
         >
             {children}
-            <DefaultIcon />
-
+            {icon || <DefaultIcon />}
             <div
                 className={clsx(
                     "select-none",

--- a/documentation/src/refine-theme/landing-testimonial.tsx
+++ b/documentation/src/refine-theme/landing-testimonial.tsx
@@ -147,13 +147,8 @@ const TestimonialCard = ({
     className,
 }) => {
     return (
-        <a
-            href={link}
-            target="_blank"
-            rel="noopener noreferrer"
+        <div
             className={clsx(
-                "appearance-none",
-                "no-underline",
                 "border dark:border-gray-700 border-gray-200",
                 "rounded-3xl",
                 className,
@@ -177,7 +172,17 @@ const TestimonialCard = ({
                 >
                     {description}
                 </div>
-                <div className={clsx("flex gap-4", "items-center")}>
+                <a
+                    href={link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={clsx(
+                        "flex gap-4",
+                        "items-center",
+                        "appearance-none",
+                        "no-underline",
+                    )}
+                >
                     <img
                         src={img}
                         alt={name}
@@ -201,9 +206,9 @@ const TestimonialCard = ({
                             {title}
                         </div>
                     </div>
-                </div>
+                </a>
             </div>
-        </a>
+        </div>
     );
 };
 

--- a/documentation/src/refine-theme/landing-testimonial.tsx
+++ b/documentation/src/refine-theme/landing-testimonial.tsx
@@ -1,5 +1,7 @@
 import clsx from "clsx";
 import React, { FC } from "react";
+import { CommonCircleChevronDown } from "./common-circle-chevron-down";
+import { CommonCircleChevronUp } from "./common-circle-chevron-up";
 import { LandingSectionCtaButton } from "./landing-section-cta-button";
 
 type Props = {
@@ -131,6 +133,13 @@ export const LandingTestimonial: FC<Props> = ({ className }) => {
             <LandingSectionCtaButton
                 className={clsx("cursor-pointer", "mt-6")}
                 onClick={() => setShowMore((prev) => !prev)}
+                icon={
+                    showMore ? (
+                        <CommonCircleChevronUp />
+                    ) : (
+                        <CommonCircleChevronDown />
+                    )
+                }
             >
                 Show {showMore ? "less" : "more"}
             </LandingSectionCtaButton>


### PR DESCRIPTION
- testimonial show more button icon changed.
- link removed from testimonial card and added to avatar-name section

<img width="350" alt="image" src="https://github.com/refinedev/refine/assets/23058882/fa0f4ff7-3e67-4213-9bc2-6563270a105c">

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
