### PR TITLE
fix(mantine): useNotification.close not working

### DIFF
--- a/.changeset/cyan-mangos-sneeze.md
+++ b/.changeset/cyan-mangos-sneeze.md
@@ -2,4 +2,4 @@
 "@refinedev/mantine": patch
 ---
 
-fix: `useNotification.close("notification-key")` not working.
+fix: `useNotification.close("notification-key")` not working. #5433

--- a/.changeset/cyan-mangos-sneeze.md
+++ b/.changeset/cyan-mangos-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mantine": patch
+---
+
+fix: `useNotification.close("notification-key")` not working.

--- a/packages/mantine/src/providers/notificationProvider.tsx
+++ b/packages/mantine/src/providers/notificationProvider.tsx
@@ -148,6 +148,7 @@ export const notificationProvider = (): NotificationProvider => {
                 } else {
                     addNotification(key);
                     showNotification({
+                        id: key!,
                         color: type === "success" ? "primary" : "red",
                         icon:
                             type === "success" ? (


### PR DESCRIPTION
fixed: `useNotification.close("notification-key")` not working.

Closes #5433

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
