### PR TITLE
fix: update node-emoji package for @refinedev/cli package

### DIFF
--- a/.changeset/clever-meals-melt.md
+++ b/.changeset/clever-meals-melt.md
@@ -2,8 +2,6 @@
 "@refinedev/cli": patch
 ---
 
-fix: use node-emoji@v2.1.2 to include latest release.
+fix: override `node-emoji` package version used by `marked-terminal` to `2.1.0`
 
-fixes Fixes the issue: https://github.com/refinedev/refine/issues/5279
-
-`node-emoji` package released a new version to fix this import issue: https://github.com/omnidan/node-emoji/pull/154
+fixes the issue: https://github.com/refinedev/refine/issues/5279

--- a/.changeset/clever-meals-melt.md
+++ b/.changeset/clever-meals-melt.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/cli": patch
+---
+
+fix: use node-emoji@v2.1.2 to include latest release.
+
+fixes Fixes the issue: https://github.com/refinedev/refine/issues/5279
+
+`node-emoji` package released a new version to fix this import issue: https://github.com/omnidan/node-emoji/pull/154

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,9 +69,12 @@
     "tslib": "^2.3.1",
     "marked": "^4.3.0",
     "marked-terminal": "^6.0.0",
-    "node-emoji": "^2.1.2",
+    "node-emoji": "2.1.0",
     "cli-table3": "^0.6.3",
     "center-align": "1.0.1"
+  },
+  "overrides": {
+    "node-emoji": "2.1.0"
   },
   "author": "refine",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,7 +69,7 @@
     "tslib": "^2.3.1",
     "marked": "^4.3.0",
     "marked-terminal": "^6.0.0",
-    "node-emoji": "2.1.0",
+    "node-emoji": "^2.1.2",
     "cli-table3": "^0.6.3",
     "center-align": "1.0.1"
   },


### PR DESCRIPTION
Updated `node-emoji` package to `2.1.2` which fixes the cause of the bug.

https://github.com/omnidan/node-emoji/pull/154

fixes: #5279 