### PR TITLE
feat(app-crm): disable algolia on local environment

### DIFF
--- a/examples/app-crm/src/App.tsx
+++ b/examples/app-crm/src/App.tsx
@@ -1,4 +1,3 @@
-import { InstantSearch } from "react-instantsearch";
 import { BrowserRouter, Outlet, Route, Routes } from "react-router-dom";
 
 import { ErrorComponent, useNotificationProvider } from "@refinedev/antd";
@@ -11,18 +10,12 @@ import routerProvider, {
     UnsavedChangesNotifier,
 } from "@refinedev/react-router-v6";
 
-import { App as AntdApp,ConfigProvider } from "antd";
+import { App as AntdApp, ConfigProvider } from "antd";
 
 import { resources, themeConfig } from "@/config";
-import {
-    authProvider,
-    dataProvider,
-    indexName,
-    liveProvider,
-    searchClient,
-} from "@/providers";
+import { authProvider, dataProvider, liveProvider } from "@/providers";
 
-import { FullScreenLoading, Layout } from "./components";
+import { FullScreenLoading, Layout, AlgoliaSearchWrapper } from "./components";
 import { useAutoLoginForDemo } from "./hooks";
 import { AuditLogPage, SettingsPage } from "./routes/administration";
 import {
@@ -84,7 +77,7 @@ const App: React.FC = () => {
     }
 
     return (
-        <InstantSearch searchClient={searchClient} indexName={indexName}>
+        <AlgoliaSearchWrapper>
             <BrowserRouter>
                 <ConfigProvider theme={themeConfig}>
                     <AntdApp>
@@ -374,7 +367,7 @@ const App: React.FC = () => {
                     </AntdApp>
                 </ConfigProvider>
             </BrowserRouter>
-        </InstantSearch>
+        </AlgoliaSearchWrapper>
     );
 };
 

--- a/examples/app-crm/src/components/index.ts
+++ b/examples/app-crm/src/components/index.ts
@@ -3,6 +3,7 @@ export * from "./custom-avatar";
 export * from "./fullscreen-loading";
 export * from "./icon";
 export * from "./layout";
+export * from "./layout/algolia-search/wrapper";
 export * from "./layout/logo";
 export * from "./layout/title";
 export * from "./list-title-button";

--- a/examples/app-crm/src/components/layout/algolia-search/wrapper.tsx
+++ b/examples/app-crm/src/components/layout/algolia-search/wrapper.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren } from "react";
+import { InstantSearch } from "react-instantsearch";
+
+import { indexName, searchClient } from "@/providers";
+
+export const AlgoliaSearchWrapper: React.FC<PropsWithChildren> = ({
+    children,
+}) => {
+    if (!searchClient) {
+        return <>{children}</>;
+    }
+
+    return (
+        <InstantSearch searchClient={searchClient} indexName={indexName}>
+            {children}
+        </InstantSearch>
+    );
+};

--- a/examples/app-crm/src/components/layout/header.tsx
+++ b/examples/app-crm/src/components/layout/header.tsx
@@ -5,6 +5,7 @@ import { Layout, Space, theme } from "antd";
 import { AlgoliaSearch } from "./algolia-search";
 import { CurrentUser } from "./current-user";
 import { Notifications } from "./notifications";
+import { searchClient } from "@/providers";
 
 const { useToken } = theme;
 
@@ -14,7 +15,7 @@ export const Header: React.FC = () => {
     const headerStyles: React.CSSProperties = {
         backgroundColor: token.colorBgElevated,
         display: "flex",
-        justifyContent: "space-between",
+        justifyContent: !!searchClient ? "space-between" : "flex-end",
         alignItems: "center",
         padding: "0px 24px",
         height: "64px",
@@ -25,7 +26,7 @@ export const Header: React.FC = () => {
 
     return (
         <Layout.Header style={headerStyles}>
-            <AlgoliaSearch />
+            {!!searchClient ? <AlgoliaSearch /> : null}
             <Space align="center" size="middle">
                 <Notifications />
                 <CurrentUser />

--- a/examples/app-crm/src/providers/search-client.tsx
+++ b/examples/app-crm/src/providers/search-client.tsx
@@ -1,8 +1,13 @@
 import algoliasearch from "algoliasearch/lite";
 
-const APP_ID = "SIY27MS63R";
-const API_KEY = "7fd59a730930ed2490543821e632aa91";
+const ALGOLIA_APP_ID = import.meta.env.ALGOLIA_APP_ID;
 
-export const searchClient = algoliasearch(APP_ID, API_KEY);
+const ALGOLIA_API_KEY = import.meta.env.ALGOLIA_API_KEY;
+
+const isAlgoliaEnabled = ALGOLIA_APP_ID && ALGOLIA_API_KEY;
+
+export const searchClient = isAlgoliaEnabled
+    ? algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY)
+    : false;
 
 export const indexName = "refine-crm";


### PR DESCRIPTION
We are exceeding our Algolia quote quickly, since credentials are hardcoded and spending quota on development environment.

- Removed hardcoded Algolia App ID and Api key.
- Now `app-crm` will check for ENV variables and conditionally render Algolia search.