### PR TITLE
chore(devtools-ui): remove unused dependencies

### DIFF
--- a/.changeset/moody-pianos-kiss.md
+++ b/.changeset/moody-pianos-kiss.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/devtools-ui": patch
+---
+
+Removed unused `use-is-in-viewport` dependency

--- a/packages/devtools-ui/package.json
+++ b/packages/devtools-ui/package.json
@@ -45,7 +45,6 @@
     "react-json-view": "^1.21.3",
     "react-router-dom": "^6.8.1",
     "@fireworks-js/react": "^2.10.7",
-    "use-is-in-viewport": "^1.0.9",
     "semver-diff": "^3.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Removed unused `use-is-in-viewport` dependency from `@refinedev/devtools-ui`

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
