### PR TITLE
docs: update data fetching guide graphql section

### DIFF
--- a/documentation/docs/data/packages/nestjs-query/index.md
+++ b/documentation/docs/data/packages/nestjs-query/index.md
@@ -36,7 +36,7 @@ import Refine from "@refinedev/core";
 import dataProvider, { GraphQLClient } from "@refinedev/nestjs-query";
 
 // highlight-next-line
-const client = new GraphQLClient("https://api.example.com/graphql");
+const client = new GraphQLClient("https://api.nestjs-query.refine.dev/graphql");
 
 const App = () => (
   <Refine
@@ -331,9 +331,9 @@ import dataProvider, { GraphQLClient, liveProvider } from "@refinedev/nestjs-que
 // highlight-next-line
 import { createClient } from "graphql-ws";
 
-const client = new GraphQLClient("https://api.example.com/graphql");
+const client = new GraphQLClient("https://api.nestjs-query.refine.dev/graphql");
 // highlight-next-line
-const wsClient = createClient({ url: "wss://api.example.com/graphql" });
+const wsClient = createClient({ url: "wss://api.nestjs-query.refine.dev/graphql" });
 
 const App = () => (
   <Refine

--- a/documentation/docs/guides-concepts/data-fetching/index.md
+++ b/documentation/docs/guides-concepts/data-fetching/index.md
@@ -118,6 +118,7 @@ Easiest way to generate GraphQL queries is to use [graphql-tag](https://www.npmj
 
 ```tsx
 import gql from "graphql-tag";
+import { useOne, useUpdate } from "@refinedev/core";
 
 const GET_PRODUCT_QUERY = gql`
   query GetProduct($id: ID!) {

--- a/packages/core/src/interfaces/metaData/graphqlQueryOptions.ts
+++ b/packages/core/src/interfaces/metaData/graphqlQueryOptions.ts
@@ -1,6 +1,53 @@
 import type { DocumentNode } from "graphql";
 
 export type GraphQLQueryOptions = {
+    /**
+     * @description GraphQL query to be used by data providers.
+     * @optional
+     * @example
+     * ```tsx
+     * import gql from 'graphql-tag'
+     * import { useOne } from '@refinedev/core'
+     *
+     * const PRODUCT_QUERY = gql`
+     *   query GetProduct($id: ID!) {
+     *     product(id: $id) {
+     *       id
+     *       name
+     *     }
+     *   }
+     * `
+     *
+     * useOne({
+     *   id: 1,
+     *   meta: { gqlQuery: PRODUCT_QUERY }
+     * })
+     * ```
+     */
     gqlQuery?: DocumentNode;
+    /**
+     * @description GraphQL mutation to be used by data providers.
+     * @optional
+     * @example
+     * ```tsx
+     * import gql from 'graphql-tag'
+     * import { useCreate } from '@refinedev/core'
+     *
+     * const PRODUCT_CREATE_MUTATION = gql`
+     *   mutation CreateProduct($input: CreateOneProductInput!) {
+     *     createProduct(input: $input) {
+     *       id
+     *       name
+     *     }
+     *   }
+     * `
+     * const { mutate } = useCreate()
+     *
+     * mutate({
+     *   values: { name: "My Product" },
+     *   meta: { gqlQuery: PRODUCT_QUERY }
+     * })
+     * ```
+     */
     gqlMutation?: DocumentNode;
 };


### PR DESCRIPTION
- Updated data fetching guide's GraphQL section to explain newly added `meta.gqlQuery` and `meta.gqlMutation` fields.
- Added JSDoc comments to `GraphQLQueryOptions` interface.
- Upated example URL in `nestjs-query` docs.