### PR TITLE
chore(devtools): avoid errors when ports are already in use

### DIFF
--- a/.changeset/good-hats-shop.md
+++ b/.changeset/good-hats-shop.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/devtools-server": patch
+---
+
+Added error conditions on WS and HTTP servers to prevent crashing if ports are already in use. (Issue: #5215, #5294)

--- a/.changeset/weak-bats-repair.md
+++ b/.changeset/weak-bats-repair.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/cli": patch
+---
+
+Updated `--devtools` flag in dev command to allow disabling devtools by `--devtools=false`. (Issue: #5215)

--- a/packages/cli/src/commands/runner/dev/index.ts
+++ b/packages/cli/src/commands/runner/dev/index.ts
@@ -1,5 +1,3 @@
-import boxen from "boxen";
-
 import { ProjectTypes } from "@definitions/projectTypes";
 import { getProjectType } from "@utils/project";
 import { Command, Option } from "commander";
@@ -29,7 +27,7 @@ const dev = (program: Command) => {
             new Option(
                 "-d, --devtools <devtools>",
                 "Start refine's devtools server",
-            ),
+            ).default("true", "true if devtools is installed"),
         )
         .argument("[args...]")
         .action(action);

--- a/packages/cli/src/commands/runner/dev/index.ts
+++ b/packages/cli/src/commands/runner/dev/index.ts
@@ -26,7 +26,10 @@ const dev = (program: Command) => {
             ),
         )
         .addOption(
-            new Option("-d, --devtools", "Start refine's devtools server"),
+            new Option(
+                "-d, --devtools <devtools>",
+                "Start refine's devtools server",
+            ),
         )
         .argument("[args...]")
         .action(action);
