### PR TITLE
fix(remark-gfm): cast as `any` to avoid type inconsistencies

### DIFF
--- a/.changeset/hungry-dolls-dress.md
+++ b/.changeset/hungry-dolls-dress.md
@@ -1,0 +1,8 @@
+---
+"@refinedev/antd": patch
+"@refinedev/chakra-ui": patch
+"@refinedev/mantine": patch
+"@refinedev/mui": patch
+---
+
+Fixed the type issue between `remark-gfm` and `react-markdown`.

--- a/.changeset/hungry-dolls-dress.md
+++ b/.changeset/hungry-dolls-dress.md
@@ -5,4 +5,4 @@
 "@refinedev/mui": patch
 ---
 
-Fixed the type issue between `remark-gfm` and `react-markdown`.
+Fixed the type issue between `remark-gfm` and `react-markdown`. #5463

--- a/packages/antd/src/components/fields/markdown/index.tsx
+++ b/packages/antd/src/components/fields/markdown/index.tsx
@@ -12,5 +12,6 @@ import { RefineFieldMarkdownProps } from "../types";
 export const MarkdownField: React.FC<RefineFieldMarkdownProps> = ({
     value = "",
 }) => {
-    return <ReactMarkdown plugins={[gfm]}>{value}</ReactMarkdown>;
+    // There's an issue related with the type inconsistency of the `remark-gfm` and `remark-rehype` packages, we need to cast the `gfm` as any. (https://github.com/orgs/rehypejs/discussions/63)
+    return <ReactMarkdown plugins={[gfm as any]}>{value}</ReactMarkdown>;
 };

--- a/packages/antd/src/components/fields/markdown/index.tsx
+++ b/packages/antd/src/components/fields/markdown/index.tsx
@@ -13,5 +13,11 @@ export const MarkdownField: React.FC<RefineFieldMarkdownProps> = ({
     value = "",
 }) => {
     // There's an issue related with the type inconsistency of the `remark-gfm` and `remark-rehype` packages, we need to cast the `gfm` as any. (https://github.com/orgs/rehypejs/discussions/63)
-    return <ReactMarkdown remarkPlugins={[gfm]}>{value}</ReactMarkdown>;
+    return (
+        <ReactMarkdown
+            remarkPlugins={[gfm] as unknown as ReactMarkdown.PluggableList}
+        >
+            {value}
+        </ReactMarkdown>
+    );
 };

--- a/packages/antd/src/components/fields/markdown/index.tsx
+++ b/packages/antd/src/components/fields/markdown/index.tsx
@@ -13,5 +13,5 @@ export const MarkdownField: React.FC<RefineFieldMarkdownProps> = ({
     value = "",
 }) => {
     // There's an issue related with the type inconsistency of the `remark-gfm` and `remark-rehype` packages, we need to cast the `gfm` as any. (https://github.com/orgs/rehypejs/discussions/63)
-    return <ReactMarkdown plugins={[gfm as any]}>{value}</ReactMarkdown>;
+    return <ReactMarkdown remarkPlugins={[gfm]}>{value}</ReactMarkdown>;
 };

--- a/packages/chakra-ui/src/components/fields/markdown/index.tsx
+++ b/packages/chakra-ui/src/components/fields/markdown/index.tsx
@@ -10,5 +10,6 @@ import { MarkdownFieldProps } from "../types";
  * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/fields/markdown} for more details.
  */
 export const MarkdownField: React.FC<MarkdownFieldProps> = ({ value = "" }) => {
-    return <ReactMarkdown plugins={[gfm]}>{value}</ReactMarkdown>;
+    // There's an issue related with the type inconsistency of the `remark-gfm` and `remark-rehype` packages, we need to cast the `gfm` as any. (https://github.com/orgs/rehypejs/discussions/63)
+    return <ReactMarkdown plugins={[gfm as any]}>{value}</ReactMarkdown>;
 };

--- a/packages/chakra-ui/src/components/fields/markdown/index.tsx
+++ b/packages/chakra-ui/src/components/fields/markdown/index.tsx
@@ -11,5 +11,11 @@ import { MarkdownFieldProps } from "../types";
  */
 export const MarkdownField: React.FC<MarkdownFieldProps> = ({ value = "" }) => {
     // There's an issue related with the type inconsistency of the `remark-gfm` and `remark-rehype` packages, we need to cast the `gfm` as any. (https://github.com/orgs/rehypejs/discussions/63)
-    return <ReactMarkdown remarkPlugins={[gfm]}>{value}</ReactMarkdown>;
+    return (
+        <ReactMarkdown
+            remarkPlugins={[gfm] as unknown as ReactMarkdown.PluggableList}
+        >
+            {value}
+        </ReactMarkdown>
+    );
 };

