### PR TITLE
feat: Ability to configure useCan's queryOptions globally and through CanAccess component

### DIFF
--- a/packages/core/src/components/canAccess/index.tsx
+++ b/packages/core/src/components/canAccess/index.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect } from "react";
-
+import {
+    useQuery,
+    UseQueryOptions,
+    UseQueryResult,
+} from "@tanstack/react-query";
 import { useCan, useResource } from "@hooks";
 import { BaseKey, IResourceItem, ITreeMenu } from "../../interfaces";
 
@@ -39,6 +43,7 @@ type CanAccessBaseProps = {
      */
     onUnauthorized?: (props: OnUnauthorizedProps) => void;
     children: React.ReactNode;
+    queryOptions?: UseQueryOptions<CanReturnType>;
 };
 
 type CanAccessWithoutParamsProps = {
@@ -59,6 +64,7 @@ export const CanAccess: React.FC<CanAccessProps> = ({
     fallback,
     onUnauthorized,
     children,
+    queryOptions,
     ...rest
 }) => {
     const {

--- a/packages/core/src/contexts/accessControl/IAccessControlContext.ts
+++ b/packages/core/src/contexts/accessControl/IAccessControlContext.ts
@@ -1,4 +1,9 @@
 import { BaseKey, IResourceItem, ITreeMenu } from "../../interfaces";
+import {
+    useQuery,
+    UseQueryOptions,
+    UseQueryResult,
+} from "@tanstack/react-query";
 
 export type CanParams = {
     /**
@@ -28,6 +33,7 @@ export type CanReturnType = {
 export interface IAccessControlContext {
     can?: ({ resource, action, params }: CanParams) => Promise<CanReturnType>;
     options?: {
+        queryOptions?: UseQueryOptions<CanReturnType>;
         buttons?: {
             enableAccessControl?: boolean;
             hideIfUnauthorized?: boolean;


### PR DESCRIPTION
Made the changes according to the issue  #5472.
please review the changes and let me know if it is correct or not.