### PR TITLE
fix(docs): landing mobile menu borders

### DIFF
--- a/documentation/src/refine-theme/common-header/mobile-menu-modal.tsx
+++ b/documentation/src/refine-theme/common-header/mobile-menu-modal.tsx
@@ -203,7 +203,13 @@ const Phone = (props: { className?: string }) => {
                                             open={open}
                                         />
 
-                                        <Disclosure.Panel>
+                                        <Disclosure.Panel
+                                            className={clsx(
+                                                open && "pb-4",
+                                                open &&
+                                                    "border-b border-gray-200 dark:border-gray-700",
+                                            )}
+                                        >
                                             {item.items.map((subItem) => (
                                                 <MenuItem
                                                     key={subItem.label}

--- a/documentation/src/refine-theme/common-header/mobile-nav-item.tsx
+++ b/documentation/src/refine-theme/common-header/mobile-nav-item.tsx
@@ -43,8 +43,8 @@ export const MobileNavItem: React.FC<MobileNavItemProps> = ({
                 "w-full",
                 "flex justify-between items-center",
                 "p-4",
-                "border-b border-gray-200 dark:border-gray-700",
                 "no-underline",
+                !open && "border-b border-gray-200 dark:border-gray-700",
             )}
             {...(href ? { to: href } : {})}
         >


### PR DESCRIPTION
before
<img width="300" alt="image" src="https://github.com/refinedev/refine/assets/23058882/24f71100-8f49-4d4d-b229-d24466861db1">

after
<img width="300" alt="image" src="https://github.com/refinedev/refine/assets/23058882/6a389ee9-9870-4d9c-8291-155b09f201e7">


Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
