### PR TITLE
feat(create-refine-app): intro animation

### DIFF
--- a/.changeset/selfish-fans-swim.md
+++ b/.changeset/selfish-fans-swim.md
@@ -1,0 +1,5 @@
+---
+"create-refine-app": minor
+---
+
+Added a small intro animation when `create-refine-app` starts.

--- a/.changeset/sharp-pots-deliver.md
+++ b/.changeset/sharp-pots-deliver.md
@@ -1,0 +1,5 @@
+---
+"create-refine-app": patch
+---
+
+Bumped `superplate-cli` version to latest

--- a/packages/create-refine-app/package.json
+++ b/packages/create-refine-app/package.json
@@ -26,6 +26,7 @@
     "@types/which-pm-runs": "^1.0.0"
   },
   "dependencies": {
+    "cowrizz": "^1.0.4",
     "boxen": "^5.1.2",
     "tslib": "^2.3.1",
     "commander": "9.4.1",

--- a/packages/create-refine-app/package.json
+++ b/packages/create-refine-app/package.json
@@ -31,7 +31,7 @@
     "tslib": "^2.3.1",
     "commander": "9.4.1",
     "execa": "^5.1.1",
-    "superplate-cli": "^1.17.9",
+    "superplate-cli": "^1.18.0",
     "got": "^11.8.5",
     "chalk": "^4.1.2",
     "ora": "^5.4.1",

--- a/packages/create-refine-app/src/greeting/index.ts
+++ b/packages/create-refine-app/src/greeting/index.ts
@@ -1,0 +1,20 @@
+import cowrizz from "cowrizz";
+
+const texts = [
+    "In a world of constraints, Refine\noffers freedom. Code on!",
+    "Refine: Because real devs don't just\nclick, they code!",
+    "Low-code? No-code? How about Pro-code\nwith Refine!",
+    "They asked for a robust B2B solution. We\nheard 'time to shine with Refine'!",
+    "They said 'Make it work, make it right, make\nit fast.' With Refine, we're already there!",
+    "Building CRUD apps with Refine? That's\nudderly fantastic! Avoid the bull, focus on\nthe code!",
+    "CRUD apps so sleek, even the cows\nwant in! Let's get mooo-ving with\nRefine!",
+];
+
+export const greeting = async () => {
+    await cowrizz({
+        text: texts[Math.floor(Math.random() * texts.length)],
+        startPause: 300,
+        endPause: 2000,
+        interval: 40,
+    });
+};

--- a/packages/create-refine-app/src/index.ts
+++ b/packages/create-refine-app/src/index.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import execa from "execa";
 import { readFileSync } from "fs";
 import handleExample from "./example";
+import { greeting } from "./greeting";
 
 const bootstrap = () => {
     const packageJson = JSON.parse(
@@ -47,8 +48,10 @@ const bootstrap = () => {
         .option("--disable-telemetry", "disable telemetry data collection")
         .allowUnknownOption(true)
         .allowExcessArguments(true)
-        .action((_, command: Command) => {
+        .action(async (_, command: Command) => {
             try {
+                await greeting();
+
                 // --example
                 if (command.getOptionValue("example")) {
                     handleExample(


### PR DESCRIPTION
Added a small intro animation when `create-refine-app` starts.


https://github.com/refinedev/refine/assets/11361964/32ecd3bd-27f0-45aa-bdc6-70c9da3b4fd2


### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
