### PR TITLE
docs(headings): remove backticks from one word headings

### DIFF
--- a/documentation/docs/advanced-tutorials/custom-layout.md
+++ b/documentation/docs/advanced-tutorials/custom-layout.md
@@ -8,7 +8,7 @@ sidebar_label: Custom Layout
 
 ## Layout Elements
 
-### `Layout`
+### Layout
 
 `<Layout>` components are designed to wrap your pages and provide a dashboard-like layout. `<Layout>` accepts rest of the layout elements in props.
 
@@ -21,7 +21,7 @@ sidebar_label: Custom Layout
 | [`OffLayoutArea`](#offlayoutarea) | `React.FC`  | Component to render outside of the layout       |
 | `children`                        | `ReactNode` | Page content.                                   |
 
-### `Sider`
+### Sider
 
 `<Sider>` components are designed to render menu items according to the resources you have defined in `<Refine>` components. [`useMenu`][usemenu] hook is used under the hood to generate menu items.
 
@@ -31,7 +31,7 @@ sidebar_label: Custom Layout
 | `render`          | [`SiderRenderFunction`](#siderrenderfunction) | Function to render the menu items and other elements inside the `<Sider>` |
 | `meta`            | `Record<string,any>`                          | Meta data to use when creating routes for the menu items                  |
 
-### `SiderRenderFunction`
+### SiderRenderFunction
 
 ```tsx
 type SiderRenderFunction = (props: {
@@ -64,19 +64,19 @@ const CustomSider = () => {
 };
 ```
 
-### `Header`
+### Header
 
 `<Header>` components are designed to render a header at the top of the layout.
 
-### `Title`
+### Title
 
 `<Title>` components are designed to render a title inside the `<Sider>` component. By default, it renders the **Refine** logo with a link to the index page.
 
-### `Footer`
+### Footer
 
 `<Footer>` components are designed to render a footer at the bottom of the layout.
 
-### `OffLayoutArea`
+### OffLayoutArea
 
 `<OffLayoutArea>` components are designed to render elements outside of the layout.
 

--- a/documentation/docs/advanced-tutorials/data-provider/handling-filters.md
+++ b/documentation/docs/advanced-tutorials/data-provider/handling-filters.md
@@ -5,7 +5,7 @@ title: Handling Filters
 
 **Refine** expects an array of type `CrudFilters` to filter results based on some field’s values. So you can use more than one filter. Even the `or` operator can be used to combine multiple filters.
 
-## `CrudFilters`
+## CrudFilters
 
 `CrudFilters` is an array of objects with the following properties:
 
@@ -55,7 +55,7 @@ type CrudFilter = LogicalFilter | ConditionalFilter;
 type CrudFilters = CrudFilter[];
 ```
 
-## `LogicalFilters`
+## LogicalFilters
 
 `LogicalFilter` works with `AND` logic. For example, if you want to filter by `name` field and `age` field, you can use the following filter:
 
@@ -76,7 +76,7 @@ const filter = [
 
 Here the query will look like: `"name" = "John" AND "age" < 30`
 
-## `ConditionalFilters`
+## ConditionalFilters
 
 `ConditionalFilter` works `or` / `and` operator and expects an array of `LogicalFilter` objects in the `value` property. For example, if you want to filter multiple `OR` by `name` field and `age` field, you can use the following filter:
 

--- a/documentation/docs/advanced-tutorials/mutation-mode.md
+++ b/documentation/docs/advanced-tutorials/mutation-mode.md
@@ -225,7 +225,7 @@ Each mode corresponds to a different type of user experience.
 
 We'll show usages of modes with editing a record examples.
 
-### `pessimistic`
+### pessimistic
 
 The mutation runs immediately. Redirection and UI updates are executed after the mutation returns successfully.
 
@@ -284,7 +284,7 @@ render(<App />);
 
 <br />
 
-### `optimistic`
+### optimistic
 
 The mutation is applied locally, redirection and UI updates are executed immediately as if the mutation is successful. If mutation returns with error, UI updates to show data prior to the mutation.
 
@@ -342,7 +342,7 @@ render(<App />);
 
 <br />
 
-### `undoable`
+### undoable
 
 The mutation is applied locally, redirection and UI updates are executed immediately as if the mutation is successful. Waits for a customizable amount of timeout period before mutation is applied. During the timeout, mutation can be cancelled from the notification with an undo button and UI will revert back accordingly.
 

--- a/documentation/docs/audit-logs/audit-log-provider/index.md
+++ b/documentation/docs/audit-logs/audit-log-provider/index.md
@@ -67,7 +67,7 @@ Refine provides the `useLog` and `useLogList` hooks that can be used to access y
 
 Let's create an `auditLogProvider` to understand how it works better. Though we will be using `dataProvider` to handle events, you can do it however you want thanks to Refine providing an agnostic API.
 
-### `get`
+### get
 
 This method is used to get a list of audit log events.
 
@@ -100,7 +100,7 @@ export const auditLogProvider: AuditLogProvider = {
 };
 ```
 
-### `create`
+### create
 
 :::simple Caution
 
@@ -290,7 +290,7 @@ export const auditLogProvider: AuditLogProvider = {
 
 For more information, refer to the [`useLog` documentation&#8594](/docs/audit-logs/hooks/use-log)
 
-### `update`
+### update
 
 This method is used to update an audit log event.
 

--- a/documentation/docs/audit-logs/hooks/use-log/index.md
+++ b/documentation/docs/audit-logs/hooks/use-log/index.md
@@ -10,7 +10,7 @@ import { useLog } from "@refinedev/core";
 const { log, rename } = useLog();
 ```
 
-## `log`
+## log
 
 The `log` mutation is used to create an audit log event using the `create` method from [`auditLogProvider`](/docs/audit-logs/audit-log-provider#create) under the hood.
 
@@ -61,7 +61,7 @@ mutate({
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | Result of the `react-query`'s useMutation | [`UseMutationResult<{ data: TData}, TError, { id: BaseKey; name: string; }, unknown>`](https://react-query.tanstack.com/reference/useMutation) |
 
-## `rename`
+## rename
 
 The `rename` mutation is used to update an audit log event using the `update` method from [`auditLogProvider`](/docs/audit-logs/audit-log-provider#update) under the hood.
 

--- a/documentation/docs/authentication/components/auth-page/index.md
+++ b/documentation/docs/authentication/components/auth-page/index.md
@@ -469,7 +469,7 @@ const authProvider: AuthBindings = {
 
 ## Props
 
-### `hideForm`
+### hideForm
 
 When you set `hideForm` to `true`, the form will be hidden. You can use this property to show only providers.
 
@@ -496,7 +496,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `providers`
+### providers
 
 `providers` property defines the list of providers used to handle login authentication. `providers` accepts an array of `Provider` type. This property is only available for `login` and `register` types.
 
@@ -523,7 +523,7 @@ const LoginPage = () => {
 
 > For more information, refer to the [Interface section down below](#interface)
 
-### `rememberMe`
+### rememberMe
 
 `rememberMe` property defines to render your own remember me component or you can pass `false` to don't render it. This property is only available for `login` type.
 
@@ -549,7 +549,7 @@ const LoginPage = () => {
 };
 ```
 
-### `loginLink`
+### loginLink
 
 `loginLink` property defines the link to the login page and also you can give a node to render. The default value is `"/login"`. This property is only available for `register` and `forgotPassword` types.
 
@@ -575,7 +575,7 @@ const MyRegisterPage = () => {
 };
 ```
 
-### `registerLink`
+### registerLink
 
 `registerLink` property defines the link to the registration page and also you can give a node to render. The default value is `"/register"`. This property is only available for `login` type.
 
@@ -602,7 +602,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `forgotPasswordLink`
+### forgotPasswordLink
 
 `forgotPasswordLink` property defines the link to the forgot password page and also you can give a node to render. The default value is `"/forgot-password"`. This property is only available for `login` type.
 
@@ -629,7 +629,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `wrapperProps`
+### wrapperProps
 
 `wrapperProps` uses for passing props to the wrapper component. In the example below you can see that the background color is changed with `wrapperProps`
 
@@ -655,7 +655,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `contentProps`
+### contentProps
 
 `contentProps` uses for passing props to the content component which is the card component. In the example below you can see that the title, header, and content styles are changed with `contentProps`.
 
@@ -676,7 +676,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `formProps`
+### formProps
 
 `formProps` uses for passing props to the form component.
 
@@ -707,7 +707,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `renderContent`
+### renderContent
 
 `renderContent` is used to render the form content. You can use this property to render your own content. `renderContent` gives you default content you can use to add some extra elements to the content.
 

--- a/documentation/docs/authentication/components/authenticated/index.md
+++ b/documentation/docs/authentication/components/authenticated/index.md
@@ -28,7 +28,7 @@ const MyPage = () => (
 
 ## Properties
 
-### `key` <PropTag required />
+### key <PropTag required />
 
 A differentiator prop for the `<Authenticated />` component. This is crucial for the authentication logic to work properly in certain scenarios where `<Authenticated />` is used multiple times in same tree level. key prop will signal React to remount the component rather than updating the current props.
 
@@ -50,7 +50,7 @@ const MyPage = () => (
 );
 ```
 
-### `redirectOnFail`
+### redirectOnFail
 
 The path to redirect to if the user is not logged in. If left empty, the user will be redirected to the value in the `redirectTo` property of the `check` function of the `AuthProvider`.
 
@@ -60,11 +60,11 @@ This property only works if the `fallback` prop is not provided.
 
 :::
 
-### `appendCurrentPathToQuery`
+### appendCurrentPathToQuery
 
 If `true`, the current path will be appended to the `to` query parameter. This is useful when you want to redirect the user to the page they were trying to access after they log in.
 
-### `fallback`
+### fallback
 
 Component to render if the user is not logged in. If `undefined`, the page will be redirected to `/login`.
 
@@ -74,7 +74,7 @@ Component to render if the user is not logged in. If `undefined`, the page will 
 </Authenticated>
 ```
 
-### `loading`
+### loading
 
 Component to render while checking whether the user is logged in.
 

--- a/documentation/docs/authorization/access-control-provider/index.md
+++ b/documentation/docs/authorization/access-control-provider/index.md
@@ -117,7 +117,7 @@ If your response from the `can` method has a `reason` property, it will be shown
 
 Refine provides a hook and a component to use the `can` method from the `accessControlProvider`.
 
-### `useCan`
+### useCan
 
 `useCan` uses the `can` for the query function for **react-query**'s `useQuery`. It takes the parameters that `can` takes, can be configured with `queryOptions` of `useQuery` and returns the result of `useQuery`.
 

--- a/documentation/docs/authorization/components/can-access/index.md
+++ b/documentation/docs/authorization/components/can-access/index.md
@@ -55,7 +55,7 @@ export const MyComponent = () => {
 
 It also accepts all the properties of [`useCan`](/docs/authorization/hooks/use-can#properties).
 
-### `onUnauthorized`
+### onUnauthorized
 
 Callback to be called when [`useCan`][use-can] returns false.
 
@@ -69,7 +69,7 @@ Callback to be called when [`useCan`][use-can] returns false.
 </CanAccess>
 ```
 
-### `fallback`
+### fallback
 
 Component to render if [`useCan`][use-can] returns false. If `undefined`, it renders `null`.
 

--- a/documentation/docs/authorization/hooks/use-can/index.md
+++ b/documentation/docs/authorization/hooks/use-can/index.md
@@ -38,7 +38,7 @@ const { data } = useCan({
 
 ## Properties
 
-### `resource` <PropTag required />
+### resource <PropTag required />
 
 Passes to [Access Control Provider's][access-control-provider] `can` function's `resource` parameter
 
@@ -48,7 +48,7 @@ useCan({
 });
 ```
 
-### `action` <PropTag required />
+### action <PropTag required />
 
 Passes to [Access Control Provider's][access-control-provider] `can` function's `action` parameter
 
@@ -58,7 +58,7 @@ useCan({
 });
 ```
 
-### `params`
+### params
 
 Passes to [Access Control Provider's][access-control-provider] `can` function's `params` parameter
 
@@ -68,7 +68,7 @@ useCan({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 Query options for [TanStack Query's][tanstack-query] [`useQuery`][use-query].
 

--- a/documentation/docs/core/components/inferencer/index.md
+++ b/documentation/docs/core/components/inferencer/index.md
@@ -92,7 +92,7 @@ const SampleEdit = () => {
 
 ## Views
 
-### `List`
+### List
 
 Generates a sample list view for your resources according to the API response. It uses the `useTable` hook from `@refinedev/react-table`.
 
@@ -146,7 +146,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-### `Show`
+### Show
 
 Generates a sample show view for your resources according to the API response. It uses the `useShow` hook from `@refinedev/core`.
 
@@ -200,7 +200,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-### `Create`
+### Create
 
 Generates a sample create view for your resources according to the first record in list API response. It uses the `useForm` hook from `@refinedev/react-hook-form`.
 
@@ -254,7 +254,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-### `Edit`
+### Edit
 
 Generates a sample edit view for your resources according to the API response. It uses the `useForm` hook from `@refinedev/react-hook-form`.
 

--- a/documentation/docs/core/hooks/utilities/use-export/index.md
+++ b/documentation/docs/core/hooks/utilities/use-export/index.md
@@ -29,7 +29,7 @@ export const PostList: React.FC = () => {
 
 ## Properties
 
-### `resource`
+### resource
 
 Determines which resource is passed to the `getList` method of your data provider. By default, it reads the resource name from the current route.
 
@@ -43,7 +43,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `mapData`
+### mapData
 
 If you want to map the data before exporting it, you can use the `mapData` property.
 
@@ -71,7 +71,7 @@ useExport<IPost>({
 });
 ```
 
-### `sorters`
+### sorters
 
 If you want to sort the data before exporting it, you can use the `sorters` property. It will be passed to the `getList` method of your data provider.
 
@@ -88,7 +88,7 @@ useExport({
 });
 ```
 
-### `filters`
+### filters
 
 If you want to filter the data before exporting it, you can use the `filters` property. It will be passed to the `getList` method of your data provider.
 
@@ -106,7 +106,7 @@ useExport({
 });
 ```
 
-### `maxItemCount`
+### maxItemCount
 
 By default, the `useExport` hook will export all the data. If you want to limit the number of items to be exported, you can use the `maxItemCount` property.
 
@@ -116,7 +116,7 @@ useExport({
 });
 ```
 
-### `pageSize`
+### pageSize
 
 Requests to fetch data are made in batches of 20 by default. The `pageSize` property determines the number of items to be fetched in each request.
 
@@ -126,7 +126,7 @@ useExport({
 });
 ```
 
-### `exportOptions`
+### exportOptions
 
 You can pass additional options to the `export-to-csv` package by using the `exportOptions` property.
 
@@ -140,7 +140,7 @@ useExport({
 });
 ```
 
-### `meta`
+### meta
 
 If you want to send additional data to the `create` or `createMany` method of your data provider, you can use the `meta` property.
 
@@ -152,7 +152,7 @@ useExport({
 });
 ```
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you can specify which one to use by passing the `dataProviderName` prop. It is useful when you have a different data provider for different resources.
 
@@ -162,7 +162,7 @@ useExport({
 });
 ```
 
-### `onError`
+### onError
 
 Callback function that is called when an error occurs while fetching data.
 
@@ -174,17 +174,17 @@ useExport({
 });
 ```
 
-### ~~`resourceName`~~ <PropTag deprecated />
+### ~~resourceName~~ <PropTag deprecated />
 
 Use `resource` instead.
 
-### ~~`sorter`~~ <PropTag deprecated />
+### ~~sorter~~ <PropTag deprecated />
 
 Use `sorters` instead.
 
 ## Return Values
 
-### `triggerExport`
+### triggerExport
 
 A function that triggers the export process.
 
@@ -194,7 +194,7 @@ const { triggerExport } = useExport();
 return <button onClick={triggerExport}>Export Button</button>;
 ```
 
-### `isLoading`
+### isLoading
 
 A boolean value that indicates whether the export process is in progress.
 

--- a/documentation/docs/core/hooks/utilities/use-import/index.md
+++ b/documentation/docs/core/hooks/utilities/use-import/index.md
@@ -28,7 +28,7 @@ export const PostList: React.FC = () => {
 
 ## Properties
 
-### `resource`
+### resource
 
 Determines which resource is passed to the `create` or `createMany` method of your data provider. By default, it reads the resource name from the current route.
 
@@ -42,7 +42,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `mapData`
+### mapData
 
 If you want to map the data before sending it to a data provider method, you can use the `mapData` property.
 
@@ -57,7 +57,7 @@ useImport({
 });
 ```
 
-### `paparseOptions`
+### paparseOptions
 
 You can pass any Papa Parse [options](https://www.papaparse.com/docs#config) to the `paparseOptions` property.
 
@@ -69,7 +69,7 @@ useImport({
 });
 ```
 
-### `batchSize`
+### batchSize
 
 If you want to send the data in batches, you can use the `batchSize` property. When the `batchSize` is 1, it calls the `create` method of your data provider for each row in the file. When the `batchSize` is greater than 1, it calls the `createMany` method of your data provider for each batch. By default, it is set to [`Number.MAX_SAFE_INTEGER`][number.max_safe_integer]
 
@@ -79,7 +79,7 @@ useImport({
 });
 ```
 
-### `onFinish`
+### onFinish
 
 If you want to do something after the import is finished, you can use the `onFinish` property. It returns an object with two properties: `succeeded` and `errored`, which contain the responses of the successful and failed requests.
 
@@ -99,7 +99,7 @@ useImport({
 });
 ```
 
-### `meta`
+### meta
 
 If you want to send additional data to the `create` or `createMany` method of your data provider, you can use the `meta` property.
 
@@ -111,7 +111,7 @@ useImport({
 });
 ```
 
-### `onProgress`
+### onProgress
 
 A callback function that is called when the import progress changes. It returns an object with two properties: `totalAmount` and `processedAmount` which contain the total amount of rows and the processed amount of rows.
 
@@ -124,7 +124,7 @@ useImport({
 });
 ```
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you can specify which one to use by passing the `dataProviderName` prop. It is useful when you have a different data provider for different resources.
 
@@ -134,13 +134,13 @@ useImport({
 });
 ```
 
-### ~~`resourceName`~~ <PropTag deprecated />
+### ~~resourceName~~ <PropTag deprecated />
 
 Use `resource` instead.
 
 ## Return Values
 
-### `inputProps`
+### inputProps
 
 `inputProps` is an object that contains the props of the `input` element. You can spread it to the `input` element.
 
@@ -150,19 +150,19 @@ const { inputProps } = useImport();
 return <input {...inputProps} />;
 ```
 
-#### `type`
+#### type
 
 It is set to `file` by default.
 
-#### `accept`
+#### accept
 
 It is set to `.csv` by default.
 
-#### `onChange`
+#### onChange
 
 It handles the file change event. If the file exists, it will call the `handleChange` method with the file as an argument.
 
-### `handleChange`
+### handleChange
 
 `handleChange` is a function that handles the file change event. It accepts an object with a `file` property which is the file that is selected by the user.
 
@@ -183,11 +183,11 @@ return (
 );
 ```
 
-### `isLoading`
+### isLoading
 
 `isLoading` is a boolean that indicates whether the import is in progress or not.
 
-### `mutationResult`
+### mutationResult
 
 Returns the result of either the [`useCreate`](/docs/data/hooks/use-create) or the [`useCreateMany`](/docs/data/hooks/use-create) hook.
 

--- a/documentation/docs/core/hooks/utilities/use-menu/index.md
+++ b/documentation/docs/core/hooks/utilities/use-menu/index.md
@@ -271,7 +271,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
 
 ## Properties
 
-### `hideOnMissingParameter`
+### hideOnMissingParameter
 
 It only affects menu items that require additional parameters to generate their URL. If the parameters are missing in the current URL neither in the `meta` property of the `useMenu` or in the `meta` property of the resource definition, the menu items that require a parameter will be hidden. By default, this property is set to `true`.
 
@@ -279,7 +279,7 @@ For example, suppose you have a resource with a list path defined as `/authors/:
 
 However, if you set `hideOnMissingParameter` to `false` when calling `useMenu`, the menu item for this resource will still be shown, even if the `authorId` parameter is missing.
 
-### `meta`
+### meta
 
 An object of parameters to use when additional parameters are present in the resource paths. For example, if you have a resource with list path defined as `/:authorId/posts` and want to show this resource in your menu:
 
@@ -291,15 +291,15 @@ If there is already an `authorId` parameter in the current URL or in the `meta` 
 
 ## Return Values
 
-### `selectedKey`
+### selectedKey
 
 If the current URL matches a resource path, the key of the resource will be returned. Otherwise, `undefined` will be returned.
 
-### `menuItems`
+### menuItems
 
 List of the menu tems returned based on the `resources` prop of the `<Refine/>` component.
 
-### `defaultOpenKeys`
+### defaultOpenKeys
 
 Array with the keys of default opened menus.
 

--- a/documentation/docs/core/hooks/utilities/use-modal/index.md
+++ b/documentation/docs/core/hooks/utilities/use-modal/index.md
@@ -47,7 +47,7 @@ To demonstrate the `close` function, we created a `<button>` that uses it in its
 
 ## Properties
 
-### `defaultVisible`
+### defaultVisible
 
 `defaultVisible` is a boolean value that determines whether the modal is visible by default. By default, it is `false`.
 
@@ -59,15 +59,15 @@ useModal({
 
 ## Return Values
 
-### `visible`
+### visible
 
 Visible state of the modal.
 
-### `show`
+### show
 
 A function that can change the `visible` state to `true`.
 
-### `close`
+### close
 
 A function that can change the `visible` state to `false`.
 

--- a/documentation/docs/data/hooks/use-create-many/index.md
+++ b/documentation/docs/data/hooks/use-create-many/index.md
@@ -55,7 +55,7 @@ When the `useCreateMany` mutation runs successfully, it will call the `log` meth
 
 ## Properties
 
-### `mutationOptions`
+### mutationOptions
 
 `mutationOptions` is used to pass options to the `useMutation` hook. It is useful when you want to pass additional options to the `useMutation` hook.
 
@@ -99,7 +99,7 @@ mutate(
 );
 ```
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -127,7 +127,7 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 
 ## Mutation Parameters
 
-### `resource` <PropTag required />
+### resource <PropTag required />
 
 This parameter will be passed to the `create` method from the `dataProvider` as a parameter. It is usually used as an API endpoint path but it all depends on how you handle the `resource` in the `create` method.
 
@@ -145,7 +145,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `values` <PropTag required />
+### values <PropTag required />
 
 This prop will be passed to the `create` method from the `dataProvider` as a parameter. It is usually used as the data to be created and contains the data that will be sent to the server.
 
@@ -166,7 +166,7 @@ mutate({
 });
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -186,7 +186,7 @@ mutate({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -206,7 +206,7 @@ mutate({
 });
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -254,7 +254,7 @@ const myDataProvider = {
 
 > For more information, refer to the [`meta` section of the General Concepts documentation&#8594](/docs/guides-concepts/general-concepts/#meta-concept)
 
-### `dataProviderName`
+### dataProviderName
 
 This prop allows you to specify which `dataProvider` if you have more than one. Just pass it like in the example:
 
@@ -266,7 +266,7 @@ mutate({
 });
 ```
 
-### `invalidates`
+### invalidates
 
 `invalidates` is used to specify which queries should be invalidated after the mutation is completed.
 
@@ -288,7 +288,7 @@ Returns an object with TanStack Query's `useMutation` return values.
 
 ### Additional Values
 
-#### `overtime`
+#### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 

--- a/documentation/docs/data/hooks/use-create/index.md
+++ b/documentation/docs/data/hooks/use-create/index.md
@@ -45,7 +45,7 @@ When the `useCreate` mutation runs successfully, it will call the `log` method f
 
 ## Properties
 
-### `mutationOptions`
+### mutationOptions
 
 `mutationOptions` is used to pass options to the `useMutation` hook. It is useful when you want to pass additional options to the `useMutation` hook.
 
@@ -83,7 +83,7 @@ mutate(
 
 [Refer to the `useMutation` documentation for more information &#8594](https://tanstack.com/query/v4/docs/react/reference/useMutation)
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -111,7 +111,7 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 
 ## Mutation Parameters
 
-### `resource` <PropTag required />
+### resource <PropTag required />
 
 This parameter will be passed to the `create` method from the `dataProvider` as a parameter. It is usually used as an API endpoint path but it all depends on how you handle the `resource` in the `create` method.
 
@@ -129,7 +129,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `values` <PropTag required />
+### values <PropTag required />
 
 This prop will be passed to the `create` method from the `dataProvider` as a parameter. It is usually used as the data to be created and contains the data that will be sent to the server.
 
@@ -144,7 +144,7 @@ mutate({
 });
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -164,7 +164,7 @@ mutate({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -184,7 +184,7 @@ mutate({
 });
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -232,7 +232,7 @@ const myDataProvider = {
 
 > For more information, refer to the [`meta` section of the General Concepts documentation&#8594](/docs/guides-concepts/general-concepts/#meta-concept)
 
-### `dataProviderName`
+### dataProviderName
 
 This prop allows you to specify which `dataProvider` if you have more than one. Just pass it like in the example:
 
@@ -244,7 +244,7 @@ mutate({
 });
 ```
 
-### `invalidates`
+### invalidates
 
 `invalidates` is used to specify which queries should be invalidated after the mutation is completed.
 
@@ -266,7 +266,7 @@ Returns an object with TanStack Query's `useMutation` return values.
 
 ### Additional Values
 
-#### `overtime`
+#### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 

--- a/documentation/docs/data/hooks/use-custom-mutation/index.md
+++ b/documentation/docs/data/hooks/use-custom-mutation/index.md
@@ -44,7 +44,7 @@ mutate({
 
 ## Properties
 
-### `mutationOptions`
+### mutationOptions
 
 `mutationOptions` is used to pass options to the `useMutation` hook. It is useful when you want to pass additional options to the `useMutation` hook.
 
@@ -84,7 +84,7 @@ mutate(
 
 ## Mutation Parameters
 
-### `url` <PropTag required />
+### url <PropTag required />
 
 It will be passed to the `custom` method from the `dataProvider` as a parameter. It is usually used to specify the endpoint of the request.
 
@@ -96,7 +96,7 @@ mutate({
 });
 ```
 
-### `method` <PropTag required />
+### method <PropTag required />
 
 It will be passed to the `custom` method from the `dataProvider` as a parameter. It is usually used to specify the HTTP method of the request.
 
@@ -108,7 +108,7 @@ mutate({
 });
 ```
 
-### `values` <PropTag required />
+### values <PropTag required />
 
 It will be passed to the `custom` method from the `dataProvider` as a parameter. The parameter is usually used as the data to be sent with the request.
 
@@ -123,7 +123,7 @@ mutate({
 });
 ```
 
-### `config.headers`
+### config.headers
 
 It will be passed to the `custom` method from the `dataProvider` as a parameter. It can be used to specify the headers of the request.
 
@@ -139,7 +139,7 @@ mutate({
 });
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -159,7 +159,7 @@ mutate({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -179,7 +179,7 @@ mutate({
 });
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -212,7 +212,7 @@ const myDataProvider = {
 
 > For more information, refer to the [`meta` section of the General Concepts documentation&#8594](/docs/guides-concepts/general-concepts/#meta-concept)
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you can specify which one to use by passing the `dataProviderName` prop. It is useful when you have a different data provider for different resources.
 
@@ -224,7 +224,7 @@ mutate({
 });
 ```
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -258,7 +258,7 @@ Returns an object with TanStack Query's `useMutation` return values.
 
 ### Additional Values
 
-#### `overtime`
+#### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 

--- a/documentation/docs/data/hooks/use-custom/index.md
+++ b/documentation/docs/data/hooks/use-custom/index.md
@@ -48,7 +48,7 @@ const { data, isLoading } = useCustom<PostUniqueCheckResponse>({
 
 ## Properties
 
-### `url` <PropTag required />
+### url <PropTag required />
 
 This prop will be passed to the `custom` method from the `dataProvider` as a parameter. It is usually used to specify the endpoint of the request.
 
@@ -58,7 +58,7 @@ useCustom({
 });
 ```
 
-### `method` <PropTag required />
+### method <PropTag required />
 
 It will be passed to the `custom` method from the `dataProvider` as a parameter. It is usually used to specify the HTTP method of the request.
 
@@ -68,7 +68,7 @@ useCustom({
 });
 ```
 
-### `config.headers`
+### config.headers
 
 It will be passed to the `custom` method from the `dataProvider` as a parameter. It can be used to specify the headers of the request.
 
@@ -82,7 +82,7 @@ useCustom({
 });
 ```
 
-### `config.query`
+### config.query
 
 It will be passed to the `custom` method from the `dataProvider` as a parameter. It can be used to specify the query parameters of the request.
 
@@ -96,7 +96,7 @@ useCustom({
 });
 ```
 
-### `config.payload`
+### config.payload
 
 It will be passed to the `custom` method from the `dataProvider` as a parameter. It can be used to specify the payload of the request.
 
@@ -110,7 +110,7 @@ useCustom({
 });
 ```
 
-### `config.sorters`
+### config.sorters
 
 It will be passed to the `custom` method from the `dataProvider` as a parameter. It can be used to send the sort query parameters of the request.
 
@@ -127,7 +127,7 @@ useCustom({
 });
 ```
 
-### `config.filters`
+### config.filters
 
 It will be passed to the `custom` method from the `dataProvider` as a parameter. It can be used to send the filter query parameters of the request.
 
@@ -149,7 +149,7 @@ useCustom({
 
 Use `config.sorters` instead.
 
-### `queryOptions`
+### queryOptions
 
 `queryOptions` is used to pass additional options to the `useQuery` hook. It is useful when you want to pass additional options to the `useQuery` hook.
 
@@ -164,7 +164,7 @@ useCustom({
 });
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -195,7 +195,7 @@ const myDataProvider = {
 
 > For more information, refer to the [`meta` section of the General Concepts documentation&#8594](/docs/guides-concepts/general-concepts/#meta-concept)
 
-### `dataProviderName`
+### dataProviderName
 
 This prop allows you to specify which `dataProvider` if you have more than one. Just pass it like in the example:
 
@@ -205,7 +205,7 @@ useCustom({
 });
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -223,7 +223,7 @@ useCustom({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -241,7 +241,7 @@ useCustom({
 });
 ```
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.

--- a/documentation/docs/data/hooks/use-delete-many/index.md
+++ b/documentation/docs/data/hooks/use-delete-many/index.md
@@ -41,7 +41,7 @@ When the `useDeleteMany` mutation runs successfully, it will invalidate the foll
 
 ## Properties
 
-### `mutationOptions`
+### mutationOptions
 
 `mutationOptions` is used to pass options to the `useMutation` hook. It is useful when you want to pass additional options to the `useMutation` hook.
 
@@ -76,7 +76,7 @@ mutate(
 );
 ```
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -104,7 +104,7 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 
 ## Mutation Parameters
 
-### `resource` <PropTag required />
+### resource <PropTag required />
 
 This parameter will be passed to the `deleteMany` method from the `dataProvider` as a parameter. It is usually used as an API endpoint path but it all depends on how you handle the `resource` in the `deleteMany` method.
 
@@ -122,7 +122,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `ids` <PropTag required />
+### ids <PropTag required />
 
 This parameter will be passed to the `deleteMany` method from the `dataProvider` as a parameter. It is used to determine which records to deleted.
 
@@ -134,7 +134,7 @@ mutate({
 });
 ```
 
-### `mutationMode`
+### mutationMode
 
 Mutation mode determines which mode the mutation runs with. Mutations can run under three different modes: `pessimistic`, `optimistic`, and `undoable`. The default mode is `pessimistic`.
 Each mode corresponds to a different type of user experience.
@@ -149,7 +149,7 @@ mutate({
 });
 ```
 
-### `undoableTimeout`
+### undoableTimeout
 
 When `mutationMode` is set to `undoable`, `undoableTimeout` is used to determine the duration to wait before executing the mutation. The default value is `5000` milliseconds.
 
@@ -162,7 +162,7 @@ mutate({
 });
 ```
 
-### `onCancel`
+### onCancel
 
 The `onCancel` property can be utilized when the `mutationMode` is set to `"undoable"`. It provides a function that can be used to cancel the ongoing mutation.
 
@@ -199,7 +199,7 @@ const MyComponent = () => {
 };
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -219,7 +219,7 @@ mutate({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -239,7 +239,7 @@ mutate({
 });
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -288,7 +288,7 @@ const myDataProvider = {
 
 > For more information, refer to the [`meta` section of the General Concepts documentation&#8594](/docs/guides-concepts/general-concepts/#meta-concept)
 
-### `dataProviderName`
+### dataProviderName
 
 This prop allows you to specify which `dataProvider` if you have more than one. Just pass it like in the example:
 
@@ -300,7 +300,7 @@ mutate({
 });
 ```
 
-### `invalidates`
+### invalidates
 
 `invalidates` is used to specify which queries should be invalidated after the mutation is completed.
 
@@ -322,7 +322,7 @@ Returns an object with TanStack Query's `useMutation` return values.
 
 ### Additional Values
 
-#### `overtime`
+#### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 

--- a/documentation/docs/data/hooks/use-delete/index.md
+++ b/documentation/docs/data/hooks/use-delete/index.md
@@ -43,7 +43,7 @@ When the `useDelete` mutation runs successfully, it will call the `log` method f
 
 ## Properties
 
-### `mutationOptions`
+### mutationOptions
 
 `mutationOptions` is used to pass options to the `useMutation` hook. It is useful when you want to pass additional options to the `useMutation` hook.
 
@@ -78,7 +78,7 @@ mutate(
 );
 ```
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -106,7 +106,7 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 
 ## Mutation Parameters
 
-### `resource` <PropTag required />
+### resource <PropTag required />
 
 This parameter will be passed to the `deleteOne` method from the `dataProvider` as a parameter. It is usually used as an API endpoint path but it all depends on how you handle the `resource` in the `deleteOne` method.
 
@@ -124,7 +124,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `id` <PropTag required />
+### id <PropTag required />
 
 This parameter will be passed to the `deleteOne` method from the `dataProvider` as a parameter. It is used to determine which record to delete.
 
@@ -136,7 +136,7 @@ mutate({
 });
 ```
 
-### `mutationMode`
+### mutationMode
 
 Mutation mode determines which mode the mutation runs with. Mutations can run under three different modes: `pessimistic`, `optimistic`, and `undoable`. The default mode is `pessimistic`.
 Each mode corresponds to a different type of user experience.
@@ -151,7 +151,7 @@ mutate({
 });
 ```
 
-### `undoableTimeout`
+### undoableTimeout
 
 When `mutationMode` is set to `undoable`, `undoableTimeout` is used to determine the duration to wait before executing the mutation. The default value is `5000` milliseconds.
 
@@ -164,7 +164,7 @@ mutate({
 });
 ```
 
-### `onCancel`
+### onCancel
 
 The `onCancel` property can be utilized when the `mutationMode` is set to `"undoable"`. It provides a function that can be used to cancel the ongoing mutation.
 
@@ -201,7 +201,7 @@ const MyComponent = () => {
 };
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -221,7 +221,7 @@ mutate({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -241,7 +241,7 @@ mutate({
 });
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -289,7 +289,7 @@ const myDataProvider = {
 
 > For more information, refer to the [`meta` section of the General Concepts documentation&#8594](/docs/guides-concepts/general-concepts/#meta-concept)
 
-### `dataProviderName`
+### dataProviderName
 
 This prop allows you to specify which `dataProvider` if you have more than one. Just pass it like in the example:
 
@@ -301,7 +301,7 @@ mutate({
 });
 ```
 
-### `invalidates`
+### invalidates
 
 `invalidates` is used to specify which queries should be invalidated after the mutation is completed.
 
@@ -323,7 +323,7 @@ Returns an object with TanStack Query's `useMutation` return values.
 
 ### Additional Values
 
-#### `overtime`
+#### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 

--- a/documentation/docs/data/hooks/use-infinite-list/index.md
+++ b/documentation/docs/data/hooks/use-infinite-list/index.md
@@ -60,7 +60,7 @@ When the `useInfiniteList` hook is mounted, it will call the `subscribe` method 
 
 ## Properties
 
-### `resource` <PropTag required />
+### resource <PropTag required />
 
 This parameter will be passed to the `getList` method from the `dataProvider` as a parameter. It is usually used as an API endpoint path but it all depends on how you handle the `resource` in the `getList` method.
 
@@ -76,7 +76,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `dataProviderName`
+### dataProviderName
 
 This prop allows you to specify which `dataProvider` if you have more than one. Just pass it like in the example:
 
@@ -86,7 +86,7 @@ useInfiniteList({
 });
 ```
 
-### `filters`
+### filters
 
 `filters` will be passed to the `getList` method from the `dataProvider` as a parameter. It is used to send filter query parameters to the API.
 
@@ -104,7 +104,7 @@ useInfiniteList({
 
 > For more information, refer to the [`CrudFilters` interface &#8594](/docs/core/interface-references#crudfilters)
 
-### `sorters`
+### sorters
 
 `sorters` will be passed to the `getList` method from the `dataProvider` as a parameter. It is used to send sort query parameters to the API.
 
@@ -121,11 +121,11 @@ useInfiniteList({
 
 > For more information, refer to the [`CrudSorting` interface &#8594](/docs/core/interface-references#crudsorting)
 
-### `pagination`
+### pagination
 
 `pagination` will be passed to the `getList` method from the `dataProvider` as a parameter. It is used to send pagination query parameters to the API.
 
-#### `current`
+#### current
 
 You can pass the `current` page number to the `pagination` property.
 
@@ -137,7 +137,7 @@ useInfiniteList({
 });
 ```
 
-#### `pageSize`
+#### pageSize
 
 You can pass the `pageSize` to the `pagination` property.
 
@@ -149,7 +149,7 @@ useInfiniteList({
 });
 ```
 
-#### `mode`
+#### mode
 
 This property can be `"off"`, `"client"` or `"server"`. It is used to determine whether to use server-side pagination or not.
 
@@ -161,7 +161,7 @@ useInfiniteList({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 `queryOptions` is used to pass additional options to the `useQuery` hook. It is useful when you want to pass additional options to the `useQuery` hook.
 
@@ -175,7 +175,7 @@ useInfiniteList({
 
 > For more information, refer to the [`useQuery` documentation&#8594](https://tanstack.com/query/v4/docs/react/reference/useQuery)
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -220,7 +220,7 @@ const myDataProvider = {
 
 > For more information, refer to the [`meta` section of the General Concepts documentation&#8594](/docs/guides-concepts/general-concepts/#meta-concept)
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -238,7 +238,7 @@ useInfiniteList({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -256,7 +256,7 @@ useInfiniteList({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -268,7 +268,7 @@ useInfiniteList({
 });
 ```
 
-### `onLiveEvent`
+### onLiveEvent
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -282,13 +282,13 @@ useInfiniteList({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
 Params to pass to liveProvider's [subscribe](/docs/realtime/live-provider#subscribe) method.
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -314,11 +314,11 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### ~~`config`~~ <PropTag deprecated />
+### ~~config~~ <PropTag deprecated />
 
 Use `pagination`, `hasPagination`, `sorters` and `filters` instead.
 
-### ~~`hasPagination`~~ <PropTag deprecated />
+### ~~hasPagination~~ <PropTag deprecated />
 
 Use `pagination.mode` instead.
 
@@ -330,7 +330,7 @@ Returns an object with TanStack Query's `useInfiniteQuery` return values.
 
 ### Additional Values
 
-#### `overtime`
+#### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 

--- a/documentation/docs/data/hooks/use-invalidate/index.md
+++ b/documentation/docs/data/hooks/use-invalidate/index.md
@@ -79,19 +79,19 @@ invalidate({
 
 ## Invalidation Parameters
 
-### `resource`
+### resource
 
 A `resource` represents an entity in an endpoint in the API (e.g. https://api.fake-rest.refine.dev/posts). It is used to invalidate the state of a particular resource.
 
-### `id`
+### id
 
 The `id` to use when invalidating the `"detail"` state.
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one [`dataProvider`][data-provider], you should specify which one to use by passing the `dataProviderName` prop.
 
-### `invalidates` <PropTag required />
+### invalidates <PropTag required />
 
 The scope of the invalidation process. These scopes can be provided in an array.
 
@@ -101,7 +101,7 @@ The scope of the invalidation process. These scopes can be provided in an array.
 - `"detail"`: Invalidates the `"detail"` state of the given `resource` and `id`.
 - `"many"`: Invalidates the `"many"` state of the given `resource`.
 
-### `invalidationFilters` and `invalidationOptions`
+### invalidationFilters and invalidationOptions
 
 The filters and options applied to the invalidation process when picking which queries to invalidate. By default Refine applies some filters and options to fine-tune the invalidation process.
 

--- a/documentation/docs/data/hooks/use-list/index.md
+++ b/documentation/docs/data/hooks/use-list/index.md
@@ -55,7 +55,7 @@ When the `useList` hook is mounted, it will call the `subscribe` method from the
 
 ## Properties
 
-### `resource` <PropTag required />
+### resource <PropTag required />
 
 This parameter will be passed to the `getList` method from the `dataProvider` as a parameter. It is usually used as an API endpoint path but it all depends on how you handle the `resource` in the `getList` method.
 
@@ -71,7 +71,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `dataProviderName`
+### dataProviderName
 
 This prop allows you to specify which `dataProvider` if you have more than one. Just pass it like in the example:
 
@@ -81,7 +81,7 @@ useList({
 });
 ```
 
-### `filters`
+### filters
 
 `filters` will be passed to the `getList` method from the `dataProvider` as a parameter. It is used to send filter query parameters to the API.
 
@@ -99,7 +99,7 @@ useList({
 
 > For more information, refer to the [`CrudFilters` interface &#8594](/docs/core/interface-references#crudfilters)
 
-### `sorters`
+### sorters
 
 `sorters` will be passed to the `getList` method from the `dataProvider` as a parameter. It is used to send sort query parameters to the API.
 
@@ -116,11 +116,11 @@ useList({
 
 > For more information, refer to the [`CrudSorting` interface &#8594](/docs/core/interface-references#crudsorting)
 
-### `pagination`
+### pagination
 
 `pagination` will be passed to the `getList` method from the `dataProvider` as a parameter. It is used to send pagination query parameters to the API.
 
-#### `current`
+#### current
 
 You can pass the `current` page number to the `pagination` property.
 
@@ -132,7 +132,7 @@ useList({
 });
 ```
 
-#### `pageSize`
+#### pageSize
 
 You can pass the `pageSize` to the `pagination` property.
 
@@ -144,7 +144,7 @@ useList({
 });
 ```
 
-#### `mode`
+#### mode
 
 This property can be `"off"`, `"client"` or `"server"`. It is used to determine whether to use server-side pagination or not.
 
@@ -156,7 +156,7 @@ useList({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 `queryOptions` is used to pass additional options to the `useQuery` hook. It is useful when you want to pass additional options to the `useQuery` hook.
 
@@ -170,7 +170,7 @@ useList({
 
 > For more information, refer to the [`useQuery` documentation&#8594](https://tanstack.com/query/v4/docs/react/reference/useQuery)
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -218,7 +218,7 @@ const myDataProvider = {
 
 > For more information, refer to the [`meta` section of the General Concepts documentation&#8594](/docs/guides-concepts/general-concepts/#meta-concept)
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -236,7 +236,7 @@ useList({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -254,7 +254,7 @@ useList({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -266,7 +266,7 @@ useList({
 });
 ```
 
-### `onLiveEvent`
+### onLiveEvent
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -280,13 +280,13 @@ useList({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
 Params to pass to liveProvider's [subscribe](/docs/realtime/live-provider#subscribe) method.
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -312,11 +312,11 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### ~~`config`~~ <PropTag deprecated />
+### ~~config~~ <PropTag deprecated />
 
 Use `pagination`, `sorters`, and `filters` instead.
 
-### ~~`hasPagination`~~ <PropTag deprecated />
+### ~~hasPagination~~ <PropTag deprecated />
 
 Use `pagination.mode` instead.
 
@@ -328,7 +328,7 @@ Returns an object with TanStack Query's `useQuery` return values.
 
 ### Additional Values
 
-#### `overtime`
+#### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 

--- a/documentation/docs/data/hooks/use-many/index.md
+++ b/documentation/docs/data/hooks/use-many/index.md
@@ -32,7 +32,7 @@ When the `useMany` hook is mounted, it will call the `subscribe` method from the
 
 ## Properties
 
-### `resource` <PropTag required />
+### resource <PropTag required />
 
 This parameter will be passed to the `getMany` method from the `dataProvider` as a parameter. t is usually used as an API endpoint path but it all depends on how you handle the `resource` in the `getMany` method.
 
@@ -48,7 +48,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `ids` <PropTag required />
+### ids <PropTag required />
 
 This prop will be passed to the `getMany` method from the `dataProvider` as a parameter. It is used to determine which records to fetch.
 
@@ -58,7 +58,7 @@ useMany({
 });
 ```
 
-### `dataProviderName`
+### dataProviderName
 
 This prop allows you to specify which `dataProvider` if you have more than one. Just pass it like in the example:
 
@@ -68,7 +68,7 @@ useMany({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 `queryOptions` is used to pass additional options to the `useQuery` hook. It is useful when you want to pass additional options to the `useQuery` hook.
 
@@ -83,7 +83,7 @@ useMany({
 
 > For more information, refer to the [`useQuery` documentation&#8594](https://tanstack.com/query/v4/docs/react/reference/useQuery)
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -131,7 +131,7 @@ const myDataProvider = {
 
 > For more information, refer to the [`meta` section of the General Concepts documentation&#8594](/docs/guides-concepts/general-concepts/#meta-concept)
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -149,7 +149,7 @@ useMany({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -167,7 +167,7 @@ useMany({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -179,7 +179,7 @@ useMany({
 });
 ```
 
-### `onLiveEvent`
+### onLiveEvent
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -193,13 +193,13 @@ useMany({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
 Params to pass to liveProvider's [subscribe](/docs/realtime/live-provider#subscribe) method.
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -233,7 +233,7 @@ Returns an object with TanStack Query's `useQuery` return values.
 
 ### Additional Values
 
-#### `overtime`
+#### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 

--- a/documentation/docs/data/hooks/use-one/index.md
+++ b/documentation/docs/data/hooks/use-one/index.md
@@ -30,7 +30,7 @@ When the `useOne` hook is mounted, it will call the `subscribe` method from the 
 
 ## Properties
 
-### `resource` <PropTag required />
+### resource <PropTag required />
 
 This parameter will be passed to the `getOne` method from the `dataProvider` as a parameter. t is usually used as an API endpoint path but it all depends on how you handle the `resource` in the `getOne` method.
 
@@ -46,7 +46,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `id` <PropTag required />
+### id <PropTag required />
 
 This prop will be passed to the `getMany` method from the `dataProvider` as a parameter. It is used to determine which records to fetch.
 
@@ -56,7 +56,7 @@ useOne({
 });
 ```
 
-### `dataProviderName`
+### dataProviderName
 
 This prop allows you to specify which `dataProvider` if you have more than one. Just pass it like in the example:
 
@@ -66,7 +66,7 @@ useOne({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 `queryOptions` is used to pass additional options to the `useQuery` hook. It is useful when you want to pass additional options to the `useQuery` hook.
 
@@ -81,7 +81,7 @@ useOne({
 
 > For more information, refer to the [`useQuery` documentation&#8594](https://tanstack.com/query/v4/docs/react/reference/useQuery)
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -127,7 +127,7 @@ const myDataProvider = {
 
 > For more information, refer to the [`meta` section of the General Concepts documentation&#8594](/docs/guides-concepts/general-concepts/#meta-concept)
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -145,7 +145,7 @@ useOne({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -163,7 +163,7 @@ useOne({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -176,7 +176,7 @@ useOne({
 });
 ```
 
-### `onLiveEvent`
+### onLiveEvent
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -190,13 +190,13 @@ useOne({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
 Params to pass to liveProvider's [subscribe](/docs/realtime/live-provider#subscribe) method.
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -230,7 +230,7 @@ Returns an object with TanStack Query's `useQuery` return values.
 
 ### Additional Values
 
-#### `overtime`
+#### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 

--- a/documentation/docs/data/hooks/use-select/index.md
+++ b/documentation/docs/data/hooks/use-select/index.md
@@ -39,7 +39,7 @@ When `useSelect` hook is mounted, it will call the `subscribe` method from the `
 
 ## Properties
 
-### `resource` <PropTag required />
+### resource <PropTag required />
 
 It will be passed to the `getList` method from the `dataProvider` as parameter via the `useList` hook. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `getList` method.
 
@@ -55,7 +55,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `optionLabel` and `optionValue`
+### optionLabel and optionValue
 
 Allows you to change the `value` and `label` of your options.
 Default values are `optionLabel = "title"` and `optionValue = "id"`
@@ -78,7 +78,7 @@ const { options } = useSelect({
 });
 ```
 
-### `sorters`
+### sorters
 
 It allows to show the options in the desired order. `sorters` will be passed to the `getList` method from the `dataProvider` as parameter via the `useList` hook. It is used to send sort query parameters to the API.
 
@@ -97,7 +97,7 @@ useSelect({
 
 > For more information, refer to the [`CrudSorting` interface &#8594](/docs/core/interface-references#crudsorting)
 
-### `filters`
+### filters
 
 It is used to show options by filtering them. `filters` will be passed to the `getList` method from the `dataProvider` as parameter via the `useList` hook. It is used to send filter query parameters to the API.
 
@@ -115,7 +115,7 @@ useSelect({
 
 > For more information, refer to the [`CrudFilters` interface &#8594](/docs/core/interface-references#crudfilters)
 
-### `defaultValue`
+### defaultValue
 
 Allows to make options selected by default. Adds extra options to `<select>` component. In some cases like there are many entries for the `<select>` and pagination is required, `defaultValue` may not be present in the current visible options and this can break the `<select>` component. To avoid such cases, A separate `useMany` query is sent to the backend with the `defaultValue` and appended to the options of `<select>`, ensuring the default values exist in the current options array. Since it uses `useMany` to query the necessary data, the `defaultValue` can be a single value or an array of values like the following:
 
@@ -127,7 +127,7 @@ useSelect({
 
 > For more information, refer to the [`useMany` documentation&#8594](/docs/data/hooks/use-many)
 
-### `debounce`
+### debounce
 
 It allows us to `debounce` the `onSearch` function.
 
@@ -138,7 +138,7 @@ useSelect({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 `queryOptions` is used to pass additional options to the `useQuery` hook. It is useful when you want to pass additional options to the `useQuery` hook.
 
@@ -152,11 +152,11 @@ useSelect({
 
 > For more information, refer to the [`useQuery` documentation&#8594](https://tanstack.com/query/v4/docs/react/reference/useQuery)
 
-### `pagination`
+### pagination
 
 `pagination` will be passed to the `getList` method from the `dataProvider` as parameter. It is used to send pagination query parameters to the API.
 
-#### `current`
+#### current
 
 You can pass the `current` page number to the `pagination` property.
 
@@ -168,7 +168,7 @@ useSelect({
 });
 ```
 
-#### `pageSize`
+#### pageSize
 
 You can pass the `pageSize` to the `pagination` property.
 
@@ -180,7 +180,7 @@ useSelect({
 });
 ```
 
-#### `mode`
+#### mode
 
 Is used to determine whether to use server-side pagination or not. It can be `"off"`, `"client"` or `"server"`
 
@@ -192,7 +192,7 @@ useSelect({
 });
 ```
 
-### `defaultValueQueryOptions`
+### defaultValueQueryOptions
 
 When the `defaultValue` property is given, the `useMany` data hook is called for the selected records. With this property, you can change the options of this query. If not given, the values given in `queryOptions` will be used.
 
@@ -207,7 +207,7 @@ const { options } = useSelect({
 });
 ```
 
-### `onSearch`
+### onSearch
 
 It allows us to `AutoComplete` the `options`.
 
@@ -221,7 +221,7 @@ It allows us to `AutoComplete` the `options`.
 
 :::
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -266,7 +266,7 @@ const myDataProvider = {
 
 > For more information, refer to the [`meta` section of the General Concepts documentation &#8594](/docs/guides-concepts/general-concepts/#meta-concept)
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you can specify which one to use by passing the `dataProviderName` prop. It is useful when you have a different data provider for different resources.
 
@@ -276,7 +276,7 @@ useSelect({
 });
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -294,7 +294,7 @@ useSelect({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -312,7 +312,7 @@ useSelect({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -325,7 +325,7 @@ useSelect({
 });
 ```
 
-### `onLiveEvent`
+### onLiveEvent
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -339,13 +339,13 @@ useSelect({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
 Params to pass to liveProvider's [subscribe](/docs/realtime/live-provider#subscribe) method.
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -371,11 +371,11 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### ~~`sort`~~ <PropTag deprecated />
+### ~~sort~~ <PropTag deprecated />
 
 Use `sorters` instead.
 
-### ~~`hasPagination`~~ <PropTag deprecated />
+### ~~hasPagination~~ <PropTag deprecated />
 
 Use `pagination.mode` instead.
 

--- a/documentation/docs/data/hooks/use-show/index.md
+++ b/documentation/docs/data/hooks/use-show/index.md
@@ -25,7 +25,7 @@ When the `useShow` hook is mounted, it will call the `subscribe` method from the
 
 ## Properties
 
-### `resource`
+### resource
 
 <PropResource
 hook={{
@@ -76,7 +76,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `id`
+### id
 
 It will be passed to the `getOne` method from the `dataProvider` as a parameter. It is used to determine which record to fetch. By default, it will try to read the `id` value from the current URL.
 
@@ -86,7 +86,7 @@ useShow({
 });
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -132,7 +132,7 @@ const myDataProvider = {
 
 > For more information, refer to the [`meta` section of the General Concepts documentation &#8594](/docs/guides-concepts/general-concepts/#meta-concept)
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you can specify which one to use by passing the `dataProviderName` prop. It is useful when you have a different data provider for different resources.
 
@@ -142,7 +142,7 @@ useShow({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 `queryOptions` is used to pass additional options to the `useQuery` hook. It is useful when you want to pass additional options to the `useQuery` hook.
 
@@ -157,7 +157,7 @@ useShow({
 
 > For more information, refer to the [`useQuery` documentation&#8594](https://tanstack.com/query/v4/docs/react/reference/useQuery)
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -175,7 +175,7 @@ useShow({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -193,7 +193,7 @@ useShow({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -207,7 +207,7 @@ useShow({
 
 > For more information, refer to the [Live / Realtime page&#8594](/docs/realtime/live-provider#livemode)
 
-### `onLiveEvent`
+### onLiveEvent
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -221,13 +221,13 @@ useShow({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
 Params to pass to liveProvider's [subscribe](/docs/realtime/live-provider#subscribe) method.
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -255,17 +255,17 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 
 ## Return Values
 
-### `queryResult`
+### queryResult
 
 It is TanStack Query's `useQuery` return values.
 
 > For more information, refer to the [`useQuery` documentation&#8594](https://tanstack.com/query/v4/docs/react/reference/useQuery)
 
-### `showId`
+### showId
 
 It is the `id` value that is used on the `useShow` hook.
 
-### `setShowId`
+### setShowId
 
 When you want to change the `showId` value, you can use this setter. It is useful when you want to change the `showId` value based on the user's action.
 
@@ -273,7 +273,7 @@ It will trigger new request to fetch the data when the `showId` value is changed
 
 ### Additional Values
 
-#### `overtime`
+#### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 

--- a/documentation/docs/data/hooks/use-table/index.md
+++ b/documentation/docs/data/hooks/use-table/index.md
@@ -78,7 +78,7 @@ When the `useTable` hook is mounted, it will call the `subscribe` method from th
 
 ## Properties
 
-### `resource`
+### resource
 
 <PropResource
 hook={{
@@ -105,7 +105,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use. It is useful when you want to use a different `dataProvider` for a specific resource.
 
@@ -116,7 +116,7 @@ useTable({
 });
 ```
 
-### `pagination.current`
+### pagination.current
 
 Sets the initial value of the page index. Defaults to `1`.
 
@@ -129,7 +129,7 @@ useTable({
 });
 ```
 
-### `pagination.pageSize`
+### pagination.pageSize
 
 Sets the initial value of the page size. Defaults to `10`.
 
@@ -142,7 +142,7 @@ useTable({
 });
 ```
 
-### `pagination.mode`
+### pagination.mode
 
 It can be `"off"`, `"server"` or `"client"`. Defaults to `"server"`.
 
@@ -159,7 +159,7 @@ useTable({
 });
 ```
 
-### `sorters.mode`
+### sorters.mode
 
 It can be `"off"`, or `"server"`. Defaults to `"server"`.
 
@@ -175,7 +175,7 @@ useTable({
 });
 ```
 
-### `sorters.initial`
+### sorters.initial
 
 Sets the initial value of the sorter. The `initial` is not permanent. It will be cleared when the user changes the sorter. If you want to set a permanent value, use the `sorters.permanent` prop.
 
@@ -195,7 +195,7 @@ useTable({
 
 > For more information, refer to the [`CrudSorting` interface&#8594](/docs/core/interface-references#crudsorting)
 
-### `sorters.permanent`
+### sorters.permanent
 
 Sets the permanent value of the sorter. The `permanent` is permanent and unchangeable. It will not be cleared when the user changes the sorter. If you want to set a temporary value, use the `sorters.initial` prop.
 
@@ -215,7 +215,7 @@ useTable({
 
 > For more information, refer to the [`CrudSorting` interface &#8594](/docs/core/interface-references#crudsorting)
 
-### `filters.mode`
+### filters.mode
 
 It can be `"off"` or `"server"`. Defaults to `"server"`.
 
@@ -231,7 +231,7 @@ useTable({
 });
 ```
 
-### `filters.initial`
+### filters.initial
 
 Sets the initial value of the filter. The `initial` is not permanent. It will be cleared when the user changes the filter. If you want to set a permanent value, use the `filters.permanent` prop.
 
@@ -252,7 +252,7 @@ useTable({
 
 > For more information, refer to the [`CrudFilters` interface &#8594](/docs/core/interface-references#crudfilters)
 
-### `filters.permanent`
+### filters.permanent
 
 Sets the permanent value of the filter. The `permanent` is permanent and unchangeable. It will not be cleared when the user changes the filter. If you want to set a temporary value, use the `filters.initial` prop.
 
@@ -273,7 +273,7 @@ useTable({
 
 > For more information, refer to the [`CrudFilters` interface &#8594](/docs/core/interface-references#crudfilters)
 
-### `filters.defaultBehavior`
+### filters.defaultBehavior
 
 The filtering behavior can be set to either `"merge"` or `"replace"`. Defaults to `"merge"`.
 
@@ -292,7 +292,7 @@ useTable({
 });
 ```
 
-### `syncWithLocation` <GlobalConfigBadge id="core/refine-component/#syncwithlocation" />
+### syncWithLocation <GlobalConfigBadge id="core/refine-component/#syncwithlocation" />
 
 When you use the `syncWithLocation` feature, the `useTable`'s state (e.g., sort order, filters, pagination) is automatically encoded in the query parameters of the URL, and when the URL changes, the `useTable` state is automatically updated to match. This makes it easy to share table state across different routes or pages, and to allow users to bookmark or share links to specific table views. By default, this feature is disabled.
 
@@ -303,7 +303,7 @@ useTable({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 `useTable` uses [`useList`](/docs/data/hooks/use-list) hook to fetch data. You can pass [`queryOptions`](https://tanstack.com/query/v4/docs/react/reference/useQuery).
 
@@ -316,7 +316,7 @@ useTable({
 });
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -365,7 +365,7 @@ const myDataProvider = {
 
 > For more information, refer to the [`meta` section of the General Concepts documentation&#8594](/docs/guides-concepts/general-concepts/#meta-concept)
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -384,7 +384,7 @@ useTable({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -403,7 +403,7 @@ useTable({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -416,7 +416,7 @@ useTable({
 });
 ```
 
-### `onLiveEvent`
+### onLiveEvent
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -431,13 +431,13 @@ useTable({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
 Params to pass to liveProvider's [subscribe](/docs/realtime/live-provider#subscribe) method.
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -464,49 +464,49 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### ~~`initialCurrent`~~ <PropTag deprecated />
+### ~~initialCurrent~~ <PropTag deprecated />
 
 Use `pagination.current` instead.
 
-### ~~`initialPageSize`~~ <PropTag deprecated />
+### ~~initialPageSize~~ <PropTag deprecated />
 
 Use `pagination.pageSize` instead.
 
-### ~~`hasPagination`~~ <PropTag deprecated />
+### ~~hasPagination~~ <PropTag deprecated />
 
 Use `pagination.mode` instead.
 
-### ~~`initialSorter`~~ <PropTag deprecated />
+### ~~initialSorter~~ <PropTag deprecated />
 
 Use `sorters.initial` instead.
 
-### ~~`permanentSorter`~~ <PropTag deprecated />
+### ~~permanentSorter~~ <PropTag deprecated />
 
 Use `sorters.permanent` instead.
 
-### ~~`initialFilter`~~ <PropTag deprecated />
+### ~~initialFilter~~ <PropTag deprecated />
 
 Use `filters.initial` instead.
 
-### ~~`permanentFilter`~~ <PropTag deprecated />
+### ~~permanentFilter~~ <PropTag deprecated />
 
 Use `filters.permanent` instead.
 
-### ~~`defaultSetFilterBehavior`~~ <PropTag deprecated />
+### ~~defaultSetFilterBehavior~~ <PropTag deprecated />
 
 Use `filters.defaultBehavior` instead.
 
 ## Return Values
 
-### `tableQueryResult`
+### tableQueryResult
 
 Returned values from [`useList`](/docs/data/hooks/use-list) hook.
 
-### `sorters`
+### sorters
 
 Current [sorters state][crudsorting].
 
-### `setSorters`
+### setSorters
 
 A function to set current [sorters state][crudsorting].
 
@@ -514,11 +514,11 @@ A function to set current [sorters state][crudsorting].
  (sorters: CrudSorting) => void;
 ```
 
-### `filters`
+### filters
 
 Current [filters state][crudfilters].
 
-### `setFilters`
+### setFilters
 
 ```tsx
 ((filters: CrudFilters, behavior?: SetFilterBehavior) => void) & ((setter: (prevFilters: CrudFilters) => CrudFilters) => void)
@@ -526,11 +526,11 @@ Current [filters state][crudfilters].
 
 A function to set current [filters state][crudfilters].
 
-### `current`
+### current
 
 Current page index state. If pagination is disabled, it will be `undefined`.
 
-### `setCurrent`
+### setCurrent
 
 ```tsx
 React.Dispatch<React.SetStateAction<number>> | undefined;
@@ -538,11 +538,11 @@ React.Dispatch<React.SetStateAction<number>> | undefined;
 
 A function to set the current page index state. If pagination is disabled, it will be `undefined`.
 
-### `pageSize`
+### pageSize
 
 Current page size state. If pagination is disabled, it will be `undefined`.
 
-### `setPageSize`
+### setPageSize
 
 ```tsx
 React.Dispatch<React.SetStateAction<number>> | undefined;
@@ -550,11 +550,11 @@ React.Dispatch<React.SetStateAction<number>> | undefined;
 
 A function to set the current page size state. If pagination is disabled, it will be `undefined`.
 
-### `pageCount`
+### pageCount
 
 Total page count state. If pagination is disabled, it will be `undefined`.
 
-### `createLinkForSyncWithLocation`
+### createLinkForSyncWithLocation
 
 ```tsx
 (params: SyncWithLocationParams) => string;
@@ -562,7 +562,7 @@ Total page count state. If pagination is disabled, it will be `undefined`.
 
 A function creates accessible links for `syncWithLocation`. It takes [SyncWithLocationParams][syncwithlocationparams] as parameters.
 
-### `overtime`
+### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 
@@ -573,11 +573,11 @@ const { overtime } = useTable();
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
 
-### ~~`sorter`~~ <PropTag deprecated />
+### ~~sorter~~ <PropTag deprecated />
 
 Use `sorters` instead.
 
-### ~~`setSorter`~~ <PropTag deprecated />
+### ~~setSorter~~ <PropTag deprecated />
 
 Use `setSorters` instead.
 

--- a/documentation/docs/data/hooks/use-update-many/index.md
+++ b/documentation/docs/data/hooks/use-update-many/index.md
@@ -45,7 +45,7 @@ When the `useUpdateMany` mutation runs successfully, by default it will invalida
 
 ## Properties
 
-### `mutationOptions`
+### mutationOptions
 
 `mutationOptions` is used to pass options to the `useMutation` hook. It is useful when you want to pass additional options to the `useMutation` hook.
 
@@ -84,7 +84,7 @@ mutate(
 );
 ```
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -112,7 +112,7 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 
 ## Mutation Parameters
 
-### `resource` <PropTag required />
+### resource <PropTag required />
 
 It will be passed to the `updateMany` method from the `dataProvider` as a parameter. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `updateMany` method. See the [creating a data provider](/docs/tutorial/understanding-dataprovider/create-dataprovider/) section for an example of how resources are handled.
 
@@ -128,7 +128,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `ids` <PropTag required />
+### ids <PropTag required />
 
 It will be passed to the `updateMany` method from the `dataProvider` as a parameter. It is used to determine which records will be updated.
 
@@ -140,7 +140,7 @@ mutate({
 });
 ```
 
-### `values` <PropTag required />
+### values <PropTag required />
 
 It will be passed to the `updateMany` method from the `dataProvider` as a parameter. The parameter is usually used as the data to be updated. It contains the new values of the record.
 
@@ -155,7 +155,7 @@ mutate({
 });
 ```
 
-### `mutationMode`
+### mutationMode
 
 Mutation mode determines which mode the mutation runs with. Mutations can run under three different modes: `pessimistic`, `optimistic`, and `undoable`. The default mode is `pessimistic`.
 Each mode corresponds to a different type of user experience.
@@ -170,7 +170,7 @@ mutate({
 });
 ```
 
-### `undoableTimeout`
+### undoableTimeout
 
 When `mutationMode` is set to `undoable`, `undoableTimeout` is used to determine duration to wait before executing the mutation. Default value is `5000` milliseconds.
 
@@ -183,7 +183,7 @@ mutate({
 });
 ```
 
-### `onCancel`
+### onCancel
 
 The `onCancel` property can be utilized when the `mutationMode` is set to `"undoable"`. It provides a function that can be used to cancel the ongoing mutation.
 
@@ -220,7 +220,7 @@ const MyComponent = () => {
 };
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -240,7 +240,7 @@ mutate({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -260,7 +260,7 @@ mutate({
 });
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -310,7 +310,7 @@ const myDataProvider = {
 };
 ```
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you can specify which one to use by passing the `dataProviderName` prop. It is useful when you have a different data provider for different resources.
 
@@ -322,7 +322,7 @@ mutate({
 });
 ```
 
-### `invalidates`
+### invalidates
 
 `invalidates` is used to specify which queries should be invalidated after the mutation is completed.
 
@@ -336,7 +336,7 @@ mutate({
 });
 ```
 
-### `optimisticUpdateMap`
+### optimisticUpdateMap
 
 If the mutation mode is defined as `optimistic` or `undoable` the `useUpdate` hook will automatically update the cache without waiting for the response from the server. You may want to disable or customize this behavior. You can do this by passing the `optimisticUpdateMap` prop.
 
@@ -457,7 +457,7 @@ Returns an object with TanStack Query's `useMutation` return values.
 
 ### Additional Values
 
-#### `overtime`
+#### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 

--- a/documentation/docs/data/hooks/use-update/index.md
+++ b/documentation/docs/data/hooks/use-update/index.md
@@ -47,7 +47,7 @@ When the `useUpdate` mutation runs successfully, it will call the `log` method f
 
 ## Properties
 
-### `mutationOptions`
+### mutationOptions
 
 `mutationOptions` is used to pass options to the `useMutation` hook. It is useful when you want to pass additional options to the `useMutation` hook.
 
@@ -88,7 +88,7 @@ mutate(
 
 ## Mutation Parameters
 
-### `resource` <PropTag required />
+### resource <PropTag required />
 
 This parameter will be passed to the `update` method from the `dataProvider` as a parameter. It is usually used as an API endpoint path but it all depends on how you handle the `resource` in the `update` method.
 
@@ -106,7 +106,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `id` <PropTag required />
+### id <PropTag required />
 
 This prop will be passed to the `update` method from the `dataProvider` as a parameter. It is used to determine which record to update.
 
@@ -118,7 +118,7 @@ mutate({
 });
 ```
 
-### `values` <PropTag required />
+### values <PropTag required />
 
 This prop will be passed to the `update` method from the `dataProvider` as a parameter. It is usually used as the data to be updated and contains the data that will be sent to the server.
 
@@ -133,7 +133,7 @@ mutate({
 });
 ```
 
-### `mutationMode`
+### mutationMode
 
 Mutation mode determines which mode the mutation runs with. Mutations can run under three different modes: `pessimistic`, `optimistic`, and `undoable`. The default mode is `pessimistic`.
 Each mode corresponds to a different type of user experience.
@@ -148,7 +148,7 @@ mutate({
 
 > For more information, refer to the [mutation mode documentation &#8594](/docs/advanced-tutorials/mutation-mode)
 
-### `undoableTimeout`
+### undoableTimeout
 
 When `mutationMode` is set to `undoable`, `undoableTimeout` is used to determine the duration to wait before executing the mutation. The default value is `5000` milliseconds.
 
@@ -161,7 +161,7 @@ mutate({
 });
 ```
 
-### `onCancel`
+### onCancel
 
 The `onCancel` property can be utilized when the `mutationMode` is set to `"undoable"`. It provides a function that can be used to cancel the ongoing mutation.
 
@@ -198,7 +198,7 @@ const MyComponent = () => {
 };
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -218,7 +218,7 @@ mutate({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -238,7 +238,7 @@ mutate({
 });
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -287,7 +287,7 @@ const myDataProvider = {
 
 [Refer to the `meta` section of the General Concepts documentation for more information &#8594](/docs/guides-concepts/general-concepts/#meta-concept)
 
-### `dataProviderName`
+### dataProviderName
 
 This prop allows you to specify which `dataProvider` if you have more than one. Just pass it like in the example:
 
@@ -299,7 +299,7 @@ mutate({
 });
 ```
 
-### `invalidates`
+### invalidates
 
 `invalidates` is used to specify which queries should be invalidated after the mutation is completed.
 
@@ -313,7 +313,7 @@ mutate({
 });
 ```
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -339,7 +339,7 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### `optimisticUpdateMap`
+### optimisticUpdateMap
 
 If the mutation mode is defined as `optimistic` or `undoable` the `useUpdate` hook will automatically update the cache without waiting for the response from the server. You may want to disable or customize this behavior. You can do this by passing the `optimisticUpdateMap` prop.
 
@@ -442,7 +442,7 @@ Returns an object with TanStack Query's `useMutation` return values.
 
 ### Additional Values
 
-#### `overtime`
+#### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 

--- a/documentation/docs/data/packages/supabase/index.md
+++ b/documentation/docs/data/packages/supabase/index.md
@@ -1451,7 +1451,7 @@ const { tableProps, sorter } = useTable<IUser>({
 });
 ```
 
-### `id`
+### id
 
 `meta` `id` property is used to match the column name of the primary key(in case the column name is different than "id") in your Supabase data table to the column name you have assigned.
 

--- a/documentation/docs/migration-guide/3x-to-4x.md
+++ b/documentation/docs/migration-guide/3x-to-4x.md
@@ -59,7 +59,7 @@ You must make this change for all packages that start with `@pankod`.
 
 ## **`@pankod/refine-core` changes**
 
-### `routerProvider`
+### routerProvider
 
 **Refine v4** includes a new interface for the `routerProvider` prop. It is now smaller and more flexible, as it leaves the control of the routes to the user and only constructs the communication and bindings of the router and **Refine**.
 
@@ -89,7 +89,7 @@ While this will allow you to use the old router provider, we do not recommend it
 
 :::
 
-### `resources`
+### resources
 
 With the new `routerProvider` interface, we also made changes to the `resources` prop, which now works more like an interaction and connection point between your API and the app rather than a necessity for the router to work. Your router can work without `resources`, in the same way your `resources` can work without a router.
 
@@ -154,7 +154,7 @@ resources={[
 ]}
 ```
 
-### `authProvider`
+### authProvider
 
 **Refine** still supports the `authProvider@v3` for backward compatibility. We changed its name to `legacyAuthProvider` and it will be removed in the next major version. If you want to continue using the `authProvider@v3` you can use it as `legacyAuthProvider` in your project.
 
@@ -491,7 +491,7 @@ const MyComponent = () => {
 }
 ```
 
-### `metaData` to `meta`
+### metaData to meta
 
 `metaData` is deprecated in all hooks and components. Use `meta` instead.
 

--- a/documentation/docs/migration-guide/auth-provider.md
+++ b/documentation/docs/migration-guide/auth-provider.md
@@ -51,7 +51,7 @@ Furthermore, the auth hooks no longer have default redirection paths, which had 
 
 ## Methods
 
-### `login`
+### login
 
 Promises must now be resolved in all cases when using the `login` method, with a return type of `AuthActionResponse`. When resolving the promise, you must always include a `success` key, and in the case of a failure, an additional `error` key.
 
@@ -92,7 +92,7 @@ type AuthActionResponse = {
 };
 ```
 
-### `logout`
+### logout
 
 Promises must now be resolved in all cases when using the `logout` method, with a return type of `AuthActionResponse`. When resolving the promise, you must always include a `success` key, and in the case of a failure, an additional `error` key.
 
@@ -120,7 +120,7 @@ type AuthActionResponse = {
 };
 ```
 
-### `register`
+### register
 
 Promises must now be resolved in all cases when using the `register` method, with a return type of `AuthActionResponse`. When resolving the promise, you must always include a `success` key, and in the case of a failure, an additional `error` key.
 
@@ -153,7 +153,7 @@ const authProvider = {
 }
 ```
 
-### `forgotPassword`
+### forgotPassword
 
 Promises must now be resolved in all cases when using the `forgotPassword` method, with a return type of `AuthActionResponse`. When resolving the promise, you must always include a `success` key, and in the case of a failure, an additional `error` key.
 
@@ -193,7 +193,7 @@ type AuthActionResponse = {
 };
 ```
 
-### `updatePassword`
+### updatePassword
 
 Promises must now be resolved in all cases when using the `updatePassword` method, with a return type of `AuthActionResponse`. When resolving the promise, you must always include a `success` key, and in the case of a failure, an additional `error` key.
 
@@ -233,7 +233,7 @@ type AuthActionResponse = {
 };
 ```
 
-### `check`
+### check
 
 The `checkAuth` method of the `authProvider` was changed to `check`. It now requires promises to be resolved in all cases, with a return type of `CheckResponse`. When resolving the promise, you must always include a `success` key, and in the case of a failure, an additional `error` key.
 
@@ -275,7 +275,7 @@ type CheckResponse = {
 };
 ```
 
-### `onError`
+### onError
 
 The `checkError` method of the `authProvider` was changed to `onError`. It now requires promises to be resolved in all cases, with a return type of `OnErrorResponse`. When resolving the promise, you must always include a `success` key, and in the case of a failure, an additional `error` key.
 
@@ -308,7 +308,7 @@ type OnErrorResponse = {
 };
 ```
 
-### `getPermissions`
+### getPermissions
 
 The `getPermissions` method now requires promises to be resolved in all cases, with a return type of `PermissionResponse`
 
@@ -333,7 +333,7 @@ const authProvider = {
 type PermissionResponse = unknown;
 ```
 
-### `getIdentity`
+### getIdentity
 
 `authProvider`'s `getUserIdentity` method was renamed to `getIdentity`, which requires promises to be resolved in all cases, with a return type of `IdentityResponse`
 

--- a/documentation/docs/notification/hooks/use-notification/index.md
+++ b/documentation/docs/notification/hooks/use-notification/index.md
@@ -29,7 +29,7 @@ close?.("notification-key");
 
 ## Properties
 
-### `open`
+### open
 
 You can call this method to open a new notification box.
 
@@ -45,7 +45,7 @@ open?.({
 
 > For more information, refer to the [`Open Notification Params` interface→](/docs/core/interface-references#open-notification-params)
 
-### `close`
+### close
 
 You can close a notification with a `key`.
 

--- a/documentation/docs/notification/notification-provider/index.md
+++ b/documentation/docs/notification/notification-provider/index.md
@@ -174,7 +174,7 @@ const App: React.FC = () => {
 export default App;
 ```
 
-### `open`
+### open
 
 Refine calls this method when it wants to open a notification. It also helps you to get the right notification by sending some parameters to the Refine open method. For example, `message`, `description`, etc.
 
@@ -317,7 +317,7 @@ open?.({
 });
 ```
 
-### `close`
+### close
 
 Refine calls this method when it wants to close a notification. Refine pass the `key` of the notification to the `close` method. So, we can handle the notification close logic with this `key`.
 

--- a/documentation/docs/packages/react-hook-form/use-form/index.md
+++ b/documentation/docs/packages/react-hook-form/use-form/index.md
@@ -265,7 +265,7 @@ If you want to show a form in a modal or drawer where necessary route params mig
 
 ## Properties
 
-### `action`
+### action
 
 `useForm` can handle `edit`, `create` and `clone` actions.
 
@@ -478,7 +478,7 @@ render(<RefineHeadlessDemo />);
 
 </Tabs>
 
-### `resource`
+### resource
 
 It will be passed to the [`dataProvider`][data-provider]'s method as a params. This parameter is usually used to as a API endpoint path. It all depends on how to handle the `resource` in your [`dataProvider`][data-provider]. See the [`creating a data provider`](/docs/data/data-provider#creating-a-data-provider) section for an example of how `resource` are handled.
 
@@ -532,7 +532,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `id`
+### id
 
 `id` is used for determining the record to `edit` or `clone`. By default, it uses the `id` from the route. It can be changed with the `setId` function or `id` property.
 
@@ -548,7 +548,7 @@ useForm({
 });
 ```
 
-### `redirect`
+### redirect
 
 `redirect` is used for determining the page to redirect after the form is submitted. By default, it uses the `list`. It can be changed with the `redirect` property.
 
@@ -562,7 +562,7 @@ useForm({
 });
 ```
 
-### `onMutationSuccess`
+### onMutationSuccess
 
 It's a callback function that will be called after the mutation is successful.
 
@@ -583,7 +583,7 @@ useForm({
 });
 ```
 
-### `onMutationError`
+### onMutationError
 
 It's a callback function that will be called after the mutation is failed.
 
@@ -604,7 +604,7 @@ useForm({
 });
 ```
 
-### `invalidates`
+### invalidates
 
 You can use it to manage the invalidations that will occur at the end of the mutation.
 
@@ -621,7 +621,7 @@ useForm({
 });
 ```
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.
 It is useful when you want to use a different `dataProvider` for a specific resource.
@@ -636,7 +636,7 @@ useForm({
 });
 ```
 
-### `mutationMode`
+### mutationMode
 
 Mutation mode determines which mode the mutation runs with. Mutations can run under three different modes: `pessimistic`, `optimistic` and `undoable`. Default mode is `pessimistic`.
 Each mode corresponds to a different type of user experience.
@@ -651,7 +651,7 @@ useForm({
 });
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`][notification-provider] is required for this prop to work.
 
@@ -671,7 +671,7 @@ useForm({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`][notification-provider] is required for this prop to work.
 
@@ -701,7 +701,7 @@ useForm({
 }
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -741,7 +741,7 @@ const myDataProvider = {
 };
 ```
 
-### `queryMeta`
+### queryMeta
 
 In addition to the [`meta`](#meta) property, you can also pass the `queryMeta` property to the `useForm` hook. This property is used to pass additional information to the `useOne` hook that is used to fetch the data in the `edit` and `clone` modes. This is useful when you have to apply different values to the `useOne` hook from the `useCreate` or `useUpdate` hook mutations.
 
@@ -755,7 +755,7 @@ useForm({
 
 If you have overlapping properties in both `meta` and `queryMeta`, the `queryMeta` property will be used.
 
-### `mutationMeta`
+### mutationMeta
 
 In addition to the [`meta`](#meta) property, you can also pass the `mutationMeta` property to the `useForm` hook. This property is used to pass additional information to the `useCreate` or `useUpdate` hook mutations. This is useful when you have to apply different values to the `useCreate` or `useUpdate` hooks from the `useOne` hook query.
 
@@ -769,7 +769,7 @@ useForm({
 
 If you have overlapping properties in both `meta` and `mutationMeta`, the `mutationMeta` property will be used.
 
-### `queryOptions`
+### queryOptions
 
 > Works only in `action: "edit"` or `action: "clone"` mode.
 
@@ -785,7 +785,7 @@ useForm({
 });
 ```
 
-### `createMutationOptions`
+### createMutationOptions
 
 > This option is only available when `action: "create"` or `action: "clone"`.
 
@@ -801,7 +801,7 @@ useForm({
 });
 ```
 
-### `updateMutationOptions`
+### updateMutationOptions
 
 > This option is only available when `action: "edit"`.
 
@@ -817,7 +817,7 @@ useForm({
 });
 ```
 
-### `warnWhenUnsavedChanges`
+### warnWhenUnsavedChanges
 
 When it's true, Shows a warning when the user tries to leave the page with unsaved changes. It can be used to prevent the user from accidentally leaving the page. Default value is `false`.
 
@@ -831,7 +831,7 @@ useForm({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 Whether to update data automatically ("auto") or not ("manual") if a related live event is received. It can be used to update and show data in Realtime throughout your app.
 For more information about live mode, please check [Live / Realtime](/docs/realtime/live-provider#livemode) page.
@@ -844,7 +844,7 @@ useForm({
 });
 ```
 
-### `onLiveEvent`
+### onLiveEvent
 
 The callback function that is executed when new events from a subscription are arrived.
 
@@ -858,11 +858,11 @@ useForm({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 Params to pass to [liveProvider's](/docs/realtime/live-provider#subscribe) subscribe method.
 
-### `autoSave`
+### autoSave
 
 If you want to save the form automatically after some delay when user edits the form, you can pass true to `autoSave.enabled` prop.
 
@@ -874,7 +874,7 @@ It also supports [`onMutationSuccess`](#onmutationsuccess) and [`onMutationError
 
 `onMutationSuccess` and `onMutationError` callbacks will be called after the mutation is successful or failed.
 
-#### `enabled`
+#### enabled
 
 To enable the `autoSave` feature, set the `enabled` parameter to `true`. By default, it is disabled.
 
@@ -888,7 +888,7 @@ useForm({
 });
 ```
 
-#### `debounce`
+#### debounce
 
 Set the debounce time for the `autoSave` prop. Default value is `1000` milliseconds.
 
@@ -904,7 +904,7 @@ useForm({
 });
 ```
 
-#### `onFinish`
+#### onFinish
 
 If you want to modify the data before sending it to the server, you can use `onFinish` callback function.
 
@@ -926,7 +926,7 @@ useForm({
 });
 ```
 
-#### `invalidateOnUnmount`
+#### invalidateOnUnmount
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when hook is unmounted. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate.
 
@@ -946,7 +946,7 @@ useForm({
 
 ## Return Values
 
-### `queryResult`
+### queryResult
 
 If the `action` is set to `"edit"` or `"clone"` or if a `resource` with an `id` is provided, `useForm` will call [`useOne`](/docs/data/hooks/use-one) and set the returned values as the `queryResult` property.
 
@@ -958,7 +958,7 @@ const {
 const { data } = queryResult;
 ```
 
-### `mutationResult`
+### mutationResult
 
 When in `"create"` or `"clone"` mode, `useForm` will call [`useCreate`](/docs/data/hooks/use-create). When in `"edit"` mode, it will call [`useUpdate`](/docs/data/hooks/use-update) and set the resulting values as the `mutationResult` property."
 
@@ -970,7 +970,7 @@ const {
 const { data } = mutationResult;
 ```
 
-### `setId`
+### setId
 
 `useForm` determine `id` from the router. If you want to change the `id` dynamically, you can use `setId` function.
 
@@ -990,7 +990,7 @@ return (
 );
 ```
 
-### `redirect`
+### redirect
 
 "By default, after a successful mutation, `useForm` will `redirect` to the `"list"` page. To redirect to a different page, you can either use the `redirect` function to programmatically specify the destination, or set the redirect [property](/docs/data/hooks/use-form/#redirect) in the hook's options.
 
@@ -1012,22 +1012,22 @@ const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
 // --
 ```
 
-### `onFinish`
+### onFinish
 
 `onFinish` is a function that is called when the form is submitted. It will call the appropriate mutation based on the `action` property.
 You can override the default behavior by passing an `onFinish` function in the hook's options.
 
 For example you can [change values before sending to the API](/docs/packages/list-of-packages#how-can-i-change-the-form-data-before-submitting-it-to-the-api).
 
-### `saveButtonProps`
+### saveButtonProps
 
 It contains all the props needed by the "submit" button within the form (disabled, onClick etc.). When `saveButtonProps.onClick` is called, it triggers `handleSubmit`function with `onFinish`. You can manually pass these props to your custom button.
 
-### `formLoading`
+### formLoading
 
 Loading state of a modal. It's `true` when `useForm` is currently being submitted or data is being fetched for the `"edit"` or `"clone"` mode.
 
-### `autoSaveProps`
+### autoSaveProps
 
 If `autoSave` is enabled, this hook returns `autoSaveProps` object with `data`, `error`, and `status` properties from mutation.
 

--- a/documentation/docs/packages/react-hook-form/use-modal-form/index.md
+++ b/documentation/docs/packages/react-hook-form/use-modal-form/index.md
@@ -597,7 +597,7 @@ All [`useForm`][refine-react-hook-form-use-form] props also available in `useMod
 
 All [`React Hook Form useForm`][react-hook-form-use-form] props also available in `useModalForm`. You can find descriptions on [`React Hook Form`][react-hook-form-use-form] docs.
 
-### `defaultValues`
+### defaultValues
 
 Default values for the form. Use this to pre-populate the form with data that needs to be displayed. This property is only available with `"create"` action.
 
@@ -609,7 +609,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `defaultVisible`
+### defaultVisible
 
 When `true`, modal will be visible by default. Defaults to `false`.
 
@@ -621,7 +621,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `autoSubmitClose`
+### autoSubmitClose
 
 When `true`, modal will be closed after successful submit. Defaults to `true`.
 
@@ -633,7 +633,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `autoResetForm`
+### autoResetForm
 
 When `true`, form will be reset after successful submit. Defaults to `true`.
 
@@ -645,7 +645,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `warnWhenUnsavedChanges`
+### warnWhenUnsavedChanges
 
 When you have unsaved changes and try to leave the current page, Refine shows a confirmation modal box. To activate this feature. By default, this feature is disabled.
 
@@ -657,7 +657,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `syncWithLocation`
+### syncWithLocation
 
 When `true`, the modals visibility state and the `id` of the record will be synced with the URL. By default, this feature is disabled.
 
@@ -669,7 +669,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `autoSave`
+### autoSave
 
 If you want to save the form automatically after some delay when user edits the form, you can pass true to `autoSave.enabled` prop.
 
@@ -681,7 +681,7 @@ It also supports `onMutationSuccess` and `onMutationError` callback functions. Y
 
 `onMutationSuccess` and `onMutationError` callbacks will be called after the mutation is successful or failed.
 
-#### `enabled`
+#### enabled
 
 To enable the `autoSave` feature, set the `enabled` parameter to `true`. By default, it is set to `false`.
 
@@ -695,7 +695,7 @@ useModalForm({
 });
 ```
 
-#### `debounce`
+#### debounce
 
 Set the debounce time for the `autoSave` prop. Default value is `1000` milliseconds.
 
@@ -711,7 +711,7 @@ useModalForm({
 });
 ```
 
-#### `onFinish`
+#### onFinish
 
 If you want to modify the data before sending it to the server, you can use `onFinish` callback function.
 
@@ -733,7 +733,7 @@ useModalForm({
 });
 ```
 
-#### `invalidateOnUnmount`
+#### invalidateOnUnmount
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when the hook is unmounted. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate. By default it is set to `false`.
 
@@ -749,7 +749,7 @@ useDrawerForm({
 });
 ```
 
-#### `invalidateOnClose`
+#### invalidateOnClose
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when the modal is closed. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate. By default it is set to `false`.
 
@@ -771,7 +771,7 @@ All [`useForm`][refine-react-hook-form-use-form] return values also available in
 
 All [`React Hook Form useForm`][react-hook-form-use-form] return values also available in `useModalForm`. You can find descriptions on [`useForm`](/docs/packages/list-of-packages#return-values) docs.
 
-### `visible`
+### visible
 
 Current visibility state of the modal.
 
@@ -783,7 +783,7 @@ const modalForm = useModalForm({
 console.log(modalForm.modal.visible); // true
 ```
 
-### `title`
+### title
 
 Title of the modal. Based on resource and action values
 
@@ -800,7 +800,7 @@ const {
 console.log(title); // "Create Post"
 ```
 
-### `close`
+### close
 
 A function that can close the modal. It's useful when you want to close the modal manually.
 
@@ -836,7 +836,7 @@ return (
 );
 ```
 
-### `submit`
+### submit
 
 A function that can submit the form. It's useful when you want to submit the form manually.
 
@@ -871,7 +871,7 @@ return (
 );
 ```
 
-### `show`
+### show
 
 A function that can show the modal.
 
@@ -904,7 +904,7 @@ return (
 );
 ```
 
-### `saveButtonProps`
+### saveButtonProps
 
 It contains all the props needed by the "submit" button within the modal (disabled,loading etc.). You can manually pass these props to your custom button.
 

--- a/documentation/docs/packages/react-hook-form/use-steps-form/index.md
+++ b/documentation/docs/packages/react-hook-form/use-steps-form/index.md
@@ -940,7 +940,7 @@ interface IPost {
 
 ## Properties
 
-### `refineCoreProps`
+### refineCoreProps
 
 All [`useForm`](/docs/ui-integrations/ant-design/hooks/use-form) properties also available in `useStepsForm`. You can find descriptions on [`useForm`](/docs/ui-integrations/ant-design/hooks/use-form#return-values) docs.
 
@@ -954,11 +954,11 @@ const stepsForm = useStepsForm({
 });
 ```
 
-### `stepsProps`
+### stepsProps
 
 The props needed by the manage state steps.
 
-#### `defaultStep`
+#### defaultStep
 
 Sets the default starting step number. Counting starts from `0`.
 
@@ -970,7 +970,7 @@ const stepsForm = useStepsForm({
 });
 ```
 
-#### `isBackValidate`
+#### isBackValidate
 
 When is `true`, validates a form fields when the user navigates to a previous step. Default is `false`.
 
@@ -982,7 +982,7 @@ const stepsForm = useStepsForm({
 });
 ```
 
-### `autoSave`
+### autoSave
 
 If you want to save the form automatically after some delay when user edits the form, you can pass true to `autoSave.enabled` prop.
 
@@ -994,7 +994,7 @@ It also supports `onMutationSuccess` and `onMutationError` callback functions. Y
 
 `onMutationSuccess` and `onMutationError` callbacks will be called after the mutation is successful or failed.
 
-#### `enabled`
+#### enabled
 
 To enable the `autoSave` feature, set the `enabled` parameter to `true`. By default, it is set to `false`.
 
@@ -1008,7 +1008,7 @@ useStepsForm({
 });
 ```
 
-#### `debounce`
+#### debounce
 
 Set the debounce time for the `autoSave` prop. By default, it is set to `1000` milliseconds.
 
@@ -1024,7 +1024,7 @@ useStepsForm({
 });
 ```
 
-#### `onFinish`
+#### onFinish
 
 If you want to modify the data before sending it to the server, you can use `onFinish` callback function.
 
@@ -1046,7 +1046,7 @@ useStepsForm({
 });
 ```
 
-#### `invalidateOnUnmount`
+#### invalidateOnUnmount
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when the hook is unmounted. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate. By default, it is set to `false`.
 
@@ -1066,15 +1066,15 @@ useStepsForm({
 
 All [`useForm`](/docs/packages/list-of-packages) return values also available in `useStepsForm`. You can find descriptions on [`useForm`](/docs/packages/list-of-packages#return-values) docs.
 
-### `steps`
+### steps
 
 The return values needed by the manage state steps.
 
-#### `currentStep`
+#### currentStep
 
 Current step, counting from `0`.
 
-#### `gotoStep`
+#### gotoStep
 
 Is a function that allows you to programmatically change the current step of a form.
 It takes in one argument, step, which is a number representing the index of the step you want to navigate to.

--- a/documentation/docs/packages/tanstack-table/use-table/index.md
+++ b/documentation/docs/packages/tanstack-table/use-table/index.md
@@ -66,7 +66,7 @@ When the `useTable` hook is mounted, it will call the `subscribe` method from th
 
 It also accepts all props of [TanStack Table](https://tanstack.com/table/v8/docs/api/core/table#options).
 
-### `resource`
+### resource
 
 <PropResource
 hook={{
@@ -94,7 +94,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use. It is useful when you want to use a different `dataProvider` for a specific resource.
 
@@ -106,7 +106,7 @@ useTable({
 });
 ```
 
-### `pagination.current`
+### pagination.current
 
 Sets the initial value of the page index. Default value is `1`.
 
@@ -120,7 +120,7 @@ useTable({
 });
 ```
 
-### `pagination.pageSize`
+### pagination.pageSize
 
 Sets the initial value of the page size. Default value is `10`.
 
@@ -134,7 +134,7 @@ useTable({
 });
 ```
 
-### `pagination.mode`
+### pagination.mode
 
 It can be `"off"`, `"server"` or `"client"`. Default value is `"server"`.
 
@@ -152,7 +152,7 @@ useTable({
 });
 ```
 
-### `sorters.initial`
+### sorters.initial
 
 Sets the initial value of the sorter. The `initial` is not permanent. It will be cleared when the user changes the sorter. If you want to set a permanent value, use the `sorters.permanent` prop.
 
@@ -173,7 +173,7 @@ useTable({
 });
 ```
 
-### `sorters.permanent`
+### sorters.permanent
 
 Sets the permanent value of the sorter. The `permanent` is permanent and unchangeable. It will not be cleared when the user changes the sorter. If you want to set a temporary value, use the `sorters.initial` prop.
 
@@ -194,7 +194,7 @@ useTable({
 });
 ```
 
-### `sorters.mode`
+### sorters.mode
 
 It can be `"off"` or `"server"`. Default value is `"server"`.
 
@@ -211,7 +211,7 @@ useTable({
 });
 ```
 
-### `filters.initial`
+### filters.initial
 
 Sets the initial value of the filter. The `initial` is not permanent. It will be cleared when the user changes the filter. If you want to set a permanent value, use the `filters.permanent` prop.
 
@@ -233,7 +233,7 @@ useTable({
 });
 ```
 
-### `filters.permanent`
+### filters.permanent
 
 Sets the permanent value of the filter. The `permanent` is permanent and unchangeable. It will not be cleared when the user changes the filter. If you want to set a temporary value, use the `filters.initial` prop.
 
@@ -255,7 +255,7 @@ useTable({
 });
 ```
 
-### `filters.defaultBehavior`
+### filters.defaultBehavior
 
 The filtering behavior can be set to either `"merge"` or `"replace"`. Default value is `"replace"`.
 
@@ -275,7 +275,7 @@ useTable({
 });
 ```
 
-### `filters.mode`
+### filters.mode
 
 It can be `"off"` or `"server"`. Default value is `"server"`.
 
@@ -292,7 +292,7 @@ useTable({
 });
 ```
 
-### `syncWithLocation` <GlobalConfigBadge id="core/refine-component/#syncwithlocation" />
+### syncWithLocation <GlobalConfigBadge id="core/refine-component/#syncwithlocation" />
 
 When you use the syncWithLocation feature, the `useTable`'s state (e.g. sort order, filters, pagination) is automatically encoded in the query parameters of the URL, and when the URL changes, the `useTable` state is automatically updated to match. This makes it easy to share table state across different routes or pages and to allow users to bookmark or share links to specific table views.
 
@@ -306,7 +306,7 @@ useTable({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 `useTable` uses [`useList`](/docs/data/hooks/use-list) hook to fetch data. You can pass [`queryOptions`](https://tanstack.com/query/v4/docs/react/reference/useQuery).
 
@@ -320,7 +320,7 @@ useTable({
 });
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -368,7 +368,7 @@ const myDataProvider = {
 };
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`][notification-provider] is required for this prop to work.
 
@@ -388,7 +388,7 @@ useTable({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`][notification-provider] is required for this prop to work.
 
@@ -408,7 +408,7 @@ useTable({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required.
 
@@ -423,7 +423,7 @@ useTable({
 });
 ```
 
-### `onLiveEvent`
+### onLiveEvent
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required.
 
@@ -439,41 +439,41 @@ useTable({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required.
 
 Params to pass to liveProvider's [subscribe](/docs/realtime/live-provider#subscribe) method.
 
-### ~~`initialCurrent`~~ <PropTag deprecated />
+### ~~initialCurrent~~ <PropTag deprecated />
 
 Use `pagination.current` instead.
 
-### ~~`initialPageSize`~~ <PropTag deprecated />
+### ~~initialPageSize~~ <PropTag deprecated />
 
 Use `pagination.pageSize` instead.
 
-### ~~`hasPagination`~~ <PropTag deprecated />
+### ~~hasPagination~~ <PropTag deprecated />
 
 Use `pagination.mode` instead.
 
-### ~~`initialSorter`~~ <PropTag deprecated />
+### ~~initialSorter~~ <PropTag deprecated />
 
 Use `sorters.initial` instead.
 
-### ~~`permanentSorter`~~ <PropTag deprecated />
+### ~~permanentSorter~~ <PropTag deprecated />
 
 Use `sorters.permanent` instead.
 
-### ~~`initialFilter`~~ <PropTag deprecated />
+### ~~initialFilter~~ <PropTag deprecated />
 
 Use `filters.initial` instead.
 
-### ~~`permanentFilter`~~ <PropTag deprecated />
+### ~~permanentFilter~~ <PropTag deprecated />
 
 Use `filters.permanent` instead.
 
-### ~~`defaultSetFilterBehavior`~~ <PropTag deprecated />
+### ~~defaultSetFilterBehavior~~ <PropTag deprecated />
 
 Use `filters.defaultBehavior` instead.
 
@@ -481,17 +481,17 @@ Use `filters.defaultBehavior` instead.
 
 It also have all return values of [TanStack Table](https://tanstack.com/table/v8/docs/api/core/table#options).
 
-### `refineCore`
+### refineCore
 
-#### `tableQueryResult`
+#### tableQueryResult
 
 Returned values from [`useList`](/docs/data/hooks/use-list) hook.
 
-### `sorters`
+### sorters
 
 Current [sorters state][crudsorting].
 
-### `setSorters`
+### setSorters
 
 A function to set current [sorters state][crudsorting].
 
@@ -501,11 +501,11 @@ A function to set current [sorters state][crudsorting].
 
 A function to set current [sorters state][crudsorting].
 
-#### `filters`
+#### filters
 
 Current [filters state][crudfilters].
 
-#### `setFilters`
+#### setFilters
 
 ```tsx
 ((filters: CrudFilters, behavior?: SetFilterBehavior) => void) & ((setter: (prevFilters: CrudFilters) => CrudFilters) => void)
@@ -513,11 +513,11 @@ Current [filters state][crudfilters].
 
 A function to set current [filters state][crudfilters].
 
-#### `current`
+#### current
 
 Current page index state. If pagination is disabled, it will be `undefined`.
 
-#### `setCurrent`
+#### setCurrent
 
 ```tsx
 React.Dispatch<React.SetStateAction<number>> | undefined;
@@ -525,11 +525,11 @@ React.Dispatch<React.SetStateAction<number>> | undefined;
 
 A function to set the current page index state. If pagination is disabled, it will be `undefined`.
 
-#### `pageSize`
+#### pageSize
 
 Current page size state. If pagination is disabled, it will be `undefined`.
 
-#### `setPageSize`
+#### setPageSize
 
 ```tsx
 React.Dispatch<React.SetStateAction<number>> | undefined;
@@ -537,11 +537,11 @@ React.Dispatch<React.SetStateAction<number>> | undefined;
 
 A function to set the current page size state. If pagination is disabled, it will be `undefined`.
 
-#### `pageCount`
+#### pageCount
 
 Total page count state. If pagination is disabled, it will be `undefined`.
 
-#### `createLinkForSyncWithLocation`
+#### createLinkForSyncWithLocation
 
 ```tsx
 (params: SyncWithLocationParams) => string;
@@ -549,13 +549,13 @@ Total page count state. If pagination is disabled, it will be `undefined`.
 
 A function creates accessible links for `syncWithLocation`. It takes [SyncWithLocationParams][syncwithlocationparams] as parameters.
 
-### ~~`sorter`~~ <PropTag deprecated />
+### ~~sorter~~ <PropTag deprecated />
 
 Use `sorters` instead.
 
 Current [sorters state][crudsorting].
 
-### ~~`setSorter`~~ <PropTag deprecated />
+### ~~setSorter~~ <PropTag deprecated />
 
 Use `setSorters` instead.
 

--- a/documentation/docs/realtime/live-provider/index.md
+++ b/documentation/docs/realtime/live-provider/index.md
@@ -144,7 +144,7 @@ Since the following hooks are derivative of `useList` hook, they will subscribe 
 | @refinedev/mui         | [useDataGrid](/docs/ui-integrations/material-ui/hooks/use-data-grid), [useAutoComplete](/docs/ui-integrations/material-ui/hooks/use-auto-complete)                                                                                                                                                                                                                                                                                           |
 | @refinedev/mantine     | [useSelect](/docs/ui-integrations/mantine/hooks/use-select)                                                                                                                                                                                                                                                                                                                                                                                  |
 
-### `useOne`
+### useOne
 
 ```ts
 useOne({ resource: "posts", id: "1" });
@@ -166,7 +166,7 @@ Since the following hooks are derivative of `useOne` hook, they will subscribe t
 | @refinedev/antd    | [useForm](/docs/ui-integrations/ant-design/hooks/use-form), [useModalForm](/docs/ui-integrations/ant-design/hooks/use-modal-form), [useDrawerForm](/docs/ui-integrations/ant-design/hooks/use-drawer-form), [useStepsForm](/docs/ui-integrations/ant-design/hooks/use-steps-form) |
 | @refinedev/mantine | [useForm](/docs/ui-integrations/mantine/hooks/use-form), [useDrawerForm](/docs/ui-integrations/mantine/hooks/use-drawer-form), [useModalForm](/docs/ui-integrations/mantine/hooks/use-modal-form), [useStepsForm](/docs/ui-integrations/mantine/hooks/use-steps-form)             |
 
-### `useMany`
+### useMany
 
 ```ts
 useMany({ resource: "posts", ids: ["1", "2"] });
@@ -189,7 +189,7 @@ Since the following hooks are using `useMany` hook, they will subscribe to the s
 
 Refine publishes these events in the hooks. Let's see the usage of hooks and what kind of events are published:
 
-### `useCreate`
+### useCreate
 
 ```ts
 const { mutate } = useCreate();
@@ -212,7 +212,7 @@ mutate({
 }
 ```
 
-### `useCreateMany`
+### useCreateMany
 
 ```ts
 const { mutate } = useCreateMany();
@@ -240,7 +240,7 @@ mutate({
 }
 ```
 
-### `useDelete`
+### useDelete
 
 ```ts
 const { mutate } = useDelete();
@@ -261,7 +261,7 @@ mutate({
 }
 ```
 
-### `useDeleteMany`
+### useDeleteMany
 
 ```ts
 const { mutate } = useDeleteMany();
@@ -282,7 +282,7 @@ mutate({
 }
 ```
 
-### `useUpdate`
+### useUpdate
 
 ```ts
 const { mutate } = useUpdate();
@@ -304,7 +304,7 @@ mutate({
 }
 ```
 
-### `useUpdateMany`
+### useUpdateMany
 
 ```ts
 const { mutate } = useUpdateMany();

--- a/documentation/docs/routing/hooks/use-get-to-path/index.md
+++ b/documentation/docs/routing/hooks/use-get-to-path/index.md
@@ -49,18 +49,18 @@ The `authorId` and `id` parameters will be inferred from the route if they are p
 
 ## Parameters
 
-### `resource`
+### resource
 
 This is the name of the resource that you want to navigate to.
 
-### `action`
+### action
 
 This is the name of the action that you want to navigate to.
 
-### `meta`
+### meta
 
 This is the meta object that you want to use to compose the URL. It will be merged with the `params` object that is parsed from the URL.
 
-### `legacy`
+### legacy
 
 This is a boolean value that indicates whether the legacy URL format should be used or not. If it is set to `true`, the URL will be composed for the legacy routers. Default value is `false`.

--- a/documentation/docs/routing/hooks/use-go/index.md
+++ b/documentation/docs/routing/hooks/use-go/index.md
@@ -82,17 +82,17 @@ const MyComponent = () => {
 
 ## Parameters
 
-### `to`
+### to
 
 The `to` parameter is the path you want to navigate to. If left empty, it will navigate to the current path, which is useful for updating the query parameters.
 
 Also, you can pass a `resource` object to the `to` parameter. The `routerProvider` will convert the resource object to the path.
 
-### `query`
+### query
 
 The `query` parameter is the query parameters you want to add to the path. It is an object which the `routerProvider` will convert to the query string.
 
-### `type`
+### type
 
 The `type` parameter is the type of navigation you want to perform. It can be one of the following:
 
@@ -100,15 +100,15 @@ The `type` parameter is the type of navigation you want to perform. It can be on
 - `replace`: It replaces the current entry on the history stack.
 - `path`: Returns the navigation path for the given config. Doesn't mutate the history stack.
 
-### `hash`
+### hash
 
 The `hash` parameter is the hash you want to add to the path.
 
-### `options.keepQuery`
+### options.keepQuery
 
 The `options.keepQuery` parameter is a boolean that determines whether the current query parameters should be kept or not. If it is `true`, the current query parameters will be merged with the new query parameters. If it is `false`, the current query parameters will be ignored.
 
-### `options.keepHash`
+### options.keepHash
 
 The `options.keepHash` parameter is a boolean that determines whether the current hash should be kept or not. If it is `true`, the current hash will be kept in the URL. If it is `false`, the current hash will be ignored.
 

--- a/documentation/docs/routing/hooks/use-link/index.md
+++ b/documentation/docs/routing/hooks/use-link/index.md
@@ -26,7 +26,7 @@ const MyComponent = () => {
 
 ## Parameters
 
-### `to`
+### to
 
 This is the path that the link will navigate to. It should be a string.
 

--- a/documentation/docs/routing/hooks/use-navigation/index.md
+++ b/documentation/docs/routing/hooks/use-navigation/index.md
@@ -19,7 +19,7 @@ const { list, create, edit, show, clone, push, replace, goBack, listUrl, createU
 
 All functions the `useNavigation` hook returns, except `push`, `replace` and `goBack`, accept a `meta` parameter. This is an optional parameter that can be used to pass additional parameters to the routes if they contain multiple parameters other than `id`.
 
-### `list`
+### list
 
 This method navigates to the list page of the given resource.
 
@@ -33,7 +33,7 @@ list("posts"); // It navigates to the `/posts` page
 
 You can also give a `type` property as a second parameter to the `list` method.
 
-### `create`
+### create
 
 This method navigates to the create page of the given resource.
 
@@ -47,7 +47,7 @@ create("posts"); // It navigates to the `/posts/create` page
 
 You can also give a `type` property as a second parameter to the `create` method.
 
-### `edit`
+### edit
 
 This method navigates to the edit page of the given `resource` and `id`. When you use this method, you need to give it the `id` of the record you want to edit.
 
@@ -61,7 +61,7 @@ edit("posts", "1"); // It navigates to the `/posts/edit/1` page
 
 You can also give a `type` property as a third parameter to the `edit` method.
 
-### `show`
+### show
 
 This method navigates to the show page of the given `resource` and `id`. When you use this method, you need to give the `id` of the record you want to show.
 
@@ -75,7 +75,7 @@ show("posts", "1"); // It navigates to the `/posts/show/1` page
 
 You can also give a `type` property as a third parameter to the `show` method.
 
-### `clone`
+### clone
 
 This method navigates to the clone page of the given `resource` and `id`. When you use this method, you need to give the `id` of the record you want to clone.
 
@@ -89,7 +89,7 @@ clone("posts", "1"); // It navigates to the `/posts/clone/1` page
 
 You can also give a `type` property as a third parameter to the `clone` method.
 
-### `push`
+### push
 
 This method pushes a new entry onto the history stack. It uses the `push` method of the `useHistory` from the [`routerProvider`][routerprovider].
 
@@ -103,7 +103,7 @@ push("custom-page"); // It navigates to the `/custom-page` page
 
 `push` method parameters are dependent on your router provider.
 
-### `replace`
+### replace
 
 This method replaces the current entry on the history stack. It uses the `replace` method of the `useHistory` from the [`routerProvider`][routerprovider].
 
@@ -117,7 +117,7 @@ replace("custom-page"); // It navigates to the `/custom-page` page
 
 `replace` method parameters are dependent on your router provider.
 
-### `goBack`
+### goBack
 
 This method navigates to the previous page. It uses the `goBack` method of the `useHistory` from the [`routerProvider`][routerprovider].
 
@@ -131,7 +131,7 @@ goBack(); // It navigates to the previous page
 
 `goBack` method parameters are dependent on your router provider.
 
-### `listUrl`
+### listUrl
 
 This method returns the list page URL of the given resource.
 
@@ -143,7 +143,7 @@ const { listUrl } = useNavigation();
 listUrl("posts"); // It returns the `/posts` URL
 ```
 
-### `createUrl`
+### createUrl
 
 This method returns the create page URL of the given resource.
 
@@ -155,7 +155,7 @@ const { createUrl } = useNavigation();
 createUrl("posts"); // It returns the `/posts/create` URL
 ```
 
-### `editUrl`
+### editUrl
 
 This method returns the edit page URL of the given resource and id.
 
@@ -167,7 +167,7 @@ const { editUrl } = useNavigation();
 editUrl("posts", "1"); // It returns the `/posts/edit/1` URL
 ```
 
-### `showUrl`
+### showUrl
 
 This method returns the show page URL of the given resource and id.
 
@@ -179,7 +179,7 @@ const { showUrl } = useNavigation();
 showUrl("posts", "1"); // It returns the `/posts/show/1` URL
 ```
 
-### `cloneUrl`
+### cloneUrl
 
 This method returns the clone page URL of the given resource and id.
 

--- a/documentation/docs/routing/hooks/use-parsed/index.md
+++ b/documentation/docs/routing/hooks/use-parsed/index.md
@@ -34,39 +34,39 @@ const MyComponent = () => {
 
 ## Return Values
 
-### `resource`
+### resource
 
 This is the active resource that is matched by the current route and the action definitions in the `resources` array of the `Refine` component. It will be `undefined` if there is no match.
 
-### `action`
+### action
 
 This is the active action that is matched by the current route and the action definitions in the `resources` array of the `Refine` component. It will be `undefined` if there is no match.
 
-### `id`
+### id
 
 This is the main parameter used by the Refine in API interactions. It will also be available in the `params` object but it is also available as a separate value for convenience. It will be `undefined` if there is no `id` parameter in the URL.
 
-### `pathname`
+### pathname
 
 This is the current pathname of the URL.
 
-### `params.filters`
+### params.filters
 
 This is the filters that are parsed from the URL. It will be `undefined` if there is no `filters` parameter in the URL. This property is used in the `syncWithLocation` feature of the `useTable`.
 
-### `params.sorters`
+### params.sorters
 
 This is the sorters that are parsed from the URL. It will be `undefined` if there is no `sorters` parameter in the URL. This property is used in the `syncWithLocation` feature of the `useTable`.
 
-### `params.current`
+### params.current
 
 This is the current page that is parsed from the URL. It will be `undefined` if there is no `current` parameter in the URL. This property is used in the `syncWithLocation` feature of the `useTable`.
 
-### `params.pageSize`
+### params.pageSize
 
 This is the page size that is parsed from the URL. It will be `undefined` if there is no `pageSize` parameter in the URL. This property is used in the `syncWithLocation` feature of the `useTable`.
 
-### `params`
+### params
 
 This is the object that contains all the parameters that are parsed from the URL. It will be an empty object if there is no parameter in the URL. `params` object contains both the URL parameters and the query parameters.
 

--- a/documentation/docs/routing/hooks/use-resource/index.md
+++ b/documentation/docs/routing/hooks/use-resource/index.md
@@ -30,27 +30,27 @@ const { resource } = useResource("posts");
 
 ## Return Values
 
-### `resources`
+### resources
 
 An array of resources that you defined in `<Refine>`.
 
-### `resource`
+### resource
 
 The `resource` object.
 
-### `resourceName`
+### resourceName
 
 Resource name of the `resource` object.
 
-### `id`
+### id
 
 `id` parameter of the current route.
 
-### `action`
+### action
 
 `action` from the current route if there is a match.
 
-### `select`
+### select
 
 The function allows you to retrieve a `resource` object and matched `identifier` by providing either a resource `name` or `identifier`. By default, if there is no match for the given `name` or `identifier`, the function will return the `resource` object and `identifier` associated with the provided value.
 
@@ -58,7 +58,7 @@ If you don't pass any parameter to `useResource`, it will try to infer the `reso
 
 The function also accepts a second parameter `force` which is `true` by default. If you set it to `false`, it will not return a `resource` object and `identifier` if there is no match.
 
-### `identifier`
+### identifier
 
 Identifier value for the current resource, this can either be the `identifier` property or the `name` property of the resource.
 

--- a/documentation/docs/routing/integrations/next-js/index.md
+++ b/documentation/docs/routing/integrations/next-js/index.md
@@ -446,7 +446,7 @@ export default function IndexPage() {
 
 `@refinedev/nextjs-router` package also includes some additional components that can be useful in some cases.
 
-### `NavigateToResource`
+### NavigateToResource
 
 A basic component to navigate to a resource page. It is useful when you want to navigate to a resource page at the index route of your app.
 
@@ -478,7 +478,7 @@ export default function IndexPage() {
 
 `meta` (optional) - The meta object to use if the route has parameters in it. The parameters in the current location will also be used to compose the route but `meta` will take precedence.
 
-### `UnsavedChangesNotifier`
+### UnsavedChangesNotifier
 
 This component enables the `warnWhenUnsavedChanges` feature of Refine. It will show a warning message when user tries to navigate away from the current page without saving the changes. Also checks for `beforeunload` event to warn the user when they try to close the browser tab or window.
 
@@ -513,11 +513,11 @@ This feature is not working in experimental `appDir` mode in Next.js due to limi
 
 `message` (optional) - The warning message. Default value is `Are you sure you want to leave? You have unsaved changes.` Useful when you don't use an i18n provider.
 
-### `parseTableParams`
+### parseTableParams
 
 This function can be used to parse the query parameters of a table page. It can be useful when you want to use the query parameters in your server side functions (`loader`) to fetch the data such as [persisting the table state](#how-to-persist-syncwithlocation-in-ssr)
 
-### `DocumentTitleHandler`
+### DocumentTitleHandler
 
 Note that this component currently only works in the `pages` directory.
 
@@ -576,7 +576,7 @@ const customTitleHandler = ({ resource, action, params }) => {
 
 ## Hooks
 
-### `useDocumentTitle`
+### useDocumentTitle
 
 Note that this hook doesn't support SSR. It will only set the document title in the client side.
 

--- a/documentation/docs/routing/integrations/react-router/index.md
+++ b/documentation/docs/routing/integrations/react-router/index.md
@@ -537,7 +537,7 @@ Refine supports route parameters defined with `:param` syntax. You can use these
 
 `@refinedev/react-router-v6` package also includes some additional components that can be useful in some cases.
 
-### `NavigateToResource`
+### NavigateToResource
 
 A basic component that extends the `Navigate` component from **react-router-dom** to navigate to a resource page. It is useful when you want to navigate to a resource page at the index route of your app.
 
@@ -573,7 +573,7 @@ const App = () => {
 
 `meta` (optional) - The meta object to use if the route has parameters in it. The parameters in the current location will also be used to compose the route but `meta` will take precedence.
 
-### `UnsavedChangesNotifier`
+### UnsavedChangesNotifier
 
 This component enables the `warnWhenUnsavedChanges` feature of Refine. It will show a warning message when user tries to navigate away from the current page without saving the changes. Also checks for `beforeunload` event to warn the user when they try to close the browser tab or window.
 
@@ -605,7 +605,7 @@ const App = () => {
 
 `message` (optional) - The warning message. Default value is `Are you sure you want to leave? You have unsaved changes.` Useful when you don't use an i18n provider.
 
-### `CatchAllNavigate`
+### CatchAllNavigate
 
 It will redirect to the given path and keep the current location in `to` query parameter to redirect back when needed. In some cases you may not want to use the `<Authenticated>` component's `redirectOnFail` prop to redirect and have a catch-all route to redirect to the desired page. This is useful when handling the 404 pages with authentication.
 
@@ -647,7 +647,7 @@ const App = () => {
 
 `to` (required) - The path to redirect to.
 
-### `DocumentTitleHandler`
+### DocumentTitleHandler
 
 This component will generate the document title for the current page.By default, it follows a set of predefined rules to generate titles based on the provided props. However, it also offers the flexibility to customize the title generation process by providing a custom `handler` function.
 The default title generation rules are as follows:
@@ -704,7 +704,7 @@ const customTitleHandler = ({ resource, action, params }) => {
 
 ## Hooks
 
-### `useDocumentTitle`
+### useDocumentTitle
 
 This hook allows you to set the document title for the current page. It can be used in any component that is a child of the `<Refine>` component.
 

--- a/documentation/docs/routing/integrations/remix/index.md
+++ b/documentation/docs/routing/integrations/remix/index.md
@@ -268,7 +268,7 @@ export default function Index() {
 
 `@refinedev/remix-router` package also includes some additional components that can be useful in some cases.
 
-### `NavigateToResource`
+### NavigateToResource
 
 A basic component to navigate to a resource page. It is useful when you want to navigate to a resource page at the index route of your app.
 
@@ -286,7 +286,7 @@ export default function IndexPage() {
 
 `meta` (optional) - The meta object to use if the route has parameters in it. The parameters in the current location will also be used to compose the route but `meta` will take precedence.
 
-### `UnsavedChangesNotifier`
+### UnsavedChangesNotifier
 
 This component enables the `warnWhenUnsavedChanges` feature of Refine. It will show a warning message when user tries to navigate away from the current page without saving the changes. Also checks for `beforeunload` event to warn the user when they try to close the browser tab or window.
 
@@ -315,7 +315,7 @@ export default function App(): JSX.Element {
 
 `message` (optional) - The warning message. Default value is `Are you sure you want to leave? You have unsaved changes.` Useful when you don't use an i18n provider.
 
-### `parseTableParams`
+### parseTableParams
 
 This function can be used to parse the query parameters of a table page. It can be useful when you want to use the query parameters in your server side functions (`loader`) to fetch the data such as [persisting the table state](#how-to-persist-syncwithlocation-in-ssr)
 
@@ -939,7 +939,7 @@ export default function NotFound() {
 }
 ```
 
-### `RefineRoutes`
+### RefineRoutes
 
 While this may work for the simple cases, it is not recommended to use this component. Defining your routes separately will give you more control over your routes and will allow you to use the full potential of your router.
 

--- a/documentation/docs/routing/router-provider/index.md
+++ b/documentation/docs/routing/router-provider/index.md
@@ -171,7 +171,7 @@ export default function App() {
 
 The `routerProvider` methods are designed to be as simple as possible and to be compatible with any router library. Refine also exports some helper functions to make it easier to create a customized `routerProvider`.
 
-### `go`
+### go
 
 The `go` method is used to navigate to a specific page. It accepts a `to` parameter, which is the path of the page to navigate to; the `query`, `hash`, and `options` parameters to customize the navigation; and the `type` parameter is used to specify the type of navigation, which can be either `push`, `replace` or `path`.
 
@@ -181,11 +181,11 @@ The `to` parameter is `undefined` by default. In this case, we expect the `go` f
 
 The `query` parameter is passed as an object to let the router library handle the query string. In our implementations, we use the `qs` library to stringify the query object, which supports nested objects. The `query` is also parsed in the `parse` method of the `routerProvider`, which allows us to implement custom ways of stringifying and parsing the queries.
 
-### `back`
+### back
 
 The `back` method is used to navigate back to the previous page. It has no parameters and has no return value.
 
-### `parse`
+### parse
 
 The `parse` method is used to parse the current path and return the current `resource`, `id` and `action` of the page as well as the `pathname` and the `params`.
 
@@ -199,7 +199,7 @@ Matching the resource route can be done with the help of the `matchResourceFromR
 
 `action` is the name of the action that is used in the current page. This can be `undefined` if there's no matching route for a resource action.
 
-### `Link`
+### Link
 
 The `Link` component is used to create links to other pages. It accepts a `to` parameter which is the path of the page to navigate to. It's meant to be used internally in UI packages and other parts of Refine to complement the router library. It's not meant to be used directly in the application.
 

--- a/documentation/docs/tutorial/2-understanding-dataprovider/1-swizzle.md
+++ b/documentation/docs/tutorial/2-understanding-dataprovider/1-swizzle.md
@@ -7,7 +7,7 @@ tutorial:
 
 # 2. Create a data provider with `swizzle`
 
-## What is `swizzle`?
+## What is swizzle?
 
 In some cases, **Refine's** built-in data providers may not fully meet your API needs, and you may want to edit the existing data provider logic. If that is the case, you should use `swizzle`.
 
@@ -15,7 +15,7 @@ The [`swizzle`](/docs/packages/list-of-packages/#swizzle) is a command in [`refi
 
 This also allows you to use the ejected file code logic as a starting point for your modifications instead of starting from scratch.
 
-## How do you use `swizzle` to create an data provider?
+## How do you use swizzle to create an data provider?
 
 1. Run the `swizzle` command in the project directory:
 

--- a/documentation/docs/ui-integrations/ant-design/components/auth-page/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/auth-page/index.md
@@ -552,7 +552,7 @@ const authProvider: AuthBindings = {
 
 ## Props
 
-### `hideForm`
+### hideForm
 
 When you set `hideForm` to `true`, the form will be hidden. You can use this property to show only providers.
 
@@ -579,7 +579,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `providers`
+### providers
 
 The `providers` property defines the list of providers used to handle login authentication. `providers` accepts an array of `Provider` type. This property is only available for types `login` and `register`.
 
@@ -607,7 +607,7 @@ const MyLoginPage = () => {
 
 > For more information, refer to the [Interface section &#8594](#interface)
 
-### `rememberMe`
+### rememberMe
 
 The `rememberMe` property defines to render your custom `<RememberMe>` component or you can pass `false` to don't render it. This property is only available for type `login`.
 
@@ -637,7 +637,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `loginLink`
+### loginLink
 
 The `loginLink` property defines the link to the login page and also you can give a node to render. The default value is `"/login"`. This property is only available for type `register` and `forgotPassword`.
 
@@ -663,7 +663,7 @@ const MyRegisterPage = () => {
 };
 ```
 
-### `registerLink`
+### registerLink
 
 The `registerLink` property defines the link to the registration page and also you can give a node to render. The default value is `"/register"`. This property is only available for type `login`.
 
@@ -690,7 +690,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `forgotPasswordLink`
+### forgotPasswordLink
 
 The `forgotPasswordLink` property defines the link to the forgot password page and also you can give a node to render. Its default value is `"/forgot-password"`. This property is only available for type `login`.
 
@@ -717,7 +717,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `wrapperProps`
+### wrapperProps
 
 The `wrapperProps` is used for passing props to the wrapper component. In the example below you can see that the background color is changed with `wrapperProps`
 
@@ -738,7 +738,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `contentProps`
+### contentProps
 
 The `contentProps` is used for passing props to the content component which is the card component. In the example below, you can see that the title, header, and content styles are changed with `contentProps`.
 
@@ -764,7 +764,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `formProps`
+### formProps
 
 The `formProps` is used for passing props to the form component. In the example below you can see that the `initialValues` are changed with `formProps` and also the `onFinish` function is changed.
 
@@ -787,7 +787,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `title`
+### title
 
 By default, `AuthPage` uses text with icon on top of page. You can use this property to change the default title.
 
@@ -817,7 +817,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `renderContent`
+### renderContent
 
 `renderContent` is used to render the form content and the [title](#title). You can use this property to render your own content, or change the default content and title that it gives you.
 

--- a/documentation/docs/ui-integrations/ant-design/components/basic-views/create/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/basic-views/create/index.md
@@ -116,7 +116,7 @@ You can swizzle this component to customize it with the [**Refine CLI**](/docs/p
 
 ## Properties
 
-### `title`
+### title
 
 `title` allows you to add a title inside the `<Create>` component. If you don't pass the title props, it uses the "Create" prefix and the singular resource name by default. For example, for the `/posts/create` resource, it would be "Create post".
 
@@ -155,7 +155,7 @@ render(
 );
 ```
 
-### `saveButtonProps`
+### saveButtonProps
 
 The `<Create>` component has a save button that submits the form by default. If you want to customize this button you can use the `saveButtonProps` property:
 
@@ -196,7 +196,7 @@ render(
 
 > For more information, refer to the [`<SaveButton>` documentation &#8594](/docs/ui-integrations/ant-design/components/buttons/save-button)
 
-### `resource`
+### resource
 
 The `<Create>` component reads the `resource` information from the route by default. If you want to use a custom resource for the `<Create>` component, you can use the `resource` prop:
 
@@ -248,7 +248,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `goBack`
+### goBack
 
 To customize the back button or to disable it, you can use the `goBack` property:
 
@@ -311,7 +311,7 @@ const PostCreate: React.FC = () => {
 };
 ```
 
-### `isLoading`
+### isLoading
 
 To toggle the loading state of the `<Create/>` component, you can use the `isLoading` property:
 
@@ -350,7 +350,7 @@ render(
 );
 ```
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default the `Breadcrumb` component from the `@refinedev/antd` package is used for breadcrumbs.
 
@@ -403,7 +403,7 @@ render(
 
 > For more information, refer to the [`Breadcrumb` documentation &#8594](/docs/ui-integrations/ant-design/components/breadcrumb)
 
-### `wrapperProps`
+### wrapperProps
 
 You can use the `wrapperProps` property if you want to customize the wrapper of the `<Create/>` component. The `@refinedev/antd` wrapper elements are simply `<div/>`s and `wrapperProps` and can get every attribute that `<div/>` can get.
 
@@ -450,7 +450,7 @@ render(
 );
 ```
 
-### `headerProps`
+### headerProps
 
 You can use the `headerProps` property to customize the header of the `<Create/>` component:
 
@@ -500,7 +500,7 @@ render(
 
 > For more information, refer to the [`PageHeader` documentation &#8594](https://procomponents.ant.design/en-US/components/page-header)
 
-### `contentProps`
+### contentProps
 
 You can use the `contentProps` property to customize the content of the `<Create/>` component:
 
@@ -549,7 +549,7 @@ render(
 
 > For more information, refer to the [`Card` documentation &#8594](https://ant.design/components/card/)
 
-### `headerButtons`
+### headerButtons
 
 You can customize the buttons at the header by using the `headerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
@@ -597,7 +597,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can use the `headerButtonProps` property to customize the wrapper element of the buttons at the header:
 
@@ -648,7 +648,7 @@ render(
 
 > For more information, refer to the [`Space` documentation &#8594](https://ant.design/components/space/)
 
-### `footerButtons`
+### footerButtons
 
 By default, the `<Create/>` component has a [`<SaveButton>`][save-button] at the footer.
 
@@ -744,7 +744,7 @@ render(
 );
 ```
 
-### `footerButtonProps`
+### footerButtonProps
 
 You can customize the wrapper element of the buttons at the footer by using the `footerButtonProps` property.
 

--- a/documentation/docs/ui-integrations/ant-design/components/basic-views/edit/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/basic-views/edit/index.md
@@ -123,7 +123,7 @@ You can swizzle this component to customize it with the [**Refine CLI**](/docs/p
 
 ## Properties
 
-### `title`
+### title
 
 `title` allows you to add a title inside the `<Edit>` component. If you don't pass title props, it uses the "Edit" prefix and the singular resource name by default. For example, for the "posts" resource, it will be "Edit post".
 
@@ -174,7 +174,7 @@ render(
 );
 ```
 
-### `saveButtonProps`
+### saveButtonProps
 
 The `<Edit>` component has a save button that submits the form by default. If you want to customize this button you can use the `saveButtonProps` property:
 
@@ -215,7 +215,7 @@ render(
 
 > For more information, refer to the [`<SaveButton>` documentation &#8594](/docs/ui-integrations/ant-design/components/buttons/save-button)
 
-### `canDelete` and `deleteButtonProps`
+### canDelete and deleteButtonProps
 
 `canDelete` allows you to add a delete button inside the `<Edit>` component. This button uses the `useDelete` method provided by the `dataProvider`
 
@@ -317,7 +317,7 @@ render(
 
 > For more information, refer to the [`usePermission` documentation &#8594](/docs/authentication/hooks/use-permissions)
 
-### `resource`
+### resource
 
 The `<Edit>` component reads the `resource` information from the route by default. If you want to use a custom resource for the `<Edit>` component, you can use the `resource` prop:
 
@@ -367,7 +367,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `recordItemId`
+### recordItemId
 
 The `<Edit>` component reads the `id` information from the route by default. When it cannot be read from the URL, which happens when it's used on a custom page, modal or drawer, `recordItemId` is used.
 
@@ -418,7 +418,7 @@ render(
 
 The `<Edit>` component needs the `id` information for the `<RefreshButton>` to work properly.
 
-### `mutationMode`
+### mutationMode
 
 Determines which mode mutation will have while executing `<DeleteButton>` .
 
@@ -537,7 +537,7 @@ render(
 
 > For more information, refer to the [mutation mode documentation &#8594](/advanced-tutorials/mutation-mode.md)
 
-### `dataProviderName`
+### dataProviderName
 
 If not specified, Refine will use the default data provider. If you have multiple data providers, you can use the `dataProviderName` property to specify which one you want to use:
 
@@ -569,7 +569,7 @@ export const App: React.FC = () => {
 };
 ```
 
-### `goBack`
+### goBack
 
 To customize the back button or to disable it, you can use the `goBack` property:
 
@@ -632,7 +632,7 @@ const PostEdit: React.FC = () => {
 };
 ```
 
-### `isLoading`
+### isLoading
 
 To toggle the loading state of the `<Edit/>` component, you can use the `isLoading` property:
 
@@ -671,7 +671,7 @@ render(
 );
 ```
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default the `Breadcrumb` component from the `@refinedev/antd` package is used for breadcrumbs.
 
@@ -724,7 +724,7 @@ render(
 
 > For more information, refer to the [`Breadcrumb` documentation &#8594](/docs/ui-integrations/ant-design/components/breadcrumb)
 
-### `wrapperProps`
+### wrapperProps
 
 You can use the `wrapperProps` property if you want to customize the wrapper of the `<Edit/>` component. The `@refinedev/antd` wrapper elements are simply `<div/>`s and `wrapperProps` and can get every attribute that `<div/>` can get.
 
@@ -771,7 +771,7 @@ render(
 );
 ```
 
-### `headerProps`
+### headerProps
 
 You can use the `headerProps` property to customize the header of the `<Edit/>` component:
 
@@ -821,7 +821,7 @@ render(
 
 > For more information, refer to the [`PageHeader` documentation &#8594](https://procomponents.ant.design/en-US/components/page-header)
 
-### `contentProps`
+### contentProps
 
 You can use the `contentProps` property to customize the content of the `<Edit/>` component:
 
@@ -870,7 +870,7 @@ render(
 
 > For more information, refer to the [`Card` documentation &#8594](https://ant.design/components/card/)
 
-### `headerButtons`
+### headerButtons
 
 By default, the `<Edit/>` component has a [`<ListButton>`][list-button] and a [`<RefreshButton>`][refresh-button] at the header.
 
@@ -969,7 +969,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can use the `headerButtonProps` property to customize the wrapper element of the buttons at the header:
 
@@ -1020,7 +1020,7 @@ render(
 
 > For more information, refer to the [`Space` documentation &#8594](https://ant.design/components/space/)
 
-### `footerButtons`
+### footerButtons
 
 By default, the `<Edit/>` component has a [`<SaveButton>`][save-button] and a [`<DeleteButton>`][delete-button] at the footer.
 
@@ -1119,7 +1119,7 @@ render(
 );
 ```
 
-### `footerButtonProps`
+### footerButtonProps
 
 You can customize the wrapper element of the buttons at the footer by using the `footerButtonProps` property.
 
@@ -1172,7 +1172,7 @@ render(
 
 > For more information, refer to the [`Space` documentation &#8594](https://ant.design/components/space/)
 
-### `autoSaveProps`
+### autoSaveProps
 
 You can use the auto save feature of the `<Edit/>` component by using the `autoSaveProps` property.
 

--- a/documentation/docs/ui-integrations/ant-design/components/basic-views/list/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/basic-views/list/index.md
@@ -85,7 +85,7 @@ You can swizzle this component to customize it with the [**Refine CLI**](/docs/p
 
 ## Properties
 
-### `title`
+### title
 
 `title` allows you to add a title to the `<List>` component. If you don't pass the title props, it uses plural form of resource name by default.
 
@@ -116,7 +116,7 @@ render(
 );
 ```
 
-### `resource`
+### resource
 
 The `<List>` component reads the `resource` information from the route by default. If you want to use a custom resource for the `<List>` component, you can use the `resource` prop:
 
@@ -166,7 +166,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `canCreate` and `createButtonProps`
+### canCreate and createButtonProps
 
 `canCreate` allows us to add the create button inside the `<List>` component. If you want to customize this button you can use `createButtonProps` property like the code below:
 
@@ -265,7 +265,7 @@ The create button redirects to the create page of the resource according to the 
 
 > For more information, refer to the [`usePermission` documentation &#8594](/docs/authentication/hooks/use-permissions)
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default it uses the `Breadcrumb` component from `@refinedev/antd` package.
 
@@ -314,7 +314,7 @@ render(
 );
 ```
 
-### `wrapperProps`
+### wrapperProps
 
 You can use the `wrapperProps` property if you want to customize the wrapper of the `<List/>` component. The `@refinedev/antd` wrapper elements are simply `<div/>`s and `wrapperProps` and can get every attribute that `<div/>` can get.
 
@@ -353,7 +353,7 @@ render(
 );
 ```
 
-### `headerProps`
+### headerProps
 
 You can use the `headerProps` property to customize the header of the `<List/>` component:
 
@@ -395,7 +395,7 @@ render(
 
 > For more information, refer to the [`PageHeader` documentation &#8594](https://procomponents.ant.design/en-US/components/page-header)
 
-### `contentProps`
+### contentProps
 
 You can use the `contentProps` property to customize the content of the `<Create/>` component. The `<List/>` components content is wrapped with a `<div/>` and `contentProps` can get every attribute that `<div/>` can get.
 
@@ -434,7 +434,7 @@ render(
 );
 ```
 
-### `headerButtons`
+### headerButtons
 
 By default, the `<List/>` component has a [`<CreateButton>`][create-button] at the header.
 
@@ -516,7 +516,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can customize the wrapper element of the buttons at the header by using the `headerButtonProps` property.
 

--- a/documentation/docs/ui-integrations/ant-design/components/basic-views/show/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/basic-views/show/index.md
@@ -73,7 +73,7 @@ You can swizzle this component to customize it with the [**Refine CLI**](/docs/p
 
 ## Properties
 
-### `title`
+### title
 
 `title` allows you to add a title inside the `<Show>` component. If you don't pass title props, it uses the "Show" prefix and the singular resource name by default. For example, for the "posts" resource, it will be "Show post".
 
@@ -124,7 +124,7 @@ render(
 );
 ```
 
-### `resource`
+### resource
 
 The `<Show>` component reads the `resource` information from the route by default. If you want to use a custom resource for the `<Show>` component, you can use the `resource` prop:
 
@@ -173,7 +173,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `canDelete` and `canEdit`
+### canDelete and canEdit
 
 `canDelete` and `canEdit` allows us to add the delete and edit buttons inside the `<Show>` component.
 
@@ -281,7 +281,7 @@ render(
 
 > For more information, refer to the [`<DeleteButton>`](/docs/ui-integrations/ant-design/components/buttons/delete-button) and the [`<EditButton>`](/docs/ui-integrations/ant-design/components/buttons/edit-button) documentations.
 
-### `recordItemId`
+### recordItemId
 
 The`<Show>` component reads the `id` information from the route by default. `recordItemId` is used when it cannot read from the URL (when used on a custom page, modal or drawer).
 
@@ -332,7 +332,7 @@ render(
 
 The `<Show>` component needs the `id` information for `<RefreshButton>` to work properly.
 
-### `dataProviderName`
+### dataProviderName
 
 If not specified, Refine will use the default data provider. If you have multiple data providers, you can use the `dataProviderName` property to specify which one you want to use:
 
@@ -364,7 +364,7 @@ export const App: React.FC = () => {
 };
 ```
 
-### `goBack`
+### goBack
 
 To customize the back button or to disable it, you can use the `goBack` property:
 
@@ -427,7 +427,7 @@ const PostShow: React.FC = () => {
 };
 ```
 
-### `isLoading`
+### isLoading
 
 Since `<Show>` uses the Ant Design [`<Card>`](https://ant.design/components/card/) component, the `isLoading` property can be set like the below:
 
@@ -466,7 +466,7 @@ render(
 );
 ```
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default the `Breadcrumb` component from the `@refinedev/antd` package is used for breadcrumbs.
 
@@ -519,7 +519,7 @@ render(
 
 > For more information, refer to the [`Breadcrumb` documentation &#8594](/docs/ui-integrations/ant-design/components/breadcrumb)
 
-### `wrapperProps`
+### wrapperProps
 
 You can use the `wrapperProps` property if you want to customize the wrapper of the `<Show/>` component. The `@refinedev/antd` wrapper elements are simply `<div/>`s and `wrapperProps` and can get every attribute that `<div/>` can get.
 
@@ -566,7 +566,7 @@ render(
 );
 ```
 
-### `headerProps`
+### headerProps
 
 You can use the `headerProps` property to customize the header of the `<Show/>` component:
 
@@ -616,7 +616,7 @@ render(
 
 > For more information, refer to the [`PageHeader` documentation &#8594](https://procomponents.ant.design/en-US/components/page-header)
 
-### `contentProps`
+### contentProps
 
 You can use the `contentProps` property to customize the content of the `<Show/>` component:
 
@@ -665,7 +665,7 @@ render(
 
 > For more information, refer to the [`Card` documentation &#8594](https://ant.design/components/card/)
 
-### `headerButtons`
+### headerButtons
 
 By default, the `<Show/>` component has a [`<ListButton>`][list-button], [`<EditButton>`][edit-button], [`<DeleteButton>`][delete-button], and a [`<RefreshButton>`][refresh-button] at the header.
 
@@ -770,7 +770,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can use the `headerButtonProps` property to customize the wrapper element of the buttons at the header:
 
@@ -821,7 +821,7 @@ render(
 
 > For more information, refer to the [`Space` documentation &#8594](https://ant.design/components/space/)
 
-### `footerButtons`
+### footerButtons
 
 You can customize the buttons at the footer by using the `footerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
@@ -869,7 +869,7 @@ render(
 );
 ```
 
-### `footerButtonProps`
+### footerButtonProps
 
 You can customize the wrapper element of the buttons at the footer by using the `footerButtonProps` property.
 

--- a/documentation/docs/ui-integrations/ant-design/components/breadcrumb/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/breadcrumb/index.md
@@ -121,7 +121,7 @@ render(
 
 :::
 
-### `breadcrumbProps`
+### breadcrumbProps
 
 The `<Breadcrumb>` component uses the Ant Design [Breadcrumb][antd-breadcrumb] component so it can be configured with the `breadcrumbProps` property.
 
@@ -140,7 +140,7 @@ export const PostList: React.FC = () => {
 };
 ```
 
-### `showHome`
+### showHome
 
 If you have a page with route `/`, it will be used as the root of the hierarchy and shown in the `Breadcrumb` with a home icon. To hide the root item, set `showHome` to `false.`
 
@@ -159,7 +159,7 @@ export const PostList: React.FC = () => {
 };
 ```
 
-### `meta`
+### meta
 
 If your routes has additional parameters in their paths, you can pass the `meta` property to the `<Breadcrumb>` component to use them while creating the paths and filling the parameters in the paths. By default, the existing URL parameters are used. You can use `meta` to override them or add new ones.
 
@@ -178,7 +178,7 @@ export const PostList: React.FC = () => {
 };
 ```
 
-### `hideIcons`
+### hideIcons
 
 If you don't want to show the resource icons on the breadcrumb, you can set `hideIcons` to `true`.
 

--- a/documentation/docs/ui-integrations/ant-design/components/buttons/clone-button/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/buttons/clone-button/index.md
@@ -67,7 +67,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` is used to append the record id to the end of the route path. By default, the `recordItemId` is inferred from the route params.
 
@@ -103,7 +103,7 @@ render(
 
 Clicking the button will trigger the `clone` method of [`useNavigation`](/docs/routing/hooks/use-navigation) and then redirect the app to the `clone` action path of the resource, filling the necessary parameters in the route.
 
-### `resource`
+### resource
 
 `resource` is used to redirect the app to the `clone` action of the given resource name. By default, the app redirects to the inferred resource's `clone` action path.
 
@@ -147,7 +147,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `clone` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, the existing parameters in the route are used by the `clone` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -159,7 +159,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 It is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -199,7 +199,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -218,7 +218,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use the `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/ant-design/components/buttons/create-button/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/buttons/create-button/index.md
@@ -68,7 +68,7 @@ render(
 
 ## Properties
 
-### `resource`
+### resource
 
 `resource` is used to redirect the app to the `create` action path of the given resource name. By default, the app redirects to the inferred resource's `create` action path.
 
@@ -117,7 +117,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `create` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `create` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -129,7 +129,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 It is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -169,7 +169,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -181,7 +181,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/ant-design/components/buttons/delete-button/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/buttons/delete-button/index.md
@@ -68,7 +68,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` allows us to manage which record will be deleted. By default, the `recordItemId` is inferred from the route params.
 
@@ -107,7 +107,7 @@ render(
 
 Clicking the button will trigger the [`useDelete`](/docs/data/hooks/use-delete) method and then the record whose resource is "posts" and whose id is "123" will be deleted.
 
-### `resource`
+### resource
 
 `resource` allows us to manage which resource's record is going to be deleted. By default, the `resource` is inferred from the route params.
 
@@ -151,7 +151,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `onSuccess`
+### onSuccess
 
 `onSuccess` can be used if you want to do something based on the results returned after the delete request.
 
@@ -208,7 +208,7 @@ const App = () => {
 render(<App />);
 ```
 
-### `mutationMode`
+### mutationMode
 
 Determines which mode mutation will have while executing `<DeleteButton>`.
 
@@ -244,7 +244,7 @@ export const PostList: React.FC = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 It is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -279,7 +279,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -291,7 +291,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/ant-design/components/buttons/edit-button/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/buttons/edit-button/index.md
@@ -67,7 +67,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` is used to append the record id to the end of the route path. By default, the `recordItemId` is inferred from the route params.
 
@@ -109,7 +109,7 @@ render(
 
 Clicking the button will trigger the `edit` method of [`useNavigation`](/docs/routing/hooks/use-navigation) and then redirect the app to the `edit` action path of the resource, filling the necessary parameters in the route.
 
-### `resource`
+### resource
 
 The redirection endpoint is defined by the `resource` property and its `edit` action path. By default, `<EditButton>` uses the inferred resource from the route.
 
@@ -165,7 +165,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `edit` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `edit` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -177,7 +177,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 It is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -215,7 +215,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -236,7 +236,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/ant-design/components/buttons/export-button/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/buttons/export-button/index.md
@@ -71,7 +71,7 @@ render(
 
 ## Properties
 
-### `hideText`
+### hideText
 
 `hideText` is used to hide the text of the button. When its `true`, only the button icon will be visible.
 

--- a/documentation/docs/ui-integrations/ant-design/components/buttons/import-button/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/buttons/import-button/index.md
@@ -72,7 +72,7 @@ render(
 
 ## Properties
 
-### `hideText`
+### hideText
 
 `hideText` is used to hide the text of the button. When its `true`, only the button icon will be visible.
 

--- a/documentation/docs/ui-integrations/ant-design/components/buttons/list-button/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/buttons/list-button/index.md
@@ -74,7 +74,7 @@ The button text is defined automatically by Refine based on the `resource` defin
 
 ## Properties
 
-### `resource`
+### resource
 
 The redirection endpoint is defined by the `resource`'s `list` action path. By default, `<ListButton>` uses the inferred resource from the route.
 
@@ -119,7 +119,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `list` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `list` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -131,7 +131,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 `hideText` is used to hide the text of the button. When its `true`, only the button icon will be visible.
 
@@ -170,7 +170,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -182,7 +182,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/ant-design/components/buttons/refresh-button/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/buttons/refresh-button/index.md
@@ -73,7 +73,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` allows us to manage which data is going to be refreshed. By default, the `recordItemId` is inferred from the route params.
 
@@ -107,7 +107,7 @@ render(
 
 Clicking the button will trigger the [`useInvalidate`][use-invalidate] hook and then fetch the record whose resource is "post" and whose id is "1".
 
-### `resource`
+### resource
 
 `resource` allows us to manage which resource is going to be refreshed. By default, the `resource` is inferred from the route params.
 
@@ -149,7 +149,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `hideText`
+### hideText
 
 `hideText` is used to hide the text of the button. When its `true`, only the button icon will be visible.
 
@@ -180,7 +180,7 @@ render(
 );
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/ant-design/components/buttons/save-button/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/buttons/save-button/index.md
@@ -74,7 +74,7 @@ The [`useForm`](/docs/ui-integrations/ant-design/hooks/use-form) hook exposes `s
 
 ## Properties
 
-### `hideText`
+### hideText
 
 `hideText` is used to hide the text of the button. When its `true`, only the button icon will be visible.
 

--- a/documentation/docs/ui-integrations/ant-design/components/buttons/show-button/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/buttons/show-button/index.md
@@ -67,7 +67,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` is used to append the record id to the end of the route path. By default, the `recordItemId` is inferred from the route params.
 
@@ -109,7 +109,7 @@ render(
 
 Clicking the button will trigger the `show` method of [`useNavigation`](/docs/routing/hooks/use-navigation) and then redirect the app to the `show` action path of the resource, filling the necessary parameters in the route.
 
-### `resource`
+### resource
 
 The redirection endpoint is defined by the `resource`'s `show` action path. By default, `<ShowButton>` uses the inferred resource from the route.
 
@@ -165,7 +165,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `show` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `show` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -177,7 +177,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 `hideText` is used to hide the text of the button. When its `true`, only the button icon will be visible.
 
@@ -215,7 +215,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip the access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with its `hideIfUnauthorized` property. However, this only works when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -236,7 +236,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/ant-design/components/filter-dropdown/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/filter-dropdown/index.md
@@ -77,11 +77,11 @@ const { selectProps: categorySelectProps } = useSelect<ICategory>({
 
 ## Properties
 
-### `selectedKeys`, `setSelectedKeys`, `confirm`, `clearFilters`
+### selectedKeys, setSelectedKeys, confirm, clearFilters
 
 These are to be passed from [`<Table.Column>`'s filterDropdown](https://ant.design/components/table/#Column) prop.
 
-### `mapValue`
+### mapValue
 
 Determines the value passed to children. `mapValue` takes `selectedKeys` as an argument.
 

--- a/documentation/docs/ui-integrations/ant-design/components/inferencer/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/inferencer/index.md
@@ -87,7 +87,7 @@ const SampleEdit = () => {
 
 ## Views
 
-### `List`
+### List
 
 Generates a sample list view for your resources according to the API response. It uses the `List` and `Table` components with the `useTable` hook from `@refinedev/antd`.
 
@@ -146,7 +146,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-### `Show`
+### Show
 
 Generates a sample show view for your resources according to the API response. It uses the `Show` and field components from `@refinedev/antd` with the `useShow` hook from `@refinedev/core`.
 
@@ -205,7 +205,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-### `Create`
+### Create
 
 Generates a sample create view for your resources according to the first record in list API response. It uses the `Create` component and the `useForm` hook from `@refinedev/antd`.
 
@@ -264,7 +264,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-### `Edit`
+### Edit
 
 Generates a sample edit view for your resources according to the API response. It uses the `Edit` component and the `useForm` hook from `@refinedev/antd`.
 

--- a/documentation/docs/ui-integrations/ant-design/components/themed-layout/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/themed-layout/index.md
@@ -112,7 +112,7 @@ Example of above showing how to use `<ThemedLayoutV2>` with [`React Router v6`](
 
 ## Props
 
-### `Sider`
+### Sider
 
 In `<ThemedLayoutV2>`, the sidebar section is rendered using the [`<ThemedSiderV2>`][themed-sider] component by default. This component is specifically designed to generate menu items based on the resources defined in [`<Refine>`][refine-component] components, using the [`useMenu`][use-menu] hook. However, if desired, it's possible to replace the default [`<ThemedSiderV2>`][themed-sider] component by passing a custom component to the `Sider` prop.
 
@@ -201,7 +201,7 @@ const App: React.FC = () => {
 };
 ```
 
-#### `Sider Props`
+#### Sider Props
 
 | Prop                 | Type                                          | Description                                                                       |
 | -------------------- | --------------------------------------------- | --------------------------------------------------------------------------------- |
@@ -220,7 +220,7 @@ type SiderRenderFunction = (props: {
 }) => React.ReactNode;
 ```
 
-### `initialSiderCollapsed`
+### initialSiderCollapsed
 
 This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
 
@@ -236,7 +236,7 @@ This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][
 </ThemedLayoutV2>
 ```
 
-### `Header`
+### Header
 
 In `<ThemedLayoutV2>`, the header section is rendered using the [`<ThemedHeaderV2>`][themed-header] component by default. It uses [`useGetIdentity`](/docs/authentication/hooks/use-get-identity) hook to display the user's name and avatar on the right side of the header. However, if desired, it's possible to replace the default [`<ThemedHeaderV2>`][themed-header] component by passing a custom component to the `Header` prop.
 
@@ -292,7 +292,7 @@ const App: React.FC = () => {
 };
 ```
 
-### `Title`
+### Title
 
 In `<ThemedLayoutV2>`, the title section is rendered using the [`<ThemedTitleV2>`][themed-title] component by default. However, if desired, it's possible to replace the default [`<ThemedTitleV2>`][themed-title] component by passing a custom component to the `Title` prop.
 
@@ -330,7 +330,7 @@ const App: React.FC = () => {
 };
 ```
 
-### `Footer`
+### Footer
 
 The footer section of the layout is displayed at the bottom of the page. Refine doesn't provide a default footer component. However, you can pass a custom component to the `Footer` prop to display a footer section.
 
@@ -439,7 +439,7 @@ const App: React.FC = () => {
 };
 ```
 
-### `OffLayoutArea`
+### OffLayoutArea
 
 Used to component is rendered outside of the main layout component, allowing it to be placed anywhere on the page while still being part of the overall layout .Refine doesn't provide a default off-layout area component. However, you can pass a custom component to the `OffLayoutArea` prop to display a custom off-layout area.
 

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-checkbox-group/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-checkbox-group/index.md
@@ -65,7 +65,7 @@ All we have to do is pass the `checkboxGroupProps` it returns to the `<Checkbox.
 
 ## Options
 
-### `resource`
+### resource
 
 ```tsx
 const { checkboxGroupProps } = useCheckboxGroup({
@@ -81,7 +81,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [Ant Design's Checkbox.Group component documentation &#8594](https://ant.design/components/checkbox)
 
-### `defaultValue`
+### defaultValue
 
 ```tsx
 const { selectProps } = useCheckboxGroup({
@@ -93,7 +93,7 @@ const { selectProps } = useCheckboxGroup({
 
 The easiest way to select default values for checkbox fields is by passing in `defaultValue`.
 
-### `optionLabel` and `optionValue`
+### optionLabel and `optionValue`
 
 ```tsx
 const { checkboxGroupProps } = useCheckboxGroup({
@@ -119,7 +119,7 @@ const { options } = useSelect({
 });
 ```
 
-### `filters`
+### filters
 
 `filters` allows us to add filters while fetching the data. For example, if you want to list only the `titles` that are equal to "Driver Deposit":
 
@@ -138,7 +138,7 @@ const { checkboxGroupProps } = useCheckboxGroup({
 });
 ```
 
-### `sorters`
+### sorters
 
 `sorters` allows us to sort the `options`. For example, if you want to sort your list according to `title` by ascending:
 
@@ -156,7 +156,7 @@ const { checkboxGroupProps } = useCheckboxGroup({
 });
 ```
 
-### `fetchSize`
+### fetchSize
 
 `fetchSize` is the amount of records to fetch in checkboxes.
 
@@ -168,7 +168,7 @@ const { selectProps } = useCheckboxGroup({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 Passing the `queryOptions` property allows us to set the [useQuery](https://react-query.tanstack.com/reference/useQuery) options
 
@@ -185,7 +185,7 @@ const { checkboxGroupProps } = useCheckboxGroup({
 });
 ```
 
-### `pagination`
+### pagination
 
 `pagination` allows us to set page and items per page values.
 
@@ -201,7 +201,7 @@ const { selectProps } = useSelect({
 
 The listing will start from page 3, showing 8 records per page.
 
-### ~~`sort`~~ <PropTag deprecated />
+### ~~sort~~ <PropTag deprecated />
 
 Use `sorters` instead.
 

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-drawer-form/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-drawer-form/index.md
@@ -271,7 +271,7 @@ Don't forget to pass the record `"id"` to `show` to fetch the record data. This 
 
 All [`useForm`][antd-use-form] props are also available in `useDrawerForm`. You can find descriptions on the [`useForm`](/docs/ui-integrations/ant-design/hooks/use-form#properties) documentation.
 
-### `syncWithLocation`
+### syncWithLocation
 
 When `syncWithLocation` is `true`, the drawers visibility state and the `id` of the record will be synced with the URL. It is `false` by default.
 
@@ -283,7 +283,7 @@ const drawerForm = useDrawerForm({
 });
 ```
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -309,7 +309,7 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### `autoSave`
+### autoSave
 
 If you want to save the form automatically after some delay when user edits the form, you can pass true to `autoSave.enabled` prop.
 
@@ -321,7 +321,7 @@ It also supports `onMutationSuccess` and `onMutationError` callback functions. Y
 
 `onMutationSuccess` and `onMutationError` callbacks will be called after the mutation is successful or failed.
 
-#### `enabled`
+#### enabled
 
 To enable the `autoSave` feature, set the `enabled` parameter to `true`. Default value is `false`.
 
@@ -333,7 +333,7 @@ useDrawerForm({
 });
 ```
 
-#### `debounce`
+#### debounce
 
 Set the debounce time for the `autoSave` prop. Default value is `1000` milliseconds.
 
@@ -347,7 +347,7 @@ useDrawerForm({
 });
 ```
 
-#### `onFinish`
+#### onFinish
 
 If you want to modify the data before sending it to the server, you can use `onFinish` callback function.
 
@@ -367,7 +367,7 @@ useDrawerForm({
 });
 ```
 
-#### `invalidateOnUnmount`
+#### invalidateOnUnmount
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when the hook is unmounted. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate. Default value is `false`.
 
@@ -381,7 +381,7 @@ useDrawerForm({
 });
 ```
 
-#### `invalidateOnClose`
+#### invalidateOnClose
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when the drawer is closed. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate. Default value is `false`.
 
@@ -397,50 +397,50 @@ useDrawerForm({
 
 ## Return values
 
-### `show`
+### show
 
 A function that opens the `<Drawer>`. It takes an optional `id` parameter. If `id` is provided, it will fetch the record data and fill the `<Form>` with it.
 
-### `close`
+### close
 
 A function that closes the `<Drawer>`. Same as `[onClose][#onClose]`.
 
-### `saveButtonProps`
+### saveButtonProps
 
 It contains the props needed by the `"submit"` button within the `<Drawer>` (disabled,loading etc.). When `saveButtonProps.onClick` is called, it triggers `form.submit()`. You can manually pass these props to your custom button.
 
-### `deleteButtonProps`
+### deleteButtonProps
 
 It contains the props needed by the `"delete"` button within the `<Drawer>` (disabled,loading etc.). When `deleteButtonProps.onSuccess` is called, it triggers it sets `id` to `undefined` and `open` to `false`. You can manually pass these props to your custom button.
 
-### `formProps`
+### formProps
 
 It's required to manage `<Form>` state and actions. Under the hood the `formProps` came from [`useForm`][antd-use-form].
 
 It contains the props to manage the [Antd `<Form>`](https://ant.design/components/form#api) component such as [_`onValuesChange`, `initialValues`, `onFieldsChange`, `onFinish` etc._](/docs/ui-integrations/ant-design/hooks/use-form#return-values)
 
-### `drawerProps`
+### drawerProps
 
 It's required to manage [`<Drawer>`](https://ant.design/components/drawer/#API) state and actions.
 
-#### `width`
+#### width
 
 It's the width of the `<Drawer>`. Default value is `"500px"`.
 
-#### `onClose`
+#### onClose
 
 A function that can close the `<Drawer>`. It's useful when you want to close the `<Drawer>` manually.
 When [`warnWhenUnsavedChanges`](/docs/ui-integrations/ant-design/hooks/use-form#warnwhenunsavedchanges) is `true`, it will show a confirmation modal before closing the `<Drawer>`. If you override this function, you have to handle this confirmation modal manually.
 
-#### `open`
+#### open
 
 Current visible state of `<Drawer>`. Default value is `false`.
 
-#### `forceRender`
+#### forceRender
 
 It renders `<Drawer>` instead of lazy rendering it. Default value is `true`.
 
-### `overtime`
+### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 
@@ -450,7 +450,7 @@ const { overtime } = useDrawerForm();
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
 
-### `autoSaveProps`
+### autoSaveProps
 
 If `autoSave` is enabled, this hook returns `autoSaveProps` object with `data`, `error`, and `status` properties from mutation.
 

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-editable-table/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-editable-table/index.md
@@ -266,7 +266,7 @@ export const PostList: React.FC = () => {
 
 All `useForm` and [`useTable`][usetable] properties are available in `useEditableTable`. You can read the documentation of [`useForm`][useform] and [`useTable`][usetable] for more information.
 
-### `autoSubmitClose`
+### autoSubmitClose
 
 `autoSubmitClose` makes the table's row close after a successful submit. It is `true` by default.
 
@@ -282,7 +282,7 @@ const editableTable = useEditableTable({
 
 All `useForm` and [`useTable`][usetable] return values are available in `useEditableTable`. You can read the documentation of [`useForm`][useform] and [`useTable`][usetable] for more information.
 
-### `cancelButtonProps`
+### cancelButtonProps
 
 `cancelButtonProps` returns the props for needed by the `<EditButton>`.
 
@@ -292,7 +292,7 @@ By default, the `onClick` function is overridden by `useEditableTable`. Which wi
 cancelButtonProps: () => ButtonProps;
 ```
 
-### `editButtonProps`
+### editButtonProps
 
 `editButtonProps` takes `id` as a parameter and returns the props needed by the `<EditButton>`.
 
@@ -304,7 +304,7 @@ editButtonProps: (id: BaseKey) => ButtonProps;
 
 It also returns a function that takes an `id` as a parameter and returns the props for the edit button.
 
-### `isEditing`
+### isEditing
 
 ```tsx
 isEditing: (id: BaseKey) => boolean;

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-form/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-form/index.md
@@ -181,7 +181,7 @@ If you want to show a form in a modal or drawer where necessary route params mig
 
 ## Properties
 
-### `action`
+### action
 
 `useForm` can handle `edit`, `create` and `clone` actions.
 
@@ -415,7 +415,7 @@ render(<RefineAntdDemo />);
 
 </Tabs>
 
-### `resource`
+### resource
 
 `resource` will be passed to the [`dataProvider`][data-provider]'s method as a params. This parameter is usually used to as a API endpoint path but it all depends on how to handle the `resource` in your [`dataProvider`][data-provider]. By default it uses the inferred resource name from the route.
 
@@ -461,7 +461,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `id`
+### id
 
 `id` is used for determining the record to `edit` or `clone`. By default the `id` is determinted from the route. It can be changed with the `setId` function or the `id` property. Keep in mind that `id` is required for `action: "edit"` and `action: "clone"`.
 
@@ -475,7 +475,7 @@ useForm({
 });
 ```
 
-### `redirect`
+### redirect
 
 `redirect` is used for determining the page to redirect after the form is submitted. By default, it uses the `list`. It can be changed with the `redirect` property.
 
@@ -487,7 +487,7 @@ useForm({
 });
 ```
 
-### `onMutationSuccess`
+### onMutationSuccess
 
 `onMutationSuccess` is a callback function that will be called after a successful mutation.
 
@@ -506,7 +506,7 @@ useForm({
 });
 ```
 
-### `onMutationError`
+### onMutationError
 
 It's a callback function that will be called after a mutation fails.
 
@@ -525,7 +525,7 @@ useForm({
 });
 ```
 
-### `invalidates`
+### invalidates
 
 You can use `invalidates` to manage the invalidations that will occur at the end of the mutation.
 
@@ -540,7 +540,7 @@ useForm({
 });
 ```
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you should pass the name of the `dataProvider` you are going to use to `dataProviderName`.
 
@@ -552,7 +552,7 @@ useForm({
 });
 ```
 
-### `mutationMode`
+### mutationMode
 
 Mutation mode determines which mode the mutation runs with. Mutations can run under three different modes: `pessimistic`, `optimistic` and `undoable`. Default mode is `pessimistic`.
 Each mode corresponds to a different type of user experience.
@@ -565,7 +565,7 @@ useForm({
 
 > For more information about mutation modes, refer to the [Mutation Mode documentation](/docs/advanced-tutorials/mutation-mode)
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -583,7 +583,7 @@ useForm({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -611,7 +611,7 @@ useForm({
 }
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -649,7 +649,7 @@ const myDataProvider = {
 };
 ```
 
-### `queryMeta`
+### queryMeta
 
 In addition to the [`meta`](#meta) property, you can also pass the `queryMeta` property to the `useForm` hook. This property is used to pass additional information to the `useOne` hook that is used to fetch the data in the `edit` and `clone` modes. This is useful when you have to apply different values to the `useOne` hook from the `useCreate` or `useUpdate` hook mutations.
 
@@ -663,7 +663,7 @@ useForm({
 
 If you have overlapping properties in both `meta` and `queryMeta`, the `queryMeta` property will be used.
 
-### `mutationMeta`
+### mutationMeta
 
 In addition to the [`meta`](#meta) property, you can also pass the `mutationMeta` property to the `useForm` hook. This property is used to pass additional information to the `useCreate` or `useUpdate` hook mutations. This is useful when you have to apply different values to the `useCreate` or `useUpdate` hooks from the `useOne` hook query.
 
@@ -677,7 +677,7 @@ useForm({
 
 If you have overlapping properties in both `meta` and `mutationMeta`, the `mutationMeta` property will be used.
 
-### `queryOptions`
+### queryOptions
 
 In the `edit` and `clone` modes, Refine uses [`useOne`](/docs/data/hooks/use-one) hook to fetch data. You can pass the [`queryOptions`](https://tanstack.com/query/v4/docs/react/reference/useQuery) options by passing the `queryOptions` property. This property will only work in the `edit` and `clone` actions.
 
@@ -689,7 +689,7 @@ useForm({
 });
 ```
 
-### `createMutationOptions`
+### createMutationOptions
 
 In the `create` and `clone` modes, Refine uses the [`useCreate`](/docs/data/hooks/use-create) hook to create data. You can pass [`mutationOptions`](https://tanstack.com/query/v4/docs/react/reference/useMutation) by passing the `createMutationOptions` property. This property will only work in the `create` and `clone` actions.
 
@@ -701,7 +701,7 @@ useForm({
 });
 ```
 
-### `updateMutationOptions`
+### updateMutationOptions
 
 In the `edit` mode, Refine uses [`useUpdate`](/docs/data/hooks/use-update) hook to update data. You can pass [`mutationOptions`](https://tanstack.com/query/v4/docs/react/reference/useMutation) by passing `updateMutationOptions` property. This property will only work in the `edit` action.
 
@@ -713,7 +713,7 @@ useForm({
 });
 ```
 
-### `warnWhenUnsavedChanges`
+### warnWhenUnsavedChanges
 
 When set to true, `warnWhenUnsavedChanges` shows a warning when the user tries to leave the page with unsaved changes. It is used to prevent the user from accidentally leaving the page. It is `false` by default
 
@@ -725,7 +725,7 @@ useForm({
 });
 ```
 
-### `submitOnEnter`
+### submitOnEnter
 
 When it's true, `submitOnEnter` will submit the form when the enter key is pressed. It can be used to prevent the user from accidentally leaving the page. It is `false` by default
 
@@ -735,7 +735,7 @@ useForm({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -747,7 +747,7 @@ useForm({
 });
 ```
 
-### `onLiveEvent`
+### onLiveEvent
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -761,13 +761,13 @@ useForm({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
 Params to pass to [liveProvider](/docs/realtime/live-provider#subscribe)'s subscribe method.
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -793,7 +793,7 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### `autoSave`
+### autoSave
 
 If you want to save the form automatically after some delay when user edits the form, you can pass true to `autoSave.enabled` prop.
 
@@ -805,7 +805,7 @@ It also supports [`onMutationSuccess`](#onmutationsuccess) and [`onMutationError
 
 `onMutationSuccess` and `onMutationError` callbacks will be called after the mutation is successful or failed.
 
-#### `enabled`
+#### enabled
 
 To enable the `autoSave` feature, set the `enabled` parameter to `true`. By default, it is `false`.
 
@@ -817,7 +817,7 @@ useForm({
 });
 ```
 
-#### `debounce`
+#### debounce
 
 Set the debounce time for the `autoSave` prop. By default, it is `1000` milliseconds.
 
@@ -831,7 +831,7 @@ useForm({
 });
 ```
 
-#### `onFinish`
+#### onFinish
 
 If you want to modify the data before sending it to the server, you can use `onFinish` callback function.
 
@@ -851,7 +851,7 @@ useForm({
 });
 ```
 
-#### `invalidateOnUnmount`
+#### invalidateOnUnmount
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when the hook is unmounted. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate. By default, it is `false`.
 
@@ -869,41 +869,41 @@ useForm({
 
 All [`Refine Core's useForm`](/docs/data/hooks/use-form/) return values also available in `useForm`.
 
-### `form`
+### form
 
 It's a [`<Form>`](https://ant.design/components/form) instance. You can refer to [Antd `<Form>` documentation](https://ant.design/components/form#api) for more information.
 
-### `formProps`
+### formProps
 
 It's required to manage [`<Form>`](https://ant.design/components/form) state and actions.
 
-#### `onFinish`
+#### onFinish
 
 `onFinish` is called when the form is submitted. It will call the appropriate mutation based on the `action` property.
 
 The only difference between `onFinish` and `formProps.onFinish` is that passing a value to `formProps.onFinish`is mandatory, whereas `onFinish` can automatically retrieve values from the form state.
 
-#### `onValuesChange`
+#### onValuesChange
 
 The `warnWhenUnsavedChanges` feature requires this function to work. If you want to override the form's `onValuesChange`, keep this in mind.
 
-#### `onKeyUp`
+#### onKeyUp
 
 `onKeyUp` is a function that will be called when a key is pressed. By default, it will call `form.submit()` function when the pressed key is `Enter`.
 
-#### `initialValues`
+#### initialValues
 
 When `action` is set to `"edit"` or `"clone"`, `initialValues` will be set to the `data` returned from [`useOne`](/docs/data/hooks/use-one) hook.
 
-### `saveButtonProps`
+### saveButtonProps
 
 It contains all the props needed by the `"submit"` button within the form (disabled,loading etc.). When `saveButtonProps.onClick` is called, it triggers `form.submit()`. You can manually pass these props to your custom button.
 
-### `formLoading`
+### formLoading
 
 `formLoading` is the loading state of a modal. It's `true` when `useForm` is currently being submitted or data is being fetched for the `"edit"` or `"clone"` mode.
 
-### `queryResult`
+### queryResult
 
 If the `action` is set to `"edit"` or `"clone"` or if a `resource` with an `id` is provided, `useForm` will call [`useOne`](/docs/data/hooks/use-one) and set the returned values as the `queryResult` property.
 
@@ -913,7 +913,7 @@ const { queryResult } = useForm();
 const { data } = queryResult;
 ```
 
-### `mutationResult`
+### mutationResult
 
 When in `"create"` or `"clone"` mode, `useForm` will call [`useCreate`](/docs/data/hooks/use-create). When in `"edit"` mode, it will call [`useUpdate`](/docs/data/hooks/use-update) and set the resulting values as the `mutationResult` property.
 
@@ -923,7 +923,7 @@ const { mutationResult } = useForm();
 const { data } = mutationResult;
 ```
 
-### `setId`
+### setId
 
 `useForm` determine the `id` from the router. If you want to change the `id` dynamically, you can use the `setId` function.
 
@@ -941,7 +941,7 @@ return (
 );
 ```
 
-### `redirect`
+### redirect
 
 By default, after a successful mutation, `useForm` will redirect to the `"list"` page. To redirect to a different page, you can either use the `redirect` function to programmatically specify the destination, or set the `redirect` [property](/docs/data/hooks/use-form/#redirect) in the hook's options.
 
@@ -961,14 +961,14 @@ const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
 // --
 ```
 
-### `onFinish`
+### onFinish
 
 `onFinish` is a function that is called when the form is submitted. It will call the appropriate mutation based on the `action` property.
 You can override the default behavior by passing an `onFinish` function in the hook's options.
 
 For example you can [change values before sending to the API](/docs/ui-integrations/ant-design/hooks/use-form#how-can-i-change-the-form-data-before-submitting-it-to-the-api).
 
-### `overtime`
+### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 
@@ -978,7 +978,7 @@ const { overtime } = useForm();
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
 
-### `autoSaveProps`
+### autoSaveProps
 
 If `autoSave` is enabled, this hook returns `autoSaveProps` object with `data`, `error`, and `status` properties from mutation.
 

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-import/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-import/index.md
@@ -45,7 +45,7 @@ export const PostList: React.FC = () => {
 
 ## Properties
 
-### `resource`
+### resource
 
 `resource` determines which resource is passed to the `create` or `createMany` method of your data provider. It reads from the URL by default.
 
@@ -59,7 +59,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation #8594](/docs/core/refine-component#identifier)
 
-### `mapData`
+### mapData
 
 If you want to map the data before sending it to a data provider method, you can use the `mapData` property.
 
@@ -74,7 +74,7 @@ useImport({
 });
 ```
 
-### `paparseOptions`
+### paparseOptions
 
 You can pass any Papa Parse [options](https://www.papaparse.com/docs#config) to the `paparseOptions` property.
 
@@ -86,7 +86,7 @@ useImport({
 });
 ```
 
-### `batchSize`
+### batchSize
 
 If you want to send the data in batches, you can use the `batchSize` property. When the `batchSize` is 1, it calls the `create` method of your data provider for each row in the file. When the `batchSize` is greater than 1, it calls the `createMany` method of your data provider for each batch. By default, it is [`Number.MAX_SAFE_INTEGER`][number.max_safe_integer]
 
@@ -96,7 +96,7 @@ useImport({
 });
 ```
 
-### `onFinish`
+### onFinish
 
 If you want to do something after the import is finished, you can use the `onFinish` property. It returns an object with two properties: `succeeded` and `errored` which contain the responses of the successful and failed requests.
 
@@ -116,7 +116,7 @@ useImport({
 });
 ```
 
-### `meta`
+### meta
 
 If you want to send additional data to the `create` or `createMany` method of your data provider, you can use the `meta` property.
 
@@ -128,7 +128,7 @@ useImport({
 });
 ```
 
-### `onProgress`
+### onProgress
 
 A callback function that is called when the import progress changes. It returns an object with two properties: `totalAmount` and `processedAmount` which contain the total amount of rows and the processed amount of rows.
 
@@ -143,7 +143,7 @@ useImport({
 
 By default, it shows a notification with the progress percentage. You can override this behavior by passing a custom `onProgress` function.
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you can specify which one to use by passing the `dataProviderName` prop. It is useful when you have a different data provider for different resources.
 
@@ -153,13 +153,13 @@ useImport({
 });
 ```
 
-### ~~`resourceName`~~ <PropTag deprecated />
+### ~~resourceName~~ <PropTag deprecated />
 
 Use `resource` instead.
 
 ## Return Values
 
-### `buttonProps`
+### buttonProps
 
 `buttonProps` are button properties that are compatible with Ant Design [`<Button>`](https://ant.design/components/button/) component.
 
@@ -174,15 +174,15 @@ export const PostList: React.FC = () => {
 };
 ```
 
-#### `type`
+#### type
 
 It is set to `default` by default.
 
-#### `loading`
+#### loading
 
 `loading` sets the loading state of the button if the import is in progress.
 
-### `uploadProps`
+### uploadProps
 
 Upload properties that are compatible with Ant Design [`<Upload>`](https://ant.design/components/upload/) component.
 
@@ -197,27 +197,27 @@ export const PostList: React.FC = () => {
 };
 ```
 
-#### `onChange`
+#### onChange
 
 Handles the file upload.
 
-#### `beforeUpload`
+#### beforeUpload
 
 By default, `() => false` is set to prevent the file from being uploaded automatically.
 
-#### `showUploadList`
+#### showUploadList
 
 By default, `false` is set to hide the upload list.
 
-#### `accept`
+#### accept
 
 By default, `".csv"` is set to accept only CSV files.
 
-### `isLoading`
+### isLoading
 
 It is a boolean value that indicates whether the import is in progress.
 
-### `mutationResult`
+### mutationResult
 
 Result of the [`useCreate`](/docs/data/hooks/use-create) or [`useCreateMany`](/docs/data/hooks/use-create) method of your data provider.
 

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-modal-form/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-modal-form/index.md
@@ -397,7 +397,7 @@ Don't forget to pass the record id to `show` to fetch the record data. This is n
 
 All [`useForm`][antd-use-form] props are also available in `useModalForm`. You can find descriptions on the [`useForm` documentation](/docs/ui-integrations/ant-design/hooks/use-form#properties).
 
-### `syncWithLocation`
+### syncWithLocation
 
 When `syncWithLocation` is `true`, the drawers visibility state and the `id` of the record will be synced with the URL. It is `false` by default.
 
@@ -409,7 +409,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `defaultFormValues`
+### defaultFormValues
 
 Default values for the form. Use this to pre-populate the form with data that needs to be displayed. This property is only available for `"create"` action.
 
@@ -421,7 +421,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `defaultVisible`
+### defaultVisible
 
 When `defaultVisible` is `true`, the modal will be visible by default. It is `false` by default.
 
@@ -431,7 +431,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `autoSubmitClose`
+### autoSubmitClose
 
 `autoSubmitClose` will make the modal close after a successful submit. It is `true` by default.
 
@@ -441,7 +441,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `autoResetForm`
+### autoResetForm
 
 `autoResetForm` will reset the form after a successful submit. It is `true` by default.
 
@@ -451,7 +451,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `warnWhenUnsavedChanges`
+### warnWhenUnsavedChanges
 
 When set to true, `warnWhenUnsavedChanges` shows a warning when the user tries to leave the page with unsaved changes. It is used to prevent the user from accidentally leaving the page. It is `false` by default
 
@@ -463,7 +463,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -489,7 +489,7 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### `autoSave`
+### autoSave
 
 If you want to save the form automatically after some delay when user edits the form, you can pass true to `autoSave.enabled` prop.
 
@@ -501,7 +501,7 @@ It also supports `onMutationSuccess` and `onMutationError` callback functions. Y
 
 `onMutationSuccess` and `onMutationError` callbacks will be called after the mutation is successful or failed.
 
-#### `enabled`
+#### enabled
 
 To enable the `autoSave` feature, set the `enabled` parameter to `true`. By default, it is `false`.
 
@@ -513,7 +513,7 @@ useModalForm({
 });
 ```
 
-#### `debounce`
+#### debounce
 
 Set the debounce time for the `autoSave` prop. By default, it is `1000` milliseconds.
 
@@ -527,7 +527,7 @@ useModalForm({
 });
 ```
 
-#### `onFinish`
+#### onFinish
 
 If you want to modify the data before sending it to the server, you can use `onFinish` callback function.
 
@@ -547,7 +547,7 @@ useModalForm({
 });
 ```
 
-#### `invalidateOnUnmount`
+#### invalidateOnUnmount
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when the hook is unmounted. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate. By default, it is `false`.
 
@@ -561,7 +561,7 @@ useModalForm({
 });
 ```
 
-#### `invalidateOnClose`
+#### invalidateOnClose
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when the modal is closed. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate. By default, it is `false`.
 
@@ -577,59 +577,59 @@ useModalForm({
 
 ## Return Values
 
-### `formProps`
+### formProps
 
 It's required to manage `<Form>` state and actions. Under the hood the `formProps` came from [`useForm`][antd-use-form].
 
 It contains the props to manage the [Antd `<Form>`](https://ant.design/components/form#api) components such as [`onValuesChange`, `initialValues`, `onFieldsChange`, `onFinish` etc.](/docs/ui-integrations/ant-design/hooks/use-form#return-values)
 
-### `modalProps`
+### modalProps
 
 The props needed by the [`<Modal>`][antd-modal] component.
 
-#### `title`
+#### title
 
 Title of the modal. Value is based on resource and action values.
 
-#### `okText`
+#### okText
 
 `okText` is the text of the `"submit"` button within the modal. It is "Save" by default.
 
-#### `cancelText`
+#### cancelText
 
 `cancelText` is the text of the `"cancel"` button within the modal. It is "Cancel" by default.
 
-#### `width`
+#### width
 
 Width of the `<Modal>`. It is `1000px` by default.
 
-#### `forceRender`
+#### forceRender
 
 `forceRender` renders the `<Modal>` instead of lazy rendering it. It is `true` by default.
 
-#### `okButtonProps`
+#### okButtonProps
 
 `okButtonProps` contains all the props needed by the `"submit"` button within the modal (disabled,loading etc.). When `okButtonProps.onClick` is called, it triggers `form.submit()`. You can manually pass these props to your custom button.
 
-#### `onOk`
+#### onOk
 
 A function that can submit the `<Form>` inside `<Modal>`. It's useful when you want to submit the form manually.
 
-#### `onCancel`
+#### onCancel
 
 > Same as `close`
 
 A function that can close the `<Modal>`. It's useful when you want to close the modal manually.
 
-#### ~~`visible`~~ <PropTag deprecated />
+#### ~~visible~~ <PropTag deprecated />
 
 Please use `open` instead.
 
-### `open`
+### open
 
 Current visible state of `<Modal>`. Default value depends on `defaultVisible` prop.
 
-### `close`
+### close
 
 A function that can close the `<Modal>`. It's useful when you want to close the modal manually.
 
@@ -654,7 +654,7 @@ return (
 );
 ```
 
-### `submit`
+### submit
 
 `submit` is a function that can submit the form. It's useful when you want to submit the form manually.
 
@@ -681,7 +681,7 @@ return (
 );
 ```
 
-### `show`
+### show
 
 `show` is a function that can show the modal.
 
@@ -738,7 +738,7 @@ return (
 );
 ```
 
-### `overtime`
+### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 
@@ -748,7 +748,7 @@ const { overtime } = useModalForm();
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
 
-### `autoSaveProps`
+### autoSaveProps
 
 If `autoSave` is enabled, this hook returns `autoSaveProps` object with `data`, `error`, and `status` properties from mutation.
 

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-radio-group/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-radio-group/index.md
@@ -64,7 +64,7 @@ All we have to do is pass the `radioGroupProps` it returns to the `<Radio.Group>
 
 ## Options
 
-### `resource`
+### resource
 
 ```tsx
 const { radioGroupProps } = useRadioGroup({
@@ -80,7 +80,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [Ant Design's `Radio.Group` component documentation &#8594](https://ant.design/components/radio)
 
-### `defaultValue`
+### defaultValue
 
 ```tsx
 const { selectProps } = useRadioGroup({
@@ -92,7 +92,7 @@ const { selectProps } = useRadioGroup({
 
 The easiest way to selecting a default value for an radio button field is by passing in `defaultValue`.
 
-### `optionLabel` and `optionValue`
+### optionLabel and `optionValue`
 
 ```tsx
 const { radioGroupProps } = useRadioGroup({
@@ -118,7 +118,7 @@ const { options } = useSelect({
 });
 ```
 
-### `filters`
+### filters
 
 `filters` allows us to add filters while fetching the data. For example, if you want to list only the `titles` that are equal to "German":
 
@@ -137,7 +137,7 @@ const { radioGroupProps } = useRadioGroup({
 });
 ```
 
-### `sorters`
+### sorters
 
 `sorters` allows us to sort the `options`. For example, if you want to sort your list according to `title` by ascending:
 
@@ -155,7 +155,7 @@ const { radioGroupProps } = useRadioGroup({
 });
 ```
 
-### `fetchSize`
+### fetchSize
 
 `fetchSize` is the amount of records to fetch in checkboxes.
 
@@ -167,7 +167,7 @@ const { selectProps } = useRadioGroup({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 Passing the `queryOptions` property allows us to set the [useQuery](https://react-query.tanstack.com/reference/useQuery) options
 
@@ -184,7 +184,7 @@ const { radioGroupProps } = useRadioGroup({
 });
 ```
 
-### `pagination`
+### pagination
 
 `pagination` allows us to set page and items per page values.
 
@@ -200,7 +200,7 @@ const { selectProps } = useSelect({
 
 The listing will start from page 3, showing 8 records per page.
 
-### ~~`sort`~~ <PropTag deprecated />
+### ~~sort~~ <PropTag deprecated />
 
 Use `sorters` instead.
 

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-select/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-select/index.md
@@ -30,7 +30,7 @@ When the `useSelect` hook is mounted, it passes some parameters (`channel`, `res
 
 ## Properties
 
-### `resource` <PropTag required />
+### resource <PropTag required />
 
 `resource` will be passed to the `getList` method from the `dataProvider` as parameter via the `useList` hook. The parameter is usually used as an API endpoint path but it all depends on how you handle the `resource` in the `getList` method.
 
@@ -46,7 +46,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `optionLabel` and `optionValue`
+### optionLabel and `optionValue`
 
 Allows you to change the `value` and `label` of your options.
 Default values are `optionLabel = "title"` and `optionValue = "id"`
@@ -69,7 +69,7 @@ const { options } = useSelect({
 });
 ```
 
-### `sorters`
+### sorters
 
 `sorters` prop allows you to show the options in the desired order. It will be passed to the `getList` method from the `dataProvider` as parameter via the `useList` hook and used to send sort query parameters to the API.
 
@@ -88,7 +88,7 @@ useSelect({
 
 > For more information, refer to the [`CrudSorting` interface documentation &#8594](/docs/core/interface-references#crudsorting)
 
-### `filters`
+### filters
 
 `filters` is used to filter the options you are showing. `filters` will be passed to the `getList` method from the `dataProvider` as parameter via the `useList` hook and used to send filter query parameters to the API.
 
@@ -106,7 +106,7 @@ useSelect({
 
 > For more information, refer to the [`CrudFilters` interface documentation &#8594](/docs/core/interface-references#crudfilters)
 
-### `defaultValue`
+### defaultValue
 
 The `defaultValue` is a property that can be used to not only set default options for a `<select>` component but also add extra options.
 
@@ -124,7 +124,7 @@ useSelect({
 
 > For more information, refer to the [`useMany` documentation &#8594](/docs/data/hooks/use-many)
 
-### `debounce`
+### debounce
 
 This prop allows us to `debounce` the `onSearch` function.
 
@@ -135,7 +135,7 @@ useSelect({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 `queryOptions` is used to pass additional options to the `useQuery` hook. It is useful when you want to pass additional options to the `useQuery` hook.
 
@@ -149,11 +149,11 @@ useSelect({
 
 > For more information, refer to the [`useQuery` documentation &#8594](https://tanstack.com/query/v4/docs/react/reference/useQuery)
 
-### `pagination`
+### pagination
 
 `pagination` will be passed to the `getList` method from the `dataProvider` as parameter. It is used to send pagination query parameters to the API.
 
-#### `current`
+#### current
 
 You can pass the `current` page number to the `pagination` property.
 
@@ -165,7 +165,7 @@ useSelect({
 });
 ```
 
-#### `pageSize`
+#### pageSize
 
 You can pass the `pageSize` to the `pagination` property.
 
@@ -177,7 +177,7 @@ useSelect({
 });
 ```
 
-#### `mode`
+#### mode
 
 It can be `"off"`, `"client"` or `"server"`. It is used to determine whether to use server-side pagination or not.
 
@@ -189,7 +189,7 @@ useSelect({
 });
 ```
 
-### `defaultValueQueryOptions`
+### defaultValueQueryOptions
 
 When the `defaultValue` property is given, the `useMany` data hook is called for the selected records. `defaultValueQueryOptions` allows you to change the options of this query.
 
@@ -206,7 +206,7 @@ const { options } = useSelect({
 });
 ```
 
-### `onSearch`
+### onSearch
 
 `onSearch` allows the addittion of `AutoComplete` to the `options`.
 
@@ -233,7 +233,7 @@ const { selectProps } = useSelect({
 />;
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -278,7 +278,7 @@ const myDataProvider = {
 
 > For more information, refer to the [`meta` section of the General Concepts documentation &#8594](/docs/guides-concepts/general-concepts/#meta-concept)
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you can specify which one to use by passing the `dataProviderName` prop. It is useful when you have different data providers for different resources.
 
@@ -288,7 +288,7 @@ useSelect({
 });
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -306,7 +306,7 @@ useSelect({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -324,7 +324,7 @@ useSelect({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -338,7 +338,7 @@ useSelect({
 
 > For more information, refer to the [Live / Realtime documentation &#8594](/docs/realtime/live-provider#livemode)
 
-### `onLiveEvent`
+### onLiveEvent
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -352,13 +352,13 @@ useSelect({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
 Params to pass to liveProvider's [subscribe](/docs/realtime/live-provider#subscribe) method.
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds while `onInterval` is the function that will be called on each interval.
@@ -384,11 +384,11 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### ~~`sort`~~ <PropTag deprecated />
+### ~~sort~~ <PropTag deprecated />
 
 Use `sorters` instead.
 
-### ~~`hasPagination`~~ <PropTag deprecated />
+### ~~hasPagination~~ <PropTag deprecated />
 
 Use `pagination.mode` instead.
 

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-simple-list/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-simple-list/index.md
@@ -85,7 +85,7 @@ When the `useSimpleList` hook is mounted, it will call the `subscribe` method fr
 
 ## Properties
 
-### `resource`
+### resource
 
 The `useSimpleList` passes the `resource` to the `dataProvider` as a param. This parameter is usually used as an API endpoint path. It all depends on how to handle the resources in your `dataProvider`.
 
@@ -137,7 +137,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `pagination.current`
+### pagination.current
 
 Sets the initial value of the page index. It is `1` by default.
 
@@ -149,7 +149,7 @@ useSimpleList({
 });
 ```
 
-### `pagination.pageSize`
+### pagination.pageSize
 
 Sets the initial value of the page size. It is `10` by default.
 
@@ -161,7 +161,7 @@ useSimpleList({
 });
 ```
 
-### `pagination.mode`
+### pagination.mode
 
 It can be `"off"`, `"server"` or `"client"`. It is `"server"` by default.
 
@@ -177,7 +177,7 @@ useSimpleList({
 });
 ```
 
-### `sorters.initial`
+### sorters.initial
 
 Sets the initial value of the sorter. The `initial` is not permanent. It will be cleared when the user changes the sorter. If you want to set a permanent value, use the `sorters.permanent` prop.
 
@@ -196,7 +196,7 @@ useSimpleList({
 });
 ```
 
-### `sorters.permanent`
+### sorters.permanent
 
 Sets the permanent value of the sorter. The `permanent` is permanent and unchangeable. It will not be cleared when the user changes the sorter. If you want to set a temporary value, use the `sorters.initial` prop.
 
@@ -215,7 +215,7 @@ useSimpleList({
 });
 ```
 
-### `filters.initial`
+### filters.initial
 
 Sets the initial value of the filter. The `initial` is not permanent. It will be cleared when the user changes the filter. If you want to set a permanent value, use the `filters.permanent` prop.
 
@@ -235,7 +235,7 @@ useSimpleList({
 });
 ```
 
-### `filters.permanent`
+### filters.permanent
 
 Sets the permanent value of the filter. The `permanent` is permanent and unchangeable. It will not be cleared when the user changes the filter. If you want to set a temporary value, use the `filters.initial` prop.
 
@@ -255,7 +255,7 @@ useSimpleList({
 });
 ```
 
-### `filters.defaultBehavior`
+### filters.defaultBehavior
 
 The filtering behavior can be set to either `"merge"` or `"replace"`. It is `merge` by default.
 
@@ -273,7 +273,7 @@ useSimpleList({
 });
 ```
 
-### `syncWithLocation` <GlobalConfigBadge id="core/refine-component/#syncwithlocation" />
+### syncWithLocation <GlobalConfigBadge id="core/refine-component/#syncwithlocation" />
 
 When you use the syncWithLocation feature, the `useSimpleList`'s state (e.g. sort order, filters, pagination) is automatically encoded in the query parameters of the URL, and when the URL changes, the `useSimpleList` state is automatically updated to match. This makes it easy to share list states across different routes or pages and allows users to bookmark or share links to specific table views. `syncWithLocation` is set to `false` by default.
 
@@ -283,7 +283,7 @@ useSimpleList({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 `useSimpleList` uses the [`useTable`](/docs/data/hooks/use-table) hook to fetch data. You can pass the [`queryOptions`](https://tanstack.com/query/v4/docs/react/reference/useQuery) to it like this:
 
@@ -295,7 +295,7 @@ useSimpleList({
 });
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -343,7 +343,7 @@ const myDataProvider = {
 };
 ```
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you can specify which one to use by passing the `dataProviderName` prop. This is useful when you have a different data provider for different resources.
 
@@ -353,7 +353,7 @@ useSimpleList({
 });
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -371,7 +371,7 @@ useSimpleList({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -389,7 +389,7 @@ useSimpleList({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -403,7 +403,7 @@ useSimpleList({
 });
 ```
 
-### `onLiveEvent`
+### onLiveEvent
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -417,13 +417,13 @@ useSimpleList({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
 Params to pass to liveProvider's [subscribe](/docs/realtime/live-provider#subscribe) method.
 
-### `onSearch`
+### onSearch
 
 When [`searchFormProps.onFinish`](#searchformprops) is called, the `onSearch` function is called with the values of the form. The `onSearch` function should return [`CrudFilters | Promise<CrudFilters>`][crudfilters]. When the `onSearch` function is called, the current page will be set to 1.
 
@@ -469,39 +469,39 @@ return (
 );
 ```
 
-### ~~`initialCurrent`~~ <PropTag deprecated />
+### ~~initialCurrent~~ <PropTag deprecated />
 
 Use `pagination.current` instead.
 
-### ~~`initialPageSize`~~ <PropTag deprecated />
+### ~~initialPageSize~~ <PropTag deprecated />
 
 Use `pagination.pageSize` instead.
 
-### ~~`hasPagination`~~ <PropTag deprecated />
+### ~~hasPagination~~ <PropTag deprecated />
 
 Use `pagination.mode` instead.
 
-### ~~`initialSorter`~~ <PropTag deprecated />
+### ~~initialSorter~~ <PropTag deprecated />
 
 Use `sorters.initial` instead.
 
-### ~~`permanentSorter`~~ <PropTag deprecated />
+### ~~permanentSorter~~ <PropTag deprecated />
 
 Use `sorters.permanent` instead.
 
-### ~~`initialFilter`~~ <PropTag deprecated />
+### ~~initialFilter~~ <PropTag deprecated />
 
 Use `filters.initial` instead.
 
-### ~~`permanentFilter`~~ <PropTag deprecated />
+### ~~permanentFilter~~ <PropTag deprecated />
 
 Use `filters.permanent` instead.
 
-### ~~`defaultSetFilterBehavior`~~ <PropTag deprecated />
+### ~~defaultSetFilterBehavior~~ <PropTag deprecated />
 
 Use `filters.defaultBehavior` instead.
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want the loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful if you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds while `onInterval` is the function that will be called on each interval.
@@ -529,11 +529,11 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 
 ## Return Values
 
-### `queryResult`
+### queryResult
 
 `queryResult` is the returned values from [`useList`](/docs/data/hooks/use-list) hook.
 
-### `searchFormProps`
+### searchFormProps
 
 `searchFormProps` returns the [`<Form>`](https://ant.design/components/form/) instance of Ant Design. When `searchFormProps.onFinish` is called, it will trigger [`onSearch`](#onsearch) function.
 You can also use `searchFormProps.form.submit` to submit the form manually.
@@ -580,27 +580,27 @@ return (
 );
 ```
 
-### `listProps`
+### listProps
 
 `listProps` is an object that contains compatible props for Ant Design [`<List>`][antd list] component.
 
-#### `dataSource`
+#### dataSource
 
 `dataSource` contains the data to be displayed in the list. Values are fetched with the [`useList`](/docs/data/hooks/use-list) hook.
 
-#### `loading`
+#### loading
 
 `loading` indicates whether the data is being fetched or not.
 
-#### `pagination`
+#### pagination
 
 `pagination` returns the pagination configuration values(pageSize, current, position, etc.).
 
-### `sorters`
+### sorters
 
 `sorters` is the current [sorters state][crudsorting].
 
-### `setSorters`
+### setSorters
 
 `setSorters` is a function to set the current[sorters state][crudsorting].
 
@@ -608,11 +608,11 @@ return (
  (sorters: CrudSorting) => void;
 ```
 
-### `filters`
+### filters
 
 `filters` is the current [filters state][crudfilters].
 
-### `setFilters`
+### setFilters
 
 ```tsx
 ((filters: CrudFilters, behavior?: SetFilterBehavior) => void) & ((setter: (prevFilters: CrudFilters) => CrudFilters) => void)
@@ -620,11 +620,11 @@ return (
 
 `setFilters` is a function to set the current [filters state][crudfilters].
 
-### `current`
+### current
 
 `current` is the current page index state. If pagination is disabled, it will be `undefined`.
 
-### `setCurrent`
+### setCurrent
 
 ```tsx
 React.Dispatch<React.SetStateAction<number>> | undefined;
@@ -632,11 +632,11 @@ React.Dispatch<React.SetStateAction<number>> | undefined;
 
 `setCurrent` is a function to set the current page index state. If pagination is disabled, it will be `undefined`.
 
-### `pageSize`
+### pageSize
 
 `pageSize` is the current page size state. If pagination is disabled, it will be `undefined`.
 
-### `setPageSize`
+### setPageSize
 
 ```tsx
 React.Dispatch<React.SetStateAction<number>> | undefined;
@@ -644,11 +644,11 @@ React.Dispatch<React.SetStateAction<number>> | undefined;
 
 `setPageSize` is a function to set the current page size state. If pagination is disabled, it will be `undefined`.
 
-### `pageCount`
+### pageCount
 
 `pageCount` is the total page count state. If pagination is disabled, it will be `undefined`.
 
-### `createLinkForSyncWithLocation`
+### createLinkForSyncWithLocation
 
 ```tsx
 (params: SyncWithLocationParams) => string;
@@ -656,7 +656,7 @@ React.Dispatch<React.SetStateAction<number>> | undefined;
 
 `createLinkForSyncWithLocation` is a function that creates accessible links for `syncWithLocation`. It takes an [SyncWithLocationParams][syncwithlocationparams] as parameters.
 
-### `overtime`
+### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 
@@ -666,11 +666,11 @@ const { overtime } = useSimpleList();
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
 
-### ~~`sorter`~~ <PropTag deprecated />
+### ~~sorter~~ <PropTag deprecated />
 
 Use `sorters` instead.
 
-### ~~`setSorter`~~ <PropTag deprecated />
+### ~~setSorter~~ <PropTag deprecated />
 
 Use `setSorters` instead.
 

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-steps-form/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-steps-form/index.md
@@ -944,7 +944,7 @@ interface IPost {
 
 All of the [`useForm`](/docs/ui-integrations/ant-design/hooks/use-form) props are also available in `useStepsForm`. You can find descriptions on [`useForm` documentation](/docs/ui-integrations/ant-design/hooks/use-form#properties).
 
-### `defaultCurrent`
+### defaultCurrent
 
 `defaultCurrent` sets the default starting step number. Counting starts from `0`.
 
@@ -954,7 +954,7 @@ const stepsForm = useStepsForm({
 });
 ```
 
-### `total`
+### total
 
 `total` is the maximum number of steps. `<Steps>` cannot go beyond this number.
 
@@ -964,7 +964,7 @@ const stepsForm = useStepsForm({
 });
 ```
 
-### `isBackValidate`
+### isBackValidate
 
 When `isBackValidate` is `true`, it validates a form fields when the user navigates to a previous step. It is `false` by default.
 
@@ -976,7 +976,7 @@ const stepsForm = useStepsForm({
 
 <br/>
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -1002,7 +1002,7 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### `autoSave`
+### autoSave
 
 If you want to save the form automatically after some delay when user edits the form, you can pass true to `autoSave.enabled` prop.
 
@@ -1014,7 +1014,7 @@ It also supports `onMutationSuccess` and `onMutationError` callback functions. Y
 
 `onMutationSuccess` and `onMutationError` callbacks will be called after the mutation is successful or failed.
 
-#### `enabled`
+#### enabled
 
 To enable the `autoSave` feature, set the `enabled` parameter to `true`. By default, it is `false`.
 
@@ -1026,7 +1026,7 @@ useStepsForm({
 });
 ```
 
-#### `debounce`
+#### debounce
 
 Set the debounce time for the `autoSave` prop. By default, it is `1000` milliseconds.
 
@@ -1040,7 +1040,7 @@ useStepsForm({
 });
 ```
 
-#### `onFinish`
+#### onFinish
 
 If you want to modify the data before sending it to the server, you can use `onFinish` callback function.
 
@@ -1060,7 +1060,7 @@ useStepsForm({
 });
 ```
 
-#### `invalidateOnUnmount`
+#### invalidateOnUnmount
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when the hook is unmounted. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate. By default, it is `false`.
 
@@ -1078,36 +1078,36 @@ useStepsForm({
 
 All [`useForm`](/docs/ui-integrations/ant-design/hooks/use-form) return values also available in `useStepsForm`. You can find descriptions on [`useForm`](/docs/ui-integrations/ant-design/hooks/use-form#return-values) docs.
 
-### `stepsProps`
+### stepsProps
 
 `stepsProps` is the props needed by the `<Steps>` component.
 
-#### `current`
+#### current
 
 `current` is the current step, counting from `0`.
 
-#### `onChange`
+#### onChange
 
 Callback function that is triggered when the current step of the form changes. The function takes in one argument, `currentStep`, which is a number representing the index of the current step.
 
-### `current`
+### current
 
 The Current step, counting from `0`.
 
-### `gotoStep`
+### gotoStep
 
 `gotoStep` is a function that allows you to programmatically change the current step of a form.
 It takes in one argument, step, which is a number representing the index of the step you want to navigate to.
 
-### `submit`
+### submit
 
 `submit` is a function that can submit the form. It's useful when you want to submit the form manually.
 
-### `defaultFormValuesLoading`
+### defaultFormValuesLoading
 
 When `action` is `"edit"` or `"clone"`, `useStepsForm` will fetch the data from the API and set it as default values. This prop is `true` when the data is being fetched.
 
-### `overtime`
+### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 
@@ -1117,7 +1117,7 @@ const { overtime } = useStepsForm();
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
 
-### `autoSaveProps`
+### autoSaveProps
 
 If `autoSave` is enabled, this hook returns `autoSaveProps` object with `data`, `error`, and `status` properties from mutation.
 

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-table/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-table/index.md
@@ -143,7 +143,7 @@ When the `useTable` hook is mounted, it will call the `subscribe` method from th
 
 ## Properties
 
-### `resource`
+### resource
 
 <PropResource
 hook={{
@@ -169,7 +169,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `onSearch`
+### onSearch
 
 When [`searchFormProps.onFinish`](#searchformprops) is called, the `onSearch` function is called with the values of the form. The `onSearch` function should return [`CrudFilters | Promise<CrudFilters>`][crudfilters].
 Also, `onSearch` will set the current page to 1.
@@ -206,7 +206,7 @@ const { searchFormProps, tableProps } = useTable({
 // ---
 ```
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use. It is useful when you want to use a different `dataProvider` for a specific resource.
 
@@ -216,7 +216,7 @@ useTable({
 });
 ```
 
-### `pagination.current`
+### pagination.current
 
 Sets the initial value of the page index. It is set to `1` by default.
 
@@ -228,7 +228,7 @@ useTable({
 });
 ```
 
-### `pagination.pageSize`
+### pagination.pageSize
 
 Sets the initial value of the page size. It is set to `10` by default.
 
@@ -240,7 +240,7 @@ useTable({
 });
 ```
 
-### `pagination.mode`
+### pagination.mode
 
 It can be `"off"`, `"server"` or `"client"`. It is set to `"server"` by default.
 
@@ -256,7 +256,7 @@ useTable({
 });
 ```
 
-### `sorters.initial`
+### sorters.initial
 
 Sets the initial value of the sorter. The `initial` is not permanent. It will be cleared when the user changes the sorter. If you want to set a permanent value, use the `sorters.permanent` prop.
 
@@ -275,7 +275,7 @@ useTable({
 });
 ```
 
-### `sorters.permanent`
+### sorters.permanent
 
 Sets the permanent value of the sorter. The `permanent` is permanent and unchangeable. It will not be cleared when the user changes the sorter. If you want to set a temporary value, use the `sorters.initial` prop.
 
@@ -294,7 +294,7 @@ useTable({
 });
 ```
 
-### `sorters.mode`
+### sorters.mode
 
 It can be `"off"`, or `"server"`. It is `"server"` by default.
 
@@ -309,7 +309,7 @@ useTable({
 });
 ```
 
-### `filters.initial`
+### filters.initial
 
 Sets the initial value of the filter. The `initial` is not permanent. It will be cleared when the user changes the filter. If you want to set a permanent value, use the `filters.permanent` prop.
 
@@ -329,7 +329,7 @@ useTable({
 });
 ```
 
-### `filters.permanent`
+### filters.permanent
 
 Sets the permanent value of the filter. The `permanent` is permanent and unchangeable. It will not be cleared when the user changes the filter. If you want to set a temporary value, use the `filters.initial` prop.
 
@@ -349,7 +349,7 @@ useTable({
 });
 ```
 
-### `filters.defaultBehavior`
+### filters.defaultBehavior
 
 The filtering behavior can be set to either `"merge"` or `"replace"`. By default, it is set to `"merge"`.
 
@@ -367,7 +367,7 @@ useTable({
 });
 ```
 
-### `filters.mode`
+### filters.mode
 
 It can be `"off"` or `"server"`. It is `"server"` by default.
 
@@ -382,7 +382,7 @@ useTable({
 });
 ```
 
-### `syncWithLocation` <GlobalConfigBadge id="core/refine-component/#syncwithlocation" />
+### syncWithLocation <GlobalConfigBadge id="core/refine-component/#syncwithlocation" />
 
 When you use the `syncWithLocation` feature, the `useTable`'s state (e.g. sort order, filters, pagination) is automatically encoded in the query parameters of the URL, and when the URL changes, the `useTable` state is automatically updated to match. This makes it easy to share table state across different routes or pages, and to allow users to bookmark or share links to specific table views. It is set to `false` by default.
 
@@ -392,7 +392,7 @@ useTable({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 `useTable` uses the [`useList`](/docs/data/hooks/use-list) hook to fetch data. You can pass the [`queryOptions`](https://tanstack.com/query/v4/docs/react/reference/useQuery) to it like this:
 
@@ -404,7 +404,7 @@ useTable({
 });
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -452,7 +452,7 @@ const myDataProvider = {
 };
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -470,7 +470,7 @@ useTable({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -488,7 +488,7 @@ useTable({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -502,7 +502,7 @@ useTable({
 });
 ```
 
-### `onLiveEvent`
+### onLiveEvent
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -516,13 +516,13 @@ useTable({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
 Params to pass to liveProvider's [subscribe](/docs/realtime/live-provider#subscribe) method.
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want the loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 
@@ -549,45 +549,45 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### ~~`initialCurrent`~~ <PropTag deprecated />
+### ~~initialCurrent~~ <PropTag deprecated />
 
 Use `pagination.current` instead.
 
-### ~~`initialPageSize`~~ <PropTag deprecated />
+### ~~initialPageSize~~ <PropTag deprecated />
 
 Use `pagination.pageSize` instead.
 
-### ~~`hasPagination`~~ <PropTag deprecated />
+### ~~hasPagination~~ <PropTag deprecated />
 
 Use `pagination.mode` instead.
 
-### ~~`initialSorter`~~ <PropTag deprecated />
+### ~~initialSorter~~ <PropTag deprecated />
 
 Use `sorters.initial` instead.
 
-### ~~`permanentSorter`~~ <PropTag deprecated />
+### ~~permanentSorter~~ <PropTag deprecated />
 
 Use `sorters.permanent` instead.
 
-### ~~`initialFilter`~~ <PropTag deprecated />
+### ~~initialFilter~~ <PropTag deprecated />
 
 Use `filters.initial` instead.
 
-### ~~`permanentFilter`~~ <PropTag deprecated />
+### ~~permanentFilter~~ <PropTag deprecated />
 
 Use `filters.permanent` instead.
 
-### ~~`defaultSetFilterBehavior`~~ <PropTag deprecated />
+### ~~defaultSetFilterBehavior~~ <PropTag deprecated />
 
 Use `filters.defaultBehavior` instead.
 
 ## Return Values
 
-### `tableProps`
+### tableProps
 
 `tableProps` are the props needed by the [`<Table>`][table] component.
 
-#### `onChange`
+#### onChange
 
 The `onChange` callback function is executed when a user interacts(filter, sort, etc.) with the table.
 
@@ -605,23 +605,23 @@ const { tableProps } = useTable()
 </Table>
 ```
 
-#### `dataSource`
+#### dataSource
 
 `dataSource` contains the data to be displayed in the table. Values fetched with [`useList`](/docs/data/hooks/use-list) hook.
 
-#### `loading`
+#### loading
 
 `loading` indicates whether the data is being fetched.
 
-#### `pagination`
+#### pagination
 
 `pagination` returns the pagination configuration values(pageSize, current, position, etc.).
 
-#### `scroll`
+#### scroll
 
 `scroll` is for making the table scrollable or not. It is set to `{ x: true }` by default.
 
-### `searchFormProps`
+### searchFormProps
 
 `searchFormProps` returns [`<Form>`](https://ant.design/components/form/) instance of Ant Design. When `searchFormProps.onFinish` is called, it will trigger [`onSearch`](#onsearch) function.
 You can also use `searchFormProps.form.submit` to submit the form manually.
@@ -673,15 +673,15 @@ const PostList: React.FC = () => {
 };
 ```
 
-### `tableQueryResult`
+### tableQueryResult
 
 `tableQueryResult` are the returned values from [`useList`](/docs/data/hooks/use-list) hook.
 
-### `sorters`
+### sorters
 
 `sorters` is the current [sorters state][crudsorting].
 
-### `setSorters`
+### setSorters
 
 `setSorters` is a function to set current [sorters state][crudsorting].
 
@@ -689,11 +689,11 @@ const PostList: React.FC = () => {
  (sorters: CrudSorting) => void;
 ```
 
-### `filters`
+### filters
 
 `filters` is the current [filters state][crudfilters].
 
-### `setFilters`
+### setFilters
 
 ```tsx
 ((filters: CrudFilters, behavior?: SetFilterBehavior) => void) & ((setter: (prevFilters: CrudFilters) => CrudFilters) => void)
@@ -701,11 +701,11 @@ const PostList: React.FC = () => {
 
 `setFilters` is a function to set current [filters state][crudfilters].
 
-### `current`
+### current
 
 `current` is the current page index state. If pagination is disabled, it will be `undefined`.
 
-### `setCurrent`
+### setCurrent
 
 ```tsx
 React.Dispatch<React.SetStateAction<number>> | undefined;
@@ -713,11 +713,11 @@ React.Dispatch<React.SetStateAction<number>> | undefined;
 
 `setCurrent` is a function to set the current page index state. If pagination is disabled, it will be `undefined`.
 
-### `pageSize`
+### pageSize
 
 `pageSize` is the current page size state. If pagination is disabled, it will be `undefined`.
 
-### `setPageSize`
+### setPageSize
 
 ```tsx
 React.Dispatch<React.SetStateAction<number>> | undefined;
@@ -725,11 +725,11 @@ React.Dispatch<React.SetStateAction<number>> | undefined;
 
 `setPageSize` is a function to set the current page size state. If pagination is disabled, it will be `undefined`.
 
-### `pageCount`
+### pageCount
 
 `pageCount` is the total page count state. If pagination is disabled, it will be `undefined`.
 
-### `createLinkForSyncWithLocation`
+### createLinkForSyncWithLocation
 
 ```tsx
 (params: SyncWithLocationParams) => string;
@@ -737,7 +737,7 @@ React.Dispatch<React.SetStateAction<number>> | undefined;
 
 `createLinkForSyncWithLocation` is a function creates accessible links for `syncWithLocation`. It takes an [SyncWithLocationParams][syncwithlocationparams] as parameters.
 
-### `overtime`
+### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 
@@ -747,11 +747,11 @@ const { overtime } = useTable();
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
 
-### ~~`sorter`~~ <PropTag deprecated />
+### ~~sorter~~ <PropTag deprecated />
 
 Use `sorters` instead.
 
-### ~~`setSorter`~~ <PropTag deprecated />
+### ~~setSorter~~ <PropTag deprecated />
 
 Use `setSorters` instead.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/auth-page/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/auth-page/index.md
@@ -576,7 +576,7 @@ const authProvider: AuthBindings = {
 
 ## Props
 
-### `hideForm`
+### hideForm
 
 When you set `hideForm` to `true`, the form will be hidden. You can use this property to show only providers.
 
@@ -603,7 +603,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `providers`
+### providers
 
 `providers` property defines the list of providers used to handle login authentication. `providers` accepts an array of `Provider` type. Check out the [Interface](#interface) section for more information. This property is only available for types `login` and `register`.
 
@@ -628,7 +628,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `rememberMe`
+### rememberMe
 
 `rememberMe` property defines to render your own remember me component or you can pass `false` to don't render it. This property is only available for type `login`.
 
@@ -638,7 +638,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `loginLink`
+### loginLink
 
 `loginLink` property defines the link to the login page and also you can give a node to render. Default value is `"/login"`. This property is only available for types `register` and `forgotPassword`.
 
@@ -659,7 +659,7 @@ const MyRegisterPage = () => {
 };
 ```
 
-### `registerLink`
+### registerLink
 
 `registerLink` property defines the link to the registration page and also you can give a node to render. Default value is `"/register"`. This property is only available for type `login`.
 
@@ -680,7 +680,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `forgotPasswordLink`
+### forgotPasswordLink
 
 `forgotPasswordLink` property defines the link to the forgot password page and also you can give a node to render. Default value is `"/forgot-password"`. This property is only available for type `login`.
 
@@ -701,7 +701,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `wrapperProps`
+### wrapperProps
 
 `wrapperProps` is used for passing props to the wrapper component. In the example below you can see that the background color is changed with `wrapperProps`
 
@@ -719,7 +719,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `contentProps`
+### contentProps
 
 `contentProps` is used for passing props to the content component which is the card component. In the example below you can see that the title, header and content styles are changed with `contentProps`.
 
@@ -737,7 +737,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `formProps`
+### formProps
 
 `formProps` is used for passing props to the form component. In the example below you can see that the `initialValues` are changed with `formProps` and also the `onSubmit` function is changed.
 
@@ -771,7 +771,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `title`
+### title
 
 By default, `AuthPage` uses text with icon on top of page. You can use this property to change the default title.
 
@@ -801,7 +801,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `renderContent`
+### renderContent
 
 `renderContent` is used to render the form content and [title](#title). You can use this property to render your own content or `renderContent` gives you default content and title you can use to add some extra elements to the content.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/basic-views/create/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/basic-views/create/index.md
@@ -135,7 +135,7 @@ You can swizzle this component with the [**Refine CLI**](/docs/packages/list-of-
 
 ## Properties
 
-### `title`
+### title
 
 `title` allows the addition of titles inside the `<Create>` component by passing title props. If you don't pass title props, however, it uses the "Create" prefix and the singular resource name by default. For example, for the `/posts/create` resource, it would be "Create post".
 
@@ -178,7 +178,7 @@ render(
 );
 ```
 
-### `saveButtonProps`
+### saveButtonProps
 
 `saveButtonProps` can be used to customize the default button of the `<Create>` component that submits the form:
 
@@ -222,7 +222,7 @@ render(
 
 > For more information, refer to the [`<SaveButton>` documentation &#8594](/docs/ui-integrations/chakra-ui/components/buttons/save-button)
 
-### `resource`
+### resource
 
 The `<Create>` component reads the `resource` information from the route by default. If you want to use a custom resource for the `<Create>` component, you can use the `resource` prop.
 
@@ -278,7 +278,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `goBack`
+### goBack
 
 To customize the back button or to disable it, you can use the `goBack` property. You can pass `false` or `null` to hide the back button.
 
@@ -322,7 +322,7 @@ render(
 );
 ```
 
-### `isLoading`
+### isLoading
 
 To toggle the loading state of the `<Create/>` component, you can use the `isLoading` property.
 
@@ -364,7 +364,7 @@ render(
 );
 ```
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default it uses the `Breadcrumb` component from `@refinedev/chakra-ui` package.
 
@@ -416,7 +416,7 @@ render(
 
 > For more information, refer to the [`Breadcrumb` documentation &#8594](/docs/ui-integrations/chakra-ui/components/breadcrumb)
 
-### `wrapperProps`
+### wrapperProps
 
 If you want to customize the wrapper of the `<Create/>` component, you can use the `wrapperProps` property. For `@refinedev/chakra-ui` wrapper element is `<Card>`s and `wrapperProps` can get every attribute that `<Box>` can get.
 
@@ -467,7 +467,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI &#8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `headerProps`
+### headerProps
 
 If you want to customize the header of the `<Create/>` component, you can use the `headerProps` property.
 
@@ -518,7 +518,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI &#8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `contentProps`
+### contentProps
 
 If you want to customize the content of the `<Create/>` component, you can use the `contentProps` property.
 
@@ -569,7 +569,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI &#8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `headerButtons`
+### headerButtons
 
 You can customize the buttons at the header by using the `headerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
@@ -622,7 +622,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can customize the wrapper element of the buttons at the header by using the `headerButtonProps` property.
 
@@ -675,7 +675,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI &#8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `footerButtons`
+### footerButtons
 
 By default, the `<Create/>` component has a [`<SaveButton>`][save-button] at the header.
 
@@ -781,7 +781,7 @@ render(
 );
 ```
 
-### `footerButtonProps`
+### footerButtonProps
 
 You can customize the wrapper element of the buttons at the footer by using the `footerButtonProps` property.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/basic-views/edit/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/basic-views/edit/index.md
@@ -148,7 +148,7 @@ You can swizzle this component to customize it with the [**Refine CLI**](/docs/p
 
 ## Properties
 
-### `title`
+### title
 
 `title` allows the addition of titles inside the `<Edit>` component. if you don't pass title props it uses the "Edit" prefix and singular resource name by default. For example, for the "posts" resource, it would be "Edit post".
 
@@ -193,7 +193,7 @@ render(
 );
 ```
 
-### `saveButtonProps`
+### saveButtonProps
 
 `saveButtonProps` can be used to customize the default button of the `<Edit>` component that submits the form:
 
@@ -239,7 +239,7 @@ render(
 
 > For more information, refer to the [`<SaveButton>` documentation &#8594](/docs/ui-integrations/chakra-ui/components/buttons/save-button)
 
-### `canDelete` and `deleteButtonProps`
+### canDelete and deleteButtonProps
 
 `canDelete` allows us to add the delete button inside the `<Edit>` component that executes the `useDelete` method provided by the `dataProvider` when clicked on.
 
@@ -344,7 +344,7 @@ render(
 
 > For more information, refer to the [`<DeleteButton>` &#8594](/docs/ui-integrations/chakra-ui/components/buttons/delete-button) and [`usePermission` &#8594](/docs/authentication/hooks/use-permissions) documentations
 
-### `resource`
+### resource
 
 `<Edit>` component reads the `resource` information from the route by default. If you want to use a custom resource for the `<Edit>` component, you can use the `resource` prop.
 
@@ -400,7 +400,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `recordItemId`
+### recordItemId
 
 The `<Edit>` component reads the `id` information from the route by default. `recordItemId` is used when it cannot read from the URL(when used on a custom page, modal or drawer).
 
@@ -477,7 +477,7 @@ The `<Edit>` component needs the `id` information for the `<RefreshButton>` to w
 
 :::
 
-### `mutationMode`
+### mutationMode
 
 `mutationMode` determines which mode the mutation will have while executing `<DeleteButton>`.
 
@@ -540,7 +540,7 @@ render(
 );
 ```
 
-### `dataProviderName`
+### dataProviderName
 
 If not specified, Refine will use the default data provider. If you have multiple data providers and want to use a different one, you can use the `dataProviderName` property.
 
@@ -571,7 +571,7 @@ export const App: React.FC = () => {
 };
 ```
 
-### `goBack`
+### goBack
 
 To customize the back button or to disable it, you can use the `goBack` property. You can pass `false` or `null` to hide the back button.
 
@@ -618,7 +618,7 @@ render(
 );
 ```
 
-### `isLoading`
+### isLoading
 
 To toggle the loading state of the `<Edit/>` component, you can use the `isLoading` property.
 
@@ -663,7 +663,7 @@ render(
 );
 ```
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default it uses the `Breadcrumb` component from `@refinedev/chakra-ui` package.
 
@@ -718,7 +718,7 @@ render(
 
 > For more information, refer to the [`Breadcrumb` documentation &#8594](/docs/ui-integrations/chakra-ui/components/breadcrumb)
 
-### `wrapperProps`
+### wrapperProps
 
 If you want to customize the wrapper of the `<Edit/>` component, you can use the `wrapperProps` property. For `@refinedev/chakra-ui` wrapper element is `<Card>`s and `wrapperProps` can get every attribute that `<Card>` can get.
 
@@ -773,7 +773,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI &#8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `headerProps`
+### headerProps
 
 If you want to customize the header of the `<Edit/>` component, you can use the `headerProps` property.
 
@@ -827,7 +827,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI &#8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `contentProps`
+### contentProps
 
 If you want to customize the content of the `<Edit/>` component, you can use the `contentProps` property.
 
@@ -882,7 +882,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI &#8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `headerButtons`
+### headerButtons
 
 By default, the `<Edit/>` component has a [`<ListButton>`][list-button] and a [`<RefreshButton>`][refresh-button] at the header.
 
@@ -997,7 +997,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can customize the wrapper element of the buttons at the header by using the `headerButtonProps` property.
 
@@ -1058,7 +1058,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI &#8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `footerButtons`
+### footerButtons
 
 By default, the `<Edit/>` component has a [`<SaveButton>`][save-button] and a [`<DeleteButton>`][delete-button] at the footer.
 
@@ -1177,7 +1177,7 @@ render(
 );
 ```
 
-### `footerButtonProps`
+### footerButtonProps
 
 You can customize the wrapper element of the buttons at the footer by using the `footerButtonProps` property.
 
@@ -1233,7 +1233,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI &#8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `autoSaveProps`
+### autoSaveProps
 
 You can use the auto save feature of the `<Edit/>` component by using the `autoSaveProps` property.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/basic-views/list/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/basic-views/list/index.md
@@ -146,7 +146,7 @@ You can swizzle this component to customize it with the [**Refine CLI**](/docs/p
 
 ## Properties
 
-### `title`
+### title
 
 It allows adding a title for the `<List>` component. if you don't pass title props, it uses plural form of resource name by default.
 
@@ -189,7 +189,7 @@ render(
 );
 ```
 
-### `resource`
+### resource
 
 `<List>` component reads the `resource` information from the route by default. If you want to use a custom resource for the `<List>` component, you can use the `resource` prop.
 
@@ -244,7 +244,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `canCreate` and `createButtonProps`
+### canCreate and createButtonProps
 
 `canCreate` allows us to add the create button inside the `<List>` component. If resource is passed a create component, Refine adds the create button by default. If you want to customize this button you can use `createButtonProps` property like the code below.
 
@@ -345,7 +345,7 @@ render(
 );
 ```
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default it uses the `Breadcrumb` component from `@refinedev/chakra-ui` package.
 
@@ -401,7 +401,7 @@ render(
 
 > For more information, refer to the [`Breadcrumb` documentation &#8594](/docs/ui-integrations/chakra-ui/components/breadcrumb)
 
-### `wrapperProps`
+### wrapperProps
 
 If you want to customize the wrapper of the `<List/>` component, you can use the `wrapperProps` property. For `@refinedev/chakra-ui` wrapper element is `<Box>`s and `wrapperProps` can get every attribute that `<Box>` can get.
 
@@ -453,7 +453,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI &#8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `headerProps`
+### headerProps
 
 If you want to customize the header of the `<List/>` component, you can use the `headerProps` property.
 
@@ -505,7 +505,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI &#8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `contentProps`
+### contentProps
 
 If you want to customize the content of the `<List/>` component, you can use the `contentProps` property.
 
@@ -557,7 +557,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI &#8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `headerButtons`
+### headerButtons
 
 By default, the `<List/>` component has a [`<CreateButton>`][create-button] at the header.
 
@@ -669,7 +669,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can customize the wrapper element of the buttons at the header by using the `headerButtonProps` property.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/basic-views/show/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/basic-views/show/index.md
@@ -130,7 +130,7 @@ You can swizzle this component with the [**Refine CLI**](/docs/packages/list-of-
 
 ## Properties
 
-### `title`
+### title
 
 `title` allows the addition of titles inside the `<Show>` component. If you don't pass title props it uses the "Show" prefix and the singular resource name by default. For example, for the "posts" resource, it will be "Show post".
 
@@ -175,7 +175,7 @@ render(
 );
 ```
 
-### `resource`
+### resource
 
 The `<Show>` component reads the `resource` information from the route by default. If you want to use a custom resource for the `<Show>` component, you can use the `resource` prop.
 
@@ -231,7 +231,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `canDelete` and `canEdit`
+### canDelete and canEdit
 
 `canDelete` and `canEdit` allows us to add the delete and edit buttons inside the `<Show>` component. If the resource has `canDelete` or `canEdit` property Refine adds the buttons by default.
 
@@ -339,7 +339,7 @@ render(
 
 > For more information, refer to the [`usePermission` documentation &#8594](/docs/authentication/hooks/use-permissions)
 
-### `recordItemId`
+### recordItemId
 
 `<Show>` component reads the `id` information from the route by default. `recordItemId` is used when it cannot read from the URL (when used on a custom page, modal or drawer).
 
@@ -411,7 +411,7 @@ The `<Edit>` component needs the `id` information for the `<RefreshButton>` to w
 
 :::
 
-### `dataProviderName`
+### dataProviderName
 
 If not specified, Refine will use the default data provider. If you have multiple data providers and want to use a different one, you can use the `dataProviderName` property.
 
@@ -443,7 +443,7 @@ export const App: React.FC = () => {
 };
 ```
 
-### `goBack`
+### goBack
 
 To customize the back button or to disable it, you can use the `goBack` property. You can pass `false` or `null` to hide the back button.
 
@@ -489,7 +489,7 @@ render(
 );
 ```
 
-### `isLoading`
+### isLoading
 
 To toggle the loading state of the `<Edit/>` component, you can use the `isLoading` property.
 
@@ -533,7 +533,7 @@ render(
 );
 ```
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default it uses the `Breadcrumb` component from `@refinedev/chakra-ui` package.
 
@@ -591,7 +591,7 @@ render(
 
 > For more information, refer to the [`Breadcrumb` documentation &#8594](/docs/ui-integrations/chakra-ui/components/breadcrumb)
 
-### `wrapperProps`
+### wrapperProps
 
 If you want to customize the wrapper of the `<Show/>` component, you can use the `wrapperProps` property. For `@refinedev/chakra-ui` wrapper element is `<Box>`s and `wrapperProps` can get every attribute that `<Card>` can get.
 
@@ -645,7 +645,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI #8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `headerProps`
+### headerProps
 
 If you want to customize the header of the `<Show/>` component, you can use the `headerProps` property.
 
@@ -698,7 +698,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI &#8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `contentProps`
+### contentProps
 
 If you want to customize the content of the `<Show/>` component, you can use the `contentProps` property.
 
@@ -752,7 +752,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI &#8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `headerButtons`
+### headerButtons
 
 By default, the `<Show/>` component has a [`<ListButton>`][list-button], [`<EditButton>`][edit-button], [`<DeleteButton>`][delete-button], and a[`<RefreshButton>`][refresh-button] at the header.
 
@@ -871,7 +871,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can customize the wrapper element of the buttons at the header by using the `headerButtonProps` property.
 
@@ -931,7 +931,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Chakra UI &#8594](https://chakra-ui.com/docs/components/box/usage)
 
-### `footerButtons`
+### footerButtons
 
 You can customize the buttons at the footer by using the `footerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
@@ -986,7 +986,7 @@ render(
 );
 ```
 
-### `footerButtonProps`
+### footerButtonProps
 
 You can customize the wrapper element of the buttons at the footer by using the `footerButtonProps` property.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/breadcrumb/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/breadcrumb/index.md
@@ -17,7 +17,7 @@ A breadcrumb displays the current location within a hierarchy. It allows going b
 
 ## Properties
 
-### `breadcrumbProps`
+### breadcrumbProps
 
 `<Breadcrumb>` component uses the Chakra UI [Breadcrumb][chakra-ui-breadcrumb] component so it can be configured with the `breadcrumbProps` property.
 
@@ -36,7 +36,7 @@ export const PostList: React.FC = () => {
 };
 ```
 
-### `showHome`
+### showHome
 
 If you have a page with route `/`, it will be used as the root of the hierarchy and shown in the `Breadcrumb` with a home icon. To hide the root item, set `showHome` to `false.`
 
@@ -55,7 +55,7 @@ export const PostList: React.FC = () => {
 };
 ```
 
-### `meta`
+### meta
 
 If your routes has additional parameters in their paths, you can pass the `meta` property to the `<Breadcrumb>` component to use them while creating the paths and filling the parameters in the paths. By default, existing URL parameters are used. You can use `meta` to override them or add new ones.
 
@@ -74,7 +74,7 @@ export const PostList: React.FC = () => {
 };
 ```
 
-### `hideIcons`
+### hideIcons
 
 If you don't want to show the resource icons on the breadcrumb, you can set `hideIcons` to `true`.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/buttons/clone-button/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/buttons/clone-button/index.md
@@ -165,7 +165,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` is used to append the record id to the end of the route path.
 
@@ -210,7 +210,7 @@ Clicking the button will trigger the `clone` method of [`useNavigation`](/docs/r
 
 :::
 
-### `resource`
+### resource
 
 `resource` is used to redirect the app to the `clone` action of the given resource name. By default, the app redirects to the inferred resource's `clone` action path.
 
@@ -257,7 +257,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `clone` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `clone` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -269,7 +269,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -307,7 +307,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 The `accessControl` prop can be used to skip the access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -319,7 +319,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/buttons/create-button/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/buttons/create-button/index.md
@@ -146,7 +146,7 @@ render(
 
 ## Properties
 
-### `resource`
+### resource
 
 `resource` is used to redirect the app to the `create` action path of the given resource name. By default, the app redirects to the inferred resource's `create` action path.
 
@@ -193,7 +193,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `create` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `create` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -205,7 +205,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -243,7 +243,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 The `accessControl` prop can be used to skip the access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -255,7 +255,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/buttons/delete-button/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/buttons/delete-button/index.md
@@ -139,7 +139,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` allows us to manage which record will be deleted. By default, it will be read from the URL.
 
@@ -193,7 +193,7 @@ render(
 
 Clicking the button will trigger the [`useDelete`](/docs/data/hooks/use-delete) method and then the record whose resource is "post" and whose id is "123" gets deleted.
 
-### `resource`
+### resource
 
 `resource` allows us to manage which resource's record is going to be deleted. By default, it will be read from the URL.
 
@@ -255,7 +255,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `onSuccess`
+### onSuccess
 
 `onSuccess` can be used if you want to do anything based on the result returned after the delete request.
 
@@ -317,7 +317,7 @@ render(
 );
 ```
 
-### `mutationMode`
+### mutationMode
 
 Determines which mode mutation will have while executing `<DeleteButton>`.
 
@@ -372,7 +372,7 @@ render(
 
 > For more information, refer to the [mutation mode docsumentation &#8594](/advanced-tutorials/mutation-mode.md)
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -424,7 +424,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 The `accessControl` prop can be used to skip the access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -436,7 +436,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/buttons/edit-button/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/buttons/edit-button/index.md
@@ -162,7 +162,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` is used to append the record id to the end of the route path.
 
@@ -200,7 +200,7 @@ render(
 );
 ```
 
-### `resource`
+### resource
 
 Redirection endpoint is defined by the `resource` property and its `edit` action path. By default, `<EditButton>` uses the inferred resource from the route.
 
@@ -247,7 +247,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `edit` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `edit` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -259,7 +259,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 It is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -297,7 +297,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 The `accessControl` prop can be used to skip the access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -309,7 +309,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/buttons/export-button/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/buttons/export-button/index.md
@@ -148,7 +148,7 @@ You can swizzle this component to customize it with the [**Refine CLI**](/docs/p
 
 ## Properties
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/buttons/import-button/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/buttons/import-button/index.md
@@ -150,7 +150,7 @@ You can swizzle this component to customize it with the [**Refine CLI**](/docs/p
 
 ## Properties
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/buttons/list-button/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/buttons/list-button/index.md
@@ -104,7 +104,7 @@ The button text is defined automatically by Refine, based on the `resource` defi
 
 ## Properties
 
-### `resource`
+### resource
 
 Redirection endpoint is defined by the `resource`'s `list` action path. By default, `<ListButton>` uses the inferred resource from the route.
 
@@ -168,7 +168,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `list` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `list` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -180,7 +180,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 It is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -217,7 +217,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 The `accessControl` prop can be used to skip the access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -229,7 +229,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/buttons/refresh-button/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/buttons/refresh-button/index.md
@@ -102,7 +102,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` allows us to manage which data is going to be refreshed. By default it will read the id information from the route.
 
@@ -140,7 +140,7 @@ render(
 
 Clicking the button will trigger the [`useInvalidate`][use-invalidate] hook and then fetch the record whose resource is "post" and whose id is "123".
 
-### `resource`
+### resource
 
 `resource` allows us to manage which resource is going to be refreshed. By default it will read the id information from the route.
 
@@ -183,7 +183,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -220,7 +220,7 @@ render(
 );
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/buttons/save-button/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/buttons/save-button/index.md
@@ -149,7 +149,7 @@ interface IPost {
 
 ## Properties
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/buttons/show-button/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/buttons/show-button/index.md
@@ -164,7 +164,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` is used to append the record id to the end of the route path. By default it will read the id information from the route.
 
@@ -203,7 +203,7 @@ render(
 
 Clicking the button will trigger the `show` method of [`useNavigation`](/docs/routing/hooks/use-navigation) and then redirect the app to the `show` action path of the resource, filling the necessary parameters in the route.
 
-### `resource`
+### resource
 
 Redirection endpoint is defined by the `resource`'s `show` action path. By default, `<ShowButton>` uses the inferred resource from the route.
 
@@ -250,7 +250,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `show` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `show` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -262,7 +262,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 It is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -300,7 +300,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 The `accessControl` prop can be used to skip the access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -312,7 +312,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/inferencer/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/inferencer/index.md
@@ -92,7 +92,7 @@ To learn more about `@refinedev/inferencer` package, please check out its [docum
 
 ## Views
 
-### `List`
+### List
 
 Generates a sample list view for your resources according to the API response. It uses the `List` component from `@refinedev/chakra-ui` and `useTable` hook from `@refinedev/react-table`.
 
@@ -150,7 +150,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-### `Show`
+### Show
 
 Generates a sample show view for your resources according to the API response. It uses the `Show` and `field` components from `@refinedev/chakra-ui` with the `useShow` hook from `@refinedev/core`.
 
@@ -208,7 +208,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-### `Create`
+### Create
 
 Generates a sample create view for your resources according to the first record in list API response. It uses the `Create` component from `@refinedev/chakra-ui` and the `useForm` hook from `@refinedev/react-hook-form`.
 
@@ -266,7 +266,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-### `Edit`
+### Edit
 
 Generates a sample edit view for your resources according to the API response. It uses the `Edit` component from `@refinedev/chakra-ui` and the `useForm` hook from `@refinedev/react-hook-form`.
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/themed-layout/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/themed-layout/index.md
@@ -119,7 +119,7 @@ Example above shows how to use `<ThemedLayoutV2>` with [`React Router v6`](/docs
 
 ## Props
 
-### `Sider`
+### Sider
 
 In `<ThemedLayoutV2>`, the sidebar section is rendered using the [`<ThemedSider>`][themed-sider] component by default. This component is specifically designed to generate menu items based on the resources defined in the [`<Refine>`][refine-component] components, using the [`useMenu`][use-menu] hook. However, if desired, it's possible to replace the default [`<ThemedSider>`][themed-sider] component by passing a custom component to the `Sider` prop.
 
@@ -185,7 +185,7 @@ const App: React.FC = () => {
 };
 ```
 
-#### `Sider Props`
+#### Sider Props
 
 | Prop                 | Type                                          | Description                                                                     |
 | -------------------- | --------------------------------------------- | ------------------------------------------------------------------------------- |
@@ -203,7 +203,7 @@ type SiderRenderFunction = (props: {
 }) => React.ReactNode;
 ```
 
-### `initialSiderCollapsed`
+### initialSiderCollapsed
 
 This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
 
@@ -219,7 +219,7 @@ This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][
 </ThemedLayoutV2>
 ```
 
-### `Header`
+### Header
 
 In `<ThemedLayoutV2>`, the header section is rendered using the [`<ThemedHeader>`][themed-header] component by default. It uses the [`useGetIdentity`](/docs/authentication/hooks/use-get-identity) hook to display the user's name and avatar on the right side of the header. However, if desired, it's possible to replace the default [`<ThemedHeader>`][themed-header] component by passing a custom component to the `Header` prop.
 
@@ -275,7 +275,7 @@ const App: React.FC = () => {
 };
 ```
 
-### `Title`
+### Title
 
 In `<ThemedLayoutV2>`, the title section is rendered using the [`<ThemedTitleV2>`][themed-title] component by default. However, if desired, it's possible to replace the default [`<ThemedTitleV2>`][themed-title] component by passing a custom component to the `Title` prop.
 
@@ -313,7 +313,7 @@ const App: React.FC = () => {
 };
 ```
 
-### `Footer`
+### Footer
 
 The footer section of the layout is displayed at the bottom of the page. Refine doesn't provide a default footer component. However, you can pass a custom component to the `Footer` prop to display a footer section.
 
@@ -411,7 +411,7 @@ const App: React.FC = () => {
 };
 ```
 
-### `OffLayoutArea`
+### OffLayoutArea
 
 off-layout area component is rendered outside of the main layout component, allowing it to be placed anywhere on the page while still being part of the overall layout .Refine doesn't provide a default off-layout area component. However, you can pass a custom component to the `OffLayoutArea` prop to display a custom off-layout area.
 

--- a/documentation/docs/ui-integrations/mantine/components/auth-page/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/auth-page/index.md
@@ -571,7 +571,7 @@ const authProvider: AuthBindings = {
 
 ## Props
 
-### `hideForm`
+### hideForm
 
 When you set `hideForm` to `true`, the form will be hidden. You can use this property to show only providers.
 
@@ -598,7 +598,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `providers`
+### providers
 
 `providers` property defines the list of providers used to handle login authentication. `providers` accepts an array of `Provider` type. Check out the [Interface](#interface) section for more information. This property is only available for types `login` and `register`.
 
@@ -621,7 +621,7 @@ const MyLoginPage = () => (
 );
 ```
 
-### `rememberMe`
+### rememberMe
 
 `rememberMe` property defines to render your own remember me component or you can pass `false` to not render it. This property is only available for type `login`.
 
@@ -631,7 +631,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `loginLink`
+### loginLink
 
 `loginLink` property defines the link to the login page and also you can give a node to render. The default value is `"/login"`. This property is only available for types `register` and `forgotPassword`.
 
@@ -657,7 +657,7 @@ const MyRegisterPage = () => {
 };
 ```
 
-### `registerLink`
+### registerLink
 
 `registerLink` property defines the link to the registration page and also you can give a node to render. The default value is `"/register"`. This property is only available for type `login`.
 
@@ -683,7 +683,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `forgotPasswordLink`
+### forgotPasswordLink
 
 `forgotPasswordLink` property defines the link to the forgot password page and also you can give a node to render. The default value is `"/forgot-password"`. This property is only available for type `login`.
 
@@ -709,7 +709,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `wrapperProps`
+### wrapperProps
 
 `wrapperProps` is used for passing props to the wrapper component. In the example below you can see that the background color is changed with `wrapperProps`
 
@@ -734,7 +734,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `contentProps`
+### contentProps
 
 `contentProps` is used for passing props to the content component which is the card component. In the example below you can see that the title, header, and content styles are changed with `contentProps`.
 
@@ -753,7 +753,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `formProps`
+### formProps
 
 `formProps` is used for passing props to the form component. In the example below you can see that the `initialValues` are changed with `formProps` and also the `onSubmit` function is changed.
 
@@ -787,7 +787,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `title`
+### title
 
 By default, `AuthPage` uses text with icon on top of page. You can use this property to change the default title.
 
@@ -817,7 +817,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `renderContent`
+### renderContent
 
 `renderContent` uses to render the form content and [title](#title). You can use this property to render your own content or `renderContent` gives you default content and title you can use to add some extra elements to the content.
 

--- a/documentation/docs/ui-integrations/mantine/components/basic-views/create/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/basic-views/create/index.md
@@ -129,7 +129,7 @@ You can swizzle this component with the [**Refine CLI**](/docs/packages/list-of-
 
 ## Properties
 
-### `title`
+### title
 
 `title` allows the addition of titles inside the `<Create>` component by passing title props. If you don't pass title props, however, it uses the "Create" prefix and the singular resource name by default. For example, for the `/posts/create` resource, it would be "Create post".
 
@@ -179,7 +179,7 @@ render(
 );
 ```
 
-### `saveButtonProps`
+### saveButtonProps
 
 `saveButtonProps` can be used to customize the default button of the `<Create>` component that submits the form:
 
@@ -230,7 +230,7 @@ render(
 
 > For more information, refer to the [`<SaveButton>` documentation &#8594](/docs/ui-integrations/mantine/components/buttons/save-button)
 
-### `resource`
+### resource
 
 The `<Create>` component reads the `resource` information from the route by default. If you want to use a custom resource for the `<Create>` component, you can use the `resource` prop.
 
@@ -286,7 +286,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `goBack`
+### goBack
 
 To customize the back button or to disable it, you can use the `goBack` property. You can pass `false` or `null` to hide the back button.
 
@@ -335,7 +335,7 @@ render(
 );
 ```
 
-### `isLoading`
+### isLoading
 
 To toggle the loading state of the `<Create/>` component, you can use the `isLoading` property.
 
@@ -384,7 +384,7 @@ render(
 );
 ```
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default it uses the `Breadcrumb` component from `@refinedev/mantine` package.
 
@@ -447,7 +447,7 @@ render(
 
 > For more information, refer to the [`Breadcrumb` documentation &#8594](/docs/ui-integrations/mantine/components/breadcrumb)
 
-### `wrapperProps`
+### wrapperProps
 
 If you want to customize the wrapper of the `<Create/>` component, you can use the `wrapperProps` property. For `@refinedev/mantine` wrapper element is `<Card>`s and `wrapperProps` can get every attribute that `<Card>` can get.
 
@@ -506,7 +506,7 @@ render(
 
 > For more information, refer to the [`Card` documentation from Mantine &#8594](https://mantine.dev/core/card/)
 
-### `headerProps`
+### headerProps
 
 If you want to customize the header of the `<Create/>` component, you can use the `headerProps` property.
 
@@ -565,7 +565,7 @@ render(
 
 > For more information, refer to the [`Group` documentation from Mantine &#8594](https://mantine.dev/core/group/)
 
-### `contentProps`
+### contentProps
 
 If you want to customize the content of the `<Create/>` component, you can use the `contentProps` property.
 
@@ -624,7 +624,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Mantine &#8594](https://mantine.dev/core/box/)
 
-### `headerButtons`
+### headerButtons
 
 You can customize the buttons at the header by using the `headerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
@@ -682,7 +682,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can customize the wrapper element of the buttons at the header by using the `headerButtonProps` property.
 
@@ -743,7 +743,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Mantine &#8594](https://mantine.dev/core/group/)
 
-### `footerButtons`
+### footerButtons
 
 By default, the `<Create/>` component has a [`<SaveButton>`][save-button] at the header.
 
@@ -859,7 +859,7 @@ render(
 );
 ```
 
-### `footerButtonProps`
+### footerButtonProps
 
 You can customize the wrapper element of the buttons at the footer by using the `footerButtonProps` property.
 

--- a/documentation/docs/ui-integrations/mantine/components/basic-views/edit/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/basic-views/edit/index.md
@@ -137,7 +137,7 @@ You can swizzle this component with the [**Refine CLI**](/docs/packages/list-of-
 
 ## Properties
 
-### `title`
+### title
 
 `title` allows the addition of titles inside the `<Edit>` component. if you don't pass title props it uses the "Edit" prefix and singular resource name by default. For example, for the "posts" resource, it will be "Edit post".
 
@@ -189,7 +189,7 @@ render(
 );
 ```
 
-### `saveButtonProps`
+### saveButtonProps
 
 `saveButtonProps` can be used to customize the default button of the `<Edit>` component that submits the form:
 
@@ -242,7 +242,7 @@ render(
 
 > For more information, refer to the [`<SaveButton>` documentation &#8594](/docs/ui-integrations/mantine/components/buttons/save-button)
 
-### `canDelete` and `deleteButtonProps`
+### canDelete and deleteButtonProps
 
 `canDelete` allows us to add the delete button inside the `<Edit>` component. If the resource has the `canDelete` property,Refine adds the delete button by default. If you want to customize this button you can use the `deleteButtonProps` property like the code below.
 
@@ -359,7 +359,7 @@ render(
 
 > For more information, refer to the documentations [`<DeleteButton>` &#8594](/docs/ui-integrations/mantine/components/buttons/delete-button) and [`usePermission` &#8594](/docs/authentication/hooks/use-permissions)
 
-### `resource`
+### resource
 
 `<Edit>` component reads the `resource` information from the route by default. If you want to use a custom resource for the `<Edit>` component, you can use the `resource` prop.
 
@@ -415,7 +415,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `recordItemId`
+### recordItemId
 
 The `<Edit>` component reads the `id` information from the route by default. `recordItemId` is used when it cannot read from the URL, such as when it is used on a custom page, modal or drawer.
 
@@ -486,7 +486,7 @@ render(
 );
 ```
 
-### `mutationMode`
+### mutationMode
 
 Determines which mode mutation will have while executing `<DeleteButton>`.
 
@@ -556,7 +556,7 @@ render(
 
 > For more information, refer to the [mutation mode documentation &#8594](/advanced-tutorials/mutation-mode.md)
 
-### `dataProviderName`
+### dataProviderName
 
 If not specified, Refine will use the default data provider. If you have multiple data providers and want to use a different one, you can use the `dataProviderName` property.
 
@@ -588,7 +588,7 @@ export const App: React.FC = () => {
 };
 ```
 
-### `goBack`
+### goBack
 
 To customize the back button or to disable it, you can use the `goBack` property. You can pass `false` or `null` to hide the back button.
 
@@ -639,7 +639,7 @@ render(
 );
 ```
 
-### `isLoading`
+### isLoading
 
 To toggle the loading state of the `<Edit/>` component, you can use the `isLoading` property.
 
@@ -690,7 +690,7 @@ render(
 );
 ```
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default it uses the `Breadcrumb` component from `@refinedev/mantine` package.
 
@@ -755,7 +755,7 @@ render(
 
 > For more information, refer to the [`Breadcrumb` documentation &#8594](/docs/ui-integrations/mantine/components/breadcrumb)
 
-### `wrapperProps`
+### wrapperProps
 
 If you want to customize the wrapper of the `<Edit/>` component, you can use the `wrapperProps` property. For `@refinedev/mantine` wrapper element is `<Card>`s and `wrapperProps` can get every attribute that `<Card>` can get.
 
@@ -816,7 +816,7 @@ render(
 
 > For more information, refer to the [`Card` documentation from Mantine &#8594](https://mantine.dev/core/card/)
 
-### `headerProps`
+### headerProps
 
 If you want to customize the header of the `<Edit/>` component, you can use the `headerProps` property.
 
@@ -877,7 +877,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Mantine &#8594](https://mantine.dev/core/group/)
 
-### `contentProps`
+### contentProps
 
 If you want to customize the content of the `<Edit/>` component, you can use the `contentProps` property.
 
@@ -938,7 +938,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Mantine &#8594](https://mantine.dev/core/box/)
 
-### `headerButtons`
+### headerButtons
 
 By default, the `<Edit/>` component has a [`<ListButton>`][list-button] and a [`<RefreshButton>`][refresh-button] at the header.
 
@@ -1065,7 +1065,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can customize the wrapper element of the buttons at the header by using the `headerButtonProps` property.
 
@@ -1132,7 +1132,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Mantine &#8594](https://mantine.dev/core/group/)
 
-### `footerButtons`
+### footerButtons
 
 By default, the `<Edit/>` component has a [`<SaveButton>`][save-button] and a [`<DeleteButton>`][delete-button] at the footer.
 
@@ -1255,7 +1255,7 @@ render(
 );
 ```
 
-### `footerButtonProps`
+### footerButtonProps
 
 You can customize the wrapper element of the buttons at the footer by using the `footerButtonProps` property.
 
@@ -1320,7 +1320,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Mantine &#8594](https://mantine.dev/core/group/)
 
-### `autoSaveProps`
+### autoSaveProps
 
 You can use the auto save feature of the `<Edit/>` component by using the `autoSaveProps` property.
 

--- a/documentation/docs/ui-integrations/mantine/components/basic-views/list/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/basic-views/list/index.md
@@ -149,7 +149,7 @@ You can swizzle this component with the [**Refine CLI**](/docs/packages/list-of-
 
 ## Properties
 
-### `title`
+### title
 
 `title` allows adding a title for the `<List>` component. If you don't pass title props, it uses plural form of resource name by default.
 
@@ -194,7 +194,7 @@ render(
 );
 ```
 
-### `resource`
+### resource
 
 `<List>` component reads the `resource` information from the route by default. If you want to use a custom resource for the `<List>` component, you can use the `resource` prop.
 
@@ -249,7 +249,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `canCreate` and `createButtonProps`
+### canCreate and createButtonProps
 
 `canCreate` allows us to add the create button inside the `<List>` component. If resource is passed a create component, Refine adds the create button by default. If you want to customize this button you can use `createButtonProps` property like the code below.
 
@@ -352,7 +352,7 @@ render(
 );
 ```
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default it uses the `Breadcrumb` component from `@refinedev/mantine` package.
 
@@ -414,7 +414,7 @@ render(
 
 > For more information, refer to the [`Breadcrumb` documentation &#8594](/docs/ui-integrations/mantine/components/breadcrumb)
 
-### `wrapperProps`
+### wrapperProps
 
 If you want to customize the wrapper of the `<List/>` component, you can use the `wrapperProps` property. For `@refinedev/mantine` wrapper element is `<Card>`s and `wrapperProps` can get every attribute that `<Card>` can get.
 
@@ -468,7 +468,7 @@ render(
 
 > For more information, refer to the [`Card` documentation from Mantine &#8594](https://mantine.dev/core/card/)
 
-### `headerProps`
+### headerProps
 
 If you want to customize the header of the `<List/>` component, you can use the `headerProps` property.
 
@@ -522,7 +522,7 @@ render(
 
 > For more information, refer to the [`Group` documentation from Mantine &#8594](https://mantine.dev/core/group/)
 
-### `contentProps`
+### contentProps
 
 If you want to customize the content of the `<List/>` component, you can use the `contentProps` property.
 
@@ -576,7 +576,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Mantine &#8594](https://mantine.dev/core/box/)
 
-### `headerButtons`
+### headerButtons
 
 By default, the `<List/>` component has a [`<CreateButton>`][create-button] at the header.
 
@@ -688,7 +688,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can customize the wrapper element of the buttons at the header by using the `headerButtonProps` property.
 

--- a/documentation/docs/ui-integrations/mantine/components/basic-views/show/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/basic-views/show/index.md
@@ -110,7 +110,7 @@ You can swizzle this component with the [**Refine CLI**](/docs/packages/list-of-
 
 ## Properties
 
-### `title`
+### title
 
 `title` allows the addition of titles inside the `<Show>` component. if you don't pass title props it uses the "Show" prefix and the singular resource name by default. For example, for the "posts" resource, it would be "Show post".
 
@@ -162,7 +162,7 @@ render(
 );
 ```
 
-### `resource`
+### resource
 
 The `<Show>` component reads the `resource` information from the route by default. TIf you want to use a custom resource for the `<Show>` component, you can use the `resource` prop.
 
@@ -219,7 +219,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `canDelete` and `canEdit`
+### canDelete and canEdit
 
 `canDelete` and `canEdit` allows us to add the delete and edit buttons inside the `<Show>` component. If the resource has `canDelete` or `canEdit` property Refine adds the buttons by default.
 
@@ -335,7 +335,7 @@ render(
 
 > For more information, refer to the [`usePermission` documentation &#8594](/docs/authentication/hooks/use-permissions)
 
-### `recordItemId`
+### recordItemId
 
 The `<Show>` component reads the `id` information from the route by default. `recordItemId` is used when it cannot read from the URL, such as when it's used on a custom page, modal or drawer.
 
@@ -406,7 +406,7 @@ render(
 );
 ```
 
-### `dataProviderName`
+### dataProviderName
 
 If not specified, Refine will use the default data provider. If you have multiple data providers and want to use a different one, you can use the `dataProviderName` property.
 
@@ -437,7 +437,7 @@ export const App: React.FC = () => {
 };
 ```
 
-### `goBack`
+### goBack
 
 To customize the back button or to disable it, you can use the `goBack` property. You can pass `false` or `null` to hide the back button.
 
@@ -488,7 +488,7 @@ render(
 );
 ```
 
-### `isLoading`
+### isLoading
 
 To toggle the loading state of the `<Edit/>` component, you can use the `isLoading` property.
 
@@ -539,7 +539,7 @@ render(
 );
 ```
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default it uses the `Breadcrumb` component from `@refinedev/mantine` package.
 
@@ -608,7 +608,7 @@ render(
 
 > For more information, refer to the [`Breadcrumb` documentation &#8594](/docs/ui-integrations/mantine/components/breadcrumb)
 
-### `wrapperProps`
+### wrapperProps
 
 If you want to customize the wrapper of the `<Show/>` component, you can use the `wrapperProps` property. For `@refinedev/mantine` wrapper element is `<Card>`s and `wrapperProps` can get every attribute that `<Card>` can get.
 
@@ -669,7 +669,7 @@ render(
 
 > For more information, refer to the [`Card` documentation from Mantine &#8594](https://mantine.dev/core/card/)
 
-### `headerProps`
+### headerProps
 
 If you want to customize the header of the `<Show/>` component, you can use the `headerProps` property.
 
@@ -730,7 +730,7 @@ render(
 
 > For more information, refer to the [`Group` documentation from Mantine &#8594](https://mantine.dev/core/group/)
 
-### `contentProps`
+### contentProps
 
 If you want to customize the content of the `<Show/>` component, you can use the `contentProps` property.
 
@@ -791,7 +791,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Mantine &#8594](https://mantine.dev/core/box/)
 
-### `headerButtons`
+### headerButtons
 
 By default, the `<Show/>` component has a [`<ListButton>`][list-button], [`<EditButton>`][edit-button], [`<DeleteButton>`][delete-button], and, [`<RefreshButton>`][refresh-button] at the header.
 
@@ -924,7 +924,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can customize the wrapper element of the buttons at the header by using the `headerButtonProps` property.
 
@@ -991,7 +991,7 @@ render(
 
 [Refer to the `Group` documentation from Mantine for detailed usage. &#8594](https://mantine.dev/core/group/)
 
-### `footerButtons`
+### footerButtons
 
 You can customize the buttons at the footer by using the `footerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
@@ -1051,7 +1051,7 @@ render(
 );
 ```
 
-### `footerButtonProps`
+### footerButtonProps
 
 You can customize the wrapper element of the buttons at the footer by using the `footerButtonProps` property.
 

--- a/documentation/docs/ui-integrations/mantine/components/breadcrumb/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/breadcrumb/index.md
@@ -17,7 +17,7 @@ A breadcrumb displays the current location within a hierarchy. It allows going b
 
 ## Properties
 
-### `breadcrumbProps`
+### breadcrumbProps
 
 The `<Breadcrumb />` component uses the Mantine [Breadcrumb][mantine-breadcrumb] component so it can be configured with the `breadcrumbProps` property.
 
@@ -36,7 +36,7 @@ const PostShow: React.FC = () => {
 };
 ```
 
-### `showHome`
+### showHome
 
 If you have a page with route `/`, it will be used as the root of the hierarchy and shown in the `Breadcrumb` with a home icon. To hide the root item, set `showHome` to `false.`
 
@@ -55,7 +55,7 @@ export const PostList: React.FC = () => {
 };
 ```
 
-### `meta`
+### meta
 
 If your routes has additional parameters in their paths, you can pass the `meta` property to the `<Breadcrumb>` component to use them while creating the paths and filling the parameters in the paths. By default, existing URL parameters are used. You can use `meta` to override them or add new ones.
 
@@ -74,7 +74,7 @@ export const PostList: React.FC = () => {
 };
 ```
 
-### `hideIcons`
+### hideIcons
 
 If you don't want to show the resource icons on the breadcrumb, you can set `hideIcons` to `true`.
 

--- a/documentation/docs/ui-integrations/mantine/components/buttons/clone-button/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/buttons/clone-button/index.md
@@ -168,7 +168,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` is used to append the record id to the end of the route path. By default `id` will be read from the route parameters.
 
@@ -207,7 +207,7 @@ render(
 
 Clicking the button will trigger the `clone` method of [`useNavigation`](/docs/routing/hooks/use-navigation) and then redirect the app to the `clone` action path of the resource, filling the necessary parameters in the route.
 
-### `resource`
+### resource
 
 It is used to redirect the app to the `clone` action of the given resource name. By default, the app redirects to the inferred resource's `clone` action path.
 
@@ -250,7 +250,7 @@ render(
 
 Clicking the button will trigger the `clone` method of [`useNavigation`](/docs/routing/hooks/use-navigation) and then redirect the app to the `clone` action path of the resource, filling the necessary parameters in the route.
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `clone` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `clone` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -266,7 +266,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -304,7 +304,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -316,7 +316,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/mantine/components/buttons/create-button/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/buttons/create-button/index.md
@@ -149,7 +149,7 @@ render(
 
 ## Properties
 
-### `resource`
+### resource
 
 It is used to redirect the app to the `create` action path of the given resource name. By default, the app redirects to the inferred resource's `create` action path.
 
@@ -197,7 +197,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `create` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `create` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -209,7 +209,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -248,7 +248,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -260,7 +260,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/mantine/components/buttons/delete-button/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/buttons/delete-button/index.md
@@ -142,7 +142,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` allows us to manage which record will be deleted. By default, `recordItemId` is read from the route parameters.
 
@@ -195,7 +195,7 @@ render(
 
 Clicking the button will trigger the [`useDelete`](/docs/data/hooks/use-delete) method and then the record whose resource is "post" and whose id is "123" gets deleted.
 
-### `resource`
+### resource
 
 `resource` allows us to manage which resource's record is going to be deleted. By default, `resource` is read from the current route.
 
@@ -256,7 +256,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `onSuccess`
+### onSuccess
 
 `onSuccess` can be used if you want to do anything based on the result returned after the delete request.
 
@@ -317,7 +317,7 @@ render(
 );
 ```
 
-### `mutationMode`
+### mutationMode
 
 Determines which mode mutation will have while executing `<DeleteButton>`.
 
@@ -370,7 +370,7 @@ render(
 );
 ```
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -421,7 +421,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 `accessControl` prop can be used to skip the access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -433,7 +433,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/mantine/components/buttons/edit-button/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/buttons/edit-button/index.md
@@ -160,7 +160,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` is used to append the record id to the end of the route path.
 
@@ -198,7 +198,7 @@ render(
 );
 ```
 
-### `resource`
+### resource
 
 Redirection endpoint is defined by the `resource` property and its `edit` action path. By default, `<EditButton>` uses the inferred resource from the route.
 
@@ -246,7 +246,7 @@ pass the `identifier` instead of the `name` of the resource. It will only be use
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `edit` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `edit` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -258,7 +258,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -296,7 +296,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -308,7 +308,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/mantine/components/buttons/export-button/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/buttons/export-button/index.md
@@ -151,7 +151,7 @@ You can swizzle this component to customize it with the [**Refine CLI**](/docs/p
 
 ## Properties
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 

--- a/documentation/docs/ui-integrations/mantine/components/buttons/import-button/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/buttons/import-button/index.md
@@ -153,7 +153,7 @@ You can swizzle this component to customize it with the [**Refine CLI**](/docs/p
 
 ## Properties
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 

--- a/documentation/docs/ui-integrations/mantine/components/buttons/list-button/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/buttons/list-button/index.md
@@ -106,7 +106,7 @@ The button text is defined automatically by Refine based on resource definition.
 
 ## Properties
 
-### `resource`
+### resource
 
 Redirection endpoint is defined by the `resource`'s `list` action path. By default, `<ListButton>` uses the inferred resource from the route.
 
@@ -172,7 +172,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -209,7 +209,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -221,7 +221,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/mantine/components/buttons/refresh-button/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/buttons/refresh-button/index.md
@@ -104,7 +104,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` allows us to manage which data is going to be refreshed. By default, it will read the record id from the route parameters.
 
@@ -142,7 +142,7 @@ render(
 
 Clicking the button will trigger the [`useInvalidate`][use-invalidate] hook and then fetch the record whose resource is "post" and whose id is "1".
 
-### `resource`
+### resource
 
 `resource` allows us to manage which resource is going to be refreshed. By default, it will read the resource from the current route.
 
@@ -191,7 +191,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -228,7 +228,7 @@ render(
 );
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/mantine/components/buttons/save-button/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/buttons/save-button/index.md
@@ -139,7 +139,7 @@ interface IPost {
 
 ## Properties
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 

--- a/documentation/docs/ui-integrations/mantine/components/buttons/show-button/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/buttons/show-button/index.md
@@ -160,7 +160,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` is used to append the record id to the end of the route path. By default `id` will be read from the route parameters.
 
@@ -199,7 +199,7 @@ render(
 
 Clicking the button will trigger the `show` method of [`useNavigation`](/docs/routing/hooks/use-navigation) and then redirect the app to the `show` action path of the resource, filling the necessary parameters in the route.
 
-### `resource`
+### resource
 
 Redirection endpoint is defined by the `resource`'s `show` action path. By default, `<ShowButton>` uses the inferred resource from the route.
 
@@ -246,7 +246,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `show` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `show` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -296,7 +296,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -308,7 +308,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/mantine/components/inferencer/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/inferencer/index.md
@@ -91,7 +91,7 @@ To learn more about `@refinedev/inferencer` package, please check out its [Docum
 
 ## Views
 
-### `List`
+### List
 
 Generates a sample list view for your resources according to the API response. It uses the `List` component and from `@refinedev/mantine` and the `useTable` hook from `@refinedev/react-table`.
 
@@ -150,7 +150,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-### `Show`
+### Show
 
 Generates a sample show view for your resources according to the API response. It uses the `Show` and field components from `@refinedev/mantine` with the `useShow` hook from `@refinedev/core`.
 
@@ -209,7 +209,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-### `Create`
+### Create
 
 Generates a sample create view for your resources according to the first record in list API response. It uses the `Create` component and the `useForm` hook from `@refinedev/mantine`.
 
@@ -268,7 +268,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-### `Edit`
+### Edit
 
 Generates a sample edit view for your resources according to the API response. It uses the `Edit` component and the `useForm` hook from `@refinedev/mantine`.
 

--- a/documentation/docs/ui-integrations/mantine/components/themed-layout/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/themed-layout/index.md
@@ -117,7 +117,7 @@ Example of above showing how to use `<ThemedLayoutV2>` with [`React Router v6`](
 
 ## Props
 
-### `Sider`
+### Sider
 
 In `<ThemedLayout>`, the sidebar section is rendered using the [`<ThemedSider>`][themed-sider] component by default. This component is specifically designed to generate menu items based on the resources defined in [`<Refine>`][refine-component] components, using the [`useMenu`][use-menu] hook. However, if desired, it's possible to replace the default [`<ThemedSider>`][themed-sider] component by passing a custom component to the `Sider` prop.
 
@@ -183,7 +183,7 @@ const App: React.FC = () => {
 };
 ```
 
-#### `Sider Props`
+#### Sider Props
 
 | Prop                 | Type                                          | Description                                                                     |
 | -------------------- | --------------------------------------------- | ------------------------------------------------------------------------------- |
@@ -201,7 +201,7 @@ type SiderRenderFunction = (props: {
 }) => React.ReactNode;
 ```
 
-### `initialSiderCollapsed`
+### initialSiderCollapsed
 
 This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][themed-sider] component.
 
@@ -217,7 +217,7 @@ This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][
 </ThemedLayoutV2>
 ```
 
-### `Header`
+### Header
 
 In `<ThemedLayoutV2>`, the header section is rendered using the [`<ThemedHeaderV2>`][themed-header] component by default. It uses the [`useGetIdentity`](/docs/authentication/hooks/use-get-identity) hook to display the user's name and avatar on the right side of the header. However, if desired, it's possible to replace the default [`<ThemedHeaderV2>`][themed-header] component by passing a custom component to the `Header` prop.
 
@@ -273,7 +273,7 @@ const App: React.FC = () => {
 };
 ```
 
-### `Title`
+### Title
 
 In `<ThemedLayoutV2>`, the title section is rendered using the [`<ThemedTitleV2V2>`][themed-title] component by default. However, if desired, it's possible to replace the default [`<ThemedTitleV2V2>`][themed-title] component by passing a custom component to the `Title` prop.
 
@@ -311,7 +311,7 @@ const App: React.FC = () => {
 };
 ```
 
-### `Footer`
+### Footer
 
 The footer section of the layout is displayed at the bottom of the page. Refine doesn't provide a default footer component. However, you can pass a custom component to the `Footer` prop to display a footer section.
 
@@ -421,7 +421,7 @@ const App: React.FC = () => {
 };
 ```
 
-### `OffLayoutArea`
+### OffLayoutArea
 
 Off-layout area component is rendered outside of the main layout component, allowing it to be placed anywhere on the page while still being part of the overall layout .Refine doesn't provide a default off-layout area component. However, you can pass a custom component to the `OffLayoutArea` prop to display a custom off-layout area.
 

--- a/documentation/docs/ui-integrations/mantine/hooks/use-drawer-form/index.md
+++ b/documentation/docs/ui-integrations/mantine/hooks/use-drawer-form/index.md
@@ -424,7 +424,7 @@ Don't forget to pass the record `"id"` to `show` to fetch the record data. This 
 
 ## Properties
 
-### `refineCoreProps`
+### refineCoreProps
 
 All [`useForm`](/docs/ui-integrations/ant-design/hooks/use-form) properties are also available in `useStepsForm`. You can find descriptions on the [`useForm`](/docs/ui-integrations/ant-design/hooks/use-form#properties) documentation.
 
@@ -438,7 +438,7 @@ const drawerForm = useDrawerForm({
 });
 ```
 
-### `initialValues`
+### initialValues
 
 Default values for the form. Use this to pre-populate the form with data that needs to be displayed. This property is only available in `"create"` action.
 
@@ -450,7 +450,7 @@ const drawerForm = useDrawerForm({
 });
 ```
 
-### `defaultVisible`
+### defaultVisible
 
 When `true`, drawer will be visible by default. It is `false` by default.
 
@@ -462,7 +462,7 @@ const drawerForm = useDrawerForm({
 });
 ```
 
-### `autoSubmitClose`
+### autoSubmitClose
 
 When `true`, drawer will be closed after successful submit. It is `true` by default.
 
@@ -474,7 +474,7 @@ const drawerForm = useDrawerForm({
 });
 ```
 
-### `autoResetForm`
+### autoResetForm
 
 When `true`, form will be reset after successful submit. It is `true` by default.
 
@@ -486,7 +486,7 @@ const drawerForm = useDrawerForm({
 });
 ```
 
-### `syncWithLocation`
+### syncWithLocation
 
 When `true`, the drawers visibility state and the `id` of the record will be synced with the URL. It is `false` by default.
 
@@ -498,7 +498,7 @@ const drawerForm = useDrawerForm({
 });
 ```
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds while `onInterval` is the function that will be called on each interval. `elapsedTime` is the elapsed time in milliseconds.
@@ -524,7 +524,7 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### `autoSave`
+### autoSave
 
 If you want to save the form automatically after some delay when user edits the form, you can pass true to `autoSave.enabled` prop.
 
@@ -536,7 +536,7 @@ It also supports `onMutationSuccess` and `onMutationError` callback functions. Y
 
 `onMutationSuccess` and `onMutationError` callbacks will be called after the mutation is successful or failed.
 
-#### `enabled`
+#### enabled
 
 To enable the `autoSave` feature, set the `enabled` parameter to `true`. Default value is `false`.
 
@@ -550,7 +550,7 @@ useDrawerForm({
 });
 ```
 
-#### `debounce`
+#### debounce
 
 Set the debounce time for the `autoSave` prop. Default value is `1000` milliseconds.
 
@@ -566,7 +566,7 @@ useDrawerForm({
 });
 ```
 
-#### `invalidateOnUnmount`
+#### invalidateOnUnmount
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when the hook is unmounted. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate. Default value is `false`.
 
@@ -582,7 +582,7 @@ useDrawerForm({
 });
 ```
 
-#### `invalidateOnClose`
+#### invalidateOnClose
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when the drawer is closed. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate. Default value is `false`.
 
@@ -604,7 +604,7 @@ All [`useForm`][use-form-refine-mantine] return values are also available in `us
 
 All [`mantine useForm`](https://mantine.dev/form/use-form/) return values also available in `useDrawerForm`. You can find descriptions on [`mantine`](https://mantine.dev/form/use-form/) docs.
 
-### `visible`
+### visible
 
 Current visibility state of the drawer.
 
@@ -616,7 +616,7 @@ const drawerForm = useDrawerForm({
 console.log(drawerForm.modal.visible); // true
 ```
 
-### `title`
+### title
 
 Title of the drawer. Based on resource and action values
 
@@ -633,7 +633,7 @@ const {
 console.log(title); // "Create Post"
 ```
 
-### `close`
+### close
 
 `close` is a function that can close the drawer. It's useful when you want to close the drawer manually.
 
@@ -654,7 +654,7 @@ return (
 );
 ```
 
-### `submit`
+### submit
 
 `submit` is a function that can submit the form. It's useful when you want to submit the form manually.
 
@@ -675,7 +675,7 @@ return (
 );
 ```
 
-### `show`
+### show
 
 `shows` is a function that can show the drawer.
 
@@ -703,7 +703,7 @@ return (
 );
 ```
 
-### `saveButtonProps`
+### saveButtonProps
 
 `saveButtonProps` contains all the props needed by the "submit" button within the drawer (disabled,loading etc.). You can manually pass these props to your custom button.
 
@@ -726,7 +726,7 @@ return (
 );
 ```
 
-### `overtime`
+### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 
@@ -736,7 +736,7 @@ const { overtime } = useDrawerForm();
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
 
-### `autoSaveProps`
+### autoSaveProps
 
 If `autoSave` is enabled, this hook returns `autoSaveProps` object with `data`, `error`, and `status` properties from mutation.
 

--- a/documentation/docs/ui-integrations/mantine/hooks/use-form/index.md
+++ b/documentation/docs/ui-integrations/mantine/hooks/use-form/index.md
@@ -233,7 +233,7 @@ If you want to show a form in a modal or drawer where necessary route params mig
 
 ## Properties
 
-### `action`
+### action
 
 `useForm` can handle the `edit`, `create` and `clone` actions.
 
@@ -441,7 +441,7 @@ render(<RefineMantineDemo />);
 
 </Tabs>
 
-### `resource`
+### resource
 
 `resource`, read from the current URL by default, will be passed to the [`dataProvider`][data-provider]'s method as a params. This parameter is usually used to as a API endpoint path. It all depends on how to handle the `resource` in your [`dataProvider`][data-provider].
 
@@ -495,7 +495,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `id`
+### id
 
 `id` is used for determining the record to `edit` or `clone`. By default, it uses the `id` from the route. It can be changed with the `setId` function or `id` property.
 
@@ -513,7 +513,7 @@ useForm({
 });
 ```
 
-### `redirect`
+### redirect
 
 `redirect` is used for determining the page to redirect after the form is submitted. By default, it uses the `list`. It can be changed with the `redirect` property.
 
@@ -527,7 +527,7 @@ useForm({
 });
 ```
 
-### `onMutationSuccess`
+### onMutationSuccess
 
 `onMutationSuccess` is a callback function that will be called after the mutation is successful.
 
@@ -548,7 +548,7 @@ useForm({
 });
 ```
 
-### `onMutationError`
+### onMutationError
 
 `onMutationError` is a callback function that will be called after the mutation is failed.
 
@@ -569,7 +569,7 @@ useForm({
 });
 ```
 
-### `invalidates`
+### invalidates
 
 You can use it to manage the invalidations that will occur at the end of the mutation.
 
@@ -586,7 +586,7 @@ useForm({
 });
 ```
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you should use pass the name of the `dataProvider` you want to use to `dataProviderName`.
 
@@ -602,7 +602,7 @@ useForm({
 });
 ```
 
-### `mutationMode`
+### mutationMode
 
 Mutation mode determines which mode the mutation runs with. Mutations can run under three different modes: `pessimistic`, `optimistic` and `undoable`. Default mode is `pessimistic`.
 Each mode corresponds to a different type of user experience.
@@ -617,7 +617,7 @@ useForm({
 });
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -637,7 +637,7 @@ useForm({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -667,7 +667,7 @@ useForm({
 }
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -707,7 +707,7 @@ const myDataProvider = {
 };
 ```
 
-### `queryMeta`
+### queryMeta
 
 In addition to the [`meta`](#meta) property, you can also pass the `queryMeta` property to the `useForm` hook. This property is used to pass additional information to the `useOne` hook that is used to fetch the data in the `edit` and `clone` modes. This is useful when you have to apply different values to the `useOne` hook from the `useCreate` or `useUpdate` hook mutations.
 
@@ -721,7 +721,7 @@ useForm({
 
 If you have overlapping properties in both `meta` and `queryMeta`, the `queryMeta` property will be used.
 
-### `mutationMeta`
+### mutationMeta
 
 In addition to the [`meta`](#meta) property, you can also pass the `mutationMeta` property to the `useForm` hook. This property is used to pass additional information to the `useCreate` or `useUpdate` hook mutations. This is useful when you have to apply different values to the `useCreate` or `useUpdate` hooks from the `useOne` hook query.
 
@@ -735,7 +735,7 @@ useForm({
 
 If you have overlapping properties in both `meta` and `mutationMeta`, the `mutationMeta` property will be used.
 
-### `queryOptions`
+### queryOptions
 
 Works only in the `action: "edit"` or `action: "clone"` modes.
 
@@ -751,7 +751,7 @@ useForm({
 });
 ```
 
-### `createMutationOptions`
+### createMutationOptions
 
 In `create` or `clone` modes, Refine uses [`useCreate`](/docs/data/hooks/use-create) hook to create data. You can pass the [`mutationOptions`](https://tanstack.com/query/v4/docs/react/reference/useMutation) by passing `createMutationOptions` property. This option is only available when `action: "create"` or `action: "clone"`.
 
@@ -765,7 +765,7 @@ useForm({
 });
 ```
 
-### `updateMutationOptions`
+### updateMutationOptions
 
 In `edit` mode, Refine uses [`useUpdate`](/docs/data/hooks/use-update) hook to update data. You can pass [`mutationOptions`](https://tanstack.com/query/v4/docs/react/reference/useMutation) by passing `updateMutationOptions` property. This option is only available when `action: "edit"`.
 
@@ -779,7 +779,7 @@ useForm({
 });
 ```
 
-### `warnWhenUnsavedChanges`
+### warnWhenUnsavedChanges
 
 When it's true, Shows a warning when the user tries to leave the page with unsaved changes. It can be used to prevent the user from accidentally leaving the page. It is `false` by default.
 
@@ -793,7 +793,7 @@ useForm({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 Whether to update data automatically ("auto") or not ("manual") if a related live event is received. It can be used to update and show data in Realtime throughout your app.
 
@@ -807,7 +807,7 @@ useForm({
 });
 ```
 
-### `onLiveEvent`
+### onLiveEvent
 
 `onLiveEvent` is a callback function that is executed when new events from a subscription are arrived.
 
@@ -821,11 +821,11 @@ useForm({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 `liveParams` are the params to pass to [liveProvider's](/docs/realtime/live-provider#subscribe) subscribe method.
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -851,7 +851,7 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### `autoSave`
+### autoSave
 
 If you want to save the form automatically after some delay when user edits the form, you can pass true to `autoSave.enabled` prop.
 
@@ -863,7 +863,7 @@ It also supports the [`onMutationSuccess`](#onmutationsuccess) and [`onMutationE
 
 `onMutationSuccess` and `onMutationError` callbacks will be called after the mutation is successful or failed.
 
-#### `enabled`
+#### enabled
 
 To enable the `autoSave` feature, set the `enabled` parameter to `true`. Default value is `false`.
 
@@ -877,7 +877,7 @@ useForm({
 });
 ```
 
-#### `debounce`
+#### debounce
 
 `debounce` allows you to set the debounce time for the `autoSave` prop. Default value is `1000` milliseconds.
 
@@ -893,7 +893,7 @@ useForm({
 });
 ```
 
-#### `invalidateOnUnmount`
+#### invalidateOnUnmount
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when the hook is unmounted. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate. Default value is `false`.
 
@@ -913,7 +913,7 @@ useForm({
 
 All [`mantine useForm`][use-form-mantine] and [`core useForm`][use-form-core] return values also available in `useForm`.
 
-### `queryResult`
+### queryResult
 
 If the `action` is set to `"edit"` or `"clone"` or if a `resource` with an `id` is provided, `useForm` will call [`useOne`](/docs/data/hooks/use-one) and set the returned values as the `queryResult` property.
 
@@ -925,7 +925,7 @@ const {
 const { data } = queryResult;
 ```
 
-### `mutationResult`
+### mutationResult
 
 When in `"create"` or `"clone"` mode, `useForm` will call [`useCreate`](/docs/data/hooks/use-create). When in `"edit"` mode, it will call [`useUpdate`](/docs/data/hooks/use-update) and set the resulting values as the `mutationResult` property."
 
@@ -937,7 +937,7 @@ const {
 const { data } = mutationResult;
 ```
 
-### `setId`
+### setId
 
 `useForm` determine `id` from the router. If you want to change the `id` dynamically, you can use `setId` function.
 
@@ -957,7 +957,7 @@ return (
 );
 ```
 
-### `redirect`
+### redirect
 
 "By default, after a successful mutation, `useForm` will `redirect` to the `"list"` page. To redirect to a different page, you can either use the `redirect` function to programmatically specify the destination, or set the redirect [property](/docs/data/hooks/use-form/#redirect) in the hook's options.
 
@@ -979,14 +979,14 @@ const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
 // --
 ```
 
-### `onFinish`
+### onFinish
 
 `onFinish` is a function that is called when the form is submitted. It will call the appropriate mutation based on the `action` property.
 You can override the default behavior by passing an `onFinish` function in the hook's options.
 
 For example you can [change values before sending to the API](/docs/ui-integrations/mantine/hooks/use-form#how-can-i-change-the-form-data-before-submitting-it-to-the-api).
 
-### `overtime`
+### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 
@@ -996,7 +996,7 @@ const { overtime } = useForm();
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
 
-### `autoSaveProps`
+### autoSaveProps
 
 If `autoSave` is enabled, this hook returns `autoSaveProps` object with `data`, `error`, and `status` properties from mutation.
 

--- a/documentation/docs/ui-integrations/mantine/hooks/use-modal-form/index.md
+++ b/documentation/docs/ui-integrations/mantine/hooks/use-modal-form/index.md
@@ -630,7 +630,7 @@ Don't forget to pass the record `"id"` to `show` to fetch the record data. This 
 
 ## Properties
 
-### `refineCoreProps`
+### refineCoreProps
 
 All [`useForm`](/docs/ui-integrations/ant-design/hooks/use-form) properties are also available in `useStepsForm`. You can find descriptions on [`useForm`](/docs/ui-integrations/ant-design/hooks/use-form#properties) documentation.
 
@@ -644,7 +644,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `initialValues`
+### initialValues
 
 Default values for the form. Use this to pre-populate the form with data that needs to be displayed. This property is only available for `"create"` action.
 
@@ -656,7 +656,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `defaultVisible`
+### defaultVisible
 
 When `true`, modal will be visible by default. It is `false` by default.
 
@@ -668,7 +668,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `autoSubmitClose`
+### autoSubmitClose
 
 When `true`, modal will be closed after successful submit. It is `true` by default.
 
@@ -680,7 +680,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `autoResetForm`
+### autoResetForm
 
 When `true`, form will be reset after successful submit. It is `true` by default.
 
@@ -692,7 +692,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `syncWithLocation`
+### syncWithLocation
 
 When `true`, the modals visibility state and the `id` of the record will be synced with the URL. It is `false` by default.
 
@@ -704,7 +704,7 @@ const modalForm = useModalForm({
 });
 ```
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds. `onInterval` is the function that will be called on each interval.
@@ -730,7 +730,7 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### `autoSave`
+### autoSave
 
 If you want to save the form automatically after some delay when user edits the form, you can pass true to `autoSave.enabled` prop.
 
@@ -742,7 +742,7 @@ It also supports `onMutationSuccess` and `onMutationError` callback functions. Y
 
 `onMutationSuccess` and `onMutationError` callbacks will be called after the mutation is successful or failed.
 
-#### `enabled`
+#### enabled
 
 To enable the `autoSave` feature, set the `enabled` parameter to `true`. Default value is `false`.
 
@@ -756,7 +756,7 @@ useModalForm({
 });
 ```
 
-#### `debounce`
+#### debounce
 
 Set the debounce time for the `autoSave` prop. Default value is `1000` milliseconds.
 
@@ -772,7 +772,7 @@ useModalForm({
 });
 ```
 
-#### `invalidateOnUnmount`
+#### invalidateOnUnmount
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when the hook is unmounted. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate. Default value is `false`.
 
@@ -788,7 +788,7 @@ useModalForm({
 });
 ```
 
-#### `invalidateOnClose`
+#### invalidateOnClose
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when the modal is closed. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate. Default value is `false`.
 
@@ -810,7 +810,7 @@ All [`useForm`][use-form-refine-mantine] return values also available in `useMod
 
 All [`mantine useForm`](https://mantine.dev/form/use-form/) return values also available in `useModalForm`. You can find descriptions on [`mantine`](https://mantine.dev/form/use-form/) docs.
 
-### `visible`
+### visible
 
 Current visibility state of the modal.
 
@@ -822,7 +822,7 @@ const modalForm = useModalForm({
 console.log(modalForm.modal.visible); // true
 ```
 
-### `title`
+### title
 
 Title of the modal. Based on resource and action values
 
@@ -839,7 +839,7 @@ const {
 console.log(title); // "Create Post"
 ```
 
-### `close`
+### close
 
 A function that can close the modal. It's useful when you want to close the modal manually.
 
@@ -860,7 +860,7 @@ return (
 );
 ```
 
-### `submit`
+### submit
 
 `submit` is a function that can submit the form. It's useful when you want to submit the form manually.
 
@@ -881,7 +881,7 @@ return (
 );
 ```
 
-### `show`
+### show
 
 `show` is a function that can show the modal.
 
@@ -909,7 +909,7 @@ return (
 );
 ```
 
-### `saveButtonProps`
+### saveButtonProps
 
 `saveButtonProps` contains all the props needed by the "submit" button within the modal (disabled,loading etc.). You can manually pass these props to your custom button.
 
@@ -932,7 +932,7 @@ return (
 );
 ```
 
-### `overtime`
+### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 
@@ -942,7 +942,7 @@ const { overtime } = useModalForm();
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
 
-### `autoSaveProps`
+### autoSaveProps
 
 If `autoSave` is enabled, this hook returns `autoSaveProps` object with `data`, `error`, and `status` properties from mutation.
 

--- a/documentation/docs/ui-integrations/mantine/hooks/use-select/index.md
+++ b/documentation/docs/ui-integrations/mantine/hooks/use-select/index.md
@@ -28,7 +28,7 @@ It is useful when you want to subscribe to the live updates.
 
 ## Properties
 
-### `resource` <PropTag required />
+### resource <PropTag required />
 
 It will be passed to the `getList` method from the `dataProvider` as parameter via the `useList` hook. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `getList` method. See the [creating a data provider](/docs/data/data-provider#creating-a-data-provider) section for an example of how resources are handled.
 
@@ -42,7 +42,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `optionLabel` and `optionValue`
+### optionLabel and `optionValue`
 
 Allows you to change the `value` and `label` of your options.
 Default values are `optionLabel = "title"` and `optionValue = "id"`
@@ -65,7 +65,7 @@ const { options } = useSelect({
 });
 ```
 
-### `sorters`
+### sorters
 
 It allows to show the options in the desired order. `sorters` will be passed to the `getList` method from the `dataProvider` as parameter via the `useList` hook. It is used to send sort query parameters to the API.
 
@@ -84,7 +84,7 @@ useSelect({
 
 <SortLivePreview />
 
-### `filters`
+### filters
 
 It is used to show options by filtering them. `filters` will be passed to the `getList` method from the `dataProvider` as parameter via the `useList` hook. It is used to send filter query parameters to the API.
 
@@ -102,7 +102,7 @@ useSelect({
 });
 ```
 
-### `defaultValue`
+### defaultValue
 
 `defaultValue` allows you to make options selected by default and adds extra options to `<select>` component. In some cases, like if there are too many entries for the `<select>` and pagination is required, `defaultValue` may not be present in the current visible options and this can break the `<select>` component. To avoid such cases, A separate `useMany` query is sent to the backend with the `defaultValue` and appended to the options of `<select>`, ensuring the default values exist in the current options array. Since it uses `useMany` to query the necessary data, the `defaultValue` can be a single value or an array of values like the following:
 
@@ -114,7 +114,7 @@ useSelect({
 
 > For more information, refer to the [`useMany` documentation &#8594](/docs/data/hooks/use-many)
 
-### `debounce`
+### debounce
 
 `debounce` allows us to `debounce` the `onSearch` function.
 
@@ -124,7 +124,7 @@ useSelect({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 `queryOptions` is used to pass additional options to the `useQuery` hook. It is useful when you want to pass additional options to the `useQuery` hook.
 
@@ -138,11 +138,11 @@ useSelect({
 });
 ```
 
-### `pagination`
+### pagination
 
 `pagination` will be passed to the `getList` method from the `dataProvider` as parameter. It is used to send pagination query parameters to the API.
 
-#### `current`
+#### current
 
 You can pass the `current` page number to the `pagination` property.
 
@@ -154,7 +154,7 @@ useSelect({
 });
 ```
 
-#### `pageSize`
+#### pageSize
 
 You can pass the `pageSize` to the `pagination` property.
 
@@ -166,7 +166,7 @@ useSelect({
 });
 ```
 
-#### `mode`
+#### mode
 
 It can be `"off"`, `"client"` or `"server"`. It is used to determine whether to use server-side pagination or not.
 
@@ -178,7 +178,7 @@ useSelect({
 });
 ```
 
-### `defaultValueQueryOptions`
+### defaultValueQueryOptions
 
 When the `defaultValue` property is given, the `useMany` data hook is called for the selected records. With this property, you can change the options of this query. If not given, the values given in `queryOptions` will be used.
 
@@ -192,7 +192,7 @@ const { options } = useSelect({
 });
 ```
 
-### `onSearch`
+### onSearch
 
 `onSearch` allows us to `AutoComplete` the `options`.
 
@@ -224,7 +224,7 @@ const [searchValue, onSearchChange] = useState("");
 />;
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -269,7 +269,7 @@ const myDataProvider = {
 };
 ```
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you can specify which one to use by passing the `dataProviderName` prop. It is useful when you have a different data provider for different resources.
 
@@ -279,7 +279,7 @@ useSelect({
 });
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -297,7 +297,7 @@ useSelect({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -315,7 +315,7 @@ useSelect({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -327,7 +327,7 @@ useSelect({
 });
 ```
 
-### `onLiveEvent`
+### onLiveEvent
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -341,13 +341,13 @@ useSelect({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
 Params to pass to liveProvider's [subscribe](/docs/realtime/live-provider#subscribe) method.
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds while `onInterval` is the function that will be called on each interval.
@@ -373,11 +373,11 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### ~~`sort`~~ <PropTag deprecated />
+### ~~sort~~ <PropTag deprecated />
 
 Use `sorters` instead.
 
-### ~~`hasPagination`~~ <PropTag deprecated />
+### ~~hasPagination~~ <PropTag deprecated />
 
 Use `pagination.mode` instead.
 

--- a/documentation/docs/ui-integrations/mantine/hooks/use-steps-form/index.md
+++ b/documentation/docs/ui-integrations/mantine/hooks/use-steps-form/index.md
@@ -735,7 +735,7 @@ const PostCreatePage: React.FC = () => {
 
 ## Properties
 
-### `refineCoreProps`
+### refineCoreProps
 
 All [`useForm`](/docs/ui-integrations/ant-design/hooks/use-form) properties also available in `useStepsForm`. You can find descriptions on [`useForm`](/docs/ui-integrations/ant-design/hooks/use-form#properties) docs.
 
@@ -749,9 +749,9 @@ const stepsForm = useStepsForm({
 });
 ```
 
-### `stepsProps`
+### stepsProps
 
-#### `defaultStep`
+#### defaultStep
 
 Sets the default starting step number. Counting starts from `0`.
 
@@ -763,7 +763,7 @@ const stepsForm = useStepsForm({
 });
 ```
 
-#### `isBackValidate`
+#### isBackValidate
 
 When is `true`, validates a form fields when the user navigates to a previous step. It is `false` by default.
 
@@ -775,7 +775,7 @@ const stepsForm = useStepsForm({
 });
 ```
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 
@@ -802,7 +802,7 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### `autoSave`
+### autoSave
 
 If you want to save the form automatically after some delay when user edits the form, you can pass true to `autoSave.enabled` prop.
 
@@ -814,7 +814,7 @@ It also supports `onMutationSuccess` and `onMutationError` callback functions. Y
 
 `onMutationSuccess` and `onMutationError` callbacks will be called after the mutation is successful or failed.
 
-#### `enabled`
+#### enabled
 
 To enable the `autoSave` feature, set the `enabled` parameter to `true`. Default is `false`.
 
@@ -828,7 +828,7 @@ useStepsForm({
 });
 ```
 
-#### `debounce`
+#### debounce
 
 `debounce` sets the debounce time for the `autoSave` prop. Default is `1000` milliseconds.
 
@@ -844,7 +844,7 @@ useStepsForm({
 });
 ```
 
-#### `invalidateOnUnmount`
+#### invalidateOnUnmount
 
 This prop is useful when you want to invalidate the `list`, `many` and `detail` queries from the current resource when the hook is unmounted. By default, it invalidates the `list`, `many` and `detail` queries associated with the current resource. Also, You can use the `invalidates` prop to select which queries to invalidate. Default is `false`.
 
@@ -864,20 +864,20 @@ useStepsForm({
 
 All [`useForm`](/docs/ui-integrations/mantine/hooks/use-form) return values also available in `useStepsForm`. You can find descriptions on [`useForm`](/docs/ui-integrations/mantine/hooks/use-form#return-values) docs.
 
-### `steps`
+### steps
 
 The props needed by the `<Stepper>` component.
 
-#### `currentStep`
+#### currentStep
 
 Current step, counting from `0`.
 
-#### `gotoStep`
+#### gotoStep
 
 Is a function that allows you to programmatically change the current step of a form.
 It takes in one argument, step, which is a number representing the index of the step you want to navigate to.
 
-### `overtime`
+### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 
@@ -887,7 +887,7 @@ const { overtime } = useStepsForm();
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
 
-### `autoSaveProps`
+### autoSaveProps
 
 If `autoSave` is enabled, this hook returns `autoSaveProps` object with `data`, `error`, and `status` properties from mutation.
 

--- a/documentation/docs/ui-integrations/material-ui/components/auth-page/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/auth-page/index.md
@@ -594,7 +594,7 @@ const authProvider: AuthBindings = {
 
 ## Props
 
-### `hideForm`
+### hideForm
 
 When you set `hideForm` to `true`, the form will be hidden. You can use this property to show only providers.
 
@@ -621,7 +621,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `providers`
+### providers
 
 `providers` property defines the list of providers used to handle login authentication. `providers` accepts an array of `Provider` type. Check out the [Interface](#interface) section for more information. This property is only available for types `login` and `register`.
 
@@ -646,7 +646,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `rememberMe`
+### rememberMe
 
 `rememberMe` property defines to render your own remember me component or you can pass `false` to don't render it. This property is only available for type `login`.
 
@@ -672,7 +672,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `loginLink`
+### loginLink
 
 `loginLink` property defines the link to the login page and also you can give a node to render. The default value is `"/login"`. This property is only available for types `register` and `forgotPassword`.
 
@@ -697,7 +697,7 @@ const MyRegisterPage = () => {
 };
 ```
 
-### `registerLink`
+### registerLink
 
 `registerLink` property defines the link to the registration page and also you can give a node to render. The default value is `"/register"`. This property is only available for type `login`.
 
@@ -723,7 +723,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `forgotPasswordLink`
+### forgotPasswordLink
 
 `forgotPasswordLink` property defines the link to the forgot password page and also you can give a node for it to render. The default value is `"/forgot-password"`. This property is only available for type `login`.
 
@@ -749,7 +749,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `wrapperProps`
+### wrapperProps
 
 `wrapperProps` uses for passing props to the wrapper component. In the example below you can see that the background color is changed with `wrapperProps`
 
@@ -769,7 +769,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `contentProps`
+### contentProps
 
 `contentProps` uses for passing props to the content component which is the card component. In the example below you can see that the title, header, and content styles are changed with `contentProps`.
 
@@ -794,7 +794,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `formProps`
+### formProps
 
 `formProps` uses for passing props to the form component. In the example below you can see that the `initialValues` are changed with `formProps` and also the `onSubmit` function is changed.
 
@@ -817,7 +817,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `title`
+### title
 
 By default, `AuthPage` uses text with icon on top of page. You can use this property to change the default title.
 
@@ -845,7 +845,7 @@ const MyLoginPage = () => {
 };
 ```
 
-### `renderContent`
+### renderContent
 
 `renderContent` uses to render the form content and [title](#title). You can use this property to render your own content or `renderContent` gives you default content and title you can use to add some extra elements to the content.
 

--- a/documentation/docs/ui-integrations/material-ui/components/basic-views/create/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/basic-views/create/index.md
@@ -115,7 +115,7 @@ You can swizzle this component with the [**Refine CLI**](/docs/packages/list-of-
 
 ## Properties
 
-### `title`
+### title
 
 `title` allows the addition of titles inside the `<Create>` component. If you don't pass title props it uses "Create" prefix and singular resource name by default. For example, for the `/posts/create` resource, it would be "Create post".
 
@@ -155,7 +155,7 @@ render(
 );
 ```
 
-### `resource`
+### resource
 
 The `<Create>` component reads the `resource` information from the route by default. If you want to use a custom resource for the `<Create>` component, you can use the `resource` prop.
 
@@ -212,7 +212,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `saveButtonProps`
+### saveButtonProps
 
 The `<Create>` component has a default button that submits the form. If you want to customize this button you can use the `saveButtonProps` property like the code below:
 
@@ -251,7 +251,7 @@ render(
 
 > For more information, refer to the [`<SaveButton>` documentation &#8594](/docs/ui-integrations/material-ui/components/buttons/save-button)
 
-### `goBack`
+### goBack
 
 To customize the back button or to disable it, you can use the `goBack` property.
 
@@ -317,7 +317,7 @@ render(
 );
 ```
 
-### `isLoading`
+### isLoading
 
 To toggle the loading state of the `<Create/>` component, you can use the `isLoading` property.
 
@@ -358,7 +358,7 @@ render(
 );
 ```
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default it uses the `Breadcrumb` component from `@refinedev/mui` package.
 
@@ -409,7 +409,7 @@ render(
 
 > For more information, refer to the [`Breadcrumb` documentation &#8594](/docs/ui-integrations/material-ui/components/breadcrumb)
 
-### `wrapperProps`
+### wrapperProps
 
 If you want to customize the wrapper of the `<Create/>` component, you can use the `wrapperProps` property.
 
@@ -457,7 +457,7 @@ render(
 
 > For more information, refer to the [`Card` documentation from Material UI &#8594](https://mui.com/material-ui/api/card/)
 
-### `headerProps`
+### headerProps
 
 If you want to customize the header of the `<Create/>` component, you can use the `headerProps` property.
 
@@ -505,7 +505,7 @@ render(
 
 > For more information, refer to the [`CardHeader` documentation from Material UI &#8594](https://mui.com/material-ui/api/card-header/)
 
-### `contentProps`
+### contentProps
 
 If you want to customize the content of the `<Create/>` component, you can use the `contentProps` property.
 
@@ -553,7 +553,7 @@ render(
 
 > For more information, refer to the [`CardContent` documentation from Material UI &#8594](https://mui.com/material-ui/api/card-content/)
 
-### `headerButtons`
+### headerButtons
 
 You can customize the buttons at the header by using the `headerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
@@ -601,7 +601,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can customize the wrapper element of the buttons at the header by using the `headerButtonProps` property.
 
@@ -656,7 +656,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Material UI &#8594](https://mui.com/material-ui/api/box/)
 
-### `footerButtons`
+### footerButtons
 
 By default, the `<Create/>` component has a [`<SaveButton>`][save-button] at the header.
 
@@ -754,7 +754,7 @@ render(
 );
 ```
 
-### `footerButtonProps`
+### footerButtonProps
 
 You can customize the wrapper element of the buttons at the footer by using the `footerButtonProps` property.
 

--- a/documentation/docs/ui-integrations/material-ui/components/basic-views/edit/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/basic-views/edit/index.md
@@ -119,7 +119,7 @@ You can swizzle this component with the [**Refine CLI**](/docs/packages/list-of-
 
 ## Properties
 
-### `title`
+### title
 
 `title` allows the addition of titles inside the `<Edit>` component. If you don't pass title props it uses "Edit" prefix and singular resource name by default. For example, for the `/posts/edit` resource, it will be "Edit post".
 
@@ -159,7 +159,7 @@ render(
 );
 ```
 
-### `resource`
+### resource
 
 The `<Edit>` component reads the `resource` information from the route by default. If you want to use a custom resource for the `<Edit>` component, you can use the `resource` prop.
 
@@ -217,7 +217,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `saveButtonProps`
+### saveButtonProps
 
 The `<Edit>` component has a save button that submits the form by default. If you want to customize this button you can use the `saveButtonProps` property like the code below:
 
@@ -256,7 +256,7 @@ render(
 
 > For more information, refer to the [`<SaveButton>` documentation &#8594](/docs/ui-integrations/material-ui/components/buttons/save-button)
 
-### `canDelete` and `deleteButtonProps`
+### canDelete and deleteButtonProps
 
 `canDelete` allows us to add the delete button inside the `<Edit>` component. If the resource has the `canDelete` property, Refine adds the delete button by default. If you want to customize this button you can use the `deleteButtonProps` property like the code below.
 
@@ -359,7 +359,7 @@ render(
 
 > For more information, refer to the [`<DeleteButton>` &#8594](/docs/ui-integrations/material-ui/components/buttons/delete-button) and [`usePermission` &#8594](/docs/authentication/hooks/use-permissions) documentations
 
-### `recordItemId`
+### recordItemId
 
 The `<Edit>` component reads the `id` information from the route by default. `recordItemId` is used when it cannot read from the URL, like when its used on a custom page, modal or drawer.
 
@@ -411,7 +411,7 @@ render(
 
 The `<Edit>` component needs the `id` information for the [`<RefreshButton>`](/docs/ui-integrations/material-ui/components/buttons/refresh-button) to work properly.
 
-### `mutationMode`
+### mutationMode
 
 Determines which mode mutation will have while executing [`<DeleteButton>`](/docs/ui-integrations/material-ui/components/buttons/delete-button).
 
@@ -527,7 +527,7 @@ render(
 
 > For more information, refer to the [mutation mode documentation &#8594](/advanced-tutorials/mutation-mode.md)
 
-### `dataProviderName`
+### dataProviderName
 
 If not specified, Refine will use the default data provider. If you have multiple data providers and want to use a different one, you can use the `dataProviderName` property.
 
@@ -559,7 +559,7 @@ export const App: React.FC = () => {
 };
 ```
 
-### `goBack`
+### goBack
 
 To customize the back button or to disable it, you can use the `goBack` property.
 
@@ -625,7 +625,7 @@ render(
 );
 ```
 
-### `isLoading`
+### isLoading
 
 To toggle the loading state of the `<Edit/>` component, you can use the `isLoading` property.
 
@@ -666,7 +666,7 @@ render(
 );
 ```
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default it uses the `Breadcrumb` component from `@refinedev/mui` package.
 
@@ -717,7 +717,7 @@ render(
 
 > For more information, refer to the [`Breadcrumb` documentation &#8594](/docs/ui-integrations/material-ui/components/breadcrumb)
 
-### `wrapperProps`
+### wrapperProps
 
 If you want to customize the wrapper of the `<Edit/>` component, you can use the `wrapperProps` property.
 
@@ -765,7 +765,7 @@ render(
 
 > For more information, refer to the [`Card` documentation from Material UI &#8594](https://mui.com/material-ui/api/card/)
 
-### `headerProps`
+### headerProps
 
 If you want to customize the header of the `<Edit/>` component, you can use the `headerProps` property.
 
@@ -813,7 +813,7 @@ render(
 
 > For more information, refer to the [`CardHeader` documentation from Material UI &#8594](https://mui.com/material-ui/api/card-header/)
 
-### `contentProps`
+### contentProps
 
 If you want to customize the content of the `<Edit/>` component, you can use the `contentProps` property.
 
@@ -861,7 +861,7 @@ render(
 
 > For more information, refer to the [`CardContent` documentation from Material UI &#8594](https://mui.com/material-ui/api/card-content/)
 
-### `headerButtons`
+### headerButtons
 
 By default, the `<Edit/>` component has a [`<ListButton>`][list-button] and a [`<RefreshButton>`][refresh-button] at the header.
 
@@ -960,7 +960,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can customize the wrapper element of the buttons at the header by using the `headerButtonProps` property.
 
@@ -1015,7 +1015,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Material UI &#8594](https://mui.com/material-ui/api/box/)
 
-### `footerButtons`
+### footerButtons
 
 By default, the `<Edit/>` component has a [`<SaveButton>`][save-button] and a [`<DeleteButton>`][delete-button] at the footer.
 
@@ -1114,7 +1114,7 @@ render(
 );
 ```
 
-### `footerButtonProps`
+### footerButtonProps
 
 You can customize the wrapper element of the buttons at the footer by using the `footerButtonProps` property.
 
@@ -1169,7 +1169,7 @@ render(
 
 > For more information, refer to the [`CardActions` documentation from Material UI &#8594](https://mui.com/material-ui/api/card-actions/)
 
-### `autoSaveProps`
+### autoSaveProps
 
 You can use the auto save feature of the `<Edit/>` component by using the `autoSaveProps` property.
 

--- a/documentation/docs/ui-integrations/material-ui/components/basic-views/list/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/basic-views/list/index.md
@@ -82,7 +82,7 @@ You can swizzle this component with the [**Refine CLI**](/docs/packages/list-of-
 
 ## Properties
 
-### `title`
+### title
 
 `title` allows the addition of titles inside the `<List>` component. If you don't pass title props it uses the plural resource name by default. For example, for the `/posts` resource, it will be "Posts".
 
@@ -116,7 +116,7 @@ render(
 );
 ```
 
-### `resource`
+### resource
 
 The `<List>` component reads the `resource` information from the route by default. If you want to use a custom resource for the `<List>` component, you can use the `resource` prop.
 
@@ -173,7 +173,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `canCreate` and `createButtonProps`
+### canCreate and createButtonProps
 
 `canCreate` allows us to add the create button inside the `<List>` component. If resource is passed a create component, Refine adds the create button by default. If you want to customize this button you can use `createButtonProps` property like the code below.
 
@@ -260,7 +260,7 @@ render(
 
 > For more information, refer to the [`usePermission` documentation &#8594](/docs/authentication/hooks/use-permissions)
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default it uses the `Breadcrumb` component from `@refinedev/mui` package.
 
@@ -313,7 +313,7 @@ render(
 
 > For more information, refer to the [`Breadcrumb` documentation &#8594](/docs/ui-integrations/material-ui/components/breadcrumb)
 
-### `wrapperProps`
+### wrapperProps
 
 If you want to customize the wrapper of the `<List/>` component, you can use the `wrapperProps` property.
 
@@ -355,7 +355,7 @@ render(
 
 > For more information, refer to the [`Card` documentation from Material UI &#8594](https://mui.com/material-ui/api/card/)
 
-### `headerProps`
+### headerProps
 
 If you want to customize the header of the `<List/>` component, you can use the `headerProps` property.
 
@@ -397,7 +397,7 @@ render(
 
 > For more information, refer to the [`CardHeader` documentation from Material UI &#8594](https://mui.com/material-ui/api/card-header/)
 
-### `contentProps`
+### contentProps
 
 If you want to customize the content of the `<List/>` component, you can use the `contentProps` property.
 
@@ -439,7 +439,7 @@ render(
 
 > For more information, refer to the [`CardContent` documentation from Material UI &#8594](https://mui.com/material-ui/api/card-content/)
 
-### `headerButtons`
+### headerButtons
 
 By default, the `<List/>` component has a [`<CreateButton>`][create-button] at the header.
 
@@ -525,7 +525,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can customize the wrapper element of the buttons at the header by using the `headerButtonProps` property.
 

--- a/documentation/docs/ui-integrations/material-ui/components/basic-views/show/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/basic-views/show/index.md
@@ -73,7 +73,7 @@ You can swizzle this component with the [**Refine CLI**](/docs/packages/list-of-
 
 ## Properties
 
-### `title`
+### title
 
 `title` allows the addition of titles inside the `<Show>` component. if you don't pass title props it uses the "Show" prefix and the singular resource name by default. For example, for the "posts" resource, it would be "Show post".
 
@@ -113,7 +113,7 @@ render(
 );
 ```
 
-### `resource`
+### resource
 
 The `<Show>` component reads the `resource` information from the route by default. If you want to use a custom resource for the `<Show>` component, you can use the `resource` prop.
 
@@ -169,7 +169,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `canDelete` and `canEdit`
+### canDelete and canEdit
 
 `canDelete` and `canEdit` allows us to add the delete and edit buttons inside the `<Show>` component. If the resource has `canDelete` or `canEdit` property Refine adds the buttons by default.
 
@@ -271,7 +271,7 @@ render(
 
 > For more information, refer to the [`<DeleteButton>` &#8594](/docs/ui-integrations/material-ui/components/buttons/delete-button), [`<EditButton>` &#8594](/docs/ui-integrations/material-ui/components/buttons/edit-button) and [`usePermission` &#8594](/docs/authentication/hooks/use-permissions) documentations.
 
-### `recordItemId`
+### recordItemId
 
 `<Show>` component reads the `id` information from the route by default. `recordItemId` is used when it cannot read from the URL (when used on a custom page, modal or drawer).
 
@@ -324,7 +324,7 @@ render(
 
 `<Show>` component needs the `id` information for [`<RefreshButton>`](/docs/ui-integrations/material-ui/components/buttons/refresh-button) to work properly.
 
-### `dataProviderName`
+### dataProviderName
 
 If not specified, Refine will use the default data provider. If you have multiple data providers and want to use a different one, you can use the `dataProviderName` property.
 
@@ -356,7 +356,7 @@ export const App: React.FC = () => {
 };
 ```
 
-### `goBack`
+### goBack
 
 To customize the back button or to disable it, you can use the `goBack` property.
 
@@ -422,7 +422,7 @@ render(
 );
 ```
 
-### `isLoading`
+### isLoading
 
 To toggle the loading state of the `<Show/>` component, you can use the `isLoading` property.
 
@@ -463,7 +463,7 @@ render(
 );
 ```
 
-### `breadcrumb` <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
+### breadcrumb <GlobalConfigBadge id="core/refine-component/#breadcrumb" />
 
 To customize or disable the breadcrumb, you can use the `breadcrumb` property. By default it uses the `Breadcrumb` component from `@refinedev/mui` package.
 
@@ -514,7 +514,7 @@ render(
 
 > For more information, refer to the [`Breadcrumb` documentation &#8594](/docs/ui-integrations/material-ui/components/breadcrumb)
 
-### `wrapperProps`
+### wrapperProps
 
 If you want to customize the wrapper of the `<Show/>` component, you can use the `wrapperProps` property.
 
@@ -562,7 +562,7 @@ render(
 
 > For more information, refer to the [`Card` documentation from Material UI &#8594](https://mui.com/material-ui/api/card/)
 
-### `headerProps`
+### headerProps
 
 If you want to customize the header of the `<Show/>` component, you can use the `headerProps` property.
 
@@ -610,7 +610,7 @@ render(
 
 > For more information, refer to the [`CardHeader` documentation from Material UI &#8594](https://mui.com/material-ui/api/card-header/)
 
-### `contentProps`
+### contentProps
 
 If you want to customize the content of the `<Show/>` component, you can use the `contentProps` property.
 
@@ -658,7 +658,7 @@ render(
 
 > For more information, refer to the [`CardContent` documentation from Material UI &#8594](https://mui.com/material-ui/api/card-content/)
 
-### `headerButtons`
+### headerButtons
 
 By default, the `<Show/>` component has a [`<ListButton>`][list-button], [`<EditButton>`][edit-button], [`<DeleteButton>`][delete-button], and, [`<RefreshButton>`][refresh-button] at the header.
 
@@ -763,7 +763,7 @@ render(
 );
 ```
 
-### `headerButtonProps`
+### headerButtonProps
 
 You can customize the wrapper element of the buttons at the header by using the `headerButtonProps` property.
 
@@ -818,7 +818,7 @@ render(
 
 > For more information, refer to the [`Box` documentation from Material UI &#8594](https://mui.com/material-ui/api/box/)
 
-### `footerButtons`
+### footerButtons
 
 You can customize the buttons at the footer by using the `footerButtons` property. It accepts `React.ReactNode` or a render function `({ defaultButtons }) => React.ReactNode` which you can use to keep the existing buttons and add your own.
 
@@ -866,7 +866,7 @@ render(
 );
 ```
 
-### `footerButtonProps`
+### footerButtonProps
 
 You can customize the wrapper element of the buttons at the footer by using the `footerButtonProps` property.
 

--- a/documentation/docs/ui-integrations/material-ui/components/breadcrumb/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/breadcrumb/index.md
@@ -79,7 +79,7 @@ render(
 
 ## Properties
 
-### `breadcrumbProps`
+### breadcrumbProps
 
 `<Breadcrumb>` component uses the Material UI's [Breadcrumb][mui-breadcrumb] component so it can be configured with the `breadcrumbProps` property.
 
@@ -91,7 +91,7 @@ export const PostList: React.FC = () => {
 };
 ```
 
-### `showHome`
+### showHome
 
 If you have a page with route `/`, it will be used as the root of the hierarchy and shown in the `Breadcrumb` with a home icon. To hide the root item, set `showHome` to `false.`
 
@@ -110,7 +110,7 @@ export const PostList: React.FC = () => {
 };
 ```
 
-### `meta`
+### meta
 
 If your routes has additional parameters in their paths, you can pass the `meta` property to the `<Breadcrumb>` component to use them while creating the paths and filling the parameters in the paths. By default, existing URL parameters are used. You can use `meta` to override them or add new ones.
 
@@ -129,7 +129,7 @@ export const PostList: React.FC = () => {
 };
 ```
 
-### `hideIcons`
+### hideIcons
 
 If you don't want to show the resource icons on the breadcrumb, you can set `hideIcons` to `true`.
 

--- a/documentation/docs/ui-integrations/material-ui/components/buttons/clone-button/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/buttons/clone-button/index.md
@@ -72,7 +72,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` is used to append the record id to the end of the route path. By default, the `recordItemId` is inferred from the route params.
 
@@ -108,7 +108,7 @@ render(
 
 Clicking the button will trigger the `clone` method of [`useNavigation`](/docs/routing/hooks/use-navigation) and then redirect the app to the `clone` action path of the resource, filling the necessary parameters in the route.
 
-### `resource`
+### resource
 
 It is used to redirect the app to the `clone` action of the given resource name. By default, the app redirects to the inferred resource's `clone` action path.
 
@@ -152,7 +152,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `clone` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `clone` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -164,7 +164,7 @@ const MyCloneComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -204,7 +204,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -216,7 +216,7 @@ export const MyCloneComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/material-ui/components/buttons/create-button/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/buttons/create-button/index.md
@@ -61,7 +61,7 @@ render(
 
 ## Properties
 
-### `resource`
+### resource
 
 It is used to redirect the app to the `create` action path of the given resource name. By default, the app redirects to the inferred resource's `create` action path.
 
@@ -110,7 +110,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `create` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `create` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -122,7 +122,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 `hideText` is used to show or hide the text of the button. When `true`, only the button icon is visible.
 
@@ -162,7 +162,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 The `accessControl` prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -174,7 +174,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/material-ui/components/buttons/delete-button/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/buttons/delete-button/index.md
@@ -87,7 +87,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` allows us to manage which record will be deleted. By default, the `recordItemId` is inferred from the route params.
 
@@ -134,7 +134,7 @@ render(
 
 Clicking the button will trigger the [`useDelete`](/docs/data/hooks/use-delete) method and then the record whose resource is `post` and whose id is `1` gets deleted.
 
-### `resource`
+### resource
 
 `resource` allows us to manage which resource's record is going to be deleted.
 
@@ -183,7 +183,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `onSuccess`
+### onSuccess
 
 `onSuccess` can be used if you want to do anything on the result returned after the delete request.
 
@@ -235,7 +235,7 @@ render(
 );
 ```
 
-### `mutationMode`
+### mutationMode
 
 Determines which mode mutation will have while executing `<DeleteButton>`.
 
@@ -294,7 +294,7 @@ interface IPost {
 
 > For more information, refer to the [mutation mode documentation &#8594](/advanced-tutorials/mutation-mode.md)
 
-### `hideText`
+### hideText
 
 `hideText` is used to show or hide the text of the button. When `true`, only the button icon is visible.
 
@@ -341,7 +341,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -353,7 +353,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/material-ui/components/buttons/edit-button/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/buttons/edit-button/index.md
@@ -70,7 +70,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` is used to append the record id to the end of the route path for the edit route. By default, the `recordItemId` is inferred from the route params.
 
@@ -112,7 +112,7 @@ render(
 
 Clicking the button will trigger the `edit` method of [`useNavigation`](/docs/routing/hooks/use-navigation) and then redirect the app to the `edit` action path of the resource, filling the necessary parameters in the route.
 
-### `resource`
+### resource
 
 Redirection endpoint is defined by the `resource` property and its `edit` action path. By default, `<EditButton>` uses the inferred resource from the route.
 
@@ -162,7 +162,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `edit` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `edit` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -174,7 +174,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 It is used to show and not show the text of the button. When `true`, only the button icon is visible.
 
@@ -214,7 +214,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -226,7 +226,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/material-ui/components/buttons/export-button/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/buttons/export-button/index.md
@@ -69,7 +69,7 @@ render(
 
 ## Properties
 
-### `hideText`
+### hideText
 
 `hideText` is used to show or hide text of the button. When `true`, only the button icon is visible.
 

--- a/documentation/docs/ui-integrations/material-ui/components/buttons/import-button/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/buttons/import-button/index.md
@@ -69,7 +69,7 @@ render(
 
 ## Properties
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and hide the text of the button. When `true`, only the button icon is visible.
 

--- a/documentation/docs/ui-integrations/material-ui/components/buttons/list-button/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/buttons/list-button/index.md
@@ -72,7 +72,7 @@ The button text is defined automatically by Refine based on the `resource` defin
 
 ## Properties
 
-### `resource`
+### resource
 
 Redirection endpoint is defined by the `resource`'s `list` action path. By default, `<ListButton>` uses the inferred resource from the route.
 
@@ -114,7 +114,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `list` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `list` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -126,7 +126,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and hide the text of the button. When `true`, only the button icon is visible.
 
@@ -166,7 +166,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -178,7 +178,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/material-ui/components/buttons/refresh-button/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/buttons/refresh-button/index.md
@@ -68,7 +68,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` allows us to manage which data is going to be refreshed. By default, `recordItemId` will be inferred from the route.
 
@@ -103,7 +103,7 @@ render(
 
 Clicking the button will trigger the [`useInvalidate`][use-invalidate] hook and then fetch the record whose resource is "post" and whose id is "1".
 
-### `resource`
+### resource
 
 `resource` allows us to manage which resource is going to be refreshed. By default, `<RefreshButton>` uses the inferred resource from the route.
 
@@ -143,7 +143,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `hideText`
+### hideText
 
 `hideText` is used to show and hide the text of the button. When `true`, only the button icon is visible.
 
@@ -177,7 +177,7 @@ render(
 );
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use the `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/material-ui/components/buttons/save-button/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/buttons/save-button/index.md
@@ -76,7 +76,7 @@ The `useForm` hook exposes `saveButtonProps` to be passed to `<SaveButton>` comp
 
 ## Properties
 
-### `hideText`
+### hideText
 
 `hideText` is used to show or hide the text of the button. When `true`, only the button icon is visible.
 

--- a/documentation/docs/ui-integrations/material-ui/components/buttons/show-button/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/buttons/show-button/index.md
@@ -70,7 +70,7 @@ render(
 
 ## Properties
 
-### `recordItemId`
+### recordItemId
 
 `recordItemId` is used to append the record id to the end of the route path. By default, the `recordItemId` is inferred from the route params.
 
@@ -112,7 +112,7 @@ render(
 
 Clicking the button will trigger the `show` method of [`useNavigation`](/docs/routing/hooks/use-navigation) and then redirect the app to the `show` action path of the resource, filling the necessary parameters in the route.
 
-### `resource`
+### resource
 
 Redirection endpoint is defined by the `resource`'s `show` action path. By default, `<ShowButton>` uses the inferred resource from the route.
 
@@ -162,7 +162,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `meta`
+### meta
 
 It is used to pass additional parameters to the `show` method of [`useNavigation`](/docs/routing/hooks/use-navigation). By default, existing parameters in the route are used by the `show` method. You can pass additional parameters or override the existing ones using the `meta` prop.
 
@@ -174,7 +174,7 @@ const MyComponent = () => {
 };
 ```
 
-### `hideText`
+### hideText
 
 `hideText` is used to show or hide the text of the button. When `true`, only the button icon is visible.
 
@@ -214,7 +214,7 @@ render(
 );
 ```
 
-### `accessControl`
+### accessControl
 
 This prop can be used to skip access control check with its `enabled` property or to hide the button when the user does not have the permission to access the resource with `hideIfUnauthorized` property. This is relevant only when an [`accessControlProvider`](/docs/authorization/access-control-provider) is provided to [`<Refine/>`](/docs/core/refine-component)
 
@@ -226,7 +226,7 @@ export const MyListComponent = () => {
 };
 ```
 
-### ~~`resourceNameOrRouteName`~~ <PropTag deprecated />
+### ~~resourceNameOrRouteName~~ <PropTag deprecated />
 
 Use `resource` prop instead.
 

--- a/documentation/docs/ui-integrations/material-ui/components/inferencer/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/inferencer/index.md
@@ -106,7 +106,7 @@ To learn more about `@refinedev/inferencer` package, please check out [Docs](/do
 
 ## Views
 
-### `List`
+### List
 
 Generates a sample list view for your resources according to the API response. It uses the `List` component and `useDatagrid` hook from `@refinedev/mui`.
 
@@ -171,7 +171,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-### `Show`
+### Show
 
 Generates a sample show view for your resources according to the API response. It uses `Show` and field components from `@refinedev/mui` with `useShow` hook from `@refinedev/core`.
 
@@ -236,7 +236,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-### `Create`
+### Create
 
 Generates a sample create view for your resources according to the first record in list API response. It uses the `Create` component from `@refinedev/mui` and `useForm` hook from `@refinedev/react-hook-form`.
 
@@ -301,7 +301,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-### `Edit`
+### Edit
 
 Generates a sample edit view for your resources according to the API response. It uses `Edit` component from `@refinedev/mui` and `useForm` hook from `@refinedev/react-hook-form`.
 

--- a/documentation/docs/ui-integrations/material-ui/components/themed-layout/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/themed-layout/index.md
@@ -115,7 +115,7 @@ Example of above showing how to use `<ThemedLayoutV2>` with [`React Router v6`](
 
 ## Props
 
-### `Sider`
+### Sider
 
 In `<ThemedLayoutV2>`, the sidebar section is rendered using the [`<ThemedSiderV2>`][themed-sider] component by default. This component is specifically designed to generate menu items based on the resources defined in [`<Refine>`][refine-component] components, using the [`useMenu`][use-menu] hook. However, if desired, it's possible to replace the default [`<ThemedSiderV2>`][themed-sider] component by passing a custom component to the `Sider` prop.
 
@@ -181,7 +181,7 @@ const App: React.FC = () => {
 };
 ```
 
-#### `Sider Props`
+#### Sider Props
 
 | Prop                 | Type                                          | Description                                                                     |
 | -------------------- | --------------------------------------------- | ------------------------------------------------------------------------------- |
@@ -199,7 +199,7 @@ type SiderRenderFunction = (props: {
 }) => React.ReactNode;
 ```
 
-### `initialSiderCollapsed`
+### initialSiderCollapsed
 
 This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][themed-sider] component. If it is `true`, It will be collapsed by default.
 
@@ -212,7 +212,7 @@ This prop is used to set the initial collapsed state of the [`<ThemedSiderV2>`][
 </ThemedLayoutV2>
 ```
 
-### `Header`
+### Header
 
 In `<ThemedLayoutV2>`, the header section is rendered using the [`<ThemedHeaderV2>`][themed-header] component by default. It uses [`useGetIdentity`](/docs/authentication/hooks/use-get-identity) hook to display the user's name and avatar on the right side of the header. However, if desired, it's possible to replace the default [`<ThemedHeaderV2>`][themed-header] component by passing a custom component to the `Header` prop.
 
@@ -268,7 +268,7 @@ const App: React.FC = () => {
 };
 ```
 
-### `Title`
+### Title
 
 In `<ThemedLayoutV2>`, the title section is rendered using the [`<ThemedTitleV2V2>`][themed-title] component by default. However, if desired, it's possible to replace the default [`<ThemedTitleV2V2>`][themed-title] component by passing a custom component to the `Title` prop.
 
@@ -306,7 +306,7 @@ const App: React.FC = () => {
 };
 ```
 
-### `Footer`
+### Footer
 
 The footer section of the layout is displayed at the bottom of the page. Refine doesn't provide a default footer component. However, you can pass a custom component to the `Footer` prop to display a footer section.
 
@@ -426,7 +426,7 @@ const App: React.FC = () => {
 };
 ```
 
-### `OffLayoutArea`
+### OffLayoutArea
 
 Used to component is rendered outside of the main layout component, allowing it to be placed anywhere on the page while still being part of the overall layout .Refine doesn't provide a default off-layout area component. However, you can pass a custom component to the `OffLayoutArea` prop to display a custom off-layout area.
 

--- a/documentation/docs/ui-integrations/material-ui/hooks/use-auto-complete/index.md
+++ b/documentation/docs/ui-integrations/material-ui/hooks/use-auto-complete/index.md
@@ -29,7 +29,7 @@ It is useful when you want to subscribe to the live updates.
 
 ## Properties
 
-### `resource` <PropTag required />
+### resource <PropTag required />
 
 It will be passed to the `getList` method from the `dataProvider` as parameter via the `useList` hook. The parameter is usually used as an API endpoint path. It all depends on how to handle the `resource` in the `getList` method. See the [creating a data provider](/docs/data/data-provider#creating-a-data-provider) section for an example of how resources are handled.
 
@@ -43,7 +43,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `sorters`
+### sorters
 
 It allows to show the options in the desired order. `sorters` will be passed to the `getList` method from the `dataProvider` as parameter via the `useList` hook. It is used to send `sorters` query parameters to the API.
 
@@ -62,7 +62,7 @@ useAutocomplete({
 
 <SortLivePreview />
 
-### `filters`
+### filters
 
 `filters` is used to show options by filtering them. `filters` will be passed to the `getList` method from the `dataProvider` as parameter via the `useList` hook. It is used to send filter query parameters to the API.
 
@@ -80,7 +80,7 @@ useAutocomplete({
 });
 ```
 
-### `defaultValue`
+### defaultValue
 
 Allows to make options selected by default. Adds extra options to `<select>` component. In some cases like there are many entries for the `<select>` and pagination is required, `defaultValue` may not be present in the current visible options and this can break the `<select>` component. To avoid such cases, A separate `useMany` query is sent to the backend with the `defaultValue` and appended to the options of `<select>`, ensuring the default values exist in the current options array. Since it uses `useMany` to query the necessary data, the `defaultValue` can be a single value or an array of values like the following:
 
@@ -92,7 +92,7 @@ useAutocomplete({
 
 > For more information, refer to the [`useMany` documentation &#8594](/docs/data/hooks/use-many)
 
-### `debounce`
+### debounce
 
 It allows us to `debounce` the `onSearch` function.
 
@@ -102,7 +102,7 @@ useAutocomplete({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 `queryOptions` is used to pass additional options to the `useQuery` hook. It is useful when you want to pass additional options to the `useQuery` hook.
 
@@ -116,11 +116,11 @@ useAutocomplete({
 });
 ```
 
-### `pagination`
+### pagination
 
 `pagination` will be passed to the `getList` method from the `dataProvider` as parameter. It is used to send pagination query parameters to the API.
 
-#### `current`
+#### current
 
 You can pass the `current` page number to the `pagination` property.
 
@@ -132,7 +132,7 @@ useAutocomplete({
 });
 ```
 
-#### `pageSize`
+#### pageSize
 
 You can pass the `pageSize` to the `pagination` property.
 
@@ -144,7 +144,7 @@ useAutocomplete({
 });
 ```
 
-#### `mode`
+#### mode
 
 It can be `"off"`, `"client"` or `"server"`. It is used to determine whether to use server-side pagination or not.
 
@@ -156,7 +156,7 @@ useAutocomplete({
 });
 ```
 
-### `defaultValueQueryOptions`
+### defaultValueQueryOptions
 
 When the `defaultValue` property is given, the `useMany` data hook is called for the selected records. With this property, you can change the options of this query. If not given, the values given in `queryOptions` will be used.
 
@@ -171,7 +171,7 @@ useAutocomplete({
 });
 ```
 
-### `onSearch`
+### onSearch
 
 It allows us to `AutoComplete` the `options`.
 
@@ -215,7 +215,7 @@ const filterOptions = createFilterOptions({
 />;
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -260,7 +260,7 @@ const myDataProvider = {
 };
 ```
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you can specify which one to use by passing the `dataProviderName` prop. It is useful when you have a different data provider for different resources.
 
@@ -270,7 +270,7 @@ useAutocomplete({
 });
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -288,7 +288,7 @@ useAutocomplete({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -306,7 +306,7 @@ useAutocomplete({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -320,7 +320,7 @@ useAutocomplete({
 });
 ```
 
-### `onLiveEvent`
+### onLiveEvent
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -334,13 +334,13 @@ useAutocomplete({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
 Params to pass to liveProvider's [subscribe](/docs/realtime/live-provider#subscribe) method.
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds while `onInterval` is the function that will be called on each interval.
@@ -366,11 +366,11 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### ~~`sort`~~ <PropTag deprecated />
+### ~~sort~~ <PropTag deprecated />
 
 Use `sorters` instead.
 
-### ~~`hasPagination`~~ <PropTag deprecated />
+### ~~hasPagination~~ <PropTag deprecated />
 
 Use `pagination.mode` instead.
 

--- a/documentation/docs/ui-integrations/material-ui/hooks/use-data-grid/index.md
+++ b/documentation/docs/ui-integrations/material-ui/hooks/use-data-grid/index.md
@@ -232,7 +232,7 @@ When the `useDataGrid` hook is mounted, it will call the `subscribe` method from
 
 ## Properties
 
-### `resource`
+### resource
 
 <PropResource
 hook={{
@@ -258,7 +258,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` section of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### `dataProviderName`
+### dataProviderName
 
 If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use. It is useful when you want to use a different `dataProvider` for a specific resource.
 
@@ -268,7 +268,7 @@ useDataGrid({
 });
 ```
 
-### `pagination.current`
+### pagination.current
 
 Sets the initial value of the page index. Default value is `1`.
 
@@ -280,7 +280,7 @@ useDataGrid({
 });
 ```
 
-### `pagination.pageSize`
+### pagination.pageSize
 
 Sets the initial value of the page size. It is `25` by default.
 
@@ -292,7 +292,7 @@ useDataGrid({
 });
 ```
 
-### `pagination.mode`
+### pagination.mode
 
 It can be `"off"`, `"server"` or `"client"`. It is `"server"` by default.
 
@@ -308,7 +308,7 @@ useDataGrid({
 });
 ```
 
-### `sorters.initial`
+### sorters.initial
 
 `sorters.initial` sets the initial value of the sorter. The `initial` is not permanent. It will be cleared when the user changes the sorter. If you want to set a permanent value, use the `sorters.permanent` prop.
 
@@ -327,7 +327,7 @@ useDataGrid({
 });
 ```
 
-### `sorters.permanent`
+### sorters.permanent
 
 `sorters.permanent` sets the permanent value of the sorter. The `permanent` is permanent and unchangeable. It will not be cleared when the user changes the sorter. If you want to set a temporary value, use the `sorters.initial` prop.
 
@@ -346,7 +346,7 @@ useDataGrid({
 });
 ```
 
-### `sorters.mode`
+### sorters.mode
 
 It can be `"off"`, or `"server"`. It is `"server"` by default.
 
@@ -361,7 +361,7 @@ useDataGrid({
 });
 ```
 
-### `filters.initial`
+### filters.initial
 
 Sets the initial value of the filter. The `initial` is not permanent. It will be cleared when the user changes the filter. If you want to set a permanent value, use the `filters.permanent` prop.
 
@@ -381,7 +381,7 @@ useDataGrid({
 });
 ```
 
-### `filters.permanent`
+### filters.permanent
 
 Sets the permanent value of the filter. The `permanent` is permanent and unchangeable. It will not be cleared when the user changes the filter. If you want to set a temporary value, use the `filters.initial` prop.
 
@@ -401,7 +401,7 @@ useDataGrid({
 });
 ```
 
-### `filters.defaultBehavior`
+### filters.defaultBehavior
 
 The filtering behavior can be set to either `"merge"` or `"replace"`. It is `"merge"` by default.
 
@@ -419,7 +419,7 @@ useDataGrid({
 });
 ```
 
-### `filters.mode`
+### filters.mode
 
 It can be `"off"` or `"server"`. It is `"server"` by default.
 
@@ -434,7 +434,7 @@ useDataGrid({
 });
 ```
 
-### `syncWithLocation` <GlobalConfigBadge id="core/refine-component/#syncwithlocation" />
+### syncWithLocation <GlobalConfigBadge id="core/refine-component/#syncwithlocation" />
 
 When you use the syncWithLocation feature, the `useDataGrid`'s state (e.g. sort order, filters, pagination) is automatically encoded in the query parameters of the URL, and when the URL changes, the `useDataGrid` state is automatically updated to match. This makes it easy to share table states across different routes or pages and allows users to bookmark or share links to specific table views. It is `false` by default.
 
@@ -444,7 +444,7 @@ useDataGrid({
 });
 ```
 
-### `queryOptions`
+### queryOptions
 
 `useDataGrid` uses [`useList`](/docs/data/hooks/use-list) hook to fetch data. You can pass [`queryOptions`](https://tanstack.com/query/v4/docs/react/reference/useQuery).
 
@@ -456,7 +456,7 @@ useDataGrid({
 });
 ```
 
-### `meta`
+### meta
 
 `meta` is a special property that can be used to pass additional information to data provider methods for the following purposes:
 
@@ -502,7 +502,7 @@ const myDataProvider = {
 };
 ```
 
-### `successNotification`
+### successNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -520,7 +520,7 @@ useDataGrid({
 });
 ```
 
-### `errorNotification`
+### errorNotification
 
 > [`NotificationProvider`](/docs/notification/notification-provider) is required for this prop to work.
 
@@ -538,7 +538,7 @@ useDataGrid({
 });
 ```
 
-### `liveMode`
+### liveMode
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -552,7 +552,7 @@ useDataGrid({
 });
 ```
 
-### `onLiveEvent`
+### onLiveEvent
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
@@ -566,13 +566,13 @@ useDataGrid({
 });
 ```
 
-### `liveParams`
+### liveParams
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.
 
 Params to pass to liveProvider's [subscribe](/docs/realtime/live-provider#subscribe) method.
 
-### `overtimeOptions`
+### overtimeOptions
 
 If you want loading overtime for the request, you can pass the `overtimeOptions` prop to the this hook. It is useful when you want to show a loading indicator when the request takes too long.
 `interval` is the time interval in milliseconds while `onInterval` is the function that will be called on each interval.
@@ -598,53 +598,53 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 }
 ```
 
-### ~~`initialCurrent`~~ <PropTag deprecated />
+### ~~initialCurrent~~ <PropTag deprecated />
 
 Use `pagination.current` instead.
 
-### ~~`initialPageSize`~~ <PropTag deprecated />
+### ~~initialPageSize~~ <PropTag deprecated />
 
 Use `pagination.pageSize` instead.
 
-### ~~`hasPagination`~~ <PropTag deprecated />
+### ~~hasPagination~~ <PropTag deprecated />
 
 Use `pagination.mode` instead.
 
-### ~~`initialSorter`~~ <PropTag deprecated />
+### ~~initialSorter~~ <PropTag deprecated />
 
 Use `sorters.initial` instead.
 
-### ~~`permanentSorter`~~ <PropTag deprecated />
+### ~~permanentSorter~~ <PropTag deprecated />
 
 Use `sorters.permanent` instead.
 
-### ~~`initialFilter`~~ <PropTag deprecated />
+### ~~initialFilter~~ <PropTag deprecated />
 
 Use `filters.initial` instead.
 
-### ~~`permanentFilter`~~ <PropTag deprecated />
+### ~~permanentFilter~~ <PropTag deprecated />
 
 Use `filters.permanent` instead.
 
-### ~~`defaultSetFilterBehavior`~~ <PropTag deprecated />
+### ~~defaultSetFilterBehavior~~ <PropTag deprecated />
 
 Use `filters.defaultBehavior` instead.
 
 ## Return Values
 
-### `dataGridProps`
+### dataGridProps
 
 The props needed by the [`<DataGrid>`][data-grid] component.
 
-#### `sortingMode`
+#### sortingMode
 
 Determines whether to use server-side sorting or not. It is `server` by default.
 
-#### `sortModel`
+#### sortModel
 
 Current `GridSortModel` compatible with [`<DataGrid>`][data-grid] component.
 
-#### `onSortModelChange`
+#### onSortModelChange
 
 When the user sorts a column, this function is called with the new sort model.
 
@@ -662,15 +662,15 @@ When the user sorts a column, this function is called with the new sort model.
 />
 ```
 
-#### `filterMode`
+#### filterMode
 
 Determines whether to use server-side filtering or not. It is `server` by default.
 
-#### `filterModel`
+#### filterModel
 
 Current `GridFilterModel` compatible with [`<DataGrid>`][data-grid] component.
 
-#### `onFilterModelChange`
+#### onFilterModelChange
 
 When the user filters a column, this function is called with the new filter model.
 
@@ -688,7 +688,7 @@ When the user filters a column, this function is called with the new filter mode
 />
 ```
 
-#### `onStateChange`
+#### onStateChange
 
 When the user sorts or filters a column, this function is called with the new state.
 
@@ -706,31 +706,31 @@ The `onStateChange` callback is used internally by the `useDataGrid` hook. If yo
 />
 ```
 
-#### `rows`
+#### rows
 
 Contains the data to be displayed in the data grid. Values fetched with [`useList`](/docs/data/hooks/use-list) hook.
 
-#### `rowCount`
+#### rowCount
 
 Total number of data. Value fetched with [`useList`](/docs/data/hooks/use-list) hook.
 
-#### `loading`
+#### loading
 
 Indicates whether the data is being fetched.
 
-#### `pagination`
+#### pagination
 
 Returns pagination configuration values(pageSize, current, setCurrent, etc.).
 
-### `tableQueryResult`
+### tableQueryResult
 
 Returned values from [`useList`](/docs/data/hooks/use-list) hook.
 
-### `sorters`
+### sorters
 
 Current [sorters state][crudsorting].
 
-### `setSorters`
+### setSorters
 
 A function to set current [sorters state][crudsorting].
 
@@ -738,11 +738,11 @@ A function to set current [sorters state][crudsorting].
  (sorters: CrudSorting) => void;
 ```
 
-### `filters`
+### filters
 
 Current [filters state][crudfilters].
 
-### `setFilters`
+### setFilters
 
 ```tsx
 ((filters: CrudFilters, behavior?: SetFilterBehavior) => void) & ((setter: (prevFilters: CrudFilters) => CrudFilters) => void)
@@ -750,11 +750,11 @@ Current [filters state][crudfilters].
 
 A function to set current [filters state][crudfilters].
 
-### `current`
+### current
 
 Current page index state. If pagination is disabled, it will be `undefined`.
 
-### `setCurrent`
+### setCurrent
 
 ```tsx
 React.Dispatch<React.SetStateAction<number>> | undefined;
@@ -762,11 +762,11 @@ React.Dispatch<React.SetStateAction<number>> | undefined;
 
 A function to set the current page index state. If pagination is disabled, it will be `undefined`.
 
-### `pageSize`
+### pageSize
 
 Current page size state. If pagination is disabled, it will be `undefined`.
 
-### `setPageSize`
+### setPageSize
 
 ```tsx
 React.Dispatch<React.SetStateAction<number>> | undefined;
@@ -774,17 +774,17 @@ React.Dispatch<React.SetStateAction<number>> | undefined;
 
 A function to set the current page size state. If pagination is disabled, it will be `undefined`.
 
-### `pageCount`
+### pageCount
 
 Total page count state. If pagination is disabled, it will be `undefined`.
 
-### `createLinkForSyncWithLocation`
+### createLinkForSyncWithLocation
 
 ```tsx
 (params: SyncWithLocationParams) => string;
 ```
 
-### `overtime`
+### overtime
 
 `overtime` object is returned from this hook. `elapsedTime` is the elapsed time in milliseconds. It becomes `undefined` when the request is completed.
 
@@ -796,11 +796,11 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 
 A function creates accessible links for `syncWithLocation`. It takes [SyncWithLocationParams][syncwithlocationparams] as parameters.
 
-### ~~`sorter`~~ <PropTag deprecated />
+### ~~sorter~~ <PropTag deprecated />
 
 Use `sorters` instead.
 
-### ~~`setSorter`~~ <PropTag deprecated />
+### ~~setSorter~~ <PropTag deprecated />
 
 Use `setSorters` instead.
 

--- a/documentation/docs/ui-integrations/material-ui/migration-guide/index.md
+++ b/documentation/docs/ui-integrations/material-ui/migration-guide/index.md
@@ -25,7 +25,7 @@ To use `@mui/x-data-grid` with version 6, [`@refinedev/mui`](https://github.com/
 
 Since there are some changes in the return values of the `useDataGrid` and the common usage of the `DataGrid` component with TypeScript, we've also released a major release to [`@refinedev/inferencer`](https://github.com/refinedev/refine/tree/master/packages/inferencer) package. If you're using the Inferencer package, you'll need to update it to `4.x.x` as well.
 
-### `useDataGrid`
+### useDataGrid
 
 We've updated the `useDataGrid` hook to return `paginationModel` and `onPaginationModelChange` instead of `page`, `pageSize`, `onPageChange` and `onPageSizeChange`. If you've modified these props, you'll need to update them to use the new API.
 


### PR DESCRIPTION
Removed backticks from one word headings;

```diff
- ## `onFinish`
+ ## onFinish
```

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
