### PR TITLE
docs(core): add `<AutoSaveIndicator />` docs

### DIFF
--- a/documentation/docs/core/components/auto-save-indicator/index.md
+++ b/documentation/docs/core/components/auto-save-indicator/index.md
@@ -12,7 +12,7 @@ The `<AutoSaveIndicator />` component is a utility component that can be used to
 
 - Refine's core [`useForm`](/docs/data/hooks/use-form) hook does not automatically trigger the auto-save feature. You need to manually trigger the `onFinishAutoSave` function returned from the `useForm` hook to trigger the auto-save feature.
 
-- Extended implementations of Refine's `useForm` such as; [@refinedev/antd`'s `useForm`](/docs/ui-integrations/ant-design/hooks/use-form), [`@refinedev/react-hook-form`'s `useForm`](/docs/packages/react-hook-form/use-form) and [`@refinedev/mantine`'s `useForm`](/docs/ui-integrations/mantine/hooks/use-form) automatically trigger the auto-save feature when a form value changes.
+- Extended implementations of Refine's `useForm` such as; [`@refinedev/antd`'s `useForm`](/docs/ui-integrations/ant-design/hooks/use-form), [`@refinedev/react-hook-form`'s `useForm`](/docs/packages/react-hook-form/use-form) and [`@refinedev/mantine`'s `useForm`](/docs/ui-integrations/mantine/hooks/use-form) automatically trigger the auto-save feature when a form value changes.
 
 - The `<AutoSaveIndicator />` component is only designed to display a visual feedback to the user about the auto-save status of the form. It does not contain any logic to trigger the auto-save feature.
 
@@ -33,6 +33,15 @@ const EditPage = () => {
       enabled: true,
     },
   });
