### PR TITLE
fix(core): hideForm on core auth page

### DIFF
--- a/.changeset/modern-singers-prove.md
+++ b/.changeset/modern-singers-prove.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": minor
+---
+
+fix: `hideForm` should remove all form fields. (submit button, form fields, rememberMe checkbox, forgot password link, etc.) but the `/register` link should be visible.

--- a/packages/core/src/components/pages/auth/components/login/index.spec.tsx
+++ b/packages/core/src/components/pages/auth/components/login/index.spec.tsx
@@ -289,4 +289,63 @@ describe("Auth Page Login", () => {
             providerName: "Google",
         });
     });
+
+    it("should not render form when `hideForm` is true", async () => {
+        const { queryByLabelText, getByText, queryByRole } = render(
+            <LoginPage
+                hideForm
+                providers={[
+                    {
+                        name: "google",
+                        label: "Google",
+                    },
+                    { name: "github", label: "GitHub" },
+                ]}
+            />,
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        expect(queryByLabelText(/email/i)).not.toBeInTheDocument();
+        expect(queryByLabelText(/password/i)).not.toBeInTheDocument();
+        expect(queryByLabelText(/remember/i)).not.toBeInTheDocument();
+        expect(
+            queryByRole("link", {
+                name: /forgot password/i,
+            }),
+        ).not.toBeInTheDocument();
+        expect(
+            queryByRole("button", {
+                name: /sign in/i,
+            }),
+        ).not.toBeInTheDocument();
+
+        expect(getByText(/google/i)).toBeInTheDocument();
+        expect(getByText(/github/i)).toBeInTheDocument();
+        expect(
+            queryByRole("link", {
+                name: /sign up/i,
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it.each([true, false])("should has default links", async (hideForm) => {
+        const { getByRole } = render(<LoginPage hideForm={hideForm} />, {
+            wrapper: TestWrapper({}),
+        });
+        expect(
+            getByRole("link", {
+                name: /sign up/i,
+            }),
+        ).toHaveAttribute("href", "/register");
+
+        if (hideForm === false) {
+            expect(
+                getByRole("link", {
+                    name: /forgot password/i,
+                }),
+            ).toHaveAttribute("href", "/forgot-password");
+        }
+    });
 });

--- a/packages/core/src/components/pages/auth/components/login/index.tsx
+++ b/packages/core/src/components/pages/auth/components/login/index.tsx
@@ -80,23 +80,23 @@ export const LoginPage: React.FC<LoginProps> = ({
                 {translate("pages.login.title", "Sign in to your account")}
             </h1>
             {renderProviders()}
-            <hr />
-            <form
-                onSubmit={(e) => {
-                    e.preventDefault();
-                    login({ email, password, remember });
-                }}
-                {...formProps}
-            >
-                <div
-                    style={{
-                        display: "flex",
-                        flexDirection: "column",
-                        padding: 25,
-                    }}
-                >
-                    {hideForm ? <></> : (
-                        <>
+            {!hideForm && (
+                <>
+                    <hr />
+                    <form
+                        onSubmit={(e) => {
+                            e.preventDefault();
+                            login({ email, password, remember });
+                        }}
+                        {...formProps}
+                    >
+                        <div
+                            style={{
+                                display: "flex",
+                                flexDirection: "column",
+                                padding: 25,
+                            }}
+                        >
                             <label htmlFor="email-input">
                                 {translate("pages.login.fields.email", "Email")}
                             </label>
@@ -113,7 +113,10 @@ export const LoginPage: React.FC<LoginProps> = ({
                                 onChange={(e) => setEmail(e.target.value)}
                             />
                             <label htmlFor="password-input">
-                                {translate("pages.login.fields.password", "Password")}
+                                {translate(
+                                    "pages.login.fields.password",
+                                    "Password",
+                                )}
                             </label>
                             <input
                                 id="password-input"
@@ -124,56 +127,74 @@ export const LoginPage: React.FC<LoginProps> = ({
                                 value={password}
                                 onChange={(e) => setPassword(e.target.value)}
                             />
-                        </>
-                    )}
-                    {rememberMe ?? (
-                        <>
-                            <label htmlFor="remember-me-input">
-                                {translate(
-                                    "pages.login.buttons.rememberMe",
-                                    "Remember me",
-                                )}
-                                <input
-                                    id="remember-me-input"
-                                    name="remember"
-                                    type="checkbox"
-                                    size={20}
-                                    checked={remember}
-                                    value={remember.toString()}
-                                    onChange={() => {
-                                        setRemember(!remember);
-                                    }}
-                                />
-                            </label>
-                        </>
-                    )}
-                    <br />
-                    {forgotPasswordLink ??
-                        renderLink(
-                            "/forgot-password",
-                            translate(
-                                "pages.login.buttons.forgotPassword",
-                                "Forgot password?",
-                            ),
-                        )}
-                    <input
-                        type="submit"
-                        value={translate("pages.login.signin", "Sign in")}
-                    />
-                    {registerLink ?? (
-                        <span>
-                            {translate(
-                                "pages.login.buttons.noAccount",
-                                "Don’t have an account?",
-                            )}{" "}
-                            {renderLink(
-                                "/register",
-                                translate("pages.login.register", "Sign up"),
+                            {rememberMe ?? (
+                                <>
+                                    <label htmlFor="remember-me-input">
+                                        {translate(
+                                            "pages.login.buttons.rememberMe",
+                                            "Remember me",
+                                        )}
+                                        <input
+                                            id="remember-me-input"
+                                            name="remember"
+                                            type="checkbox"
+                                            size={20}
+                                            checked={remember}
+                                            value={remember.toString()}
+                                            onChange={() => {
+                                                setRemember(!remember);
+                                            }}
+                                        />
+                                    </label>
+                                </>
                             )}
-                        </span>
+                            <br />
+                            {forgotPasswordLink ??
+                                renderLink(
+                                    "/forgot-password",
+                                    translate(
+                                        "pages.login.buttons.forgotPassword",
+                                        "Forgot password?",
+                                    ),
+                                )}
+                            <input
+                                type="submit"
+                                value={translate(
+                                    "pages.login.signin",
+                                    "Sign in",
+                                )}
+                            />
+                            {registerLink ?? (
+                                <span>
+                                    {translate(
+                                        "pages.login.buttons.noAccount",
+                                        "Don’t have an account?",
+                                    )}{" "}
+                                    {renderLink(
+                                        "/register",
+                                        translate(
+                                            "pages.login.register",
+                                            "Sign up",
+                                        ),
+                                    )}
+                                </span>
+                            )}
+                        </div>
+                    </form>
+                </>
+            )}
+            {registerLink !== false && hideForm && (
+                <div style={{ textAlign: "center" }}>
+                    {translate(
+                        "pages.login.buttons.noAccount",
+                        "Don’t have an account?",
+                    )}{" "}
+                    {renderLink(
+                        "/register",
+                        translate("pages.login.register", "Sign up"),
                     )}
                 </div>
-            </form>
+            )}
         </div>
     );
 

--- a/packages/core/src/components/pages/auth/components/register/index.spec.tsx
+++ b/packages/core/src/components/pages/auth/components/register/index.spec.tsx
@@ -228,4 +228,54 @@ describe("Auth Page Register", () => {
             providerName: "Google",
         });
     });
+
+    it("should not render form when `hideForm` is true", async () => {
+        const { queryByLabelText, getByText, queryByRole } = render(
+            <RegisterPage
+                hideForm
+                providers={[
+                    {
+                        name: "google",
+                        label: "Google",
+                    },
+                    { name: "github", label: "GitHub" },
+                ]}
+            />,
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        expect(queryByLabelText(/email/i)).not.toBeInTheDocument();
+        expect(queryByLabelText(/password/i)).not.toBeInTheDocument();
+        expect(
+            queryByRole("link", {
+                name: /forgot password/i,
+            }),
+        ).not.toBeInTheDocument();
+        expect(
+            queryByRole("button", {
+                name: /sign up/i,
+            }),
+        ).not.toBeInTheDocument();
+
+        expect(getByText(/google/i)).toBeInTheDocument();
+        expect(getByText(/github/i)).toBeInTheDocument();
+        expect(
+            queryByRole("link", {
+                name: /sign in/i,
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it.each([true, false])("should has default links", async (hideForm) => {
+        const { getByRole } = render(<RegisterPage hideForm={hideForm} />, {
+            wrapper: TestWrapper({}),
+        });
+        expect(
+            getByRole("link", {
+                name: /sign in/i,
+            }),
+        ).toHaveAttribute("href", "/login");
+    });
 });

--- a/packages/core/src/components/pages/auth/components/register/index.tsx
+++ b/packages/core/src/components/pages/auth/components/register/index.tsx
@@ -86,25 +86,28 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                 {translate("pages.register.title", "Sign up for your account")}
             </h1>
             {renderProviders()}
-            <hr />
-            <form
-                onSubmit={(e) => {
-                    e.preventDefault();
-                    register({ email, password });
-                }}
-                {...formProps}
-            >
-                <div
-                    style={{
-                        display: "flex",
-                        flexDirection: "column",
-                        padding: 25,
-                    }}
-                >
-                    {hideForm ? <></> : (
-                        <>
+            {!hideForm && (
+                <>
+                    <hr />
+                    <form
+                        onSubmit={(e) => {
+                            e.preventDefault();
+                            register({ email, password });
+                        }}
+                        {...formProps}
+                    >
+                        <div
+                            style={{
+                                display: "flex",
+                                flexDirection: "column",
+                                padding: 25,
+                            }}
+                        >
                             <label htmlFor="email-input">
-                                {translate("pages.register.fields.email", "Email")}
+                                {translate(
+                                    "pages.register.fields.email",
+                                    "Email",
+                                )}
                             </label>
                             <input
                                 id="email-input"
@@ -133,32 +136,47 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                                 value={password}
                                 onChange={(e) => setPassword(e.target.value)}
                             />
-                        </>
-                    )}
-                    <input
-                        type="submit"
-                        value={translate(
-                            "pages.register.buttons.submit",
-                            "Sign up",
-                        )}
-                        disabled={isLoading}
-                    />
-                    {loginLink ?? (
-                        <>
-                            <span>
-                                {translate(
-                                    "pages.login.buttons.haveAccount",
-                                    "Have an account?",
-                                )}{" "}
-                                {renderLink(
-                                    "/login",
-                                    translate("pages.login.signin", "Sign in"),
+                            <input
+                                type="submit"
+                                value={translate(
+                                    "pages.register.buttons.submit",
+                                    "Sign up",
                                 )}
-                            </span>
-                        </>
+                                disabled={isLoading}
+                            />
+                            {loginLink ?? (
+                                <>
+                                    <span>
+                                        {translate(
+                                            "pages.login.buttons.haveAccount",
+                                            "Have an account?",
+                                        )}{" "}
+                                        {renderLink(
+                                            "/login",
+                                            translate(
+                                                "pages.login.signin",
+                                                "Sign in",
+                                            ),
+                                        )}
+                                    </span>
+                                </>
+                            )}
+                        </div>
+                    </form>
+                </>
+            )}
+            {loginLink !== false && hideForm && (
+                <div style={{ textAlign: "center" }}>
+                    {translate(
+                        "pages.login.buttons.haveAccount",
+                        "Have an account?",
+                    )}{" "}
+                    {renderLink(
+                        "/login",
+                        translate("pages.login.signin", "Sign in"),
                     )}
                 </div>
-            </form>
+            )}
         </div>
     );
 


### PR DESCRIPTION
fix: `hideForm` should remove all form fields. (submit button, form fields, rememberMe checkbox, forgot password link, etc.) but the `/register` link should be visible.

<img width="300" alt="Sign in to your account" src="https://github.com/refinedev/refine/assets/23058882/0870d27e-6060-4238-9364-9d286a3dced8">

<img width="300" alt="Sign in to your account" src="https://github.com/refinedev/refine/assets/23058882/bf93269b-924b-46ec-99f9-e0e74252415a">


### Test plan (required)

<img width="200" alt="image" src="https://github.com/refinedev/refine/assets/23058882/c70fcce9-a957-4a68-849b-e31e749099e8">

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
