### PR TITLE
test(e2e): update mantine's form fill command to delay in textareas

### DIFF
--- a/cypress/support/commands/mantine/index.ts
+++ b/cypress/support/commands/mantine/index.ts
@@ -21,7 +21,9 @@ export const fillMantineForm = () => {
         cy.get("#title").clear().type(mockPost.title);
         cy.get("#content textarea")
             .clear({ force: true })
-            .type(mockPost.content);
+            .type(mockPost.content, {
+                delay: 32,
+            });
         cy.get("#status").click().get("#status-0").click();
         cy.get("#categoryId").clear().get("#categoryId-1").click();
     });


### PR DESCRIPTION
Updated `fillForm` method for Mantine UI integrations in e2e test commands.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
