### PR TITLE
fix(docs): images dont respect color mode

### DIFF
--- a/documentation/src/css/custom.css
+++ b/documentation/src/css/custom.css
@@ -1228,7 +1228,7 @@ form.DocSearch-Form label.DocSearch-MagnifierLabel svg.DocSearch-Search-Icon {
 }
 
 .template-detail-markdown a {
-    @apply text-blue-600 font-semibold;
+    @apply dark:text-refine-link-dark text-refine-link-light font-semibold;
 }
 
 .template-detail-markdown strong a {

--- a/documentation/src/pages/about/index.tsx
+++ b/documentation/src/pages/about/index.tsx
@@ -17,6 +17,7 @@ import { backedBy } from "../../assets/backed-by";
 import { team } from "../../assets/team";
 import { useColorMode } from "@docusaurus/theme-common";
 import { YCombinatorCircleIcon } from "@site/src/refine-theme/icons/ycombinator-circle";
+import { CommonThemedImage } from "@site/src/refine-theme/common-themed-image";
 
 const About: React.FC = () => {
     const { colorMode } = useColorMode();
@@ -509,11 +510,13 @@ const About: React.FC = () => {
                                 key={name}
                                 className="flex justify-start flex-col text-center"
                             >
-                                <img
-                                    srcSet={`${avatar[colorMode]} 1500w`}
-                                    src={avatar[colorMode]}
-                                    alt={name}
+                                <CommonThemedImage
                                     className="w-full not-prose m-0 mb-6"
+                                    srcDark={avatar.dark}
+                                    srcLight={avatar.light}
+                                    srcSetDark={`${avatar.dark} 1500w`}
+                                    srcSetLight={`${avatar.light} 1500w`}
+                                    alt={name}
                                 />
                                 <span
                                     className={clsx(

--- a/documentation/src/pages/templates/index.tsx
+++ b/documentation/src/pages/templates/index.tsx
@@ -14,9 +14,7 @@ import {
     Mantine,
     Medusa,
     Mui,
-    Rest,
     RestWithoutText,
-    ShadCnUI,
     Strapi,
     Supabase,
 } from "@site/src/assets/integration-icons";
@@ -332,7 +330,7 @@ const dataTemplates: {
             {
                 label: "Rest API",
                 icon: (props: SVGProps<SVGSVGElement>) => (
-                    <Rest width={16} height={16} {...props} />
+                    <RestWithoutText width={16} height={16} {...props} />
                 ),
             },
         ],
@@ -353,7 +351,7 @@ const dataTemplates: {
             {
                 label: "Rest API",
                 icon: (props: SVGProps<SVGSVGElement>) => (
-                    <Rest width={16} height={16} {...props} />
+                    <RestWithoutText width={16} height={16} {...props} />
                 ),
             },
         ],
@@ -374,7 +372,7 @@ const dataTemplates: {
             {
                 label: "Rest API",
                 icon: (props: SVGProps<SVGSVGElement>) => (
-                    <Rest width={16} height={16} {...props} />
+                    <RestWithoutText width={16} height={16} {...props} />
                 ),
             },
         ],
@@ -478,7 +476,7 @@ const dataTemplates: {
             {
                 label: "Rest API",
                 icon: (props: SVGProps<SVGSVGElement>) => (
-                    <Rest width={16} height={16} {...props} />
+                    <RestWithoutText width={16} height={16} {...props} />
                 ),
             },
         ],
@@ -541,7 +539,7 @@ const dataTemplates: {
             {
                 label: "Rest API",
                 icon: (props: SVGProps<SVGSVGElement>) => (
-                    <Rest width={16} height={16} {...props} />
+                    <RestWithoutText width={16} height={16} {...props} />
                 ),
             },
         ],
@@ -562,7 +560,7 @@ const dataTemplates: {
             {
                 label: "Rest API",
                 icon: (props: SVGProps<SVGSVGElement>) => (
-                    <Rest width={16} height={16} {...props} />
+                    <RestWithoutText width={16} height={16} {...props} />
                 ),
             },
         ],
@@ -583,7 +581,7 @@ const dataTemplates: {
             {
                 label: "Rest API",
                 icon: (props: SVGProps<SVGSVGElement>) => (
-                    <Rest width={16} height={16} {...props} />
+                    <RestWithoutText width={16} height={16} {...props} />
                 ),
             },
         ],
@@ -604,7 +602,7 @@ const dataTemplates: {
             {
                 label: "Rest API",
                 icon: (props: SVGProps<SVGSVGElement>) => (
-                    <Rest width={16} height={16} {...props} />
+                    <RestWithoutText width={16} height={16} {...props} />
                 ),
             },
         ],

--- a/documentation/src/refine-theme/common-themed-image.tsx
+++ b/documentation/src/refine-theme/common-themed-image.tsx
@@ -1,0 +1,34 @@
+import React, { FC } from "react";
+import { useColorMode } from "@docusaurus/theme-common";
+import BrowserOnly from "@docusaurus/BrowserOnly";
+
+type Props = Omit<
+    React.DetailedHTMLProps<
+        React.ImgHTMLAttributes<HTMLImageElement>,
+        HTMLImageElement
+    >,
+    "src"
+> & {
+    srcDark: string;
+    srcLight: string;
+    srcSetDark?: string;
+    srcSetLight?: string;
+};
+
+export const CommonThemedImage: FC<Props> = ({
+    srcDark,
+    srcLight,
+    srcSetDark,
+    srcSetLight,
+    ...props
+}) => {
+    const { colorMode } = useColorMode();
+    const src = colorMode === "dark" ? srcDark : srcLight;
+    const srcSet = colorMode === "dark" ? srcSetDark : srcSetLight;
+
+    return (
+        <BrowserOnly>
+            {() => <img {...props} src={src} srcSet={srcSet} />}
+        </BrowserOnly>
+    );
+};

--- a/documentation/src/refine-theme/enterprise-flexibility.tsx
+++ b/documentation/src/refine-theme/enterprise-flexibility.tsx
@@ -1,15 +1,13 @@
 import React from "react";
 import clsx from "clsx";
-import { useColorMode } from "@docusaurus/theme-common";
 import { LandingPureReactCode } from "./landing-pure-react-code";
+import { CommonThemedImage } from "./common-themed-image";
 
 export const EnterpriseFlexibility = ({
     className,
 }: {
     className?: string;
 }) => {
-    const { colorMode } = useColorMode();
-
     return (
         <div className={clsx("flex flex-col", "not-prose", className)}>
             <div
@@ -52,13 +50,10 @@ export const EnterpriseFlexibility = ({
                         "rounded-2xl landing-sm:rounded-3xl",
                     )}
                 >
-                    <img
+                    <CommonThemedImage
                         className={clsx("rounded-2xl landing-sm:rounded-3xl")}
-                        src={
-                            colorMode === "dark"
-                                ? `https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/lego-pieces-dark.png`
-                                : `https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/lego-pieces-light.png`
-                        }
+                        srcDark="https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/lego-pieces-dark.png"
+                        srcLight="https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/lego-pieces-light.png"
                     />
                     <div
                         className={clsx(

--- a/documentation/src/refine-theme/enterprise-frequent-updates.tsx
+++ b/documentation/src/refine-theme/enterprise-frequent-updates.tsx
@@ -1,14 +1,12 @@
 import React from "react";
 import clsx from "clsx";
-import { useColorMode } from "@docusaurus/theme-common";
+import { CommonThemedImage } from "./common-themed-image";
 
 export const EnterpriseFrequentUpdates = ({
     className,
 }: {
     className?: string;
 }) => {
-    const { colorMode } = useColorMode();
-
     return (
         <div className={clsx("flex flex-col", "not-prose", className)}>
             <div
@@ -100,18 +98,15 @@ export const EnterpriseFrequentUpdates = ({
                     </div>
                 </div>
 
-                <img
+                <CommonThemedImage
                     className={clsx(
                         "block",
                         "object-cover",
                         "w-[232px] landing-sm:w-[360px]",
                         "h-[232px] landing-sm:h-[360px]",
                     )}
-                    src={
-                        colorMode === "dark"
-                            ? `https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/refine-git-history-logo-dark.png`
-                            : `https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/refine-git-history-logo-light.png`
-                    }
+                    srcDark="https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/refine-git-history-logo-dark.png"
+                    srcLight="https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/refine-git-history-logo-light.png"
                 />
             </div>
         </div>

--- a/documentation/src/refine-theme/enterprise-get-support.tsx
+++ b/documentation/src/refine-theme/enterprise-get-support.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 import clsx from "clsx";
-import { useColorMode } from "@docusaurus/theme-common";
 import { ClockIcon } from "./icons/clock";
 import { SlackIcon } from "../assets/integration-icons";
+import { CommonThemedImage } from "./common-themed-image";
 
 export const EnterpriseGetSupport = ({ className }: { className?: string }) => {
-    const { colorMode } = useColorMode();
-
     return (
         <div className={clsx("flex flex-col", "not-prose", className)}>
             <div
@@ -56,16 +54,13 @@ export const EnterpriseGetSupport = ({ className }: { className?: string }) => {
                         "rounded-2xl landing-sm:rounded-3xl",
                     )}
                 >
-                    <img
+                    <CommonThemedImage
                         className={clsx(
                             "rounded-2xl landing-sm:rounded-3xl",
                             "landing-lg:h-[360px]",
                         )}
-                        src={
-                            colorMode === "dark"
-                                ? `https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/priority-support-dark.png`
-                                : `https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/priority-support-light.png`
-                        }
+                        srcDark="https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/priority-support-dark.png"
+                        srcLight="https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/priority-support-light.png"
                     />
                     <div
                         className={clsx(
@@ -147,12 +142,13 @@ export const EnterpriseGetSupport = ({ className }: { className?: string }) => {
                         "rounded-2xl landing-sm:rounded-3xl",
                     )}
                 >
-                    <img
+                    <CommonThemedImage
                         className={clsx(
                             "rounded-2xl landing-sm:rounded-3xl",
                             "landing-lg:h-[360px]",
                         )}
-                        src={`https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/onboarding-${colorMode}.png`}
+                        srcDark="https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/onboarding-dark.png"
+                        srcLight="https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/onboarding-light.png"
                     />
                     <div
                         className={clsx(

--- a/documentation/src/refine-theme/enterprise-hero-section.tsx
+++ b/documentation/src/refine-theme/enterprise-hero-section.tsx
@@ -1,15 +1,13 @@
 import React from "react";
 import clsx from "clsx";
-import { useColorMode } from "@docusaurus/theme-common";
 import { EnterpriseGetInTouchButton } from "./enterprise-get-in-touch-button";
+import { CommonThemedImage } from "./common-themed-image";
 
 export const EnterpriseHeroSection = ({
     className,
 }: {
     className?: string;
 }) => {
-    const { colorMode } = useColorMode();
-
     return (
         <div
             className={clsx(
@@ -85,16 +83,13 @@ export const EnterpriseHeroSection = ({
                     "mt-12 landing-sm:mt-16 landing-md:mt-0",
                 )}
             >
-                <img
+                <CommonThemedImage
                     className={clsx(
                         "landing-md:h-[360px] landing-md:w-[360px]",
                         "landing-md:h-[360px] landing-md:w-[360px]",
                     )}
-                    src={
-                        colorMode === "dark"
-                            ? `https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/enterprise-hero-image-dark.png`
-                            : `https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/enterprise-hero-image-light.png`
-                    }
+                    srcDark="https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/enterprise-hero-image-dark.png"
+                    srcLight="https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/enterprise-hero-image-light.png"
                     alt="refine enterprise image"
                 />
             </div>

--- a/documentation/src/refine-theme/enterprise-sso-mutlifactor-auth.tsx
+++ b/documentation/src/refine-theme/enterprise-sso-mutlifactor-auth.tsx
@@ -1,14 +1,12 @@
 import React from "react";
 import clsx from "clsx";
-import { useColorMode } from "@docusaurus/theme-common";
+import { CommonThemedImage } from "./common-themed-image";
 
 export const EnterpriseSSOMultifactorAuth = ({
     className,
 }: {
     className?: string;
 }) => {
-    const { colorMode } = useColorMode();
-
     return (
         <div className={clsx("flex flex-col", "not-prose", className)}>
             <div
@@ -26,13 +24,10 @@ export const EnterpriseSSOMultifactorAuth = ({
                         "rounded-2xl landing-sm:rounded-3xl",
                     )}
                 >
-                    <img
+                    <CommonThemedImage
                         className={clsx("rounded-2xl landing-sm:rounded-3xl")}
-                        src={
-                            colorMode === "dark"
-                                ? `https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/sign-in-dark.png`
-                                : `https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/sign-in-light.png`
-                        }
+                        srcDark="https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/sign-in-dark.png"
+                        srcLight="https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/sign-in-light.png"
                     />
                     <div
                         className={clsx(
@@ -71,9 +66,10 @@ export const EnterpriseSSOMultifactorAuth = ({
                         "rounded-2xl landing-sm:rounded-3xl",
                     )}
                 >
-                    <img
+                    <CommonThemedImage
                         className={clsx("rounded-2xl landing-sm:rounded-3xl")}
-                        src={`https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/multifactor-${colorMode}.png`}
+                        srcDark="https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/multifactor-dark.png"
+                        srcLight="https://refine.ams3.cdn.digitaloceanspaces.com/enterprise/multifactor-light.png"
                     />
                     <div
                         className={clsx(

--- a/documentation/src/refine-theme/templates-hero.tsx
+++ b/documentation/src/refine-theme/templates-hero.tsx
@@ -1,12 +1,10 @@
 import clsx from "clsx";
 import React, { FC } from "react";
-import { useColorMode } from "@docusaurus/theme-common";
+import { CommonThemedImage } from "./common-themed-image";
 
 type Props = { className?: string };
 
 export const TemplatesHero: FC<Props> = ({ className }) => {
-    const { colorMode } = useColorMode();
-
     return (
         <div
             className={clsx(
@@ -23,18 +21,15 @@ export const TemplatesHero: FC<Props> = ({ className }) => {
                 className,
             )}
         >
-            <img
+            <CommonThemedImage
                 className={clsx(
                     "absolute",
                     "hidden landing-md:block",
                     "w-[1200px]",
                     "max-w-[1200px]",
                 )}
-                src={
-                    colorMode === "dark"
-                        ? "https://refine.ams3.cdn.digitaloceanspaces.com/templates/templates-hero-dark.png"
-                        : "https://refine.ams3.cdn.digitaloceanspaces.com/templates/templates-hero-light.png"
-                }
+                srcDark="https://refine.ams3.cdn.digitaloceanspaces.com/templates/templates-hero-dark.png"
+                srcLight="https://refine.ams3.cdn.digitaloceanspaces.com/templates/templates-hero-light.png"
                 alt="Refine Templates"
             />
             <h2


### PR DESCRIPTION
While the images are conditionally rendered according to the `colorMode`, they are not rehydrated properly in the first render and are opened as default dark mode.

This issue is fixed by using https://docusaurus.io/docs/docusaurus-core#browseronly

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
