### PR TITLE
feat(core): add `<AutoSaveIndicator />` component

### DIFF
--- a/.changeset/cool-planets-bake.md
+++ b/.changeset/cool-planets-bake.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/core": minor
+---
+
+Added `<AutoSaveIndicator />` component and updated the `AutoSaveIndicatorProps` type to allow `elements` to be passed in.
+
+`elements` prop is an object with `success`, `error`, `loading` and `idle` keys. Each key is a React element that will be rendered when the corresponding state is active.
+
+By default every state will render a `span` with the translated text of the `autoSave.${state}` key.

--- a/.changeset/cyan-falcons-know.md
+++ b/.changeset/cyan-falcons-know.md
@@ -1,0 +1,8 @@
+---
+"@refinedev/antd": patch
+"@refinedev/chakra-ui": patch
+"@refinedev/mantine": patch
+"@refinedev/mui": patch
+---
+
+Updated `<AutoSaveIndicator />` component to extend the `<AutoSaveIndicator />` from `@refinedev/core` with custom elements and render appropriate element based on the state.

--- a/packages/antd/src/components/autoSaveIndicator/index.tsx
+++ b/packages/antd/src/components/autoSaveIndicator/index.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { AutoSaveIndicatorProps, useTranslate } from "@refinedev/core";
+import {
+    AutoSaveIndicatorProps,
+    useTranslate,
+    AutoSaveIndicator as AutoSaveIndicatorCore,
+} from "@refinedev/core";
 import { Typography, theme } from "antd";
 import {
     EllipsisOutlined,
@@ -10,34 +14,62 @@ import {
 
 export const AutoSaveIndicator: React.FC<AutoSaveIndicatorProps> = ({
     status,
+    elements: {
+        success = (
+            <Message
+                key="autoSave.success"
+                defaultMessage="saved"
+                icon={<CheckCircleOutlined />}
+            />
+        ),
+        error = (
+            <Message
+                key="autoSave.error"
+                defaultMessage="auto save failure"
+                icon={<ExclamationCircleOutlined />}
+            />
+        ),
+        loading = (
+            <Message
+                key="autoSave.loading"
+                defaultMessage="saving..."
+                icon={<SyncOutlined />}
+            />
+        ),
+        idle = (
+            <Message
+                key="autoSave.idle"
+                defaultMessage="waiting for changes"
+                icon={<EllipsisOutlined />}
+            />
+        ),
+    } = {},
+}) => {
+    return (
+        <AutoSaveIndicatorCore
+            status={status}
+            elements={{
+                success,
+                error,
+                loading,
+                idle,
+            }}
+        />
+    );
+};
+
+const Message = ({
+    key,
+    defaultMessage,
+    icon,
+}: {
+    key: string;
+    defaultMessage: string;
+    icon: React.ReactNode;
 }) => {
     const translate = useTranslate();
     const { useToken } = theme;
     const { token } = useToken();
-
-    let message = null;
-    let icon = <EllipsisOutlined />;
-
-    switch (status) {
-        case "success":
-            message = translate("autoSave.success", "saved");
-            icon = <CheckCircleOutlined />;
-            break;
-        case "error":
-            message = translate("autoSave.error", "auto save failure");
-            icon = <ExclamationCircleOutlined />;
-
-            break;
-        case "loading":
-            message = translate("autoSave.loading", "saving...");
-            icon = <SyncOutlined />;
-
-            break;
-        default:
-            // for idle
-            message = translate("autoSave.idle", "waiting for changes");
-            break;
-    }
 
     return (
         <Typography.Text
@@ -47,7 +79,7 @@ export const AutoSaveIndicator: React.FC<AutoSaveIndicatorProps> = ({
                 fontSize: ".8rem",
             }}
         >
-            {message}
+            {translate(key, defaultMessage)}
             <span style={{ marginLeft: ".2rem" }}>{icon}</span>
         </Typography.Text>
     );

--- a/packages/chakra-ui/src/components/autoSaveIndicator/index.tsx
+++ b/packages/chakra-ui/src/components/autoSaveIndicator/index.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { AutoSaveIndicatorProps, useTranslate } from "@refinedev/core";
+import {
+    AutoSaveIndicatorProps,
+    useTranslate,
+    AutoSaveIndicator as AutoSaveIndicatorCore,
+} from "@refinedev/core";
 import { Text } from "@chakra-ui/react";
 import {
     IconDots,
@@ -10,29 +14,61 @@ import {
 
 export const AutoSaveIndicator: React.FC<AutoSaveIndicatorProps> = ({
     status,
+    elements: {
+        success = (
+            <Message
+                key="autoSave.success"
+                defaultMessage="saved"
+                icon={<IconCircleCheck size="18px" />}
+            />
+        ),
+        error = (
+            <Message
+                key="autoSave.error"
+                defaultMessage="auto save failure"
+                icon={<IconExclamationCircle size="18px" />}
+            />
+        ),
+        loading = (
+            <Message
+                key="autoSave.loading"
+                defaultMessage="saving..."
+                icon={<IconRefresh size="18px" />}
+            />
+        ),
+        idle = (
+            <Message
+                key="autoSave.idle"
+                defaultMessage="waiting for changes"
+                icon={<IconDots size="18px" />}
+            />
+        ),
+    } = {},
+}) => {
+    return (
+        <AutoSaveIndicatorCore
+            status={status}
+            elements={{
+                success,
+                error,
+                loading,
+                idle,
+            }}
+        />
+    );
+};
+
+const Message = ({
+    key,
+    defaultMessage,
+    icon,
+}: {
+    key: string;
+    defaultMessage: string;
+    icon: React.ReactNode;
 }) => {
     const translate = useTranslate();
-    let message = null;
-    let icon = <IconDots size="18px" />;
 
-    switch (status) {
-        case "success":
-            message = translate("autoSave.success", "saved");
-            icon = <IconCircleCheck size="18px" />;
-            break;
-        case "error":
-            message = translate("autoSave.error", "auto save failure");
-            icon = <IconExclamationCircle size="18px" />;
-            break;
-        case "loading":
-            message = translate("autoSave.loading", "saving...");
-            icon = <IconRefresh size="18px" />;
-            break;
-        default:
-            // for idle
-            message = translate("autoSave.idle", "waiting for changes");
-            break;
-    }
     return (
         <Text
             display="flex"
@@ -42,7 +78,7 @@ export const AutoSaveIndicator: React.FC<AutoSaveIndicatorProps> = ({
             marginRight="2"
             fontSize="sm"
         >
-            {message}
+            {translate(key, defaultMessage)}
             <span style={{ marginLeft: "3px" }}>{icon}</span>
         </Text>
     );

--- a/packages/core/refine.config.js
+++ b/packages/core/refine.config.js
@@ -73,6 +73,16 @@ module.exports = {
                     },
                 ],
             },
+            {
+                group: "Other",
+                label: "AutoSaveIndicator",
+                files: [
+                    {
+                        src: "./src/components/autoSaveIndicator/index.tsx",
+                        dest: "./components/autoSaveIndicator.tsx",
+                    },
+                ],
+            },
         ],
         transform: (content) => {
             let newContent = content;

--- a/packages/core/src/components/autoSaveIndicator/index.spec.tsx
+++ b/packages/core/src/components/autoSaveIndicator/index.spec.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render } from "@test";
+
+import { AutoSaveIndicator } from "./";
+
+describe("AutoSaveIndicator", () => {
+    it("should render success", async () => {
+        const { findByText, getByText } = render(
+            <AutoSaveIndicator status="success" />,
+        );
+        await findByText("saved");
+        getByText("saved");
+    });
+
+    it("should render error", async () => {
+        const { findByText, getByText } = render(
+            <AutoSaveIndicator status="error" />,
+        );
+
+        await findByText("auto save failure");
+        getByText("auto save failure");
+    });
+
+    it("should render idle", async () => {
+        const { findByText, getByText } = render(
+            <AutoSaveIndicator status="idle" />,
+        );
+
+        await findByText("waiting for changes");
+        getByText("waiting for changes");
+    });
+
+    it("should render loading", async () => {
+        const { findByText, getByText } = render(
+            <AutoSaveIndicator status="loading" />,
+        );
+
+        await findByText("saving...");
+        getByText("saving...");
+    });
+});

--- a/packages/core/src/components/autoSaveIndicator/index.tsx
+++ b/packages/core/src/components/autoSaveIndicator/index.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { AutoSaveIndicatorProps } from "../../interfaces";
+import { useTranslate } from "@hooks/translate";
+
+export const AutoSaveIndicator: React.FC<AutoSaveIndicatorProps> = ({
+    status,
+    elements: {
+        success = <Message key="autoSave.success" defaultMessage="saved" />,
+        error = (
+            <Message key="autoSave.error" defaultMessage="auto save failure" />
+        ),
+        loading = <Message key="autoSave.loading" defaultMessage="saving..." />,
+        idle = (
+            <Message key="autoSave.idle" defaultMessage="waiting for changes" />
+        ),
+    } = {},
+}) => {
+    switch (status) {
+        case "success":
+            return <>{success}</>;
+        case "error":
+            return <>{error}</>;
+        case "loading":
+            return <>{loading}</>;
+        default:
+            return <>{idle}</>;
+    }
+};
+
+const Message = ({
+    key,
+    defaultMessage,
+}: {
+    key: string;
+    defaultMessage: string;
+}) => {
+    const translate = useTranslate();
+
+    return <span>{translate(key, defaultMessage)}</span>;
+};

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -7,3 +7,4 @@ export { Authenticated } from "./authenticated";
 export { RouteChangeHandler } from "./routeChangeHandler";
 export { CanAccess, CanAccessProps } from "./canAccess";
 export { GitHubBanner } from "./gh-banner";
+export { AutoSaveIndicator } from "./autoSaveIndicator";

--- a/packages/core/src/interfaces/autoSave.ts
+++ b/packages/core/src/interfaces/autoSave.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { BaseRecord, HttpError, UpdateResponse } from ".";
 import { UseUpdateReturnType } from "../hooks/data/useUpdate";
 
@@ -25,6 +26,10 @@ export type AutoSaveReturnType<
     ) => Promise<UpdateResponse<TData> | void> | void;
 };
 
+export type AutoSaveIndicatorElements = Partial<
+    Record<"success" | "error" | "loading" | "idle", React.ReactNode>
+>;
+
 export type AutoSaveIndicatorProps<
     TData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
@@ -42,4 +47,8 @@ export type AutoSaveIndicatorProps<
      * The status of the update request.
      */
     status: UseUpdateReturnType<TData, TError, TVariables>["status"];
+    /**
+     * The elements to display for each status.
+     */
+    elements?: AutoSaveIndicatorElements;
 };

--- a/packages/mantine/src/components/autoSaveIndicator/index.tsx
+++ b/packages/mantine/src/components/autoSaveIndicator/index.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { AutoSaveIndicatorProps, useTranslate } from "@refinedev/core";
+import {
+    AutoSaveIndicatorProps,
+    useTranslate,
+    AutoSaveIndicator as AutoSaveIndicatorCore,
+} from "@refinedev/core";
 import { Text } from "@mantine/core";
 import {
     IconDots,
@@ -10,33 +14,64 @@ import {
 
 export const AutoSaveIndicator: React.FC<AutoSaveIndicatorProps> = ({
     status,
+    elements: {
+        success = (
+            <Message
+                key="autoSave.success"
+                defaultMessage="saved"
+                icon={<IconCircleCheck size="18px" />}
+            />
+        ),
+        error = (
+            <Message
+                key="autoSave.error"
+                defaultMessage="auto save failure"
+                icon={<IconExclamationCircle size="18px" />}
+            />
+        ),
+        loading = (
+            <Message
+                key="autoSave.loading"
+                defaultMessage="saving..."
+                icon={<IconRefresh size="18px" />}
+            />
+        ),
+        idle = (
+            <Message
+                key="autoSave.idle"
+                defaultMessage="waiting for changes"
+                icon={<IconDots size="18px" />}
+            />
+        ),
+    } = {},
+}) => {
+    return (
+        <AutoSaveIndicatorCore
+            status={status}
+            elements={{
+                success,
+                error,
+                loading,
+                idle,
+            }}
+        />
+    );
+};
+
+const Message = ({
+    key,
+    defaultMessage,
+    icon,
+}: {
+    key: string;
+    defaultMessage: string;
+    icon: React.ReactNode;
 }) => {
     const translate = useTranslate();
-    let message = null;
-    let icon = <IconDots size="18px" />;
-
-    switch (status) {
-        case "success":
-            message = translate("autoSave.success", "saved");
-            icon = <IconCircleCheck size="18px" />;
-            break;
-        case "error":
-            message = translate("autoSave.error", "auto save failure");
-            icon = <IconExclamationCircle size="18px" />;
-            break;
-        case "loading":
-            message = translate("autoSave.loading", "saving...");
-            icon = <IconRefresh size="18px" />;
-            break;
-        default:
-            // for idle
-            message = translate("autoSave.idle", "waiting for changes");
-            break;
-    }
 
     return (
         <Text size="sm" display="flex" align="center" mr="2" color="gray">
-            {message}
+            {translate(key, defaultMessage)}
             <span
                 style={{ position: "relative", top: "3px", marginLeft: "3px" }}
             >

--- a/packages/mui/src/components/autoSaveIndicator/index.tsx
+++ b/packages/mui/src/components/autoSaveIndicator/index.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { AutoSaveIndicatorProps, useTranslate } from "@refinedev/core";
+import {
+    AutoSaveIndicatorProps,
+    useTranslate,
+    AutoSaveIndicator as AutoSaveIndicatorCore,
+} from "@refinedev/core";
 import Typography from "@mui/material/Typography";
 import MoreHorizOutlinedIcon from "@mui/icons-material/MoreHorizOutlined";
 import SyncOutlinedIcon from "@mui/icons-material/SyncOutlined";
@@ -8,30 +12,60 @@ import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
 
 export const AutoSaveIndicator: React.FC<AutoSaveIndicatorProps> = ({
     status,
+    elements: {
+        success = (
+            <Message
+                key="autoSave.success"
+                defaultMessage="saved"
+                icon={<TaskAltOutlinedIcon fontSize="small" />}
+            />
+        ),
+        error = (
+            <Message
+                key="autoSave.error"
+                defaultMessage="auto save failure"
+                icon={<ErrorOutlineOutlinedIcon fontSize="small" />}
+            />
+        ),
+        loading = (
+            <Message
+                key="autoSave.loading"
+                defaultMessage="saving..."
+                icon={<SyncOutlinedIcon fontSize="small" />}
+            />
+        ),
+        idle = (
+            <Message
+                key="autoSave.idle"
+                defaultMessage="waiting for changes"
+                icon={<MoreHorizOutlinedIcon fontSize="small" />}
+            />
+        ),
+    } = {},
+}) => {
+    return (
+        <AutoSaveIndicatorCore
+            status={status}
+            elements={{
+                success,
+                error,
+                loading,
+                idle,
+            }}
+        />
+    );
+};
+
+const Message = ({
+    key,
+    defaultMessage,
+    icon,
+}: {
+    key: string;
+    defaultMessage: string;
+    icon: React.ReactNode;
 }) => {
     const translate = useTranslate();
-    let message = null;
-    let icon = <MoreHorizOutlinedIcon fontSize="small" />;
-
-    switch (status) {
-        case "success":
-            message = translate("autoSave.success", "saved");
-            icon = <TaskAltOutlinedIcon fontSize="small" />;
-            break;
-        case "error":
-            message = translate("autoSave.error", "auto save failure");
-            icon = <ErrorOutlineOutlinedIcon fontSize="small" />;
-
-            break;
-        case "loading":
-            message = translate("autoSave.loading", "saving...");
-            icon = <SyncOutlinedIcon fontSize="small" />;
-            break;
-        default:
-            // for idle
-            message = translate("autoSave.idle", "waiting for changes");
-            break;
-    }
 
     return (
         <Typography
@@ -43,7 +77,7 @@ export const AutoSaveIndicator: React.FC<AutoSaveIndicatorProps> = ({
             flexWrap="wrap"
             marginRight=".3rem"
         >
-            {message}
+            {translate(key, defaultMessage)}
             <span
                 style={{ position: "relative", top: "3px", marginLeft: "3px" }}
             >


### PR DESCRIPTION
- Added `<AutoSaveIndicator />` component to `@refinedev/core`
- Added `elements: { success, error, loading, idle }` prop to `AutoSaveIndicatorProps` to allow customizing state elements.
- Updated `@refinedev/antd`, `@refinedev/mantine`, `@refinedev/chakra-ui` and `@refinedev/mui` to use `<AutoSaveIndicator />` component of `@refinedev/core` with customized elements.
- 
### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [ ] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
