### PR TITLE
ci(examples): updated example build script

### DIFF
--- a/.github/workflows/build-example-chunks.js
+++ b/.github/workflows/build-example-chunks.js
@@ -13,7 +13,7 @@ const BUILD_ALL_EXAMPLES = process.env.BUILD_ALL_EXAMPLES === "true";
 const getChangedPackages = () => {
     const p = require.resolve("lerna/cli.js");
 
-    const output = execSync(`node ${p} ls --since origin/${BASE_REF} --json`, {
+    const output = execSync(`node ${p} ls --since ${BASE_REF} --json`, {
         stdio: "pipe",
     });
 
@@ -24,6 +24,10 @@ const getChangedPackages = () => {
 
 const isExampleAffected = (example, changedPackages) => {
     const examplePath = path.join(EXAMPLES_DIR, example);
+
+    if (changedPackages.length === 0) {
+        return false;
+    }
 
     const pkgJson = JSON.parse(
         fs.readFileSync(path.join(examplePath, "package.json")),

--- a/.github/workflows/build-example-chunks.js
+++ b/.github/workflows/build-example-chunks.js
@@ -13,7 +13,7 @@ const BUILD_ALL_EXAMPLES = process.env.BUILD_ALL_EXAMPLES === "true";
 const getChangedPackages = () => {
     const p = require.resolve("lerna/cli.js");
 
-    const output = execSync(`node ${p} ls --since ${BASE_REF} --json`, {
+    const output = execSync(`node ${p} ls --since origin/master --json`, {
         stdio: "pipe",
     });
 
@@ -45,7 +45,7 @@ const isExampleAffected = (example, changedPackages) => {
 
 const isExampleModified = (example) => {
     const output = execSync(
-        `git diff --quiet HEAD ${BASE_REF} -- ${EXAMPLES_DIR}/${example} || echo changed`,
+        `git diff --quiet HEAD origin/master -- ${EXAMPLES_DIR}/${example} || echo changed`,
         { stdio: "pipe" },
     );
 

--- a/.github/workflows/build-example-chunks.js
+++ b/.github/workflows/build-example-chunks.js
@@ -13,7 +13,7 @@ const BUILD_ALL_EXAMPLES = process.env.BUILD_ALL_EXAMPLES === "true";
 const getChangedPackages = () => {
     const p = require.resolve("lerna/cli.js");
 
-    const output = execSync(`node ${p} ls --since ${BASE_REF} --json`, {
+    const output = execSync(`node ${p} ls --since origin/${BASE_REF} --json`, {
         stdio: "pipe",
     });
 

--- a/.github/workflows/build-example-chunks.js
+++ b/.github/workflows/build-example-chunks.js
@@ -45,7 +45,7 @@ const isExampleAffected = (example, changedPackages) => {
 
 const isExampleModified = (example) => {
     const output = execSync(
-        `git diff --quiet HEAD ${BASE_REF} -- ${EXAMPLES_DIR}/${example} || echo changed`,
+        `git diff --quiet HEAD origin/${BASE_REF} -- ${EXAMPLES_DIR}/${example} || echo changed`,
         { stdio: "pipe" },
     );
 

--- a/.github/workflows/build-example-chunks.js
+++ b/.github/workflows/build-example-chunks.js
@@ -8,6 +8,7 @@ const EXAMPLES_DIR = "./examples";
 const ignoredRegexes = [/^monorepo-/, /^with-nx/];
 const CHUNK_COUNT = Number(process.env.CHUNKS ? process.env.CHUNKS : 1);
 const BASE_REF = process.env.BASE_REF ? process.env.BASE_REF : "master";
+const BUILD_ALL_EXAMPLES = process.env.BUILD_ALL_EXAMPLES === "true";
 
 const getChangedPackages = () => {
     const p = require.resolve("lerna/cli.js");
@@ -76,8 +77,10 @@ const getExamples = () => {
 //
 const changedPackages = getChangedPackages();
 
-const examples = getExamples().filter(
-    (dir) => isExampleAffected(dir, changedPackages) || isExampleModified(dir),
+const examples = getExamples().filter((dir) =>
+    BUILD_ALL_EXAMPLES
+        ? true
+        : isExampleAffected(dir, changedPackages) || isExampleModified(dir),
 );
 
 console.log(

--- a/.github/workflows/build-example-chunks.js
+++ b/.github/workflows/build-example-chunks.js
@@ -13,7 +13,7 @@ const BUILD_ALL_EXAMPLES = process.env.BUILD_ALL_EXAMPLES === "true";
 const getChangedPackages = () => {
     const p = require.resolve("lerna/cli.js");
 
-    const output = execSync(`node ${p} ls --since origin/master --json`, {
+    const output = execSync(`node ${p} ls --since ${BASE_REF} --json`, {
         stdio: "pipe",
     });
 
@@ -45,7 +45,7 @@ const isExampleAffected = (example, changedPackages) => {
 
 const isExampleModified = (example) => {
     const output = execSync(
-        `git diff --quiet HEAD origin/master -- ${EXAMPLES_DIR}/${example} || echo changed`,
+        `git diff --quiet HEAD ${BASE_REF} -- ${EXAMPLES_DIR}/${example} || echo changed`,
         { stdio: "pipe" },
     );
 

--- a/.github/workflows/build-example-chunks.js
+++ b/.github/workflows/build-example-chunks.js
@@ -21,7 +21,7 @@ const getChangedPackages = () => {
     return changedPackages.map((pkg) => pkg.name);
 };
 
-const isExampleChanged = (example, changedPackages) => {
+const isExampleAffected = (example, changedPackages) => {
     const examplePath = path.join(EXAMPLES_DIR, example);
 
     const pkgJson = JSON.parse(
@@ -36,6 +36,15 @@ const isExampleChanged = (example, changedPackages) => {
     return allDependencies.some((dependency) => {
         return changedPackages.includes(dependency);
     });
+};
+
+const isExampleModified = (example) => {
+    const output = execSync(
+        `git diff --quiet HEAD ${BASE_REF} -- ${EXAMPLES_DIR}/${example} || echo changed`,
+        { stdio: "pipe" },
+    );
+
+    return output.toString().includes("changed");
 };
 
 const hasPackageJson = (example) => {
@@ -67,8 +76,8 @@ const getExamples = () => {
 //
 const changedPackages = getChangedPackages();
 
-const examples = getExamples().filter((dir) =>
-    isExampleChanged(dir, changedPackages),
+const examples = getExamples().filter(
+    (dir) => isExampleAffected(dir, changedPackages) || isExampleModified(dir),
 );
 
 console.log(

--- a/.github/workflows/build-example-chunks.js
+++ b/.github/workflows/build-example-chunks.js
@@ -2,33 +2,105 @@
 
 const fs = require("fs");
 const path = require("path");
+const { execSync } = require("child_process");
 
 const EXAMPLES_DIR = "./examples";
-
 const ignoredRegexes = [/^monorepo-/, /^with-nx/];
+const CHUNK_COUNT = Number(process.env.CHUNKS ? process.env.CHUNKS : 1);
+const BASE_REF = process.env.BASE_REF ? process.env.BASE_REF : "master";
 
-const CHUNK_COUNT = Number(process.env.CHUNKS ? process.env.CHUNKS : 0);
+const getChangedPackages = () => {
+    const p = require.resolve("lerna/cli.js");
 
-const examples = fs
-    .readdirSync(EXAMPLES_DIR)
-    .filter((dir) => {
-        return fs.statSync(EXAMPLES_DIR + "/" + dir).isDirectory();
-    })
-    .filter((dir) => {
-        return !ignoredRegexes.some((regex) => regex.test(dir));
+    const output = execSync(`node ${p} ls --since ${BASE_REF} --json`, {
+        stdio: "pipe",
     });
 
+    const changedPackages = JSON.parse(output.toString());
+
+    return changedPackages.map((pkg) => pkg.name);
+};
+
+const isExampleChanged = (example, changedPackages) => {
+    const examplePath = path.join(EXAMPLES_DIR, example);
+
+    const pkgJson = JSON.parse(
+        fs.readFileSync(path.join(examplePath, "package.json")),
+    );
+
+    const dependencies = Object.keys(pkgJson.dependencies || {});
+    const devDependencies = Object.keys(pkgJson.devDependencies || {});
+
+    const allDependencies = [...dependencies, ...devDependencies];
+
+    return allDependencies.some((dependency) => {
+        return changedPackages.includes(dependency);
+    });
+};
+
+const hasPackageJson = (example) => {
+    return fs.existsSync(path.join(EXAMPLES_DIR, example, "package.json"));
+};
+
+const hasE2eTests = (example) => {
+    return fs.existsSync(path.join(EXAMPLES_DIR, example, "cypress.config.ts"));
+};
+
+const isDirectory = (example) => {
+    return fs.statSync(path.join(EXAMPLES_DIR, example)).isDirectory();
+};
+
+const isIgnored = (example) => {
+    return ignoredRegexes.some((regex) => regex.test(example));
+};
+
+const getExamples = () => {
+    return fs
+        .readdirSync(EXAMPLES_DIR)
+        .filter((dir) => isDirectory(dir))
+        .filter((dir) => !isIgnored(dir))
+        .filter((dir) => hasPackageJson(dir));
+};
+
+//
+// Get changed packages and affected examples
+//
+const changedPackages = getChangedPackages();
+
+const examples = getExamples().filter((dir) =>
+    isExampleChanged(dir, changedPackages),
+);
+
+console.log(
+    `Changed packages (${changedPackages.length}):\n- ` +
+        changedPackages.join("\n- "),
+);
+
+console.log("");
+
+console.log(
+    `Affected examples (${examples.length}):\n- ` + examples.join("\n- "),
+);
+
+//
+// Get examples with and without e2e tests
+//
+const examplesWithE2eTests = examples.filter((dir) => hasE2eTests(dir));
+
+const examplesWithoutE2eTests = examples.filter(
+    (dir) => !examplesWithE2eTests.includes(dir),
+);
+
+console.log(
+    `\nFound ${examplesWithE2eTests.length} examples with e2e tests and ${examplesWithoutE2eTests.length} without.\n`,
+);
+
+//
+// Split examples into chunks
+//
 const chunkSize = Math.ceil(examples.length / CHUNK_COUNT);
 
 const chunks = [];
-
-const examplesWithE2eTests = examples.filter((dir) => {
-    return fs.existsSync(path.join("examples", dir, "cypress.config.ts"));
-});
-
-const examplesWithoutE2eTests = examples.filter((dir) => {
-    return !examplesWithE2eTests.includes(dir);
-});
 
 for (let i = 0; i < examples.length; i += chunkSize) {
     const tempChunk = [];
@@ -37,11 +109,13 @@ for (let i = 0; i < examples.length; i += chunkSize) {
         if (j % (CHUNK_COUNT / 2) === 1) {
             if (examplesWithE2eTests.length > 0) {
                 tempChunk.push(examplesWithE2eTests.shift());
-            } else {
+            } else if (examplesWithoutE2eTests.length > 0) {
                 tempChunk.push(examplesWithoutE2eTests.shift());
             }
         } else {
-            tempChunk.push(examplesWithoutE2eTests.shift());
+            if (examplesWithoutE2eTests.length > 0) {
+                tempChunk.push(examplesWithoutE2eTests.shift());
+            }
         }
     }
 
@@ -54,6 +128,9 @@ for (let i = 0; i < examples.length; i += chunkSize) {
     chunks.push(tempChunk);
 }
 
+//
+// Set outputs
+//
 chunks.forEach((chunk, i) => {
     console.log("::set-output name=CHUNK_" + (i + 1) + "::" + chunk.join(","));
 });

--- a/.github/workflows/e2e-examples.js
+++ b/.github/workflows/e2e-examples.js
@@ -256,7 +256,7 @@ const runTests = async () => {
         try {
             if (!failed) {
                 const params = `-- --record --key ${KEY} --group ${path}`;
-                const runner = `npm run lerna run cypress:run -- --since=origin/${BASE_REF} --scope ${path} ${params}`;
+                const runner = `npm run lerna run cypress:run -- --scope ${path} ${params}`;
 
                 prettyLog("blue", `Running tests for ${path}`);
 

--- a/.github/workflows/examples-build.yml
+++ b/.github/workflows/examples-build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
     types:
+      - labeled
       - synchronize
       - opened
       - reopened
@@ -61,9 +62,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org/
 
+      - name: log event name
+        run: echo ${{ github.event_name }}
+
       - name: Split Into Chunks
         id: chunkstep
-        run: CHUNKS=8 node ./.github/workflows/build-example-chunks.js
+        run: CHUNKS=8 BASE_REF=${{ github.base_ref }} BUILD_ALL_EXAMPLES=${{ (contains(steps.pr-labels.outputs.labels, ' build-examples ') || github.event_name == 'schedule' ) && 'true' || 'false' }} node ./.github/workflows/build-example-chunks.js
 
   build-chunk-1:
     runs-on: ubuntu-latest

--- a/.github/workflows/examples-build.yml
+++ b/.github/workflows/examples-build.yml
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Prune branches
-        run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+        run: git fetch --no-tags --prune --depth=1 origin +refs/heads/master:refs/remotes/origin/master
 
       # run npm ci
       - name: Use Node.js ${{ matrix.node-version }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Split Into Chunks
         id: chunkstep
-        run: CHUNKS=8 BASE_REF=${{ github.base_ref }} BUILD_ALL_EXAMPLES=${{ (contains(steps.pr-labels.outputs.labels, ' build-examples ') || github.event_name == 'schedule' ) && 'true' || 'false' }} node ./.github/workflows/build-example-chunks.js
+        run: CHUNKS=8 BUILD_ALL_EXAMPLES=${{ (contains(steps.pr-labels.outputs.labels, ' build-examples ') || github.event_name == 'schedule' ) && 'true' || 'false' }} node ./.github/workflows/build-example-chunks.js
 
   build-chunk-1:
     runs-on: ubuntu-latest

--- a/.github/workflows/examples-build.yml
+++ b/.github/workflows/examples-build.yml
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Prune branches
-        run: git fetch --prune
+        run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
 
       # run npm ci
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/examples-build.yml
+++ b/.github/workflows/examples-build.yml
@@ -57,8 +57,8 @@ jobs:
         with:
           fetch-depth: '0'
 
-      - name: Prune branches
-        run: git fetch --no-tags --prune --depth=1 origin +refs/heads/master:refs/remotes/origin/master
+      - name: Fetch commits
+        run: git fetch origin ${{ github.base_ref || 'master' }} --depth=1
 
       # run npm ci
       - name: Use Node.js ${{ matrix.node-version }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Split Into Chunks
         id: chunkstep
-        run: CHUNKS=8 BUILD_ALL_EXAMPLES=${{ (contains(steps.pr-labels.outputs.labels, ' build-examples ') || github.event_name == 'schedule' ) && 'true' || 'false' }} node ./.github/workflows/build-example-chunks.js
+        run: CHUNKS=8 BASE_REF=${{ github.base_ref }} BUILD_ALL_EXAMPLES=${{ (contains(steps.pr-labels.outputs.labels, ' build-examples ') || github.event_name == 'schedule' ) && 'true' || 'false' }} node ./.github/workflows/build-example-chunks.js
 
   build-chunk-1:
     runs-on: ubuntu-latest

--- a/.github/workflows/examples-build.yml
+++ b/.github/workflows/examples-build.yml
@@ -57,8 +57,8 @@ jobs:
         with:
           fetch-depth: '0'
 
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.base_ref || 'master' }} --depth=1
+      - name: Prune branches
+        run: git fetch --prune
 
       # run npm ci
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/examples-build.yml
+++ b/.github/workflows/examples-build.yml
@@ -10,9 +10,6 @@ on:
       - opened
       - reopened
       - ready_for_review
-    paths:
-      - "packages/**"
-      - "examples/**"
   push:
     branches:
       - master

--- a/.github/workflows/examples-build.yml
+++ b/.github/workflows/examples-build.yml
@@ -62,6 +62,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org/
 
+      - name: Install Dependencies
+        run: npm ci
+
       - name: log event name
         run: echo ${{ github.event_name }}
 

--- a/.github/workflows/examples-build.yml
+++ b/.github/workflows/examples-build.yml
@@ -55,7 +55,10 @@ jobs:
         uses: joerick/pr-labels-action@v1.0.6
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: '0'
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref || 'master' }} --depth=1
 
       # run npm ci
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/examples-build.yml
+++ b/.github/workflows/examples-build.yml
@@ -54,6 +54,8 @@ jobs:
         id: pr-labels
         uses: joerick/pr-labels-action@v1.0.6
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       # run npm ci
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/examples-build.yml
+++ b/.github/workflows/examples-build.yml
@@ -70,9 +70,6 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: log event name
-        run: echo ${{ github.event_name }}
-
       - name: Split Into Chunks
         id: chunkstep
         run: CHUNKS=8 BASE_REF=${{ github.base_ref }} BUILD_ALL_EXAMPLES=${{ (contains(steps.pr-labels.outputs.labels, ' build-examples ') || github.event_name == 'schedule' ) && 'true' || 'false' }} node ./.github/workflows/build-example-chunks.js
@@ -97,9 +94,6 @@ jobs:
         uses: joerick/pr-labels-action@v1.0.6
       - uses: actions/checkout@v3
 
-      - name: Fetch commits
-        run: git fetch origin ${{ github.base_ref || 'master' }} --depth=1
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -110,10 +104,10 @@ jobs:
         run: npm ci
 
       - name: Bootstrap
-        run: npm run bootstrap -- --scope={${{ needs.chunks.outputs.CHUNK_1 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: npm run bootstrap -- --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_1 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Build
-        run: npm run build -- --no-bail --scope={${{ needs.chunks.outputs.CHUNK_1 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: npm run build -- --no-bail --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_1 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Get short SHA
         id: slug
@@ -142,9 +136,6 @@ jobs:
         uses: joerick/pr-labels-action@v1.0.6
       - uses: actions/checkout@v3
 
-      - name: Fetch commits
-        run: git fetch origin ${{ github.base_ref || 'master' }} --depth=1
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -155,10 +146,10 @@ jobs:
         run: npm ci
 
       - name: Bootstrap
-        run: npm run bootstrap -- --scope={${{ needs.chunks.outputs.CHUNK_2 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: npm run bootstrap -- --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_2 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Build
-        run: REFINE_NO_TELEMETRY=true npm run build -- --no-bail --scope={${{ needs.chunks.outputs.CHUNK_2 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: REFINE_NO_TELEMETRY=true npm run build -- --no-bail --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_2 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Get short SHA
         id: slug
@@ -187,9 +178,6 @@ jobs:
         uses: joerick/pr-labels-action@v1.0.6
       - uses: actions/checkout@v3
 
-      - name: Fetch commits
-        run: git fetch origin ${{ github.base_ref || 'master' }} --depth=1
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -200,10 +188,10 @@ jobs:
         run: npm ci
 
       - name: Bootstrap
-        run: npm run bootstrap -- --scope={${{ needs.chunks.outputs.CHUNK_3 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: npm run bootstrap -- --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_3 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Build
-        run: npm run build -- --no-bail --scope={${{ needs.chunks.outputs.CHUNK_3 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: npm run build -- --no-bail --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_3 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Get short SHA
         id: slug
@@ -232,9 +220,6 @@ jobs:
         uses: joerick/pr-labels-action@v1.0.6
       - uses: actions/checkout@v3
 
-      - name: Fetch commits
-        run: git fetch origin ${{ github.base_ref || 'master' }} --depth=1
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -245,10 +230,10 @@ jobs:
         run: npm ci
 
       - name: Bootstrap
-        run: npm run bootstrap -- --scope={${{ needs.chunks.outputs.CHUNK_4 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: npm run bootstrap -- --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_4 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Build
-        run: npm run build -- --no-bail --scope={${{ needs.chunks.outputs.CHUNK_4 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: npm run build -- --no-bail --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_4 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Get short SHA
         id: slug
@@ -277,9 +262,6 @@ jobs:
         uses: joerick/pr-labels-action@v1.0.6
       - uses: actions/checkout@v3
 
-      - name: Fetch commits
-        run: git fetch origin ${{ github.base_ref || 'master' }} --depth=1
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -290,10 +272,10 @@ jobs:
         run: npm ci
 
       - name: Bootstrap
-        run: npm run bootstrap -- --scope={${{ needs.chunks.outputs.CHUNK_5 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: npm run bootstrap -- --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_5 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Build
-        run: npm run build -- --no-bail --scope={${{ needs.chunks.outputs.CHUNK_5 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: npm run build -- --no-bail --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_5 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Get short SHA
         id: slug
@@ -322,9 +304,6 @@ jobs:
         uses: joerick/pr-labels-action@v1.0.6
       - uses: actions/checkout@v3
 
-      - name: Fetch commits
-        run: git fetch origin ${{ github.base_ref || 'master' }} --depth=1
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -335,10 +314,10 @@ jobs:
         run: npm ci
 
       - name: Bootstrap
-        run: npm run bootstrap -- --scope={${{ needs.chunks.outputs.CHUNK_6 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: npm run bootstrap -- --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_6 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Build
-        run: npm run build -- --no-bail --scope={${{ needs.chunks.outputs.CHUNK_6 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: npm run build -- --no-bail --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_6 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Get short SHA
         id: slug
@@ -367,9 +346,6 @@ jobs:
         uses: joerick/pr-labels-action@v1.0.6
       - uses: actions/checkout@v3
 
-      - name: Fetch commits
-        run: git fetch origin ${{ github.base_ref || 'master' }} --depth=1
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -380,10 +356,10 @@ jobs:
         run: npm ci
 
       - name: Bootstrap
-        run: npm run bootstrap -- --scope={${{ needs.chunks.outputs.CHUNK_7 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: npm run bootstrap -- --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_7 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Build
-        run: npm run build -- --no-bail --scope={${{ needs.chunks.outputs.CHUNK_7 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: npm run build -- --no-bail --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_7 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Get short SHA
         id: slug
@@ -412,9 +388,6 @@ jobs:
         uses: joerick/pr-labels-action@v1.0.6
       - uses: actions/checkout@v3
 
-      - name: Fetch commits
-        run: git fetch origin ${{ github.base_ref || 'master' }} --depth=1
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -425,10 +398,10 @@ jobs:
         run: npm ci
 
       - name: Bootstrap
-        run: npm run bootstrap -- --scope={${{ needs.chunks.outputs.CHUNK_8 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: npm run bootstrap -- --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_8 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Build
-        run: npm run build -- --no-bail --scope={${{ needs.chunks.outputs.CHUNK_8 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
+        run: npm run build -- --no-bail --scope={@refinedev/core,${{ needs.chunks.outputs.CHUNK_8 }}} --ignore blog-sveltekit-crud --ignore blog-react-aria
 
       - name: Get short SHA
         id: slug

--- a/examples/base-antd/README.md
+++ b/examples/base-antd/README.md
@@ -41,3 +41,5 @@ npm create refine-app@latest -- --example base-antd
 <br/>
 
 [![Open base-antd example from refine](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/embed/github/refinedev/refine/tree/master/examples/base-antd?view=preview&theme=dark&codemirror=1)
+
+<br/>

--- a/examples/base-antd/README.md
+++ b/examples/base-antd/README.md
@@ -41,5 +41,3 @@ npm create refine-app@latest -- --example base-antd
 <br/>
 
 [![Open base-antd example from refine](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/embed/github/refinedev/refine/tree/master/examples/base-antd?view=preview&theme=dark&codemirror=1)
-
-<br/>


### PR DESCRIPTION
Updated `build-examples` workflows to only run build & tests for examples affected from the changed packages of the owner branch.

Previously it was trying to do the same but fails due to `lerna`'s `--since` command not working properly.

Previously this error has caused missing the broken e2e tests in `server-side-validation-material-ui` example.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
