### PR TITLE
ci(changesets): use refine bot to commit versions

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -46,10 +46,15 @@ jobs:
         run: npm run lint
       - name: Test
         run: npm run test:all
+      - name: Set Git User
+        run: |
+          git config --global user.email "bot@refine.dev"
+          git config --global user.name "Refine Community Bot"
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
+          setupGitUser: false
           version: npm run changeset version
           publish: npm run changeset publish
           commit: "ci(changesets): version packages"


### PR DESCRIPTION
Updated `master-push` action to use @refine-bot instead of Github Bot to commit changes.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
