### PR TITLE
fix(cli): bump `node-emoji` to `^2.1.3`

### DIFF
--- a/.changeset/early-mayflies-promise.md
+++ b/.changeset/early-mayflies-promise.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/cli": patch
+---
+
+Bump `node-emoji` dependency resolution to `^2.1.3` to fix broken CJS builds.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,12 +69,12 @@
     "tslib": "^2.3.1",
     "marked": "^4.3.0",
     "marked-terminal": "^6.0.0",
-    "node-emoji": "2.1.0",
+    "node-emoji": "^2.1.3",
     "cli-table3": "^0.6.3",
     "center-align": "1.0.1"
   },
   "overrides": {
-    "node-emoji": "2.1.0"
+    "node-emoji": "^2.1.3"
   },
   "author": "refine",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -73,9 +73,6 @@
     "cli-table3": "^0.6.3",
     "center-align": "1.0.1"
   },
-  "overrides": {
-    "node-emoji": "^2.1.3"
-  },
   "author": "refine",
   "license": "MIT",
   "gitHead": "829f5a516f98c06f666d6be3e6e6099c75c07719",


### PR DESCRIPTION
Bump `node-emoji` dependency resolution to `^2.1.3` to fix broken CJS builds. Thanks to @JoshuaKGoldberg

### Closing issues

Fixes #5279

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
