### PR TITLE
fix(nextjs-router): bindings.parse returns corrupted data

### DIFF
--- a/.changeset/fluffy-seahorses-care.md
+++ b/.changeset/fluffy-seahorses-care.md
@@ -1,0 +1,43 @@
+---
+"@refinedev/nextjs-router": patch
+---
+
+fix: `meta` has corrupted route parameters.
+
+`parse` function from `@refinedev/nextjs-router` provides returns search params as following structure:
+
+```json
+{
+  "pageSize": "25",
+  "current": "1",
+  "sorters[0][field]": "status",
+  "sorters[0][order]": "asc",
+  "filters[0][field]": "status",
+  "filters[0][value]": "draft",
+  "filters[0][operator]": "contains"
+}
+```
+
+This structure is not predictable and not sanitazble. So, `parse` function has been updated to provide following structure:
+
+```json
+{
+  "pageSize": "25",
+  "current": "1",
+  "sorters": [
+    {
+      "field": "status",
+      "order": "asc"
+    }
+  ],
+  "filters": [
+    {
+      "field": "status",
+      "value": "draft",
+      "operator": "contains"
+    }
+  ]
+}
+```
+
+With this schema we can easily sanitize, deduplicate and predict the structure of the query parameters.

--- a/packages/nextjs-router/src/pages/bindings.tsx
+++ b/packages/nextjs-router/src/pages/bindings.tsx
@@ -113,9 +113,12 @@ export const routerBindings: RouterBindings = {
         }, [pathname]);
 
         const fn = React.useCallback(() => {
+            const parsedQuery = parse(query as Record<string, string>, {
+                ignoreQueryPrefix: true,
+            });
             const combinedParams = {
                 ...inferredParams,
-                ...query,
+                ...parsedQuery,
                 ...parsedParams,
             };
 


### PR DESCRIPTION
fix: `meta` has corrupted route parameters.

`parse` function from `@refinedev/nextjs-router` provides returns search params as following structure:

```json
{
  "pageSize": "25",
  "current": "1",
  "sorters[0][field]": "status",
  "sorters[0][order]": "asc",
  "filters[0][field]": "status",
  "filters[0][value]": "draft",
  "filters[0][operator]": "contains"
}
```

This structure is not predictable and not sanitazble. So, `parse` function has been updated to provide following structure:

```json
{
  "pageSize": "25",
  "current": "1",
  "sorters": [
    {
      "field": "status",
      "order": "asc"
    }
  ],
  "filters": [
    {
      "field": "status",
      "value": "draft",
      "operator": "contains"
    }
  ]
}
```

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [ ] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
