### PR TITLE
block javascript url to prevent xss in @refinedev/sdk

### DIFF
--- a/packages/sdk/src/services/auth.ts
+++ b/packages/sdk/src/services/auth.ts
@@ -1,6 +1,7 @@
 import { Client } from "../client";
 import { ISession, IUser } from "../interfaces";
 
+
 class Auth {
     private client: Client;
 
@@ -30,6 +31,11 @@ class Auth {
             const baseUrl = this.client.getBaseUrl();
             const clientId = this.client.getClientId();
 
+            const isJavaScriptProtocol = /^[\u0000-\u001F ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*\:/i
+
+            if (isJavaScriptProtocol.test(baseUrl)) {
+                return;
+            }
             return window.location.replace(
                 `${baseUrl}/oauth/${provider}?applicationClientId=${clientId}`,
             );


### PR DESCRIPTION
## Fix for Cross-Site Scripting (XSS) Vulnerability

I've identified a Cross-Site Scripting (XSS) vulnerability in this package.

**Vulnerability Details:**
- **Severity**: High/Critical
- **Description**: There's a risk of malicious script execution when the baseUrl parameter passed to createClient is controlled by an adversary.

**Steps to Reproduce:**
In a React.js project:
```
import { createClient, Auth } from '@refinedev/sdk'
const client = createClient({ baseUrl: "javascript:alert(1)" });
const auth = new Auth(client);
auth.login({ provider: "foo" });
```
Then the malicious code alert(1) will be executed.

**Suggested Fix or Mitigation:**
It is best practice for an SDK to ensure security. Before creating a client, it is suggested to validate the baseUrl; otherwise, any application using this package is vulnerable to XSS attacks.

I've already fixed and tested this issue, and have submitted a pull request with the necessary changes. Please review and merge my pull request to resolve this vulnerability. Thanks!