@@ -34,7 +37,7 @@ const dev = (program: Command) => {
 
 const action = async (
     args: string[],
-    { platform, devtools }: { devtools: boolean; platform: ProjectTypes },
+    { platform, ...params }: { devtools: string; platform: ProjectTypes },
 ) => {
     const projectType = getProjectType(platform);
 
@@ -46,7 +49,13 @@ const action = async (
 
     const devtoolsDefault = await isDevtoolsInstalled();
 
-    if (devtools ?? devtoolsDefault) {
+    const devtools = Boolean(
+        params.devtools === "false"
+            ? false
+            : params.devtools ?? devtoolsDefault,
+    );
+
+    if (devtools) {
         devtoolsRunner();
     }
 

--- a/packages/cli/src/commands/runner/dev/index.ts
+++ b/packages/cli/src/commands/runner/dev/index.ts
@@ -47,11 +47,7 @@ const action = async (
 
     const devtoolsDefault = await isDevtoolsInstalled();
 
-    const devtools = Boolean(
-        params.devtools === "false"
-            ? false
-            : params.devtools ?? devtoolsDefault,
-    );
+    const devtools = params.devtools === "false" ? false : devtoolsDefault;
 
     if (devtools) {
         devtoolsRunner();

--- a/packages/devtools-server/src/index.ts
+++ b/packages/devtools-server/src/index.ts
@@ -130,10 +130,4 @@ export const server = async ({ projectPath = process.cwd() }: Options = {}) => {
     serveApi(app, db);
     serveProxy(app);
     serveOpenInEditor(app, projectPath);
-
-    console.log(
-        `\n${cyanBright.bold("\u2713 ")}${bold(
-            "refine devtools",
-        )} is running at port ${cyanBright.bold(SERVER_PORT)}\n`,
-    );
 };

--- a/packages/devtools-server/src/serve-ws.ts
+++ b/packages/devtools-server/src/serve-ws.ts
@@ -1,15 +1,29 @@
 import WebSocket from "ws";
 import { SERVER_PORT, WS_PORT } from "./constants";
 import { DevtoolsEvent, send } from "@refinedev/devtools-shared";
+import { bold, cyanBright } from "chalk";
 
 export const serveWs = () => {
-    const ws = new WebSocket.Server({ port: WS_PORT });
-
-    if (__DEVELOPMENT__) {
-        console.log(`WebSocket server started on PORT ${WS_PORT}`);
-    }
+    const ws = new WebSocket.Server({ port: WS_PORT }).on(
+        "error",
+        (error: any) => {
+            if (error?.code === "EADDRINUSE") {
+                console.error(
+                    `\n${cyanBright.bold("\u2717 ")}${bold(
+                        "refine devtools",
+                    )} failed to start. Port ${WS_PORT} is already in use, please make sure no other devtools server is running\n`,
+                );
+            } else {
+                console.error(error);
+            }
+            process.exit(1);
+        },
+    );
 
     ws.on("connection", (client) => {
+        if (__DEVELOPMENT__) {
+            console.log(`WebSocket server started on PORT ${WS_PORT}`);
+        }
         // send client the devtools client url
         send(client as any, DevtoolsEvent.DEVTOOLS_HANDSHAKE, {
             url: `http://localhost:${SERVER_PORT}`,

--- a/packages/devtools-server/src/serve-ws.ts
+++ b/packages/devtools-server/src/serve-ws.ts
@@ -14,7 +14,12 @@ export const serveWs = () => {
                     )} failed to start. Port ${WS_PORT} is already in use, please make sure no other devtools server is running\n`,
                 );
             } else {
-                console.error(error);
+                console.error(
+                    `\n${cyanBright.bold("\u2717 ")}${bold(
+                        "error from refine devtools",
+                    )}`,
+                    error,
+                );
             }
             process.exit(1);
         },

--- a/packages/devtools-server/src/setup-server.ts
+++ b/packages/devtools-server/src/setup-server.ts
@@ -17,7 +17,12 @@ export const setupServer = (app: Express) => {
                     )} failed to start. Port ${SERVER_PORT} is already in use, please make sure no other devtools server is running\n`,
                 );
             } else {
-                console.error(error);
+                console.error(
+                    `\n${cyanBright.bold("\u2717 ")}${bold(
+                        "error from refine devtools",
+                    )}`,
+                    error,
+                );
             }
             process.exit(1);
         })

--- a/packages/devtools-server/src/setup-server.ts
+++ b/packages/devtools-server/src/setup-server.ts
@@ -1,12 +1,33 @@
 import type { Express } from "express";
 import { SERVER_PORT } from "./constants";
+import { bold, cyanBright } from "chalk";
 
 export const setupServer = (app: Express) => {
-    const server = app.listen(SERVER_PORT, () => {
-        if (__DEVELOPMENT__) {
-            console.log(`Server started on PORT ${SERVER_PORT}`);
-        }
-    });
+    const server = app
+        .listen(SERVER_PORT, () => {
+            if (__DEVELOPMENT__) {
+                console.log(`Server started on PORT ${SERVER_PORT}`);
+            }
+        })
+        .on("error", (error: any) => {
+            if (error?.code === "EADDRINUSE") {
+                console.error(
+                    `\n${cyanBright.bold("\u2717 ")}${bold(
+                        "refine devtools",
+                    )} failed to start. Port ${SERVER_PORT} is already in use, please make sure no other devtools server is running\n`,
+                );
+            } else {
+                console.error(error);
+            }
+            process.exit(1);
+        })
+        .on("listening", () => {
+            console.log(
+                `\n${cyanBright.bold("\u2713 ")}${bold(
+                    "refine devtools",
+                )} is running at port ${cyanBright.bold(SERVER_PORT)}\n`,
+            );
+        });
 
     process.on("SIGTERM", () => {
         server.close(() => {


### PR DESCRIPTION
- `@refinedev/devtools-server`: Added error conditions on WS and HTTP servers to prevent crashing if ports are already in use.
- `@refinedev/cli`: Updated `--devtools` flag in dev command to allow disabling devtools by `--devtools=false`.

### Closing issues

Resolves #5215
Resolves #5294

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
