### PR TITLE
feat(core): add `meta` field to `useGo`

### DIFF
--- a/.changeset/ten-numbers-warn.md
+++ b/.changeset/ten-numbers-warn.md
@@ -1,0 +1,44 @@
+---
+"@refinedev/core": patch
+---
+
+Added the ability to pass `meta` properties when using `useGo`'s `go` function with `to` as a resource object. This allows you to pass additional path parameters to the path defined in the resources array within the `<Refine />` component. Resolves [#5451](https://github.com/refinedev/refine/issues/5451)
+
+Assume we have the following resource defined in the `<Refine />` component:
+
+```tsx
+{
+    name: "posts",
+    list: "/posts",
+    edit: "/:foo/posts/:id/edit",
+}
+```
+
+```tsx
+import { useGo } from "@refinedev/core";
+
+const MyButton = () => {
+  const go = useGo();
+
+  return (
+    <Button
+      onClick={() => {
+        go({
+          to: {
+            resource: "posts",
+            action: "edit",
+            id: "1",
+            meta: {
+              foo: "bar",
+            },
+          },
+          type: "push",
+        });
+        // generated path will be "/bar/posts/1/edit"
+      }}
+    >
+      Go Posts
+    </Button>
+  );
+};
+```

--- a/documentation/docs/routing/hooks/use-go/index.md
+++ b/documentation/docs/routing/hooks/use-go/index.md
@@ -47,6 +47,7 @@ type ToWithResource = {
   resource: string; // resource name or identifier
   id?: BaseKey; // required when `action` is `"edit"`, `"show"`, or `"clone"`.
   action: "list" | "create" | "edit" | "show" | "clone"; // action name
+  meta?: Record<string, unknown>; // meta data to be used when composing the path (use if you have additional path parameters)
 };
 ```
 

--- a/packages/core/src/hooks/router/use-go/index.tsx
+++ b/packages/core/src/hooks/router/use-go/index.tsx
@@ -16,6 +16,7 @@ type ResourceWithoutId = {
     resource: string;
     action: Extract<Action, "create" | "list">;
     id?: never;
+    meta?: Record<string, unknown>;
 };
 
 type ResourceWithId = {
@@ -25,6 +26,7 @@ type ResourceWithId = {
     resource: string;
     action: Extract<Action, "edit" | "show" | "clone">;
     id: BaseKey;
+    meta?: Record<string, unknown>;
 };
 
 export type Resource = ResourceWithoutId | ResourceWithId;
@@ -60,6 +62,7 @@ export const useGo = () => {
                 action: config.to.action,
                 meta: {
                     id: config.to.id,
+                    ...config.to.meta,
                 },
             });
 


### PR DESCRIPTION

Added the ability to pass `meta` properties when using `useGo`'s `go` function with `to` as a resource object. This allows you to pass additional path parameters to the path defined in the resources array within the `<Refine />` component. Resolves [#5451](https://github.com/refinedev/refine/issues/5451)

Assume we have the following resource defined in the `<Refine />` component:

```tsx
{
    name: "posts",
    list: "/posts",
    edit: "/:foo/posts/:id/edit",
}
```

```tsx
import { useGo } from "@refinedev/core";

const MyButton = () => {
  const go = useGo();

  return (
    <Button
      onClick={() => {
        go({
          to: {
            resource: "posts",
            action: "edit",
            id: "1",
            meta: {
              foo: "bar",
            },
          },
          type: "push",
        });
        // generated path will be "/bar/posts/1/edit"
      }}
    >
      Go Posts
    </Button>
  );
};
```

### Closing issues

Resolves #5451

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
