### PR TITLE
chore: update @ory/client version to 1.5.2

### DIFF
--- a/.changeset/tricky-waves-approve.md
+++ b/.changeset/tricky-waves-approve.md
@@ -1,0 +1,6 @@
+---
+"@refinedev/devtools-server": patch
+"@refinedev/devtools-ui": patch
+---
+
+chore: upgrade @ory/client package version to 1.5.2 #5530

--- a/packages/devtools-server/package.json
+++ b/packages/devtools-server/package.json
@@ -33,7 +33,7 @@
     "express": "^4.18.2",
     "@refinedev/devtools-ui": "1.1.15",
     "@refinedev/devtools-shared": "1.1.2",
-    "@ory/client": "^1.1.25",
+    "@ory/client": "^1.5.2",
     "http-proxy-middleware": "^2.0.6",
     "boxen": "^5.1.2",
     "chalk": "^4.1.2",

--- a/packages/devtools-ui/package.json
+++ b/packages/devtools-ui/package.json
@@ -34,7 +34,7 @@
   "module": "dist/esm/index.js",
   "dependencies": {
     "@headlessui/react": "^1.7.17",
-    "@ory/client": "^1.1.25",
+    "@ory/client": "^1.5.2",
     "@refinedev/devtools-shared": "1.1.2",
     "@tanstack/react-table": "^8.2.6",
     "clsx": "^1.1.1",


### PR DESCRIPTION
Updated `@ory/client` version to `1.5.2` to fix audit warning.

https://github.com/ory/sdk/issues/289#issuecomment-1916527928