--- a/packages/chakra-ui/src/components/fields/markdown/index.tsx
+++ b/packages/chakra-ui/src/components/fields/markdown/index.tsx
@@ -11,5 +11,5 @@ import { MarkdownFieldProps } from "../types";
  */
 export const MarkdownField: React.FC<MarkdownFieldProps> = ({ value = "" }) => {
     // There's an issue related with the type inconsistency of the `remark-gfm` and `remark-rehype` packages, we need to cast the `gfm` as any. (https://github.com/orgs/rehypejs/discussions/63)
-    return <ReactMarkdown plugins={[gfm as any]}>{value}</ReactMarkdown>;
+    return <ReactMarkdown remarkPlugins={[gfm]}>{value}</ReactMarkdown>;
 };

--- a/packages/mantine/src/components/fields/markdown/index.tsx
+++ b/packages/mantine/src/components/fields/markdown/index.tsx
@@ -14,7 +14,8 @@ export const MarkdownField: React.FC<MarkdownFieldProps> = ({
     ...rest
 }) => {
     return (
-        <ReactMarkdown plugins={[gfm]} {...rest}>
+        // There's an issue related with the type inconsistency of the `remark-gfm` and `remark-rehype` packages, we need to cast the `gfm` as any. (https://github.com/orgs/rehypejs/discussions/63)
+        <ReactMarkdown plugins={[gfm as any]} {...rest}>
             {value}
         </ReactMarkdown>
     );

--- a/packages/mantine/src/components/fields/markdown/index.tsx
+++ b/packages/mantine/src/components/fields/markdown/index.tsx
@@ -15,7 +15,7 @@ export const MarkdownField: React.FC<MarkdownFieldProps> = ({
 }) => {
     return (
         // There's an issue related with the type inconsistency of the `remark-gfm` and `remark-rehype` packages, we need to cast the `gfm` as any. (https://github.com/orgs/rehypejs/discussions/63)
-        <ReactMarkdown plugins={[gfm as any]} {...rest}>
+        <ReactMarkdown remarkPlugins={[gfm]} {...rest}>
             {value}
         </ReactMarkdown>
     );

--- a/packages/mantine/src/components/fields/markdown/index.tsx
+++ b/packages/mantine/src/components/fields/markdown/index.tsx
@@ -15,7 +15,10 @@ export const MarkdownField: React.FC<MarkdownFieldProps> = ({
 }) => {
     return (
         // There's an issue related with the type inconsistency of the `remark-gfm` and `remark-rehype` packages, we need to cast the `gfm` as any. (https://github.com/orgs/rehypejs/discussions/63)
-        <ReactMarkdown remarkPlugins={[gfm]} {...rest}>
+        <ReactMarkdown
+            remarkPlugins={[gfm] as unknown as ReactMarkdown.PluggableList}
+            {...rest}
+        >
             {value}
         </ReactMarkdown>
     );

--- a/packages/mui/src/components/fields/markdown/index.tsx
+++ b/packages/mui/src/components/fields/markdown/index.tsx
@@ -10,5 +10,6 @@ import { MarkdownFieldProps } from "../types";
  * @see {@link https://refine.dev/docs/api-reference/mui/components/fields/markdown} for more details.
  */
 export const MarkdownField: React.FC<MarkdownFieldProps> = ({ value = "" }) => {
-    return <ReactMarkdown plugins={[gfm]}>{value}</ReactMarkdown>;
+    // There's an issue related with the type inconsistency of the `remark-gfm` and `remark-rehype` packages, we need to cast the `gfm` as any. (https://github.com/orgs/rehypejs/discussions/63)
+    return <ReactMarkdown plugins={[gfm as any]}>{value}</ReactMarkdown>;
 };

--- a/packages/mui/src/components/fields/markdown/index.tsx
+++ b/packages/mui/src/components/fields/markdown/index.tsx
@@ -11,5 +11,11 @@ import { MarkdownFieldProps } from "../types";
  */
 export const MarkdownField: React.FC<MarkdownFieldProps> = ({ value = "" }) => {
     // There's an issue related with the type inconsistency of the `remark-gfm` and `remark-rehype` packages, we need to cast the `gfm` as any. (https://github.com/orgs/rehypejs/discussions/63)
-    return <ReactMarkdown remarkPlugins={[gfm]}>{value}</ReactMarkdown>;
+    return (
+        <ReactMarkdown
+            remarkPlugins={[gfm] as unknown as ReactMarkdown.PluggableList}
+        >
+            {value}
+        </ReactMarkdown>
+    );
 };

--- a/packages/mui/src/components/fields/markdown/index.tsx
+++ b/packages/mui/src/components/fields/markdown/index.tsx
@@ -11,5 +11,5 @@ import { MarkdownFieldProps } from "../types";
  */
 export const MarkdownField: React.FC<MarkdownFieldProps> = ({ value = "" }) => {
     // There's an issue related with the type inconsistency of the `remark-gfm` and `remark-rehype` packages, we need to cast the `gfm` as any. (https://github.com/orgs/rehypejs/discussions/63)
-    return <ReactMarkdown plugins={[gfm as any]}>{value}</ReactMarkdown>;
+    return <ReactMarkdown remarkPlugins={[gfm]}>{value}</ReactMarkdown>;
 };


### PR DESCRIPTION
Updated the usage of `remark-gfm` and casted as `any` to avoid type inconsistencies between `remark-gfm` and `react-markdown`.

closing #5463

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
