### PR TITLE
chore(create-refine-app): update superplate-cli dependency to 1.19.0

### DIFF
--- a/.changeset/six-adults-smell.md
+++ b/.changeset/six-adults-smell.md
@@ -1,0 +1,5 @@
+---
+"create-refine-app": patch
+---
+
+chore: update superplate-cli dependency to 1.19.0

--- a/packages/create-refine-app/package.json
+++ b/packages/create-refine-app/package.json
@@ -31,7 +31,7 @@
     "tslib": "^2.3.1",
     "commander": "9.4.1",
     "execa": "^5.1.1",
-    "superplate-cli": "^1.18.1",
+    "superplate-cli": "^1.19.0",
     "got": "^11.8.5",
     "chalk": "^4.1.2",
     "ora": "^5.4.1",


### PR DESCRIPTION
Updated `create-refine-app`'s `superplate-cli` dependency to `1.19.0`.