### PR TITLE
Make contributing to docs easier

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -30,8 +30,9 @@ const siteConfig = {
                     : {
                           path: "./docs",
                           sidebarPath: require.resolve("./sidebars.js"),
-                          editUrl:
-                              "https://github.com/refinedev/refine/tree/master/documentation",
+                          editUrl: ({ docPath }) => {
+                               return `https://holocron.so/github/pr/refinedev/refine/master/editor/documentation/docs/${docPath}`
+                          },
                           showLastUpdateAuthor: true,
                           showLastUpdateTime: true,
                           disableVersioning:


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/refinedev/refine/master/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb