### PR TITLE
feat(docs): add `<InstallPackagesCommand/>` and `<CreateRefineAppCommand />`

### DIFF
--- a/documentation/docs/advanced-tutorials/access-control.md
+++ b/documentation/docs/advanced-tutorials/access-control.md
@@ -260,9 +260,7 @@ We will be using **[Casbin](https://casbin.org/)** in this guide for users with 
 
 We need to install Casbin.
 
-```bash
-npm install casbin
-```
+<InstallPackagesCommand args="casbin"/>
 
 :::caution
 

--- a/documentation/docs/advanced-tutorials/auth/auth0.md
+++ b/documentation/docs/advanced-tutorials/auth/auth0.md
@@ -12,9 +12,7 @@ We will show you how to use Auth0 with Refine
 
 Run the following command within your project directory to install the Auth0 React SDK:
 
-```
-npm install @auth0/auth0-react
-```
+<InstallPackagesCommand args="@auth0/auth0-react"/>
 
 #### Configure the Auth0Provider component
 

--- a/documentation/docs/advanced-tutorials/auth/azure-ad.md
+++ b/documentation/docs/advanced-tutorials/auth/azure-ad.md
@@ -22,9 +22,7 @@ We will be using the javascript version of msal library and a helper for react. 
 
 To install the required dependencies, run the following command:
 
-```bash
-npm install @azure/msal-browser @azure/msal-react
-```
+<InstallPackagesCommand args="@azure/msal-browser @azure/msal-react"/>
 
 Detailed documentation for using msal with react can be found here: [docs](https://learn.microsoft.com/en-us/azure/active-directory/develop/single-page-app-quickstart?pivots=devlang-react)
 

--- a/documentation/docs/advanced-tutorials/multi-tenancy/appwrite.md
+++ b/documentation/docs/advanced-tutorials/multi-tenancy/appwrite.md
@@ -22,9 +22,7 @@ This guide has been prepared to assume you know the basics of **Refine**. If you
 
 ## Setup
 
-```bash
-npm install @refinedev/appwrite
-```
+<InstallPackagesCommand args="@refinedev/appwrite"/>
 
 :::caution
 

--- a/documentation/docs/advanced-tutorials/multi-tenancy/strapi.md
+++ b/documentation/docs/advanced-tutorials/multi-tenancy/strapi.md
@@ -22,9 +22,7 @@ This guide has been prepared to assume you know the basics of **Refine**. If you
 
 ## Setup
 
-```bash
-npm i @refinedev/strapi-v4
-```
+<InstallPackagesCommand args="@refinedev/strapi-v4"/>
 
 :::caution
 

--- a/documentation/docs/advanced-tutorials/real-time.md
+++ b/documentation/docs/advanced-tutorials/real-time.md
@@ -14,9 +14,7 @@ We will be using [Ably](https://ably.com) in this guide to provide Realtime feat
 
 We need to install the Ably live provider package from **Refine**.
 
-```bash
-npm install @refinedev/ably
-```
+<InstallPackagesCommand args="@refinedev/ably"/>
 
 :::caution
 

--- a/documentation/docs/advanced-tutorials/web3/ethereum-signin.md
+++ b/documentation/docs/advanced-tutorials/web3/ethereum-signin.md
@@ -15,10 +15,7 @@ We will show you how to log in to your Metamask wallet with **Refine**.
 
 We will need [web3](https://github.com/ChainSafe/web3.js) and [web3-modal](https://github.com/web3modal/web3modal) packages in our project. Let's start by downloading these packages.
 
-```bash
-npm install web3
-npm install --save web3modal
-```
+<InstallPackagesCommand args="web3 web3modal"/>
 
 :::caution
 

--- a/documentation/docs/core/providers/i18n-provider/index.md
+++ b/documentation/docs/core/providers/i18n-provider/index.md
@@ -64,39 +64,8 @@ Let's add multi-language support to our application using the `react-i18next` fr
 ### Installation
 
 To install both `react-i18next` and `i18next` packages, run the following command within your project directory:
-<Tabs
-defaultValue="npm"
-values={[
-{label: 'use npm', value: 'npm'},
-{label: 'use yarn', value: 'yarn'},
-{label: 'use pnpm', value: 'pnpm'},
-]}>
 
-<TabItem value="npm">
-
-```bash
-npm install react-i18next i18next i18next-http-backend i18next-browser-languagedetector
-```
-
-</TabItem>
-
-<TabItem value="yarn">
-
-```bash
-yarn add react-i18next i18next i18next-http-backend i18next-browser-languagedetector
-```
-
-</TabItem>
-
-<TabItem value="pnpm">
-
-```bash
-pnpm install react-i18next i18next i18next-http-backend i18next-browser-languagedetector
-```
-
-</TabItem>
-
-</Tabs>
+<InstallPackagesCommand args="react-i18next i18next i18next-http-backend i18next-browser-languagedetector"/>
 
 ### Creating the i18n Instance
 

--- a/documentation/docs/enterprise-edition/okta/index.md
+++ b/documentation/docs/enterprise-edition/okta/index.md
@@ -10,13 +10,7 @@ Okta is an enterprise-grade identity management service. Refine's integration of
 
 This package is included in Refine's Enterprise Edition. To learn more about Refine's Enterprise Edition, please [contact us](https://s.refine.dev/okta-enterprise).
 
-<Tabs>
-
-<TabItem value="npm" label="npm" default>
-
-```bash
-npm i @refinedev-ee/okta @okta/okta-auth-js
-```
+<InstallPackagesCommand args="@refinedev-ee/okta @okta/okta-auth-js">
 
 ```yml title=".npmrc"
 # A registry with the auth token should be added for the @refinedev-ee scope
@@ -24,37 +18,7 @@ npm i @refinedev-ee/okta @okta/okta-auth-js
 //registry.npmjs.org/:_authToken=$NPM_TOKEN
 ```
 
-</TabItem>
-
-<TabItem value="yarn" label="yarn" default>
-
-```bash
-yarn add @refinedev-ee/okta @okta/okta-auth-js
-```
-
-```yml title=".yarnrc"
-# A registry with the auth token should be added for the @refinedev-ee scope
-@refinedev-ee:registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken=$NPM_TOKEN
-```
-
-</TabItem>
-
-<TabItem value="pnpm" label="pnpm" default>
-
-```bash
-pnpm i @refinedev-ee/okta @okta/okta-auth-js
-```
-
-```yml title=".pnpmrc"
-# A registry with the auth token should be added for the @refinedev-ee scope
-@refinedev-ee:registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken=$NPM_TOKEN
-```
-
-</TabItem>
-
-</Tabs>
+</InstallPackagesCommand>
 
 ## Usage
 

--- a/documentation/docs/guides-concepts/development/index.md
+++ b/documentation/docs/guides-concepts/development/index.md
@@ -21,9 +21,7 @@ To use the browser-based scaffolding tool, you can visit [refine.dev](https://re
 
 To use the command-line interface, you can simply run the following command in your terminal:
 
-```bash
-npx create refine-app my-refine-app
-```
+<CreateRefineAppCommand args="my-refine-app" />
 
 After running the command, you will be prompted to select the options you want to use for your project. After you are done with the options, the CLI will create your project in the `my-refine-app` directory.
 

--- a/documentation/docs/packages/cli/index.md
+++ b/documentation/docs/packages/cli/index.md
@@ -379,28 +379,7 @@ View the details of the development environment.
 
 If you want to add the [@refinedev/cli](https://github.com/refinedev/refine/tree/master/packages/cli) to your existing project, you have to add it to your project's `dependencies`.
 
-<Tabs
-defaultValue="npm"
-values={[
-{label: 'use npm', value: 'npm'},
-{label: 'use yarn', value: 'yarn'},
-]}>
-
-<TabItem value="npm">
-
-```bash
-npm i @refinedev/cli
-```
-
-</TabItem>
-<TabItem value="yarn">
-
-```bash
-yarn add @refinedev/cli
-```
-
-</TabItem>
-</Tabs>
+<InstallPackagesCommand args="@refinedev/cli"/>
 
 Then add the `refine` command to your scripts in your `package.json` file
 

--- a/documentation/docs/packages/command-palette/index.md
+++ b/documentation/docs/packages/command-palette/index.md
@@ -214,9 +214,7 @@ Refine supports the command palette feature and use the
 
 Install the [@refinedev/kbar][refine-kbar] library.
 
-```bash
-npm i @refinedev/kbar
-```
+<InstallPackagesCommand args="@refinedev/kbar"/>
 
 ## Usage
 

--- a/documentation/docs/packages/data-providers/airtable/index.md
+++ b/documentation/docs/packages/data-providers/airtable/index.md
@@ -16,9 +16,7 @@ Refine provides a data provider for [Airtable](https://airtable.com/), a spreads
 
 ## Installation
 
-```bash
-npm i @refinedev/airtable
-```
+<InstallPackagesCommand args="@refinedev/airtable"/>
 
 ## Usage
 

--- a/documentation/docs/packages/data-providers/appwrite/index.md
+++ b/documentation/docs/packages/data-providers/appwrite/index.md
@@ -282,9 +282,7 @@ Refine provides a data provider for [Appwrite](https://appwrite.io/), a backend 
 
 ## Installation
 
-```bash
-npm i @refinedev/appwrite
-```
+<InstallPackagesCommand args="@refinedev/appwrite"/>
 
 ## Usage
 

--- a/documentation/docs/packages/data-providers/graphql/index.md
+++ b/documentation/docs/packages/data-providers/graphql/index.md
@@ -26,9 +26,7 @@ Refine provides a data provider for GraphQL APIs that has all the features of Re
 
 ## Installation
 
-```bash
-npm i @refinedev/graphql
-```
+<InstallPackagesCommand args="@refinedev/graphql"/>
 
 ## Usage
 

--- a/documentation/docs/packages/data-providers/hasura/index.md
+++ b/documentation/docs/packages/data-providers/hasura/index.md
@@ -17,9 +17,7 @@ Refine provides a data provider for APIs powered with [Hasura](https://hasura.io
 
 ## Installation
 
-```bash
-npm i @refinedev/hasura
-```
+<InstallPackagesCommand args="@refinedev/hasura"/>
 
 ## Usage
 

--- a/documentation/docs/packages/data-providers/nestjsx-crud/index.md
+++ b/documentation/docs/packages/data-providers/nestjsx-crud/index.md
@@ -15,9 +15,7 @@ Refine provides a data provider for APIs powered with [Nest.js CRUD](https://git
 
 ## Installation
 
-```bash
-npm i @refinedev/nestjsx-crud
-```
+<InstallPackagesCommand args="@refinedev/nestjsx-crud"/>
 
 ## Usage
 

--- a/documentation/docs/packages/data-providers/simple-rest/index.md
+++ b/documentation/docs/packages/data-providers/simple-rest/index.md
@@ -10,9 +10,7 @@ You can use this data provider to quickly get started with Refine and then custo
 
 ## Installation
 
-```bash
-npm i @refinedev/simple-rest
-```
+<InstallPackagesCommand args="@refinedev/simple-rest"/>
 
 ## Usage
 

--- a/documentation/docs/packages/data-providers/strapi-graphql/index.md
+++ b/documentation/docs/packages/data-providers/strapi-graphql/index.md
@@ -26,9 +26,7 @@ Refine provides a data provider for Strapi's GraphQL APIs that works similar to 
 
 ## Installation
 
-```bash
-npm i @refinedev/strapi-graphql
-```
+<InstallPackagesCommand args="@refinedev/strapi-graphql"/>
 
 ## Usage
 

--- a/documentation/docs/packages/data-providers/strapi-v4/index.md
+++ b/documentation/docs/packages/data-providers/strapi-v4/index.md
@@ -76,9 +76,7 @@ However, we can use [normalizeData](https://github.com/refinedev/refine/blob/27a
 
 ## Setup
 
-```bash
-npm i @refinedev/strapi-v4
-```
+<InstallPackagesCommand args="@refinedev/strapi-v4"/>
 
 :::caution
 

--- a/documentation/docs/packages/inferencer/index.md
+++ b/documentation/docs/packages/inferencer/index.md
@@ -8,27 +8,7 @@ The package exports components for **List**, **Show**, **Create** and **Edit** v
 
 ## Installation
 
-<Tabs
-defaultValue="npm"
-values={[
-{label: 'use npm', value: 'npm'},
-{label: 'use yarn', value: 'yarn'}
-]}>
-<TabItem value="npm">
-
-```bash
-npm i @refinedev/inferencer
-```
-
-  </TabItem>
-    <TabItem value="yarn">
-
-```bash
-yarn add @refinedev/inferencer
-```
-
-  </TabItem>
-</Tabs>
+<InstallPackagesCommand args="@refinedev/inferencer"/>
 
 ## Available UI Inferencers
 

--- a/documentation/docs/packages/react-hook-form/introduction/index.md
+++ b/documentation/docs/packages/react-hook-form/introduction/index.md
@@ -16,39 +16,7 @@ This package exports following hooks to manage your forms:
 
 Install the [`@refinedev/react-hook-form`][refine-react-hook-form] library.
 
-<Tabs
-defaultValue="npm"
-values={[
-{label: 'npm', value: 'npm'},
-{label: 'yarn', value: 'yarn'},
-{label: 'pnpm', value: 'pnpm'}
-]}>
-
-<TabItem value="npm">
-
-```bash
-npm i @refinedev/react-hook-form
-```
-
-</TabItem>
-
-<TabItem value="yarn">
-
-```bash
-yarn add @refinedev/react-hook-form
-```
-
-</TabItem>
-
-<TabItem value="pnpm">
-
-```bash
-pnpm add @refinedev/react-hook-form
-```
-
-</TabItem>
-
-</Tabs>
+<InstallPackagesCommand args="@refinedev/react-hook-form"/>
 
 ## Usage
 

--- a/documentation/docs/packages/react-hook-form/use-form/index.md
+++ b/documentation/docs/packages/react-hook-form/use-form/index.md
@@ -178,9 +178,7 @@ const PostCreate: React.FC = () => {
 
 Install the [`@refinedev/react-hook-form`][refine-react-hook-form] library.
 
-```bash
-npm i @refinedev/react-hook-form
-```
+<InstallPackagesCommand args="@refinedev/react-hook-form"/>
 
 ## Usage
 

--- a/documentation/docs/packages/tanstack-table/introduction/index.md
+++ b/documentation/docs/packages/tanstack-table/introduction/index.md
@@ -15,39 +15,7 @@ Refine provides an integration package for [TanStack Table][tanstack-table] libr
 
 Install the [`@refinedev/react-table`][refine-react-table] library.
 
-<Tabs
-defaultValue="npm"
-values={[
-{label: 'npm', value: 'npm'},
-{label: 'yarn', value: 'yarn'},
-{label: 'pnpm', value: 'pnpm'}
-]}>
-
-<TabItem value="npm">
-
-```bash
-npm i @refinedev/react-table
-```
-
-</TabItem>
-
-<TabItem value="yarn">
-
-```bash
-yarn add @refinedev/react-table
-```
-
-</TabItem>
-
-<TabItem value="pnpm">
-
-```bash
-pnpm add @refinedev/react-table
-```
-
-</TabItem>
-
-</Tabs>
+<InstallPackagesCommand args="@refinedev/react-table"/>
 
 ## Usage
 

--- a/documentation/docs/packages/tanstack-table/use-table/index.md
+++ b/documentation/docs/packages/tanstack-table/use-table/index.md
@@ -20,39 +20,7 @@ All of [TanStack Table's][tanstack-table] features are supported and you can use
 
 Install the [`@refinedev/react-table`][refine-react-table] library.
 
-<Tabs
-defaultValue="npm"
-values={[
-{label: 'npm', value: 'npm'},
-{label: 'yarn', value: 'yarn'},
-{label: 'pnpm', value: 'pnpm'}
-]}>
-
-<TabItem value="npm">
-
-```bash
-npm i @refinedev/react-table
-```
-
-</TabItem>
-
-<TabItem value="yarn">
-
-```bash
-yarn add @refinedev/react-table
-```
-
-</TabItem>
-
-<TabItem value="pnpm">
-
-```bash
-pnpm add @refinedev/react-table
-```
-
-</TabItem>
-
-</Tabs>
+<InstallPackagesCommand args="@refinedev/react-table"/>
 
 ## Usage
 

--- a/documentation/docs/router-integrations/next-js/index.md
+++ b/documentation/docs/router-integrations/next-js/index.md
@@ -4,15 +4,11 @@ title: Next.js
 
 Refine provides router bindings and utilities for [Next.js](https://nextjs.org/). This package will provide easy integration between Refine and **Next.js** for both existing projects and new projects without giving up the benefits of **Next.js**.
 
-```bash
-npm i @refinedev/nextjs-router
-```
+<InstallPackagesCommand args="@refinedev/nextjs-router"/>
 
 We recommend using `create refine-app` to initialize your Refine projects. It configures the project according to your needs including SSR with Next.js!
 
-```sh
-npm create refine-app@latest -- -o refine-nextjs my-refine-nextjs-app
-```
+<CreateRefineAppCommand args="-o refine-nextjs my-refine-nextjs-app" />
 
 [Refer to the Router Provider documentation for detailed information. &#8594][routerprovider]
 
@@ -644,9 +640,7 @@ For page level authentication, server-side approach is recommended.
 
 First, let's install the `nookies` packages in our project.
 
-```sh
-npm i nookies
-```
+<InstallPackagesCommand args="@refinedev/nookies"/>
 
 We will set/destroy cookies in the `login`, `logout` and `check` functions of our `AuthProvider`.
 

--- a/documentation/docs/router-integrations/react-router/index.md
+++ b/documentation/docs/router-integrations/react-router/index.md
@@ -4,15 +4,11 @@ title: React Router v6
 
 Refine provides router bindings and utilities for [React Router v6](https://reactrouter.com/). It is built on top of the `react-router-dom` package. This package will provide easy integration between Refine and **react-router-dom** for both existing projects and new projects.
 
-```bash
-npm i @refinedev/react-router-v6 react-router-dom
-```
+<InstallPackagesCommand args="@refinedev/react-router-v6 react-router-dom"/>
 
 We recommend using `create refine-app` to initialize your Refine projects. It gives you a good boilerplate to start with using React Router v6.
 
-```sh
-npm create refine-app@latest -- -p refine-react my-refine-app
-```
+<CreateRefineAppCommand args="-p refine-react my-refine-app" />
 
 [Refer to the Router Provider documentation for detailed information. &#8594][routerprovider]
 

--- a/documentation/docs/router-integrations/remix/index.md
+++ b/documentation/docs/router-integrations/remix/index.md
@@ -4,15 +4,11 @@ title: Remix
 
 Refine provides router bindings and utilities for [Remix](https://remix.run). This package will provide easy integration between Refine and **Remix** for both existing projects and new projects without giving up the benefits of **Remix**.
 
-```bash
-npm i @refinedev/remix-router
-```
+<InstallPackagesCommand args="@refinedev/remix-router"/>
 
 We recommend using `create refine-app` to initialize your Refine projects. It configures the project according to your needs including SSR with Remix!
 
-```sh
-npm create refine-app@latest -- -o refine-remix my-refine-remix-app
-```
+<CreateRefineAppCommand args="-o refine-remix my-refine-remix-app" />
 
 [Refer to the Router Provider documentation for detailed information. &#8594][routerprovider]
 
@@ -601,12 +597,9 @@ export const loader: LoaderFunction = async ({ request }) => {
 
 First, let's install the `js-cookie` and `cookie` packages in our project.
 
-```sh
-npm i js-cookie cookie
+<InstallPackagesCommand args="js-cookie cookie"/>
 
-# typescript types
-npm i -D @types/js-cookie
-```
+<InstallPackagesCommand args="-D @types/js-cookie"/>
 
 We will set/destroy cookies in the `login`, `logout` and `check` functions of our `AuthProvider`.
 

--- a/documentation/docs/tutorial/1-getting-started/antd/2-create-project.md
+++ b/documentation/docs/tutorial/1-getting-started/antd/2-create-project.md
@@ -15,37 +15,7 @@ The easiest way to create a new project is using the **Refine CLI**. This tool w
 
 1. Launch your terminal and type the following command using your preferred package manager:
 
-   <Tabs
-   defaultValue="npm"
-   values={[ {label: 'npm', value: 'npm'}, {label: 'pnpm', value: 'pnpm'}, {label: 'yarn', value: 'yarn'} ]}>
-
-   <TabItem value="npm">
-
-   ```bash
-   npm create refine-app@latest -- -o refine-antd tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="pnpm">
-
-   ```bash
-   pnpm create refine-app@latest -- -o refine-antd tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="yarn">
-
-   ```bash
-   yarn create refine-app -- -o refine-antd tutorial
-   ```
-
-   > Only supports yarn@1 version.
-
-   </TabItem>
-
-   </Tabs>
+   <CreateRefineAppCommand args="-o refine-antd tutorial" />
 
 2. Confirm `y` to installation of `create-refine-app`
 

--- a/documentation/docs/tutorial/1-getting-started/chakra-ui/2-create-project.md
+++ b/documentation/docs/tutorial/1-getting-started/chakra-ui/2-create-project.md
@@ -15,37 +15,7 @@ The easiest way to create a new project is using the **Refine CLI**. This tool w
 
 1. Launch your terminal and type the following command using your preferred package manager:
 
-   <Tabs
-   defaultValue="npm"
-   values={[ {label: 'npm', value: 'npm'}, {label: 'pnpm', value: 'pnpm'}, {label: 'yarn', value: 'yarn'} ]}>
-
-   <TabItem value="npm">
-
-   ```bash
-   npm create refine-app@latest -- -o refine-chakra-ui tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="pnpm">
-
-   ```bash
-   pnpm create refine-app@latest -- -o refine-chakra-ui tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="yarn">
-
-   ```bash
-   yarn create refine-app -- -o refine-chakra-ui tutorial
-   ```
-
-   > Only supports yarn@1 version.
-
-   </TabItem>
-
-   </Tabs>
+<CreateRefineAppCommand args="-o refine-chakra-ui tutorial" />
 
 2. Confirm `y` to installation of `create-refine-app`
 

--- a/documentation/docs/tutorial/1-getting-started/headless/2-create-project.md
+++ b/documentation/docs/tutorial/1-getting-started/headless/2-create-project.md
@@ -15,37 +15,7 @@ The easiest way to create a new project is using the **Refine CLI**. This tool w
 
 1. Launch your terminal and type the following command using your preferred package manager:
 
-   <Tabs
-   defaultValue="npm"
-   values={[ {label: 'npm', value: 'npm'}, {label: 'pnpm', value: 'pnpm'}, {label: 'yarn', value: 'yarn'} ]}>
-
-   <TabItem value="npm">
-
-   ```bash
-   npm create refine-app@latest -- -o refine-headless tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="pnpm">
-
-   ```bash
-   pnpm create refine-app@latest -- -o refine-headless tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="yarn">
-
-   ```bash
-   yarn create refine-app -- -o refine-headless tutorial
-   ```
-
-   > Only supports yarn@1 version.
-
-   </TabItem>
-
-   </Tabs>
+<CreateRefineAppCommand args="-o refine-headless tutorial" />
 
 2. Confirm `y` to installation of `create-refine-app`
 

--- a/documentation/docs/tutorial/1-getting-started/headless/3-generate-crud-pages.md
+++ b/documentation/docs/tutorial/1-getting-started/headless/3-generate-crud-pages.md
@@ -38,35 +38,7 @@ The `@refinedev/inferencer` package provides the `<HeadlessInferencer/>` compone
 
 Before we start using Inferencer, we need to add the `@refinedev/react-hook-form` and `@refinedev/react-table` packages to our project. Since these packages are used by Inferencer to generate forms and tables, they need to be installed in our project.
 
-<Tabs
-defaultValue="npm"
-values={[ {label: 'npm', value: 'npm'}, {label: 'pnpm', value: 'pnpm'}, {label: 'yarn', value: 'yarn'} ]}>
-
-<TabItem value="npm">
-
-```bash
-npm i @refinedev/react-table @refinedev/react-hook-form
-```
-
-</TabItem>
-
-<TabItem value="pnpm">
-
-```bash
-pnpm i @refinedev/react-table @refinedev/react-hook-form
-```
-
-</TabItem>
-
-<TabItem value="yarn">
-
-```bash
-yarn add @refinedev/react-table @refinedev/react-hook-form
-```
-
-</TabItem>
-
-</Tabs>
+<InstallPackagesCommand args="@refinedev/react-table @refinedev/react-hook-form"/>
 
 Then, we need to add the `<HeadlessInferencer/>` component which is used by passing appropriate values to the `resources` prop of the `<Refine/>` component in `App.tsx` as shown below:
 

--- a/documentation/docs/tutorial/1-getting-started/mantine/2-create-project.md
+++ b/documentation/docs/tutorial/1-getting-started/mantine/2-create-project.md
@@ -15,37 +15,7 @@ The easiest way to create a new project is using the **Refine CLI**. This tool w
 
 1. Launch your terminal and type the following command using your preferred package manager:
 
-   <Tabs
-   defaultValue="npm"
-   values={[ {label: 'npm', value: 'npm'}, {label: 'pnpm', value: 'pnpm'}, {label: 'yarn', value: 'yarn'} ]}>
-
-   <TabItem value="npm">
-
-   ```bash
-   npm create refine-app@latest -- -o refine-mantine tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="pnpm">
-
-   ```bash
-   pnpm create refine-app@latest -- -o refine-mantine tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="yarn">
-
-   ```bash
-   yarn create refine-app -- -o refine-mantine tutorial
-   ```
-
-   > Only supports yarn@1 version.
-
-   </TabItem>
-
-   </Tabs>
+<CreateRefineAppCommand args="-o refine-mantine tutorial" />
 
 2. Confirm `y` to installation of `create-refine-app`
 

--- a/documentation/docs/tutorial/1-getting-started/mui/2-create-project.md
+++ b/documentation/docs/tutorial/1-getting-started/mui/2-create-project.md
@@ -15,37 +15,7 @@ The easiest way to create a new project is using the **Refine CLI**. This tool w
 
 1. Launch your terminal and type the following command using your preferred package manager:
 
-   <Tabs
-   defaultValue="npm"
-   values={[ {label: 'npm', value: 'npm'}, {label: 'pnpm', value: 'pnpm'}, {label: 'yarn', value: 'yarn'} ]}>
-
-   <TabItem value="npm">
-
-   ```bash
-   npm create refine-app@latest -- -o refine-mui tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="pnpm">
-
-   ```bash
-   pnpm create refine-app@latest -- -o refine-mui tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="yarn">
-
-   ```bash
-   yarn create refine-app -- -o refine-mui tutorial
-   ```
-
-   > Only supports yarn@1 version.
-
-   </TabItem>
-
-   </Tabs>
+<CreateRefineAppCommand args="-o refine-mui tutorial" />
 
 2. Confirm `y` to installation of `create-refine-app`
 

--- a/documentation/docs/tutorial/2-understanding-dataprovider/2-create-dataprovider.md
+++ b/documentation/docs/tutorial/2-understanding-dataprovider/2-create-dataprovider.md
@@ -22,15 +22,11 @@ We will begin developing our data provider by creating a file and adding additio
 
 To get started, install `axios` in your project.
 
-```bash
-npm install axios
-```
+<InstallPackagesCommand args="axios"/>
 
 Using the `stringify` library will allow us to convert the query parameters into a string format. This can be useful when we need to pass query parameters as part of an HTTP request.
 
-```bash
-npm install query-string@7
-```
+<InstallPackagesCommand args="query-string@7"/>
 
 After that, create the following file.
 

--- a/documentation/docs/ui-integrations/ant-design/introduction/index.md
+++ b/documentation/docs/ui-integrations/ant-design/introduction/index.md
@@ -12,9 +12,7 @@ import Example from "./previews/example.tsx";
 
 Installing the package is as simple as just by running the following command without any additional configuration:
 
-```bash
-npm install @refinedev/antd antd
-```
+<InstallPackagesCommand args="@refinedev/antd antd"/>
 
 ## Usage
 

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/index.md
@@ -12,9 +12,7 @@ import Example from "./previews/example.tsx";
 
 Installing the package is as simple as just by running the following command without any additional configuration:
 
-```bash
-npm install @refinedev/chakra-ui @chakra-ui/react @refinedev/react-table @refinedev/react-hook-form @tanstack/react-table react-hook-form @tabler/icons@1
-```
+<InstallPackagesCommand args="@refinedev/chakra-ui @chakra-ui/react @refinedev/react-table @refinedev/react-hook-form @tanstack/react-table react-hook-form @tabler/icons@1"/>
 
 ## Usage
 

--- a/documentation/docs/ui-integrations/mantine/introduction/index.md
+++ b/documentation/docs/ui-integrations/mantine/introduction/index.md
@@ -12,9 +12,7 @@ import Example from "./previews/example.tsx";
 
 Installing the package is as simple as just by running the following command without any additional configuration:
 
-```bash
-npm install @refinedev/mantine @refinedev/react-table @mantine/core@5 @mantine/hooks@5 @mantine/form@5 @mantine/notifications@5 @emotion/react@11 @tabler/icons@1 @tanstack/react-table
-```
+<InstallPackagesCommand args="@refinedev/mantine @refinedev/react-table @mantine/core@5 @mantine/hooks@5 @mantine/form@5 @mantine/notifications@5 @emotion/react@11 @tabler/icons@1 @tanstack/react-table"/>
 
 :::info Version Support
 Refine's Mantine integration currently uses Mantine v5.

--- a/documentation/docs/ui-integrations/material-ui/introduction/index.md
+++ b/documentation/docs/ui-integrations/material-ui/introduction/index.md
@@ -12,9 +12,7 @@ import Example from "./previews/example.tsx";
 
 Installing the package is as simple as just by running the following command without any additional configuration:
 
-```bash
-npm install @refinedev/mui @refinedev/react-hook-form @emotion/react @emotion/styled @mui/lab @mui/material @mui/x-data-grid react-hook-form
-```
+<InstallPackagesCommand args="@refinedev/mui @refinedev/react-hook-form @emotion/react @emotion/styled @mui/lab @mui/material @mui/x-data-grid react-hook-form"/>
 
 ## Usage
 

--- a/documentation/src/partials/npm-scripts/create-refine-app-command.tsx
+++ b/documentation/src/partials/npm-scripts/create-refine-app-command.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+import Tabs from "@site/src/refine-theme/common-tabs";
+import TabItem from "@docusaurus/theme-classic/lib/theme/TabItem";
+import { CodeBlock } from "@site/src/theme/CodeBlock/base";
+import ReactMarkdown from "react-markdown";
+
+export const CreateRefineAppCommand = ({ args }: { args?: string }) => {
+    const argsString = args ? `-- ${args}` : "";
+
+    const commands = {
+        npm: `npm create refine-app@latest ${argsString}`,
+        pnpm: `pnpm create refine-app@latest ${argsString}`,
+        yarn: `yarn create refine-app@latest ${argsString}`,
+    };
+
+    return (
+        <Tabs>
+            <TabItem value="npm" label="npm" default>
+                <CodeBlock className="language-bash">{commands.npm}</CodeBlock>
+            </TabItem>
+            <TabItem value="pnpm" label="pnpm">
+                <CodeBlock className="language-bash">{commands.pnpm}</CodeBlock>
+            </TabItem>
+            <TabItem value="yarn" label="yarn">
+                <CodeBlock className="language-bash">{commands.yarn}</CodeBlock>
+                <ReactMarkdown>
+                    {`> Only supports yarn@1 version.`}
+                </ReactMarkdown>
+            </TabItem>
+        </Tabs>
+    );
+};

--- a/documentation/src/partials/npm-scripts/install-packages-commands.tsx
+++ b/documentation/src/partials/npm-scripts/install-packages-commands.tsx
@@ -1,0 +1,39 @@
+import React, { FC, PropsWithChildren } from "react";
+
+import Tabs from "@site/src/refine-theme/common-tabs";
+import { CodeBlock } from "@site/src/theme/CodeBlock/base";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import TabItem from "@theme/TabItem";
+
+type Props = {
+    args?: string;
+};
+
+export const InstallPackagesCommand: FC<PropsWithChildren<Props>> = ({
+    args,
+    children,
+}) => {
+    const commands = {
+        npm: `npm i ${args}`,
+        pnpm: `pnpm add ${args}`,
+        yarn: `yarn add ${args}`,
+    };
+
+    return (
+        <Tabs>
+            <TabItem value="npm" label="npm" default>
+                <CodeBlock className="language-bash">{commands.npm}</CodeBlock>
+                {children}
+            </TabItem>
+            <TabItem value="pnpm" label="pnpm">
+                <CodeBlock className="language-bash">{commands.pnpm}</CodeBlock>
+                {children}
+            </TabItem>
+            <TabItem value="yarn" label="yarn">
+                <CodeBlock className="language-bash">{commands.yarn}</CodeBlock>
+                {children}
+            </TabItem>
+        </Tabs>
+    );
+};

--- a/documentation/src/theme/MDXComponents/index.js
+++ b/documentation/src/theme/MDXComponents/index.js
@@ -24,6 +24,8 @@ import CommonTabItem from "@site/src/refine-theme/common-tab-item";
 import CommonTabs from "@site/src/refine-theme/common-tabs";
 import { Image } from "@site/src/components/image";
 import { Table } from "@site/src/refine-theme/common-table";
+import { CreateRefineAppCommand } from "@site/src/partials/npm-scripts/create-refine-app-command.tsx";
+import { InstallPackagesCommand } from "@site/src/partials/npm-scripts/install-packages-commands";
 
 export default {
     ...MDXComponents,
@@ -51,4 +53,6 @@ export default {
     GlobalConfigBadge,
     Image,
     table: Table,
+    CreateRefineAppCommand: CreateRefineAppCommand,
+    InstallPackagesCommand: InstallPackagesCommand,
 };

--- a/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/access-control.md
+++ b/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/access-control.md
@@ -20,9 +20,7 @@ We will be using **[Casbin](https://casbin.org/)** in this guide for users with 
 
 We need to install Casbin.
 
-```bash
-npm install casbin
-```
+<InstallPackagesCommand args="casbin"/>
 
 :::caution
 To make this example more visual, we used the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/antd) package. If you are using Refine headless, you need to provide the components, hooks, or helpers imported from the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/antd) package.

--- a/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/auth/auth0.md
+++ b/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/auth/auth0.md
@@ -11,9 +11,7 @@ We will show you how to use Auth0 with refine
 
 Run the following command within your project directory to install the Auth0 React SDK:
 
-```
-npm install @auth0/auth0-react
-```
+<InstallPackagesCommand args="@auth0/auth0-react"/>
 
 #### Configure the Auth0Provider component
 
@@ -31,17 +29,17 @@ import App from "./App";
 const container = document.getElementById("root");
 const root = createRoot(container!);
 root.render(
-    <React.StrictMode>
-        // highlight-start
-        <Auth0Provider
-            domain="YOUR_DOMAIN"
-            clientId="YOUR_CLIENT_ID"
-            redirectUri={window.location.origin}
-        >
-            <App />
-        </Auth0Provider>
-        // highlight-end
-    </React.StrictMode>,
+  <React.StrictMode>
+    // highlight-start
+    <Auth0Provider
+      domain="YOUR_DOMAIN"
+      clientId="YOUR_CLIENT_ID"
+      redirectUri={window.location.origin}
+    >
+      <App />
+    </Auth0Provider>
+    // highlight-end
+  </React.StrictMode>,
 );
 ```
 
@@ -58,34 +56,34 @@ import { AntdLayout, Button } from "@pankod/refine-antd";
 import { useAuth0 } from "@auth0/auth0-react";
 
 export const Login: React.FC = () => {
-    // highlight-next-line
-    const { loginWithRedirect } = useAuth0();
+  // highlight-next-line
+  const { loginWithRedirect } = useAuth0();
 
-    return (
-        <AntdLayout
-            style={{
-                background: `radial-gradient(50% 50% at 50% 50%, #63386A 0%, #310438 100%)`,
-                backgroundSize: "cover",
-            }}
-        >
-            <div style={{ height: "100vh", display: "flex" }}>
-                <div style={{ maxWidth: "200px", margin: "auto" }}>
-                    <div style={{ marginBottom: "28px" }}>
-                        <img src="./refine.svg" alt="Refine" />
-                    </div>
-                    <Button
-                        type="primary"
-                        size="large"
-                        block
-                        //highlight-next-line
-                        onClick={() => loginWithRedirect()}
-                    >
-                        Sign in
-                    </Button>
-                </div>
-            </div>
-        </AntdLayout>
-    );
+  return (
+    <AntdLayout
+      style={{
+        background: `radial-gradient(50% 50% at 50% 50%, #63386A 0%, #310438 100%)`,
+        backgroundSize: "cover",
+      }}
+    >
+      <div style={{ height: "100vh", display: "flex" }}>
+        <div style={{ maxWidth: "200px", margin: "auto" }}>
+          <div style={{ marginBottom: "28px" }}>
+            <img src="./refine.svg" alt="Refine" />
+          </div>
+          <Button
+            type="primary"
+            size="large"
+            block
+            //highlight-next-line
+            onClick={() => loginWithRedirect()}
+          >
+            Sign in
+          </Button>
+        </div>
+      </div>
+    </AntdLayout>
+  );
 };
 ```
 
@@ -101,10 +99,10 @@ In refine, authentication and authorization processes are performed with the aut
 ```tsx title="App.tsx"
 import { Refine, AuthProvider } from "@pankod/refine-core";
 import {
-    Layout,
-    ReadyPage,
-    notificationProvider,
-    ErrorComponent,
+  Layout,
+  ReadyPage,
+  notificationProvider,
+  ErrorComponent,
 } from "@pankod/refine-antd";
 import dataProvider from "@pankod/refine-simple-rest";
 import routerProvider from "@pankod/refine-react-router-v6";
@@ -119,65 +117,65 @@ import axios from "axios";
 const API_URL = "https://api.fake-rest.refine.dev";
 
 const App = () => {
-    const { isLoading, isAuthenticated, user, logout, getIdTokenClaims } =
-        useAuth0();
+  const { isLoading, isAuthenticated, user, logout, getIdTokenClaims } =
+    useAuth0();
 
-    if (isLoading) {
-        return <span>loading...</span>;
+  if (isLoading) {
+    return <span>loading...</span>;
+  }
+
+  const authProvider: AuthProvider = {
+    login: () => {
+      return Promise.resolve();
+    },
+    logout: () => {
+      logout({ returnTo: window.location.origin });
+      return Promise.resolve("/");
+    },
+    checkError: () => Promise.resolve(),
+    checkAuth: () => {
+      if (isAuthenticated) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject();
+    },
+    getPermissions: () => Promise.resolve(),
+    getUserIdentity: () => {
+      if (user) {
+        return Promise.resolve({
+          ...user,
+          avatar: user.picture,
+        });
+      }
+    },
+  };
+
+  getIdTokenClaims().then((token) => {
+    if (token) {
+      axios.defaults.headers.common = {
+        Authorization: `Bearer ${token.__raw}`,
+      };
     }
+  });
 
-    const authProvider: AuthProvider = {
-        login: () => {
-            return Promise.resolve();
+  return (
+    <Refine
+      LoginPage={Login}
+      routerProvider={routerProvider}
+      authProvider={authProvider}
+      dataProvider={dataProvider(API_URL, axios)}
+      Layout={Layout}
+      ReadyPage={ReadyPage}
+      notificationProvider={notificationProvider}
+      catchAll={<ErrorComponent />}
+      resources={[
+        {
+          name: "posts",
         },
-        logout: () => {
-            logout({ returnTo: window.location.origin });
-            return Promise.resolve("/");
-        },
-        checkError: () => Promise.resolve(),
-        checkAuth: () => {
-            if (isAuthenticated) {
-                return Promise.resolve();
-            }
-
-            return Promise.reject();
-        },
-        getPermissions: () => Promise.resolve(),
-        getUserIdentity: () => {
-            if (user) {
-                return Promise.resolve({
-                    ...user,
-                    avatar: user.picture,
-                });
-            }
-        },
-    };
-
-    getIdTokenClaims().then((token) => {
-        if (token) {
-            axios.defaults.headers.common = {
-                Authorization: `Bearer ${token.__raw}`,
-            };
-        }
-    });
-
-    return (
-        <Refine
-            LoginPage={Login}
-            routerProvider={routerProvider}
-            authProvider={authProvider}
-            dataProvider={dataProvider(API_URL, axios)}
-            Layout={Layout}
-            ReadyPage={ReadyPage}
-            notificationProvider={notificationProvider}
-            catchAll={<ErrorComponent />}
-            resources={[
-                {
-                    name: "posts",
-                },
-            ]}
-        />
-    );
+      ]}
+    />
+  );
 };
 
 export default App;

--- a/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/auth/azure-ad.md
+++ b/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/auth/azure-ad.md
@@ -19,9 +19,7 @@ We will be using the javascript version of msal library and a helper for react. 
 
 To install the required dependencies, run the following command:
 
-```bash
-npm install @azure/msal-browser @azure/msal-react
-```
+<InstallPackagesCommand args="@azure/msal-browser @azure/msal-react"/>
 
 Detailed documentation for using msal with react can be found here: [docs](https://learn.microsoft.com/en-us/azure/active-directory/develop/single-page-app-quickstart?pivots=devlang-react)
 

--- a/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/data-provider/appwrite.md
+++ b/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/data-provider/appwrite.md
@@ -19,9 +19,7 @@ This guide has been prepared assuming you know the basics of **refine**. If you 
 
 ## Setup
 
-```bash
-npm install @pankod/refine-appwrite
-```
+<InstallPackagesCommand args="@pankod/refine-appwrite"/>
 
 :::caution
 To make this example more visual, we used the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/refine-antd) package. If you are using Refine headless, you need to provide the components, hooks or helpers imported from the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/refine-antd) package.

--- a/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/data-provider/graphql.md
+++ b/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/data-provider/graphql.md
@@ -35,9 +35,7 @@ Hooks and components that support `MetaDataQuery`:
 
 ## Setup
 
-```bash
-npm i @pankod/refine-core @pankod/refine-antd @pankod/refine-strapi-graphql
-```
+<InstallPackagesCommand args="@pankod/refine-core @pankod/refine-antd @pankod/refine-strapi-graphql"/>
 
 :::caution
 To make this example more visual, we used the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/refine-antd) package. If you are using Refine headless, you need to provide the components, hooks or helpers imported from the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/refine-antd) package.

--- a/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/data-provider/strapi-v4.md
+++ b/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/data-provider/strapi-v4.md
@@ -64,9 +64,7 @@ However, we can use [normalizeData](https://github.com/refinedev/refine/blob/27a
 
 ## Setup
 
-```bash
-npm i @pankod/refine-strapi-v4
-```
+<InstallPackagesCommand args="@pankod/refine-strapi-v4"/>
 
 :::caution
 To make this example more visual, we used the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/refine-antd) package. If you are using Refine headless, you need to provide the components, hooks, or helpers imported from the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/refine-antd) package.

--- a/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/multi-tenancy/appwrite.md
+++ b/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/multi-tenancy/appwrite.md
@@ -19,9 +19,7 @@ This guide has been prepared to assume you know the basics of **refine**. If you
 
 ## Setup
 
-```bash
-npm install @pankod/refine-appwrite
-```
+<InstallPackagesCommand args="@pankod/refine-appwrite"/>
 
 :::caution
 To make this example more visual, we used the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/refine-antd) package. If you are using Refine headless, you need to provide the components, hooks, or helpers imported from the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/refine-antd) package.

--- a/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/multi-tenancy/strapi.md
+++ b/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/multi-tenancy/strapi.md
@@ -19,9 +19,7 @@ This guide has been prepared to assume you know the basics of **refine**. If you
 
 ## Setup
 
-```bash
-npm i @pankod/refine-strapi-v4
-```
+<InstallPackagesCommand args="@pankod/refine-strapi-v4"/>
 
 :::caution
 To make this example more visual, we used the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/refine-antd) package. If you are using Refine headless, you need to provide the components, hooks, or helpers imported from the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/refine-antd) package.
@@ -106,9 +104,9 @@ If you need the population for the `/me` request, you can use it like this in yo
 const strapiAuthHelper = AuthHelper(API_URL + "/api");
 
 strapiAuthHelper.me("token", {
-    metaData: {
-        populate: ["role"],
-    },
+  metaData: {
+    populate: ["role"],
+  },
 });
 ```
 
@@ -119,10 +117,10 @@ strapiAuthHelper.me("token", {
 ```tsx title="App.tsx"
 import { Refine } from "@pankod/refine-core";
 import {
-    Layout,
-    ReadyPage,
-    notificationProvider,
-    ErrorComponent,
+  Layout,
+  ReadyPage,
+  notificationProvider,
+  ErrorComponent,
 } from "@pankod/refine-antd";
 import { DataProvider } from "@pankod/refine-strapi-v4";
 import routerProvider from "@pankod/refine-react-router-v6";
@@ -135,19 +133,19 @@ import { authProvider, axiosInstance } from "./authProvider";
 const API_URL = "YOUR_API_URL";
 
 const App: React.FC = () => {
-    return (
-        <Refine
-            //highlight-start
-            authProvider={authProvider}
-            dataProvider={DataProvider(API_URL + "/api", axiosInstance)}
-            //highlight-end
-            routerProvider={routerProvider}
-            Layout={Layout}
-            ReadyPage={ReadyPage}
-            notificationProvider={notificationProvider}
-            catchAll={<ErrorComponent />}
-        />
-    );
+  return (
+    <Refine
+      //highlight-start
+      authProvider={authProvider}
+      dataProvider={DataProvider(API_URL + "/api", axiosInstance)}
+      //highlight-end
+      routerProvider={routerProvider}
+      Layout={Layout}
+      ReadyPage={ReadyPage}
+      notificationProvider={notificationProvider}
+      catchAll={<ErrorComponent />}
+    />
+  );
 };
 ```
 
@@ -161,32 +159,32 @@ We created three collections on Strapi as store, product, and order and added a 
 
 `Stores`
 
--   Title: Text
--   Relation with Products
--   Relation with Orders
+- Title: Text
+- Relation with Products
+- Relation with Orders
 
 <img src="https://refine.ams3.cdn.digitaloceanspaces.com/website/static/img/guides-and-concepts/multi-tenant/strapi/stores.png" alt="stores" />
 <br/>
 
 `Products`
 
--   Title: Text
--   Description: Text
--   Image: Media
--   Relation with Stores
--   Relation with Orders
+- Title: Text
+- Description: Text
+- Image: Media
+- Relation with Stores
+- Relation with Orders
 
 <img src="https://refine.ams3.cdn.digitaloceanspaces.com/website/static/img/guides-and-concepts/multi-tenant/strapi/products.png" alt="products" />
 <br/>
 
 `Orders`
 
--   Status: Text
--   Customer Name: Text
--   Customer Address: Text
--   Quantity: Number
--   Relation with Stores
--   Relation with Product
+- Status: Text
+- Customer Name: Text
+- Customer Address: Text
+- Quantity: Number
+- Relation with Stores
+- Relation with Product
 
 <img src="https://refine.ams3.cdn.digitaloceanspaces.com/website/static/img/guides-and-concepts/multi-tenant/strapi/orders.png" alt="orders" />
 <br/>
@@ -205,19 +203,19 @@ import { createContext, useState } from "react";
 export const StoreContext = createContext<any[]>([]);
 
 export const StoreProvider = (props: any) => {
-    const [store, setStore] = useState(1);
+  const [store, setStore] = useState(1);
 
-    return <StoreContext.Provider value={[store, setStore]} {...props} />;
+  return <StoreContext.Provider value={[store, setStore]} {...props} />;
 };
 ```
 
 ```tsx title="App.tsx"
 import { Refine } from "@pankod/refine-core";
 import {
-    Layout,
-    ReadyPage,
-    notificationProvider,
-    ErrorComponent,
+  Layout,
+  ReadyPage,
+  notificationProvider,
+  ErrorComponent,
 } from "@pankod/refine-antd";
 import { DataProvider } from "@pankod/refine-strapi-v4";
 import routerProvider from "@pankod/refine-react-router-v6";
@@ -231,21 +229,21 @@ import { authProvider, axiosInstance } from "./authProvider";
 const API_URL = "YOUR_API_URL";
 
 const App: React.FC = () => {
-    return (
-        //highlight-next-line
-        <StoreProvider>
-            <Refine
-                authProvider={authProvider}
-                dataProvider={DataProvider(API_URL + "/api", axiosInstance)}
-                routerProvider={routerProvider}
-                Layout={Layout}
-                ReadyPage={ReadyPage}
-                notificationProvider={notificationProvider}
-                catchAll={<ErrorComponent />}
-            />
-            //highlight-next-line
-        </StoreProvider>
-    );
+  return (
+    //highlight-next-line
+    <StoreProvider>
+      <Refine
+        authProvider={authProvider}
+        dataProvider={DataProvider(API_URL + "/api", axiosInstance)}
+        routerProvider={routerProvider}
+        Layout={Layout}
+        ReadyPage={ReadyPage}
+        notificationProvider={notificationProvider}
+        catchAll={<ErrorComponent />}
+      />
+      //highlight-next-line
+    </StoreProvider>
+  );
 };
 ```
 
@@ -261,36 +259,36 @@ import { StoreContext } from "context/store";
 import { IStore } from "interfaces";
 
 type SelectProps = {
-    onSelect: () => void;
+  onSelect: () => void;
 };
 
 export const StoreSelect: React.FC<SelectProps> = ({ onSelect }) => {
-    const [store, setStore] = useContext(StoreContext);
+  const [store, setStore] = useContext(StoreContext);
 
-    const { selectProps: storeSelectProps } = useSelect<IStore>({
-        resource: "stores",
-        optionLabel: "title",
-        optionValue: "id",
-    });
+  const { selectProps: storeSelectProps } = useSelect<IStore>({
+    resource: "stores",
+    optionLabel: "title",
+    optionValue: "id",
+  });
 
-    const handleChange = (selectedValue: string) => {
-        setStore(selectedValue);
-    };
+  const handleChange = (selectedValue: string) => {
+    setStore(selectedValue);
+  };
 
-    return (
-        <Select
-            defaultValue={store}
-            style={{ width: 130 }}
-            onChange={handleChange}
-            onSelect={onSelect}
-        >
-            {storeSelectProps.options?.map(({ value, label }) => (
-                <Select.Option key={value} value={value}>
-                    {label}
-                </Select.Option>
-            ))}
-        </Select>
-    );
+  return (
+    <Select
+      defaultValue={store}
+      style={{ width: 130 }}
+      onChange={handleChange}
+      onSelect={onSelect}
+    >
+      {storeSelectProps.options?.map(({ value, label }) => (
+        <Select.Option key={value} value={value}>
+          {label}
+        </Select.Option>
+      ))}
+    </Select>
+  );
 };
 ```
 
@@ -307,12 +305,12 @@ Let's define the select component in the **refine** Sider Menu. First, we need t
 ```tsx title="src/components/sider/CustomSider.tsx"
 import React, { useState } from "react";
 import {
-    useTitle,
-    useMenu,
-    useLogout,
-    CanAccess,
-    ITreeMenu,
-    useRouterContext,
+  useTitle,
+  useMenu,
+  useLogout,
+  CanAccess,
+  ITreeMenu,
+  useRouterContext,
 } from "@pankod/refine-core";
 import { AntdLayout, Menu, Grid, Icons } from "@pankod/refine-antd";
 
@@ -320,97 +318,89 @@ import { StoreSelect } from "components/select";
 import { antLayoutSider, antLayoutSiderMobile } from "./styles";
 
 export const CustomSider: React.FC = () => {
-    const [collapsed, setCollapsed] = useState<boolean>(false);
-    const { mutate: logout } = useLogout();
-    const { Link } = useRouterContext();
-    const Title = useTitle();
-    const { menuItems, selectedKey } = useMenu();
-    const breakpoint = Grid.useBreakpoint();
+  const [collapsed, setCollapsed] = useState<boolean>(false);
+  const { mutate: logout } = useLogout();
+  const { Link } = useRouterContext();
+  const Title = useTitle();
+  const { menuItems, selectedKey } = useMenu();
+  const breakpoint = Grid.useBreakpoint();
 
-    const isMobile =
-        typeof breakpoint.lg === "undefined" ? false : !breakpoint.lg;
+  const isMobile =
+    typeof breakpoint.lg === "undefined" ? false : !breakpoint.lg;
 
-    const renderTreeView = (tree: ITreeMenu[], selectedKey: string) => {
-        return tree.map((item: ITreeMenu) => {
-            const { icon, label, route, name, children, parentName } = item;
+  const renderTreeView = (tree: ITreeMenu[], selectedKey: string) => {
+    return tree.map((item: ITreeMenu) => {
+      const { icon, label, route, name, children, parentName } = item;
 
-            if (children.length > 0) {
-                return (
-                    <SubMenu
-                        key={route}
-                        icon={icon ?? <Icons.UnorderedListOutlined />}
-                        title={label}
-                    >
-                        {renderTreeView(children, selectedKey)}
-                    </SubMenu>
-                );
-            }
-            const isSelected = route === selectedKey;
-            const isRoute = !(
-                parentName !== undefined && children.length === 0
-            );
-            return (
-                <CanAccess
-                    key={route}
-                    resource={name.toLowerCase()}
-                    action="list"
-                >
-                    <Menu.Item
-                        key={route}
-                        style={{
-                            fontWeight: isSelected ? "bold" : "normal",
-                        }}
-                        icon={
-                            icon ?? (isRoute && <Icons.UnorderedListOutlined />)
-                        }
-                    >
-                        <Link to={route}>{label}</Link>
-                        {!collapsed && isSelected && (
-                            <div className="ant-menu-tree-arrow" />
-                        )}
-                    </Menu.Item>
-                </CanAccess>
-            );
-        });
-    };
+      if (children.length > 0) {
+        return (
+          <SubMenu
+            key={route}
+            icon={icon ?? <Icons.UnorderedListOutlined />}
+            title={label}
+          >
+            {renderTreeView(children, selectedKey)}
+          </SubMenu>
+        );
+      }
+      const isSelected = route === selectedKey;
+      const isRoute = !(parentName !== undefined && children.length === 0);
+      return (
+        <CanAccess key={route} resource={name.toLowerCase()} action="list">
+          <Menu.Item
+            key={route}
+            style={{
+              fontWeight: isSelected ? "bold" : "normal",
+            }}
+            icon={icon ?? (isRoute && <Icons.UnorderedListOutlined />)}
+          >
+            <Link to={route}>{label}</Link>
+            {!collapsed && isSelected && (
+              <div className="ant-menu-tree-arrow" />
+            )}
+          </Menu.Item>
+        </CanAccess>
+      );
+    });
+  };
 
-    return (
-        <AntdLayout.Sider
-            collapsible
-            collapsedWidth={isMobile ? 0 : 80}
-            collapsed={collapsed}
-            breakpoint="lg"
-            onCollapse={(collapsed: boolean): void => setCollapsed(collapsed)}
-            style={isMobile ? antLayoutSiderMobile : antLayoutSider}
+  return (
+    <AntdLayout.Sider
+      collapsible
+      collapsedWidth={isMobile ? 0 : 80}
+      collapsed={collapsed}
+      breakpoint="lg"
+      onCollapse={(collapsed: boolean): void => setCollapsed(collapsed)}
+      style={isMobile ? antLayoutSiderMobile : antLayoutSider}
+    >
+      {Title && <Title collapsed={collapsed} />}
+      <Menu
+        selectedKeys={[selectedKey]}
+        mode="inline"
+        onClick={() => {
+          if (!breakpoint.lg) {
+            setCollapsed(true);
+          }
+        }}
+      >
+        <Menu.Item key={route} icon={<Icons.AppstoreAddOutlined />}>
+          <StoreSelect
+            onSelect={() => {
+              setCollapsed(true);
+            }}
+          />
+        </Menu.Item>
+        {renderTreeView(menuItems, selectedKey)}
+        <Menu.Item
+          key="logout"
+          onClick={() => logout()}
+          icon={<Icons.LoginOutlined />}
         >
-            {Title && <Title collapsed={collapsed} />}
-            <Menu
-                selectedKeys={[selectedKey]}
-                mode="inline"
-                onClick={() => {
-                    if (!breakpoint.lg) {
-                        setCollapsed(true);
-                    }
-                }}
-            >
-                <Menu.Item key={route} icon={<Icons.AppstoreAddOutlined />}>
-                    <StoreSelect
-                        onSelect={() => {
-                            setCollapsed(true);
-                        }}
-                    />
-                </Menu.Item>
-                {renderTreeView(menuItems, selectedKey)}
-                <Menu.Item
-                    key="logout"
-                    onClick={() => logout()}
-                    icon={<Icons.LoginOutlined />}
-                >
-                    Logout
-                </Menu.Item>
-            </Menu>
-        </AntdLayout.Sider>
-    );
+          Logout
+        </Menu.Item>
+      </Menu>
+    </AntdLayout.Sider>
+  );
 };
 ```
 
@@ -432,9 +422,9 @@ We separate the products of different stores by using the `permanentFilter` with
 const [store] = useContext(StoreContext);
 //highlight-end
 const { listProps } = useSimpleList<IProduct>({
-    //highlight-start
-    permanentFilter: [{ field: "stores][id]", operator: "eq", value: store }],
-    //highlight-end
+  //highlight-start
+  permanentFilter: [{ field: "stores][id]", operator: "eq", value: store }],
+  //highlight-end
 });
 ```
 
@@ -446,12 +436,12 @@ const { listProps } = useSimpleList<IProduct>({
 import { useContext } from "react";
 import { IResourceComponentsProps, HttpError } from "@pankod/refine-core";
 import {
-    useSimpleList,
-    AntdList,
-    useModalForm,
-    useDrawerForm,
-    CreateButton,
-    List,
+  useSimpleList,
+  AntdList,
+  useModalForm,
+  useDrawerForm,
+  CreateButton,
+  List,
 } from "@pankod/refine-antd";
 
 import { IProduct } from "interfaces";
@@ -460,36 +450,34 @@ import { ProductItem } from "components/product";
 import { StoreContext } from "context/store";
 
 export const ProductList: React.FC<IResourceComponentsProps> = () => {
-    //highlight-start
-    const [store] = useContext(StoreContext);
-    const { listProps } = useSimpleList<IProduct>({
-        permanentFilter: [
-            { field: "stores][id]", operator: "eq", value: store },
-        ],
-        metaData: { populate: ["image"] },
-    });
-    //highlight-end
+  //highlight-start
+  const [store] = useContext(StoreContext);
+  const { listProps } = useSimpleList<IProduct>({
+    permanentFilter: [{ field: "stores][id]", operator: "eq", value: store }],
+    metaData: { populate: ["image"] },
+  });
+  //highlight-end
 
-    return (
-        <List
-            headerProps={{
-                extra: <CreateButton onClick={() => createShow()} />,
-            }}
-        >
-            <AntdList
-                grid={{ gutter: 16, xs: 1 }}
-                style={{
-                    justifyContent: "center",
-                }}
-                {...listProps}
-                renderItem={(item) => (
-                    <AntdList.Item>
-                        <ProductItem item={item} editShow={editShow} />
-                    </AntdList.Item>
-                )}
-            />
-        </List>
-    );
+  return (
+    <List
+      headerProps={{
+        extra: <CreateButton onClick={() => createShow()} />,
+      }}
+    >
+      <AntdList
+        grid={{ gutter: 16, xs: 1 }}
+        style={{
+          justifyContent: "center",
+        }}
+        {...listProps}
+        renderItem={(item) => (
+          <AntdList.Item>
+            <ProductItem item={item} editShow={editShow} />
+          </AntdList.Item>
+        )}
+      />
+    </List>
+  );
 };
 ```
 
@@ -534,121 +522,117 @@ const [store, setStore] = useContext(StoreContext);
 import { useContext } from "react";
 import { useApiUrl } from "@pankod/refine-core";
 import {
-    Create,
-    Drawer,
-    DrawerProps,
-    Form,
-    FormProps,
-    Input,
-    ButtonProps,
-    Upload,
-    Grid,
+  Create,
+  Drawer,
+  DrawerProps,
+  Form,
+  FormProps,
+  Input,
+  ButtonProps,
+  Upload,
+  Grid,
 } from "@pankod/refine-antd";
 
 import { StoreContext } from "context/store";
 
 import {
-    useStrapiUpload,
-    mediaUploadMapper,
-    getValueProps,
+  useStrapiUpload,
+  mediaUploadMapper,
+  getValueProps,
 } from "@pankod/refine-strapi-v4";
 
 import { TOKEN_KEY } from "../../constants";
 
 type CreateProductProps = {
-    drawerProps: DrawerProps;
-    formProps: FormProps;
-    saveButtonProps: ButtonProps;
+  drawerProps: DrawerProps;
+  formProps: FormProps;
+  saveButtonProps: ButtonProps;
 };
 
 export const CreateProduct: React.FC<CreateProductProps> = ({
-    drawerProps,
-    formProps,
-    saveButtonProps,
+  drawerProps,
+  formProps,
+  saveButtonProps,
 }) => {
-    const API_URL = useApiUrl();
-    //highlight-start
-    const [store, setStore] = useContext(StoreContext);
-    //highlight-end
+  const API_URL = useApiUrl();
+  //highlight-start
+  const [store, setStore] = useContext(StoreContext);
+  //highlight-end
 
-    const breakpoint = Grid.useBreakpoint();
+  const breakpoint = Grid.useBreakpoint();
 
-    const { ...uploadProps } = useStrapiUpload({
-        maxCount: 1,
-    });
+  const { ...uploadProps } = useStrapiUpload({
+    maxCount: 1,
+  });
 
-    return (
-        <Drawer
-            {...drawerProps}
-            width={breakpoint.sm ? "500px" : "100%"}
-            bodyStyle={{ padding: 0 }}
+  return (
+    <Drawer
+      {...drawerProps}
+      width={breakpoint.sm ? "500px" : "100%"}
+      bodyStyle={{ padding: 0 }}
+    >
+      <Create saveButtonProps={saveButtonProps}>
+        <Form
+          {...formProps}
+          layout="vertical"
+          initialValues={{
+            isActive: true,
+          }}
+          //highlight-start
+          onFinish={(values) => {
+            return formProps.onFinish?.({
+              ...mediaUploadMapper(values),
+              stores: store,
+            });
+          }}
+          //highlight-end
         >
-            <Create saveButtonProps={saveButtonProps}>
-                <Form
-                    {...formProps}
-                    layout="vertical"
-                    initialValues={{
-                        isActive: true,
-                    }}
-                    //highlight-start
-                    onFinish={(values) => {
-                        return formProps.onFinish?.({
-                            ...mediaUploadMapper(values),
-                            stores: store,
-                        });
-                    }}
-                    //highlight-end
-                >
-                    <Form.Item
-                        label="Title"
-                        name="title"
-                        rules={[
-                            {
-                                required: true,
-                            },
-                        ]}
-                    >
-                        <Input />
-                    </Form.Item>
-                    <Form.Item label="Description" name="description">
-                        <Input />
-                    </Form.Item>
-                    <Form.Item label="Image">
-                        <Form.Item
-                            name="image"
-                            valuePropName="fileList"
-                            getValueProps={(data) =>
-                                getValueProps(data, API_URL)
-                            }
-                            noStyle
-                            rules={[
-                                {
-                                    required: true,
-                                },
-                            ]}
-                        >
-                            <Upload.Dragger
-                                name="files"
-                                action={`${API_URL}/upload`}
-                                headers={{
-                                    Authorization: `Bearer ${localStorage.getItem(
-                                        TOKEN_KEY,
-                                    )}`,
-                                }}
-                                listType="picture"
-                                multiple
-                                {...uploadProps}
-                            >
-                                <p className="ant-upload-text">
-                                    Drag & drop a file in this area
-                                </p>
-                            </Upload.Dragger>
-                        </Form.Item>
-                    </Form.Item>
-                </Form>
-            </Create>
-        </Drawer>
-    );
+          <Form.Item
+            label="Title"
+            name="title"
+            rules={[
+              {
+                required: true,
+              },
+            ]}
+          >
+            <Input />
+          </Form.Item>
+          <Form.Item label="Description" name="description">
+            <Input />
+          </Form.Item>
+          <Form.Item label="Image">
+            <Form.Item
+              name="image"
+              valuePropName="fileList"
+              getValueProps={(data) => getValueProps(data, API_URL)}
+              noStyle
+              rules={[
+                {
+                  required: true,
+                },
+              ]}
+            >
+              <Upload.Dragger
+                name="files"
+                action={`${API_URL}/upload`}
+                headers={{
+                  Authorization: `Bearer ${localStorage.getItem(TOKEN_KEY)}`,
+                }}
+                listType="picture"
+                multiple
+                {...uploadProps}
+              >
+                <p className="ant-upload-text">
+                  Drag & drop a file in this area
+                </p>
+              </Upload.Dragger>
+            </Form.Item>
+          </Form.Item>
+        </Form>
+      </Create>
+    </Drawer>
+  );
 };
 ```
 

--- a/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/real-time.md
+++ b/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/real-time.md
@@ -13,9 +13,7 @@ We will be using [Ably](https://ably.com) in this guide to provide Realtime feat
 
 We need to install the Ably live provider package from **refine**.
 
-```bash
-npm install @pankod/refine-ably
-```
+<InstallPackagesCommand args="@pankod/refine-ably"/>
 
 :::caution
 To make this example more visual, we used the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/refine-antd) package. If you are using Refine headless, you need to provide the components, hooks, or helpers imported from the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/refine-antd) package.
@@ -44,10 +42,10 @@ Then pass `liveProvider` from [`@pankod/refine-ably`](https://github.com/refined
 ```tsx title="src/App.tsx"
 import { Refine } from "@pankod/refine-core";
 import {
-    Layout,
-    ReadyPage,
-    notificationProvider,
-    ErrorComponent,
+  Layout,
+  ReadyPage,
+  notificationProvider,
+  ErrorComponent,
 } from "@pankod/refine-antd";
 import dataProvider from "@pankod/refine-simple-rest";
 import routerProvider from "@pankod/refine-react-router-v6";
@@ -62,30 +60,30 @@ import { ablyClient } from "utility/ablyClient";
 import { PostList, PostCreate, PostEdit, PostShow } from "pages/posts";
 
 const App: React.FC = () => {
-    return (
-        <Refine
-            routerProvider={routerProvider}
-            dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
-            Layout={Layout}
-            ReadyPage={ReadyPage}
-            notificationProvider={notificationProvider}
-            catchAll={<ErrorComponent />}
-            //highlight-start
-            liveProvider={liveProvider(ablyClient)}
-            options={{ liveMode: "auto" }}
-            //highlight-end
-            resources={[
-                {
-                    name: "posts",
-                    list: PostList,
-                    create: PostCreate,
-                    edit: PostEdit,
-                    show: PostShow,
-                    canDelete: true,
-                },
-            ]}
-        />
-    );
+  return (
+    <Refine
+      routerProvider={routerProvider}
+      dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
+      Layout={Layout}
+      ReadyPage={ReadyPage}
+      notificationProvider={notificationProvider}
+      catchAll={<ErrorComponent />}
+      //highlight-start
+      liveProvider={liveProvider(ablyClient)}
+      options={{ liveMode: "auto" }}
+      //highlight-end
+      resources={[
+        {
+          name: "posts",
+          list: PostList,
+          create: PostCreate,
+          edit: PostEdit,
+          show: PostShow,
+          canDelete: true,
+        },
+      ]}
+    />
+  );
 };
 
 export default App;
@@ -113,59 +111,57 @@ We will be alerted about changes in an alert box on top of the form instead of c
 // ...
 
 export const PostEdit: React.FC = () => {
+  //highlight-start
+  const [deprecated, setDeprecated] = useState<
+    "deleted" | "updated" | undefined
+  >();
+  //highlight-end
+
+  const { formProps, saveButtonProps, queryResult } = useForm<IPost>({
     //highlight-start
-    const [deprecated, setDeprecated] = useState<
-        "deleted" | "updated" | undefined
-    >();
+    liveMode: "manual",
+    onLiveEvent: (event) => {
+      if (event.type === "deleted" || event.type === "updated") {
+        setDeprecated(event.type);
+      }
+    },
     //highlight-end
+  });
 
-    const { formProps, saveButtonProps, queryResult } = useForm<IPost>({
-        //highlight-start
-        liveMode: "manual",
-        onLiveEvent: (event) => {
-            if (event.type === "deleted" || event.type === "updated") {
-                setDeprecated(event.type);
-            }
-        },
-        //highlight-end
-    });
+  //highlight-start
+  const handleRefresh = () => {
+    queryResult?.refetch();
+    setDeprecated(undefined);
+  };
+  //highlight-end
 
-    //highlight-start
-    const handleRefresh = () => {
-        queryResult?.refetch();
-        setDeprecated(undefined);
-    };
-    //highlight-end
+  // ...
 
-    // ...
-
-    return (
-        <Edit /* ... */>
-            //highlight-start
-            {deprecated === "deleted" && (
-                <Alert
-                    message="This post is deleted."
-                    type="warning"
-                    style={{ marginBottom: 20 }}
-                    action={<ListButton size="small" />}
-                />
-            )}
-            {deprecated === "updated" && (
-                <Alert
-                    message="This post is updated. Refresh to see changes."
-                    type="warning"
-                    style={{ marginBottom: 20 }}
-                    action={
-                        <RefreshButton size="small" onClick={handleRefresh} />
-                    }
-                />
-            )}
-            //highlight-end
-            <Form {...formProps} layout="vertical">
-                // ....
-            </Form>
-        </Edit>
-    );
+  return (
+    <Edit /* ... */>
+      //highlight-start
+      {deprecated === "deleted" && (
+        <Alert
+          message="This post is deleted."
+          type="warning"
+          style={{ marginBottom: 20 }}
+          action={<ListButton size="small" />}
+        />
+      )}
+      {deprecated === "updated" && (
+        <Alert
+          message="This post is updated. Refresh to see changes."
+          type="warning"
+          style={{ marginBottom: 20 }}
+          action={<RefreshButton size="small" onClick={handleRefresh} />}
+        />
+      )}
+      //highlight-end
+      <Form {...formProps} layout="vertical">
+        // ....
+      </Form>
+    </Edit>
+  );
 };
 ```
 
@@ -193,92 +189,82 @@ Firstly, let's implement a custom sider like in [this example](/examples/customi
 ```tsx title="src/components/sider.tsx"
 import React, { useState } from "react";
 import {
-    useTitle,
-    ITreeMenu,
-    CanAccess,
-    useRouterContext,
-    useMenu,
+  useTitle,
+  ITreeMenu,
+  CanAccess,
+  useRouterContext,
+  useMenu,
 } from "@pankod/refine-core";
 import { AntdLayout, Menu, Grid, Icons } from "@pankod/refine-antd";
 import { antLayoutSider, antLayoutSiderMobile } from "./styles";
 
 export const CustomSider: React.FC = () => {
-    const [collapsed, setCollapsed] = useState<boolean>(false);
-    const { Link } = useRouterContext();
-    const Title = useTitle();
-    const { menuItems, selectedKey } = useMenu();
-    const breakpoint = Grid.useBreakpoint();
+  const [collapsed, setCollapsed] = useState<boolean>(false);
+  const { Link } = useRouterContext();
+  const Title = useTitle();
+  const { menuItems, selectedKey } = useMenu();
+  const breakpoint = Grid.useBreakpoint();
 
-    const isMobile =
-        typeof breakpoint.lg === "undefined" ? false : !breakpoint.lg;
+  const isMobile =
+    typeof breakpoint.lg === "undefined" ? false : !breakpoint.lg;
 
-    const renderTreeView = (tree: ITreeMenu[], selectedKey: string) => {
-        return tree.map((item: ITreeMenu) => {
-            const { icon, label, route, name, children, parentName } = item;
+  const renderTreeView = (tree: ITreeMenu[], selectedKey: string) => {
+    return tree.map((item: ITreeMenu) => {
+      const { icon, label, route, name, children, parentName } = item;
 
-            if (children.length > 0) {
-                return (
-                    <SubMenu
-                        key={route}
-                        icon={icon ?? <Icons.UnorderedListOutlined />}
-                        title={label}
-                    >
-                        {renderTreeView(children, selectedKey)}
-                    </SubMenu>
-                );
-            }
-            const isSelected = route === selectedKey;
-            const isRoute = !(
-                parentName !== undefined && children.length === 0
-            );
-            return (
-                <CanAccess
-                    key={route}
-                    resource={name.toLowerCase()}
-                    action="list"
-                >
-                    <Menu.Item
-                        key={route}
-                        style={{
-                            fontWeight: isSelected ? "bold" : "normal",
-                        }}
-                        icon={
-                            icon ?? (isRoute && <Icons.UnorderedListOutlined />)
-                        }
-                    >
-                        <Link to={route}>{label}</Link>
-                        {!collapsed && isSelected && (
-                            <Icons.UnorderedListOutlined />
-                        )}
-                    </Menu.Item>
-                </CanAccess>
-            );
-        });
-    };
+      if (children.length > 0) {
+        return (
+          <SubMenu
+            key={route}
+            icon={icon ?? <Icons.UnorderedListOutlined />}
+            title={label}
+          >
+            {renderTreeView(children, selectedKey)}
+          </SubMenu>
+        );
+      }
+      const isSelected = route === selectedKey;
+      const isRoute = !(parentName !== undefined && children.length === 0);
+      return (
+        <CanAccess key={route} resource={name.toLowerCase()} action="list">
+          <Menu.Item
+            key={route}
+            style={{
+              fontWeight: isSelected ? "bold" : "normal",
+            }}
+            icon={icon ?? (isRoute && <Icons.UnorderedListOutlined />)}
+          >
+            <Link to={route}>{label}</Link>
+            {!collapsed && isSelected && <Icons.UnorderedListOutlined />}
+          </Menu.Item>
+        </CanAccess>
+      );
+    });
+  };
 
-    return (
-        <AntdLayout.Sider
-            collapsible
-            collapsedWidth={isMobile ? 0 : 80}
-            collapsed={collapsed}
-            breakpoint="lg"
-            onCollapse={(collapsed: boolean): void => setCollapsed(collapsed)}
-            style={isMobile ? antLayoutSiderMobile : antLayoutSider}
-        >
-            <Title collapsed={collapsed} />
-            <Menu
-                selectedKeys={[selectedKey]}
-                mode="inline"
-                onClick={({ key }) => {
-                    if (!breakpoint.lg) {
-                        setCollapsed(true);
-                    }
-                }}
-            >
-                {renderTreeView(menuItems, selectedKey)}
-            </Menu>
-        </AntdLayout.Sider>
-    );
+  return (
+    <AntdLayout.Sider
+      collapsible
+      collapsedWidth={isMobile ? 0 : 80}
+      collapsed={collapsed}
+      breakpoint="lg"
+      onCollapse={(collapsed: boolean): void => setCollapsed(collapsed)}
+      style={isMobile ? antLayoutSiderMobile : antLayoutSider}
+    >
+      <Title collapsed={collapsed} />
+      <Menu
+        selectedKeys={[selectedKey]}
+        mode="inline"
+        onClick={({ key }) => {
+          if (!breakpoint.lg) {
+            setCollapsed(true);
+          }
+        }}
+      >
+        {renderTreeView(menuItems, selectedKey)}
+      </Menu>
+    </AntdLayout.Sider>
+  );
 };
 ```
 
@@ -289,125 +275,117 @@ Now, let's add a badge for the number of create and update events for **_posts_*
 ```tsx
 import React, { useState } from "react";
 import {
-    useTitle,
-    ITreeMenu,
-    CanAccess,
-    useMenu,
-    //highlight-start
-    useSubscription,
-    //highlight-end
+  useTitle,
+  ITreeMenu,
+  CanAccess,
+  useMenu,
+  //highlight-start
+  useSubscription,
+  //highlight-end
 } from "@pankod/refine-core";
 import {
-    AntdLayout,
-    Menu,
-    Grid,
-    Icons,
-    //highlight-start
-    Badge,
-    //highlight-end
+  AntdLayout,
+  Menu,
+  Grid,
+  Icons,
+  //highlight-start
+  Badge,
+  //highlight-end
 } from "@pankod/refine-antd";
 import { antLayoutSider, antLayoutSiderMobile } from "./styles";
 
 export const CustomSider: React.FC = () => {
-    const [subscriptionCount, setSubscriptionCount] = useState(0);
-    const [collapsed, setCollapsed] = useState<boolean>(false);
-    const { Link } = useRouterContext();
-    const Title = useTitle();
-    const { menuItems, selectedKey } = useMenu();
-    const breakpoint = Grid.useBreakpoint();
+  const [subscriptionCount, setSubscriptionCount] = useState(0);
+  const [collapsed, setCollapsed] = useState<boolean>(false);
+  const { Link } = useRouterContext();
+  const Title = useTitle();
+  const { menuItems, selectedKey } = useMenu();
+  const breakpoint = Grid.useBreakpoint();
 
-    const isMobile =
-        typeof breakpoint.lg === "undefined" ? false : !breakpoint.lg;
+  const isMobile =
+    typeof breakpoint.lg === "undefined" ? false : !breakpoint.lg;
 
-    //highlight-start
-    useSubscription({
-        channel: "resources/posts",
-        type: ["created", "updated"],
-        onLiveEvent: () => setSubscriptionCount((prev) => prev + 1),
+  //highlight-start
+  useSubscription({
+    channel: "resources/posts",
+    type: ["created", "updated"],
+    onLiveEvent: () => setSubscriptionCount((prev) => prev + 1),
+  });
+  //highlight-end
+
+  const renderTreeView = (tree: ITreeMenu[], selectedKey: string) => {
+    return tree.map((item: ITreeMenu) => {
+      const { icon, label, route, name, children, parentName } = item;
+
+      if (children.length > 0) {
+        return (
+          <SubMenu
+            key={name}
+            icon={icon ?? <Icons.UnorderedListOutlined />}
+            title={label}
+          >
+            {renderTreeView(children, selectedKey)}
+          </SubMenu>
+        );
+      }
+      const isSelected = route === selectedKey;
+      const isRoute = !(parentName !== undefined && children.length === 0);
+      return (
+        <CanAccess key={route} resource={name.toLowerCase()} action="list">
+          <Menu.Item
+            key={route}
+            style={{
+              fontWeight: isSelected ? "bold" : "normal",
+            }}
+            icon={icon ?? (isRoute && <Icons.UnorderedListOutlined />)}
+          >
+            //highlight-start
+            <div>
+              <Link to={route}>{label}</Link>
+              {label === "Posts" && (
+                <Badge
+                  size="small"
+                  count={subscriptionCount}
+                  offset={[2, -15]}
+                />
+              )}
+            </div>
+            //highlight-end
+          </Menu.Item>
+        </CanAccess>
+      );
     });
-    //highlight-end
+  };
 
-    const renderTreeView = (tree: ITreeMenu[], selectedKey: string) => {
-        return tree.map((item: ITreeMenu) => {
-            const { icon, label, route, name, children, parentName } = item;
+  return (
+    <AntdLayout.Sider
+      collapsible
+      collapsedWidth={isMobile ? 0 : 80}
+      collapsed={collapsed}
+      breakpoint="lg"
+      onCollapse={(collapsed: boolean): void => setCollapsed(collapsed)}
+      style={isMobile ? antLayoutSiderMobile : antLayoutSider}
+    >
+      <Title collapsed={collapsed} />
+      <Menu
+        selectedKeys={[selectedKey]}
+        mode="inline"
+        onClick={() => {
+          if (!breakpoint.lg) {
+            setCollapsed(true);
+          }
 
-            if (children.length > 0) {
-                return (
-                    <SubMenu
-                        key={name}
-                        icon={icon ?? <Icons.UnorderedListOutlined />}
-                        title={label}
-                    >
-                        {renderTreeView(children, selectedKey)}
-                    </SubMenu>
-                );
-            }
-            const isSelected = route === selectedKey;
-            const isRoute = !(
-                parentName !== undefined && children.length === 0
-            );
-            return (
-                <CanAccess
-                    key={route}
-                    resource={name.toLowerCase()}
-                    action="list"
-                >
-                    <Menu.Item
-                        key={route}
-                        style={{
-                            fontWeight: isSelected ? "bold" : "normal",
-                        }}
-                        icon={
-                            icon ?? (isRoute && <Icons.UnorderedListOutlined />)
-                        }
-                    >
-                        //highlight-start
-                        <div>
-                            <Link to={route}>{label}</Link>
-                            {label === "Posts" && (
-                                <Badge
-                                    size="small"
-                                    count={subscriptionCount}
-                                    offset={[2, -15]}
-                                />
-                            )}
-                        </div>
-                        //highlight-end
-                    </Menu.Item>
-                </CanAccess>
-            );
-        });
-    };
-
-    return (
-        <AntdLayout.Sider
-            collapsible
-            collapsedWidth={isMobile ? 0 : 80}
-            collapsed={collapsed}
-            breakpoint="lg"
-            onCollapse={(collapsed: boolean): void => setCollapsed(collapsed)}
-            style={isMobile ? antLayoutSiderMobile : antLayoutSider}
-        >
-            <Title collapsed={collapsed} />
-            <Menu
-                selectedKeys={[selectedKey]}
-                mode="inline"
-                onClick={() => {
-                    if (!breakpoint.lg) {
-                        setCollapsed(true);
-                    }
-
-                    //highlight-start
-                    if (key === "/posts") {
-                        setSubscriptionCount(0);
-                    }
-                    //highlight-end
-                }}
-            >
-                {renderTreeView(menuItems, selectedKey)}
-            </Menu>
-        </AntdLayout.Sider>
-    );
+          //highlight-start
+          if (key === "/posts") {
+            setSubscriptionCount(0);
+          }
+          //highlight-end
+        }}
+      >
+        {renderTreeView(menuItems, selectedKey)}
+      </Menu>
+    </AntdLayout.Sider>
+  );
 };
 ```
 
@@ -417,14 +395,14 @@ You can subscribe to specific `ids` with `params`. For example, you can subscrib
 
 ```tsx
 useSubscription({
-    channel: "resources/posts",
-    type: ["deleted", "updated"],
-    //highlight-start
-    params: {
-        ids: ["1", "2"],
-    },
-    //highlight-end
-    onLiveEvent: () => setSubscriptionCount((prev) => prev + 1),
+  channel: "resources/posts",
+  type: ["deleted", "updated"],
+  //highlight-start
+  params: {
+    ids: ["1", "2"],
+  },
+  //highlight-end
+  onLiveEvent: () => setSubscriptionCount((prev) => prev + 1),
 });
 ```
 

--- a/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/ssr/nextjs.md
+++ b/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/ssr/nextjs.md
@@ -9,16 +9,12 @@ title: Next.js
 
 [**nextjs-router**][nextjsrouter] package provided by **refine** must be used for the [`routerProvider`][routerprovider]
 
-```bash
-npm i @pankod/refine-core @pankod/refine-antd @pankod/refine-nextjs-router
-```
+<InstallPackagesCommand args="@refinedev/nextjs-router"/>
 
 :::tip
 We recommend using `create refine-app` to initialize your refine projects. It configures the project according to your needs including SSR with Next.js.
 
-```
-npm create refine-app@latest -- -o refine-nextjs my-refine-nextjs-app
-```
+<CreateRefineAppCommand args="-o refine-nextjs my-refine-nextjs-app" />
 
 :::
 

--- a/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/ssr/remix.md
+++ b/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/ssr/remix.md
@@ -7,16 +7,12 @@ title: Remix
 
 ## Setup
 
-```bash
-npm i @pankod/refine-core @pankod/refine-remix-router @pankod/refine-simple-rest
-```
+<InstallPackagesCommand args="@refinedev/remix-router"/>
 
 :::tip
 We recommend using `create refine-app` to initialize your refine projects. It configures the project according to your needs including SSR with Remix!
 
-```sh
-npm create refine-app@latest -- -o refine-remix my-refine-remix-app
-```
+<CreateRefineAppCommand args="-o refine-remix my-refine-remix-app" />
 
 :::
 
@@ -690,12 +686,9 @@ export const loader: LoaderFunction = async ({ request }) => {
 
 First, let's install the `js-cookie` and `cookie` packages in our project.
 
-```sh
-npm i js-cookie cookie
+<InstallPackagesCommand args="js-cookie cookie"/>
 
-# typescript types
-npm i -D @types/js-cookie
-```
+<InstallPackagesCommand args="-D @types/js-cookie"/>
 
 We will set/destroy cookies in the `login`, `logout` and `checkAuth` functions of our `AuthProvider`.
 

--- a/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/web3/ethereum-signin.md
+++ b/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/web3/ethereum-signin.md
@@ -15,10 +15,7 @@ We will show you how to log in to your Metamask wallet with **refine**.
 
 We will need [web3](https://github.com/ChainSafe/web3.js) and [web3-modal](https://github.com/web3modal/web3modal) packages in our project. Let's start by downloading these packages
 
-```bash
-npm install web3
-npm install --save web3modal
-```
+<InstallPackagesCommand args="web3 web3modal"/>
 
 :::caution
 To make this example more visual, we used the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/refine-antd) package. If you are using Refine headless, you need to provide the components, hooks or helpers imported from the [`@pankod/refine-antd`](https://github.com/refinedev/refine/tree/v3/packages/refine-antd) package.
@@ -43,61 +40,61 @@ export const TOKEN_KEY = "refine-auth";
 
 const providerOptions = {};
 const web3Modal = new Web3Modal({
-    cacheProvider: true,
-    providerOptions,
+  cacheProvider: true,
+  providerOptions,
 });
 
 let provider: any | null = null;
 
 export const authProvider: AuthProvider = {
-    login: async () => {
-        if (window.ethereum) {
-            provider = await web3Modal.connect();
-            const web3 = new Web3(provider);
-            const accounts = await web3.eth.getAccounts();
-            localStorage.setItem(TOKEN_KEY, accounts[0]);
-            return Promise.resolve();
-        } else {
-            return Promise.reject(
-                new Error(
-                    "Not set ethereum wallet or invalid. You need to install Metamask",
-                ),
-            );
-        }
-    },
-    logout: async () => {
-        localStorage.removeItem(TOKEN_KEY);
-        if (provider && provider.close) {
-            await provider.close;
+  login: async () => {
+    if (window.ethereum) {
+      provider = await web3Modal.connect();
+      const web3 = new Web3(provider);
+      const accounts = await web3.eth.getAccounts();
+      localStorage.setItem(TOKEN_KEY, accounts[0]);
+      return Promise.resolve();
+    } else {
+      return Promise.reject(
+        new Error(
+          "Not set ethereum wallet or invalid. You need to install Metamask",
+        ),
+      );
+    }
+  },
+  logout: async () => {
+    localStorage.removeItem(TOKEN_KEY);
+    if (provider && provider.close) {
+      await provider.close;
 
-            provider = null;
-            await web3Modal.clearCachedProvider();
-        }
-        return Promise.resolve();
-    },
-    checkError: () => Promise.resolve(),
-    checkAuth: () => {
-        const token = localStorage.getItem(TOKEN_KEY);
-        if (token) {
-            return Promise.resolve();
-        }
+      provider = null;
+      await web3Modal.clearCachedProvider();
+    }
+    return Promise.resolve();
+  },
+  checkError: () => Promise.resolve(),
+  checkAuth: () => {
+    const token = localStorage.getItem(TOKEN_KEY);
+    if (token) {
+      return Promise.resolve();
+    }
 
-        return Promise.reject();
-    },
-    getPermissions: () => Promise.resolve(),
-    getUserIdentity: async () => {
-        const address = localStorage.getItem(TOKEN_KEY);
-        if (!address) {
-            return Promise.reject();
-        }
+    return Promise.reject();
+  },
+  getPermissions: () => Promise.resolve(),
+  getUserIdentity: async () => {
+    const address = localStorage.getItem(TOKEN_KEY);
+    if (!address) {
+      return Promise.reject();
+    }
 
-        const balance = await getBalance(address);
+    const balance = await getBalance(address);
 
-        return Promise.resolve({
-            address,
-            balance,
-        });
-    },
+    return Promise.resolve({
+      address,
+      balance,
+    });
+  },
 };
 ```
 
@@ -107,15 +104,15 @@ We use web3's `getBalance()` function to find out the ethereum amount of the acc
 const web3 = new Web3(window.ethereum);
 
 export const getBalance = async (account: string): Promise<string> => {
-    return new Promise((resolve, reject) => {
-        web3.eth.getBalance(account, (err: any, result: any) => {
-            if (err) {
-                reject(err);
-            } else {
-                resolve(web3.utils.fromWei(result, "ether"));
-            }
-        });
+  return new Promise((resolve, reject) => {
+    web3.eth.getBalance(account, (err: any, result: any) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(web3.utils.fromWei(result, "ether"));
+      }
     });
+  });
 };
 ```
 
@@ -128,57 +125,54 @@ import { useLogin } from "@pankod/refine-core";
 import { AntdLayout, Button, Icon, Row, Col } from "@pankod/refine-antd";
 
 export const Login: React.FC = () => {
-    const { mutate: login, isLoading } = useLogin();
+  const { mutate: login, isLoading } = useLogin();
 
-    return (
-        <AntdLayout
+  return (
+    <AntdLayout
+      style={{
+        background: `radial-gradient(50% 50% at 50% 50%, #63386A 0%, #310438 100%)`,
+        backgroundSize: "cover",
+      }}
+    >
+      <Row
+        justify="center"
+        align="middle"
+        style={{
+          height: "100vh",
+        }}
+      >
+        <Col xs={22}>
+          <div
             style={{
-                background: `radial-gradient(50% 50% at 50% 50%, #63386A 0%, #310438 100%)`,
-                backgroundSize: "cover",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              marginBottom: "28px",
             }}
-        >
-            <Row
-                justify="center"
-                align="middle"
-                style={{
-                    height: "100vh",
-                }}
+          >
+            <img src="./refine.svg" alt="Refine" />
+          </div>
+          <div style={{ display: "flex", justifyContent: "center" }}>
+            <Button
+              type="primary"
+              size="large"
+              icon={
+                <Icon
+                  component={() => (
+                    <img alt={"ethereum.png"} src="./ethereum.png" />
+                  )}
+                />
+              }
+              loading={isLoading}
+              onClick={() => login({})}
             >
-                <Col xs={22}>
-                    <div
-                        style={{
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            marginBottom: "28px",
-                        }}
-                    >
-                        <img src="./refine.svg" alt="Refine" />
-                    </div>
-                    <div style={{ display: "flex", justifyContent: "center" }}>
-                        <Button
-                            type="primary"
-                            size="large"
-                            icon={
-                                <Icon
-                                    component={() => (
-                                        <img
-                                            alt={"ethereum.png"}
-                                            src="./ethereum.png"
-                                        />
-                                    )}
-                                />
-                            }
-                            loading={isLoading}
-                            onClick={() => login({})}
-                        >
-                            SIGN-IN WITH ETHEREUM
-                        </Button>
-                    </div>
-                </Col>
-            </Row>
-        </AntdLayout>
-    );
+              SIGN-IN WITH ETHEREUM
+            </Button>
+          </div>
+        </Col>
+      </Row>
+    </AntdLayout>
+  );
 };
 ```
 
@@ -193,52 +187,50 @@ After connecting with our account, we can now retrieve account information. We w
 import React from "react";
 import { useGetIdentity } from "@pankod/refine-core";
 import {
-    Row,
-    Col,
-    Card,
-    Typography,
-    Space,
-    Button,
-    Modal,
-    useModal,
-    Form,
-    Input,
+  Row,
+  Col,
+  Card,
+  Typography,
+  Space,
+  Button,
+  Modal,
+  useModal,
+  Form,
+  Input,
 } from "@pankod/refine-antd";
 
 const { Text } = Typography;
 
 export const DashboardPage: React.FC = () => {
-    const { data, isLoading } = useGetIdentity<{
-        address: string;
-        balance: string;
-    }>();
+  const { data, isLoading } = useGetIdentity<{
+    address: string;
+    balance: string;
+  }>();
 
-    return (
-        <Row gutter={24}>
-            <Col span={12}>
-                <Card
-                    title="Ethereum Public ID"
-                    style={{ height: "150px", borderRadius: "15px" }}
-                    headStyle={{ textAlign: "center" }}
-                >
-                    <Space align="center" direction="horizontal">
-                        <Text>{isLoading ? "loading" : data?.address}</Text>
-                    </Space>
-                </Card>
-            </Col>
-            <Col span={8}>
-                <Card
-                    title="Account Balance"
-                    style={{ height: "150px", borderRadius: "15px" }}
-                    headStyle={{ textAlign: "center" }}
-                >
-                    <Text>{`${
-                        isLoading ? "loading" : data?.balance
-                    } Ether`}</Text>
-                </Card>
-            </Col>
-        </Row>
-    );
+  return (
+    <Row gutter={24}>
+      <Col span={12}>
+        <Card
+          title="Ethereum Public ID"
+          style={{ height: "150px", borderRadius: "15px" }}
+          headStyle={{ textAlign: "center" }}
+        >
+          <Space align="center" direction="horizontal">
+            <Text>{isLoading ? "loading" : data?.address}</Text>
+          </Space>
+        </Card>
+      </Col>
+      <Col span={8}>
+        <Card
+          title="Account Balance"
+          style={{ height: "150px", borderRadius: "15px" }}
+          headStyle={{ textAlign: "center" }}
+        >
+          <Text>{`${isLoading ? "loading" : data?.balance} Ether`}</Text>
+        </Card>
+      </Col>
+    </Row>
+  );
 };
 ```
 
@@ -253,22 +245,22 @@ Here we use the `sendTransaction` function to send ethereum with your browser en
 
 ```tsx title="src/utility.ts"
 export const sendEthereum = async (
-    sender: string,
-    receiver: string,
-    amount: string,
+  sender: string,
+  receiver: string,
+  amount: string,
 ) => {
-    try {
-        const params = {
-            from: sender,
-            to: receiver,
-            value: web3.utils.toHex(web3.utils.toWei(amount, "ether")),
-            gas: 39000,
-        };
-        await window.ethereum.enable();
-        return await web3.eth.sendTransaction(params);
-    } catch (error) {
-        new Error("Something went wrong!");
-    }
+  try {
+    const params = {
+      from: sender,
+      to: receiver,
+      value: web3.utils.toHex(web3.utils.toWei(amount, "ether")),
+      gas: 39000,
+    };
+    await window.ethereum.enable();
+    return await web3.eth.sendTransaction(params);
+  } catch (error) {
+    new Error("Something went wrong!");
+  }
 };
 ```
 
@@ -276,17 +268,17 @@ export const sendEthereum = async (
 import React, { useState } from "react";
 import { useGetIdentity } from "@pankod/refine-core";
 import {
-    Row,
-    Col,
-    Card,
-    Typography,
-    Space,
-    Button,
-    Modal,
-    useModal,
-    Form,
-    Input,
-    notification,
+  Row,
+  Col,
+  Card,
+  Typography,
+  Space,
+  Button,
+  Modal,
+  useModal,
+  Form,
+  Input,
+  notification,
 } from "@pankod/refine-antd";
 
 import { sendEthereum } from "../utility";
@@ -294,101 +286,98 @@ import { sendEthereum } from "../utility";
 const { Text } = Typography;
 
 export const DashboardPage: React.FC = () => {
-    const { data, isLoading } = useGetIdentity<{
-        address: string;
-        balance: string;
-    }>();
-    const { modalProps, show, close } = useModal();
-    const [form] = Form.useForm();
-    const [loading, setLoading] = useState(false);
+  const { data, isLoading } = useGetIdentity<{
+    address: string;
+    balance: string;
+  }>();
+  const { modalProps, show, close } = useModal();
+  const [form] = Form.useForm();
+  const [loading, setLoading] = useState(false);
 
-    const handleModal = async (values: any) => {
-        setLoading(true);
-        const tx: any | undefined = await sendEthereum(
-            data?.address!!,
-            values.receiver,
-            values.amount,
-        );
-        const status = tx ? tx.status : undefined;
-        setLoading(false);
-
-        if (status) {
-            close();
-            notification["success"]({
-                message: "Transaction Success",
-                description:
-                    "Transaction successfull you can check on Etherscan.io",
-            });
-        } else {
-            notification["warning"]({
-                message: "Transaction Failed",
-                description: "Transaction failed try again",
-            });
-        }
-    };
-
-    return (
-        <>
-            <Row gutter={24}>
-                <Col span={12}>
-                    <Card
-                        title="Ethereum Public ID"
-                        style={{ height: "150px", borderRadius: "15px" }}
-                        headStyle={{ textAlign: "center" }}
-                    >
-                        <Space align="center" direction="horizontal">
-                            <Text>{isLoading ? "loading" : data?.address}</Text>
-                        </Space>
-                    </Card>
-                </Col>
-                <Col span={8}>
-                    <Card
-                        title="Account Balance"
-                        style={{ height: "150px", borderRadius: "15px" }}
-                        headStyle={{ textAlign: "center" }}
-                    >
-                        <Text>{`${
-                            isLoading ? "loading" : data?.balance
-                        } Ether`}</Text>
-                    </Card>
-                </Col>
-                <Col span={12}>
-                    <Button
-                        style={{ maxWidth: 300, marginTop: 24 }}
-                        type="primary"
-                        size="large"
-                        onClick={() => show()}
-                    >
-                        Send Ethereum
-                    </Button>
-                    <Button
-                        style={{ maxWidth: 300, marginTop: 24, marginLeft: 12 }}
-                        type="primary"
-                        size="large"
-                        href={`https://ropsten.etherscan.io/address/${data?.address}`}
-                    >
-                        View on Etherscan
-                    </Button>
-                </Col>
-            </Row>
-            <Modal
-                {...modalProps}
-                okText={"Send"}
-                title={"Send Test Ethereum via Ropsten Chain"}
-                onOk={form.submit}
-                okButtonProps={{ loading: loading }}
-            >
-                <Form layout="vertical" onFinish={handleModal} form={form}>
-                    <Form.Item name="receiver" label="Receiver Public Adress">
-                        <Input />
-                    </Form.Item>
-                    <Form.Item name="amount" label="Amaount Ether">
-                        <Input />
-                    </Form.Item>
-                </Form>
-            </Modal>
-        </>
+  const handleModal = async (values: any) => {
+    setLoading(true);
+    const tx: any | undefined = await sendEthereum(
+      data?.address!!,
+      values.receiver,
+      values.amount,
     );
+    const status = tx ? tx.status : undefined;
+    setLoading(false);
+
+    if (status) {
+      close();
+      notification["success"]({
+        message: "Transaction Success",
+        description: "Transaction successfull you can check on Etherscan.io",
+      });
+    } else {
+      notification["warning"]({
+        message: "Transaction Failed",
+        description: "Transaction failed try again",
+      });
+    }
+  };
+
+  return (
+    <>
+      <Row gutter={24}>
+        <Col span={12}>
+          <Card
+            title="Ethereum Public ID"
+            style={{ height: "150px", borderRadius: "15px" }}
+            headStyle={{ textAlign: "center" }}
+          >
+            <Space align="center" direction="horizontal">
+              <Text>{isLoading ? "loading" : data?.address}</Text>
+            </Space>
+          </Card>
+        </Col>
+        <Col span={8}>
+          <Card
+            title="Account Balance"
+            style={{ height: "150px", borderRadius: "15px" }}
+            headStyle={{ textAlign: "center" }}
+          >
+            <Text>{`${isLoading ? "loading" : data?.balance} Ether`}</Text>
+          </Card>
+        </Col>
+        <Col span={12}>
+          <Button
+            style={{ maxWidth: 300, marginTop: 24 }}
+            type="primary"
+            size="large"
+            onClick={() => show()}
+          >
+            Send Ethereum
+          </Button>
+          <Button
+            style={{ maxWidth: 300, marginTop: 24, marginLeft: 12 }}
+            type="primary"
+            size="large"
+            href={`https://ropsten.etherscan.io/address/${data?.address}`}
+          >
+            View on Etherscan
+          </Button>
+        </Col>
+      </Row>
+      <Modal
+        {...modalProps}
+        okText={"Send"}
+        title={"Send Test Ethereum via Ropsten Chain"}
+        onOk={form.submit}
+        okButtonProps={{ loading: loading }}
+      >
+        <Form layout="vertical" onFinish={handleModal} form={form}>
+          <Form.Item name="receiver" label="Receiver Public Adress">
+            <Input />
+          </Form.Item>
+          <Form.Item name="amount" label="Amaount Ether">
+            <Input />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
+  );
 };
 ```
 

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/core/providers/i18n-provider.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/core/providers/i18n-provider.md
@@ -69,39 +69,7 @@ Let's add multi-language support using the [`react-i18next`][react-i18next] fram
 
 Run the following command within your project directory to install both [`react-i18next`][react-i18next] and `i18next` packages :
 
-<Tabs
-defaultValue="npm"
-values={[
-{label: 'use npm', value: 'npm'},
-{label: 'use yarn', value: 'yarn'},
-{label: 'use pnpm', value: 'pnpm'},
-]}>
-
-<TabItem value="npm">
-
-```bash
-npm install react-i18next i18next
-```
-
-</TabItem>
-
-<TabItem value="yarn">
-
-```bash
-yarn add react-i18next i18next
-```
-
-</TabItem>
-
-<TabItem value="pnpm">
-
-```bash
-pnpm install react-i18next i18next
-```
-
-</TabItem>
-
-</Tabs>
+<InstallPackagesCommand args="react-i18next i18next"/>
 
 ### Creating i18n Instance
 

--- a/documentation/versioned_docs/version-3.xx.xx/packages/documentation/cli.md
+++ b/documentation/versioned_docs/version-3.xx.xx/packages/documentation/cli.md
@@ -409,28 +409,7 @@ View the details of the development environment.
 
 If you want to add the [@pankod/refine-cli](https://github.com/refinedev/refine/tree/v3/packages/cli) to your existing project, you have to add it to your project's `dependencies`.
 
-<Tabs
-defaultValue="npm"
-values={[
-{label: 'use npm', value: 'npm'},
-{label: 'use yarn', value: 'yarn'},
-]}>
-
-<TabItem value="npm">
-
-```bash
-npm i @pankod/refine-cli
-```
-
-</TabItem>
-<TabItem value="yarn">
-
-```bash
-yarn add @pankod/refine-cli
-```
-
-</TabItem>
-</Tabs>
+<InstallPackagesCommand args="@pankod/refine-cli"/>
 
 Then add the `refine` command to your scripts in your `package.json` file
 

--- a/documentation/versioned_docs/version-3.xx.xx/packages/documentation/command-palette.md
+++ b/documentation/versioned_docs/version-3.xx.xx/packages/documentation/command-palette.md
@@ -3,7 +3,6 @@ id: command-palette
 title: Command Palette
 ---
 
-
 **refine** supports the command palette feature and use the
 [**kbar**][kbar]. **kbar** is a fully extensible `cmd` + `k`(MacOS) or `ctrl` + `k`(Linux/Windows) interface for your site.
 
@@ -11,9 +10,8 @@ title: Command Palette
 
 Install the [@pankod/refine-kbar][refine-kbar] library.
 
-```bash
-npm i @pankod/refine-kbar
-```
+<InstallPackagesCommand args="@pankod/refine-kbar"/>
+
 ## Basic Usage
 
 First of all, you need to import the `@pankod/refine-kbar` library and we will use `RefineKbarProvider` to wrap the whole application.
@@ -27,44 +25,44 @@ import { RefineKbarProvider } from "@pankod/refine-kbar";
 
 import { PostList, PostCreate, PostEdit, PostShow } from "pages/posts";
 import {
-    CategoriesList,
-    CategoriesCreate,
-    CategoriesEdit,
+  CategoriesList,
+  CategoriesCreate,
+  CategoriesEdit,
 } from "pages/categories";
 
 // highlight-start
 export const OffLayoutArea: React.FC = () => {
-    return <RefineKbar />;
+  return <RefineKbar />;
 };
 // highlight-end
 
 const App: React.FC = () => {
-    return (
-        <RefineKbarProvider>
-            <Refine
-                resources={[
-                    {
-                        name: "posts",
-                        list: PostList,
-                        create: PostCreate,
-                        edit: PostEdit,
-                        show: PostShow,
-                        icon: <Icons.StarOutlined />,
-                        canDelete: true,
-                    },
-                    {
-                        name: "categories",
-                        list: CategoriesList,
-                        create: CategoriesCreate,
-                        edit: CategoriesEdit,
-                        canDelete: true,
-                    },
-                ]}
-                //highlight-next-line
-                OffLayoutArea={OffLayoutArea}
-            />
-        </RefineKbarProvider>
-    );
+  return (
+    <RefineKbarProvider>
+      <Refine
+        resources={[
+          {
+            name: "posts",
+            list: PostList,
+            create: PostCreate,
+            edit: PostEdit,
+            show: PostShow,
+            icon: <Icons.StarOutlined />,
+            canDelete: true,
+          },
+          {
+            name: "categories",
+            list: CategoriesList,
+            create: CategoriesCreate,
+            edit: CategoriesEdit,
+            canDelete: true,
+          },
+        ]}
+        //highlight-next-line
+        OffLayoutArea={OffLayoutArea}
+      />
+    </RefineKbarProvider>
+  );
 };
 ```
 
@@ -97,12 +95,12 @@ You can use the `createAction` to create a new action and use the `useRegisterAc
 import { createAction, useRegisterActions } from "@pankod/refine-kbar";
 
 const customAction = createAction({
-    name: "my custom action",
-    section: "custom-actions",
-    perform: () => {
-        console.log("onSelect my custom action");
-    },
-    priority: Priority.HIGH,
+  name: "my custom action",
+  section: "custom-actions",
+  perform: () => {
+    console.log("onSelect my custom action");
+  },
+  priority: Priority.HIGH,
 });
 
 useRegisterActions(customAction);

--- a/documentation/versioned_docs/version-3.xx.xx/packages/documentation/inferencer.md
+++ b/documentation/versioned_docs/version-3.xx.xx/packages/documentation/inferencer.md
@@ -9,27 +9,7 @@ The package exports components for **List**, **Show**, **Create** and **Edit** v
 
 ## Installation
 
-<Tabs
-defaultValue="npm"
-values={[
-{label: 'use npm', value: 'npm'},
-{label: 'use yarn', value: 'yarn'}
-]}>
-<TabItem value="npm">
-
-```bash
-npm i @pankod/refine-inferencer
-```
-
-  </TabItem>
-    <TabItem value="yarn">
-
-```bash
-yarn add @pankod/refine-inferencer
-```
-
-  </TabItem>
-</Tabs>
+<InstallPackagesCommand args="@pankod/refine-inferencer"/>
 
 ## Available UI Inferencers
 

--- a/documentation/versioned_docs/version-3.xx.xx/packages/documentation/react-hook-form/useForm.md
+++ b/documentation/versioned_docs/version-3.xx.xx/packages/documentation/react-hook-form/useForm.md
@@ -192,9 +192,7 @@ The [`@pankod/refine-react-hook-form`][refine-react-hook-form] adapter allows yo
 
 Install the [`@pankod/refine-react-hook-form`][refine-react-hook-form] library.
 
-```bash
-npm i @pankod/refine-react-hook-form
-```
+<InstallPackagesCommand args="@pankod/refine-react-hook-form"/>
 
 ## Basic Usage
 

--- a/documentation/versioned_docs/version-3.xx.xx/packages/documentation/react-table/index.md
+++ b/documentation/versioned_docs/version-3.xx.xx/packages/documentation/react-table/index.md
@@ -22,39 +22,7 @@ All of [TanStack Table's][tanstack-table] features are supported and you can use
 
 Install the [`@pankod/refine-react-table`][refine-react-table] library.
 
-<Tabs
-defaultValue="npm"
-values={[
-{label: 'npm', value: 'npm'},
-{label: 'yarn', value: 'yarn'},
-{label: 'pnpm', value: 'pnpm'}
-]}>
-
-<TabItem value="npm">
-
-```bash
-npm i @pankod/refine-react-table
-```
-
-</TabItem>
-
-<TabItem value="yarn">
-
-```bash
-yarn add @pankod/refine-react-table
-```
-
-</TabItem>
-
-<TabItem value="pnpm">
-
-```bash
-pnpm add @pankod/refine-react-table
-```
-
-</TabItem>
-
-</Tabs>
+<InstallPackagesCommand args="@pankod/refine-react-table"/>
 
 ## Basic Usage
 

--- a/documentation/versioned_docs/version-3.xx.xx/tutorial/1-getting-started/antd/2-create-project.md
+++ b/documentation/versioned_docs/version-3.xx.xx/tutorial/1-getting-started/antd/2-create-project.md
@@ -15,37 +15,7 @@ The easiest way to create a new project is to use the **refine CLI**. This tool 
 
 1. Launch your terminal and type the following command using your preferred package manager:
 
-   <Tabs
-   defaultValue="npm"
-   values={[ {label: 'npm', value: 'npm'}, {label: 'pnpm', value: 'pnpm'}, {label: 'yarn', value: 'yarn'} ]}>
-
-   <TabItem value="npm">
-
-   ```bash
-   npm create refine-app@latest -- -o refine-antd tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="pnpm">
-
-   ```bash
-   pnpm create refine-app@latest -- -o refine-antd tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="yarn">
-
-   ```bash
-   yarn create refine-app -- -o refine-antd tutorial
-   ```
-
-   > Only support yarn@1 version.
-
-   </TabItem>
-
-   </Tabs>
+<CreateRefineAppCommand args="-o refine-antd tutorial" />
 
 2. Confirm `y` to installation of `create-refine-app`
 

--- a/documentation/versioned_docs/version-3.xx.xx/tutorial/1-getting-started/chakra-ui/2-create-project.md
+++ b/documentation/versioned_docs/version-3.xx.xx/tutorial/1-getting-started/chakra-ui/2-create-project.md
@@ -15,37 +15,7 @@ The easiest way to create a new project is to use the **refine CLI**. This tool 
 
 1. Launch your terminal and type the following command using your preferred package manager:
 
-   <Tabs
-   defaultValue="npm"
-   values={[ {label: 'npm', value: 'npm'}, {label: 'pnpm', value: 'pnpm'}, {label: 'yarn', value: 'yarn'} ]}>
-
-   <TabItem value="npm">
-
-   ```bash
-   npm create refine-app@latest -- -o refine-chakra-ui tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="pnpm">
-
-   ```bash
-   pnpm create refine-app@latest -- -o refine-chakra-ui tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="yarn">
-
-   ```bash
-   yarn create refine-app -- -o refine-chakra-ui tutorial
-   ```
-
-   > Only support yarn@1 version.
-
-   </TabItem>
-
-   </Tabs>
+<CreateRefineAppCommand args="-o refine-chakra-ui tutorial" />
 
 2. Confirm `y` to installation of `create-refine-app`
 

--- a/documentation/versioned_docs/version-3.xx.xx/tutorial/1-getting-started/headless/2-create-project.md
+++ b/documentation/versioned_docs/version-3.xx.xx/tutorial/1-getting-started/headless/2-create-project.md
@@ -15,45 +15,15 @@ The easiest way to create a new project is to use the **refine CLI**. This tool 
 
 1. Launch your terminal and type the following command using your preferred package manager:
 
-   <Tabs
-   defaultValue="npm"
-   values={[ {label: 'npm', value: 'npm'}, {label: 'pnpm', value: 'pnpm'}, {label: 'yarn', value: 'yarn'} ]}>
+<CreateRefineAppCommand args="-o refine-headless tutorial" />
 
-   <TabItem value="npm">
+1. Confirm `y` to installation of `create-refine-app`
 
-   ```bash
-   npm create refine-app@latest -- -o refine-headless tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="pnpm">
-
-   ```bash
-   pnpm create refine-app@latest -- -o refine-headless tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="yarn">
-
-   ```bash
-   yarn create refine-app -- -o refine-headless tutorial
-   ```
-
-   > Only support yarn@1 version.
-
-   </TabItem>
-
-   </Tabs>
-
-2. Confirm `y` to installation of `create-refine-app`
-
-3. The `-o refine-headless` flag in the command above tells the CLI to install the project with the `refine-headless` preset. This preset selects some options for you in accordance with this tutorial.
+2. The `-o refine-headless` flag in the command above tells the CLI to install the project with the `refine-headless` preset. This preset selects some options for you in accordance with this tutorial.
 
    > We use a preset here to sync the tutorial content with the code. Outside of the tutorial, you can skip this flag and select your own options.
 
-4. The CLI will ask if you agree to share your selection anonymously with the **refine** team. You can choose whatever you prefer.
+3. The CLI will ask if you agree to share your selection anonymously with the **refine** team. You can choose whatever you prefer.
 
 Once the installation wizard is finished, you can close this terminal window and open VS Code to continue your journey.
 

--- a/documentation/versioned_docs/version-3.xx.xx/tutorial/1-getting-started/headless/3-generate-crud-pages.md
+++ b/documentation/versioned_docs/version-3.xx.xx/tutorial/1-getting-started/headless/3-generate-crud-pages.md
@@ -36,35 +36,7 @@ The `@pankod/refine-inferencer` package provides the `<HeadlessInferencer/>` com
 
 Before we start using Inferencer, we need to add `@pankod/refine-react-hook-form` and `@pankod/refine-react-table` packages to our project. Since these packages are used by Inferencer to generate forms and tables, they need to be installed in our project.
 
-<Tabs
-defaultValue="npm"
-values={[ {label: 'npm', value: 'npm'}, {label: 'pnpm', value: 'pnpm'}, {label: 'yarn', value: 'yarn'} ]}>
-
-<TabItem value="npm">
-
-```bash
-npm i @pankod/refine-react-table @pankod/refine-react-hook-form
-```
-
-</TabItem>
-
-<TabItem value="pnpm">
-
-```bash
-pnpm i @pankod/refine-react-table @pankod/refine-react-hook-form
-```
-
-</TabItem>
-
-<TabItem value="yarn">
-
-```bash
-yarn add @pankod/refine-react-table @pankod/refine-react-hook-form
-```
-
-</TabItem>
-
-</Tabs>
+<InstallPackagesCommand args="@pankod/refine-react-table @pankod/refine-react-hook-form"/>
 
 Then, we need to add the `<HeadlessInferencer/>` component is used by passing to appropriate values in the `resources` prop of the `<Refine/>` component in `App.tsx` as shown below:
 

--- a/documentation/versioned_docs/version-3.xx.xx/tutorial/1-getting-started/mantine/2-create-project.md
+++ b/documentation/versioned_docs/version-3.xx.xx/tutorial/1-getting-started/mantine/2-create-project.md
@@ -15,37 +15,7 @@ The easiest way to create a new project is to use the **refine CLI**. This tool 
 
 1. Launch your terminal and type the following command using your preferred package manager:
 
-   <Tabs
-   defaultValue="npm"
-   values={[ {label: 'npm', value: 'npm'}, {label: 'pnpm', value: 'pnpm'}, {label: 'yarn', value: 'yarn'} ]}>
-
-   <TabItem value="npm">
-
-   ```bash
-   npm create refine-app@latest -- -o refine-mantine tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="pnpm">
-
-   ```bash
-   pnpm create refine-app@latest -- -o refine-mantine tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="yarn">
-
-   ```bash
-   yarn create refine-app -- -o refine-mantine tutorial
-   ```
-
-   > Only support yarn@1 version.
-
-   </TabItem>
-
-   </Tabs>
+<CreateRefineAppCommand args="-o refine-mantine tutorial" />
 
 2. Confirm `y` to installation of `create-refine-app`
 

--- a/documentation/versioned_docs/version-3.xx.xx/tutorial/1-getting-started/mui/2-create-project.md
+++ b/documentation/versioned_docs/version-3.xx.xx/tutorial/1-getting-started/mui/2-create-project.md
@@ -15,37 +15,7 @@ The easiest way to create a new project is to use the **refine CLI**. This tool 
 
 1. Launch your terminal and type the following command using your preferred package manager:
 
-   <Tabs
-   defaultValue="npm"
-   values={[ {label: 'npm', value: 'npm'}, {label: 'pnpm', value: 'pnpm'}, {label: 'yarn', value: 'yarn'} ]}>
-
-   <TabItem value="npm">
-
-   ```bash
-   npm create refine-app@latest -- -o refine-mui tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="pnpm">
-
-   ```bash
-   pnpm create refine-app@latest -- -o refine-mui tutorial
-   ```
-
-   </TabItem>
-
-   <TabItem value="yarn">
-
-   ```bash
-   yarn create refine-app -- -o refine-mui tutorial
-   ```
-
-   > Only support yarn@1 version.
-
-   </TabItem>
-
-   </Tabs>
+<CreateRefineAppCommand args="-o refine-mui tutorial" />
 
 2. Confirm `y` to installation of `create-refine-app`
 

--- a/documentation/versioned_docs/version-3.xx.xx/tutorial/2-understanding-dataprovider/2-create-dataprovider.md
+++ b/documentation/versioned_docs/version-3.xx.xx/tutorial/2-understanding-dataprovider/2-create-dataprovider.md
@@ -18,15 +18,11 @@ As shown below, we will begin by creating a file and adding additional methods a
 Using `axios` as our HTTP client will allow us to make efficient and reliable HTTP requests to our server. Interceptors provide several benefits, such as centralized error handling, the ability to modify request or response data, and show global loading indicators.  
 To get started, install the `axios` to our project.
 
-```bash
-npm install axios
-```
+<InstallPackagesCommand args="axios"/>
 
 Using the `stringify` library will allow us to convert the query parameters into a string format. This can be useful when we need to pass query parameters as part of an HTTP request.
 
-```bash
-npm install query-string@7
-```
+<InstallPackagesCommand args="query-string@7"/>
 
 For our own data provider, the first step is to create the following file.
 


### PR DESCRIPTION
We have install scripts around, some of them npm only, some of them has pnpm yarn vs too.
We can create a component that will accept list of packages and render scripts.


#### Usage

```tsx
<InstallPackagesCommand args="@refinedev/cli"/>
```

<img width="300" alt="image" src="https://github.com/refinedev/refine/assets/23058882/3cbf3c0c-bdff-47c2-82ad-5e09e7e58972">


```tsx
<CreateRefineAppCommand args="-o refine-nextjs my-refine-nextjs-app" />
```

<img width="300" alt="image" src="https://github.com/refinedev/refine/assets/23058882/358e7112-d766-4ae0-857e-4d3d3b7a120f">


### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
