### PR TITLE
docs: handle missing redirects

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -79,10 +79,10 @@ const siteConfig = {
             {
                 redirects: redirectJson.redirects,
                 createRedirects(existingPath) {
-                    if (existingPath.includes("/api-reference/")) {
+                    if (existingPath.includes("/api-reference/core/")) {
                         return [
                             existingPath.replace(
-                                "/api-reference/",
+                                "/api-reference/core/",
                                 "/api-references/",
                             ),
                         ];

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -78,6 +78,17 @@ const siteConfig = {
             "@docusaurus/plugin-client-redirects",
             {
                 redirects: redirectJson.redirects,
+                createRedirects(existingPath) {
+                    if (existingPath.includes("/api-reference/")) {
+                        return [
+                            existingPath.replace(
+                                "/api-reference/",
+                                "/api-references/",
+                            ),
+                        ];
+                    }
+                    return undefined; // Return a falsy value: no redirect created
+                },
             },
         ],
         [
@@ -109,7 +120,8 @@ const siteConfig = {
                       "./plugins/blog-plugin.js",
                       {
                           blogTitle: "Blog",
-                          blogDescription: "A resource for Refine, front-end ecosystem, and web development",
+                          blogDescription:
+                              "A resource for Refine, front-end ecosystem, and web development",
                           routeBasePath: "/blog",
                           postsPerPage: 12,
                           blogSidebarTitle: "All posts",


### PR DESCRIPTION
There was a change from `/api-references` to `/api-reference` which the redirects were not handled properly. Added a client redirect configuration to handle them.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
