### PR TITLE
fix(cli): fix node-emoji version to 2.1.0

### DIFF
--- a/.changeset/pretty-adults-search.md
+++ b/.changeset/pretty-adults-search.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/cli": patch
+---
+
+Fixed the version of `node-emoji` to `2.1.0`. Since `v2.1.1` depends on an ESM-only package, it breaks the build.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,6 +69,7 @@
     "tslib": "^2.3.1",
     "marked": "^4.3.0",
     "marked-terminal": "^6.0.0",
+    "node-emoji": "2.1.0",
     "cli-table3": "^0.6.3",
     "center-align": "1.0.1"
   },


### PR DESCRIPTION
Fixed the version of `node-emoji` to `2.1.0`. Since `v2.1.1` depends on an ESM-only package, it breaks the build.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