+
+  console.log(autoSaveProps);
+  /*
+    {
+      status: "success",  // "loading" | "error" | "idle" | "success"
+      error: null,        // HttpError | null
+      data: { ... },      // UpdateResponse | undefined,
+    }
+  */
 
   return (
     <div>
@@ -56,8 +65,41 @@ import Usage from "./usage.tsx";
 
 <Usage />
 
+### Customizing the indicator
+
+The `<AutoSaveIndicator />` component accepts an `elements` prop which can be used to customize the indicator for each status.
+
+```tsx
+import { AutoSaveIndicator, useForm } from "@refinedev/core";
+
+const EditPage = () => {
+  const { autoSaveProps } = useForm({
+    autoSave: {
+      enabled: true,
+    },
+  });
+
+  return (
+    <div>
+      <AutoSaveIndicator
+        {...autoSaveProps}
+        // highlight-start
+        elements={{
+          loading: <span>saving...</span>,
+          error: <span>auto save error.</span>,
+          idle: <span>waiting for changes.</span>,
+          success: <span>saved.</span>,
+        }}
+        // highlight-end
+      />
+      {/* ... */}
+    </div>
+  );
+};
+```
+
 ## API Reference
 
 ### Properties
 
-<PropsTable module="@refinedev/core/AutoSaveIndicator" />
+<PropsTable module="@refinedev/core/AutoSaveIndicator" elements-type={'Partial<Record<"loading" \\| "error" \\| "idle" \\| "success", ReactNode>>'} />

--- a/documentation/docs/core/components/auto-save-indicator/index.md
+++ b/documentation/docs/core/components/auto-save-indicator/index.md
@@ -1,0 +1,63 @@
+---
+title: <AutoSaveIndicator />
+description: <AutoSaveIndicator> component shows `autoSave` status on edit actions.
+source: packages/core/src/components/autoSaveIndicator/index.tsx
+---
+
+Refine's forms provide a built-in auto-save feature. This allows you to automatically save the form when the user makes changes to the form which can be useful for forms that are long or complex and the user may not want to lose their progress.
+
+The `<AutoSaveIndicator />` component is a utility component that can be used to show a visual indicator to the user about the auto-save status of the form.
+
+:::simple Good to know
+
+- Refine's core [`useForm`](/docs/data/hooks/use-form) hook does not automatically trigger the auto-save feature. You need to manually trigger the `onFinishAutoSave` function returned from the `useForm` hook to trigger the auto-save feature.
+
+- Extended implementations of Refine's `useForm` such as; [@refinedev/antd`'s `useForm`](/docs/ui-integrations/ant-design/hooks/use-form), [`@refinedev/react-hook-form`'s `useForm`](/docs/packages/react-hook-form/use-form) and [`@refinedev/mantine`'s `useForm`](/docs/ui-integrations/mantine/hooks/use-form) automatically trigger the auto-save feature when a form value changes.
+
+- The `<AutoSaveIndicator />` component is only designed to display a visual feedback to the user about the auto-save status of the form. It does not contain any logic to trigger the auto-save feature.
+
+- To learn more about the auto-save feature check out [Auto Save section in Forms guide](/docs/guides-concepts/forms/#auto-save)
+
+:::
+
+## Usage
+
+Usage is as simple as spreading the `autoSaveProps` object returned from the [`useForm`](/docs/data/hooks/use-form) hook into the `<AutoSaveIndicator />` component. It will automatically determine the auto-save status and display the appropriate indicator.
+
+```tsx
+import { AutoSaveIndicator, useForm } from "@refinedev/core";
+
+const EditPage = () => {
+  const { autoSaveProps } = useForm({
+    autoSave: {
+      enabled: true,
+    },
+  });
+
+  return (
+    <div>
+      {/* highlight-start */}
+      {/* We'll pass the autoSaveProps from useForm's response to the <AutoSaveIndicator /> component. */}
+      <AutoSaveIndicator {...autoSaveProps} />
+      {/* highlight-end */}
+      <form
+      // ...
+      >
+        {/* ... */}
+      </form>
+    </div>
+  );
+};
+```
+
+Example below shows the `<AutoSaveIndicator />` component in action.
+
+import Usage from "./usage.tsx";
+
+<Usage />
+
+## API Reference
+
+### Properties
+
+<PropsTable module="@refinedev/core/AutoSaveIndicator" />

--- a/documentation/docs/core/components/auto-save-indicator/usage.tsx
+++ b/documentation/docs/core/components/auto-save-indicator/usage.tsx
@@ -1,0 +1,211 @@
+import { Sandpack } from "@site/src/components/sandpack";
+import React from "react";
+
+export default function BasicUsage() {
+  return (
+    <Sandpack
+      showOpenInCodeSandbox={false}
+      dependencies={{
+        "@refinedev/core": "latest",
+        "@refinedev/simple-rest": "latest",
+        "@refinedev/react-router-v6": "latest",
+        "react-router-dom": "latest",
+        "react-router": "latest",
+      }}
+      startRoute="/products/edit/123"
+      files={{
+        "/App.tsx": {
+          code: AppTsxCode,
+          hidden: true,
+        },
+        "/style.css": {
+          code: StyleCssCode,
+          hidden: true,
+        },
+        "/edit.tsx": {
+          code: EditTsxCode,
+          active: true,
+        },
+      }}
+    />
+  );
+}
+
+const AppTsxCode = /* jsx */ `
+import React from "react";
+import { Refine } from "@refinedev/core";
+import dataProvider from "@refinedev/simple-rest";
+import { BrowserRouter, Route, Routes, Navigate, Link, Outlet } from "react-router-dom";
+import routerProvider from "@refinedev/react-router-v6";
+
+import "./style.css";
+
+import { Edit } from "./edit.tsx";
+
+export default function App() {
+    return (
+        <BrowserRouter>
+            <Refine
+                routerProvider={routerProvider}
+                dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
+                resources={[
+                    {
+                        name: "products",
+                        edit: "/products/edit/:id",
+                    }
+                ]}
+            >
+                <Routes>
+                    <Route index element={<Navigate to="/products/edit/123" />} />
+                    <Route path="/products" element={<Outlet />}>
+                        <Route path="edit/:id" element={<Edit />} />
+                    </Route>
+                </Routes>
+            </Refine>
+        </BrowserRouter>
+    );
+}
+`.trim();
+
+const StyleCssCode = `
+html {
+    margin: 0;
+    padding: 0;
+}
+body {
+    margin: 0;
+    padding: 12px;
+}
+* {
+    box-sizing: border-box;
+}
+body {
+    font-family: sans-serif;
+}
+form button {
+    display: block;
+    // width: 100%;
+    margin-bottom: 6px;
+}
+.page {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.page form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  max-width: 400px;
+}
+.page form label {
+  display: flex;
+  align-items: center;
+}
+.page form label input, .page form label textarea, .page form label select {
+  flex: 1;
+}
+.page form label span {
+  width: 90px;
+}
+.auto-save-wrapper {
+  padding: 6px 0;
+  font-weight: 600;
+}
+`.trim();
+
+const EditTsxCode = /* jsx */ `import React from "react";
+import { useForm, useSelect, AutoSaveIndicator, HttpError, BaseKey } from "@refinedev/core";
+
+export const Edit: React.FC = () => {
+  const { queryResult, isLoading, onFinish, autoSaveProps, onFinishAutoSave } = useForm<
+    IProduct,
+    HttpError,
+    FormValues
+  >({
+    autoSave: {
+      enabled: true,
+      interval: 1000,
+    },
+  });
+
+  const { options: categorySelectOptions } = useSelect({
+    resource: "categories",
+  });
+
+  const defaultValues = queryResult?.data?.data;
+
+  return (
+    <div className="page">
+      <form
+        onChange={(event) => {
+          const formData = new FormData(event.currentTarget);
+
+          onFinishAutoSave(transformValues(Object.fromEntries(formData.entries()) as RawFormValues));
+        }}
+        onSubmit={(event) => {
+          event.preventDefault();
+          const formData = new FormData(event.currentTarget);
+
+          onFinish(transformValues(Object.fromEntries(formData.entries()) as RawFormValues));
+        }}
+      >
+        <label htmlFor="name">
+          <span>Name</span>
+          <input name="name" placeholder="Name" defaultValue={defaultValues?.name} />
+        </label>
+        <label htmlFor="description">
+          <span>Description</span>
+          <textarea name="description" placeholder="Description" defaultValue={defaultValues?.description} />
+        </label>
+        <label htmlFor="material">
+          <span>Material</span>
+          <input name="material" placeholder="Material" defaultValue={defaultValues?.material} />
+        </label>
+        <label htmlFor="category">
+          <span>Category</span>
+          <select name="category" defaultValue={defaultValues?.category?.id}>
+            {categorySelectOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button type="submit">Submit</button>
+        <div className="auto-save-wrapper">
+          <AutoSaveIndicator {...autoSaveProps} />
+        </div>
+      </form>
+    </div>
+  );
+};
+
+const transformValues = (values: RawFormValues): FormValues => {
+  return {
+    ...values,
+    category: values.category ? { id: values.category } : undefined,
+  };
+};
+
+interface IProduct {
+  id: BaseKey;
+  name: string;
+  material: string;
+  description: string;
+  category: { id: BaseKey; name: string };
+}
+
+interface FormValues {
+  name?: string;
+  material?: string;
+  description?: string;
+  category?: { id: BaseKey };
+}
+
+interface RawFormValues extends FormValues {
+  category?: BaseKey;
+}
+`.trim();

--- a/documentation/docs/core/components/auto-save-indicator/usage.tsx
+++ b/documentation/docs/core/components/auto-save-indicator/usage.tsx
@@ -139,6 +139,9 @@ export const Edit: React.FC = () => {
 
   return (
     <div className="page">
+      <div className="auto-save-wrapper">
+        <AutoSaveIndicator {...autoSaveProps} />
+      </div>
       <form
         onChange={(event) => {
           const formData = new FormData(event.currentTarget);
@@ -175,9 +178,6 @@ export const Edit: React.FC = () => {
           </select>
         </label>
         <button type="submit">Submit</button>
-        <div className="auto-save-wrapper">
-          <AutoSaveIndicator {...autoSaveProps} />
-        </div>
       </form>
     </div>
   );

--- a/documentation/docs/guides-concepts/forms/index.md
+++ b/documentation/docs/guides-concepts/forms/index.md
@@ -740,7 +740,7 @@ const { autoSaveProps } = useForm({
 
 ### `<AutoSaveIndicator />`
 
-Refine's core and ui integrations are shipped with an `<AutoSaveIndicator />` component that can be used to show a visual indicator to the user when the auto save is triggered. The `autoSaveProps` value from the `useForm`'s return value can be passed to the `<AutoSaveIndicator />` to show the auto save status to the user. It will automatically show the loading, success and error states to the user.
+Refine's core and ui integrations are shipped with an [`<AutoSaveIndicator />`](/docs/core/components/auto-save-indicator) component that can be used to show a visual indicator to the user when the auto save is triggered. The `autoSaveProps` value from the `useForm`'s return value can be passed to the `<AutoSaveIndicator />` to show the auto save status to the user. It will automatically show the loading, success and error states to the user.
 
 ```tsx title="edit.tsx"
 import { AutoSaveIndicator } from "@refinedev/core";

--- a/documentation/docs/ui-integrations/ant-design/components/auto-save-indicator/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/auto-save-indicator/index.md
@@ -24,6 +24,15 @@ const MyComponent = () => {
     },
   });
 
+  console.log(autoSaveProps);
+  /*
+    {
+      status: "success",  // "loading" | "error" | "idle" | "success"
+      error: null,        // HttpError | null
+      data: { ... },      // UpdateResponse | undefined,
+    }
+  */
+
   return <AutoSaveIndicator {...autoSaveProps} />;
 };
 ```

--- a/documentation/docs/ui-integrations/ant-design/components/auto-save-indicator/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/auto-save-indicator/index.md
@@ -6,6 +6,12 @@ source: packages/antd/src/components/autoSaveIndicator/index.tsx
 
 `<AutoSaveIndicator>` component from Refine for **Ant Design** can be used to communicate auto-save status to the user.
 
+:::simple Good to know
+
+This component is an extended version of the [`<AutoSaveIndicator>`](/docs/core/components/auto-save-indicator) component from Refine's core package. It provides a set of elements which align with Ant Design's components and styling.
+
+:::
+
 ## Usage
 
 ```tsx

--- a/documentation/docs/ui-integrations/chakra-ui/components/auto-save-indicator/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/auto-save-indicator/index.md
@@ -30,6 +30,15 @@ const MyComponent = () => {
     },
   });
 
+  console.log(autoSaveProps);
+  /*
+    {
+      status: "success",  // "loading" | "error" | "idle" | "success"
+      error: null,        // HttpError | null
+      data: { ... },      // UpdateResponse | undefined,
+    }
+  */
+
   return <AutoSaveIndicator {...autoSaveProps} />;
 };
 ```

--- a/documentation/docs/ui-integrations/chakra-ui/components/auto-save-indicator/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/auto-save-indicator/index.md
@@ -6,6 +6,12 @@ source: packages/chakra-ui/src/components/autoSaveIndicator/index.tsx
 
 `<AutoSaveIndicator>` component from Refine for **Chakra UI** can be used to communicate auto-save status to the user.
 
+:::simple Good to know
+
+This component is an extended version of the [`<AutoSaveIndicator>`](/docs/core/components/auto-save-indicator) component from Refine's core package. It provides a set of elements which align with Chakra UI's components and styling.
+
+:::
+
 ## Usage
 
 Simple usage is as follows:

--- a/documentation/docs/ui-integrations/mantine/components/auto-save-indicator/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/auto-save-indicator/index.md
@@ -6,6 +6,12 @@ source: packages/antd/src/components/autoSaveIndicator/index.tsx
 
 `<AutoSaveIndicator>` component from Refine for **Mantine** can be used to communicate auto-save status to the user.
 
+:::simple Good to know
+
+This component is an extended version of the [`<AutoSaveIndicator>`](/docs/core/components/auto-save-indicator) component from Refine's core package. It provides a set of elements which align with Mantine's components and styling.
+
+:::
+
 ## Usage
 
 ```tsx

--- a/documentation/docs/ui-integrations/mantine/components/auto-save-indicator/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/auto-save-indicator/index.md
@@ -28,6 +28,15 @@ const MyComponent = () => {
     },
   });
 
+  console.log(autoSaveProps);
+  /*
+    {
+      status: "success",  // "loading" | "error" | "idle" | "success"
+      error: null,        // HttpError | null
+      data: { ... },      // UpdateResponse | undefined,
+    }
+  */
+
   return <AutoSaveIndicator {...autoSaveProps} />;
 };
 ```

--- a/documentation/docs/ui-integrations/material-ui/components/auto-save-indicator/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/auto-save-indicator/index.md
@@ -6,6 +6,12 @@ source: packages/antd/src/components/autoSaveIndicator/index.tsx
 
 `<AutoSaveIndicator>` component from Refine for **Material UI** can be used to communicate auto-save status to the user.
 
+:::simple Good to know
+
+This component is an extended version of the [`<AutoSaveIndicator>`](/docs/core/components/auto-save-indicator) component from Refine's core package. It provides a set of elements which align with Material UI's components and styling.
+
+:::
+
 ## Usage
 
 ```tsx

--- a/documentation/docs/ui-integrations/material-ui/components/auto-save-indicator/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/auto-save-indicator/index.md
@@ -28,6 +28,15 @@ const MyComponent = () => {
     },
   });
 
+  console.log(autoSaveProps);
+  /*
+    {
+      status: "success",  // "loading" | "error" | "idle" | "success"
+      error: null,        // HttpError | null
+      data: { ... },      // UpdateResponse | undefined,
+    }
+  */
+
   return <AutoSaveIndicator {...autoSaveProps} />;
 };
 ```

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -555,7 +555,7 @@ module.exports = {
                     collapsed: false,
                     items: [
                         // TODO: add doc
-                        // "core/components/auto-save-indicator/index",
+                        "core/components/auto-save-indicator/index",
                         "core/components/inferencer/index",
                     ],
                 },

--- a/documentation/src/css/custom.css
+++ b/documentation/src/css/custom.css
@@ -956,6 +956,7 @@ html[data-theme="dark"]:not([data-customized="true"])
 .props-table__description-cell *,
 .props-table__default-value-cell *,
 .props-list__info-item * {
+    @apply 2xl:my-0;
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
- Added API documentation for `<AutoSaveIndicator />` component of `@refinedev/core`.
- Updated UI integration versions to include info about the core's implementation.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
