### PR TITLE
feat(core): make method, useGqlQuery, useGqlMutation props are condit…

### DIFF
--- a/.changeset/sweet-rings-wink.md
+++ b/.changeset/sweet-rings-wink.md
@@ -1,0 +1,26 @@
+---
+"@refinedev/core": minor
+---
+
+feat: The following changes implemented to improve `useCustom` hook's developer experience. #5600
+
+- `url` prop is now optional. If not provided, the hook will use the data provider URL.
+
+- From now on, at least one of the `gqlQuery`, `gqlMutation`, or `method` props must be required.
+  - If user provides `method`, `gqlQuery` and `gqlMutation` props type will be `never`.
+  - If user provides `gqlQuery`, or `gqlMutation`, `method` prop type will be `never`.
+
+```tsx
+import { useCustom } from "@refinedev/core";
+
+useCustom({}); // Error: At least one of the `gqlQuery`, `gqlMutation`, or `method` props must be required.
+
+useCustom({ method: "GET" }); // OK
+
+useCustom({ gqlQuery: "query { ... }" }); // OK
+useCustom({ gqlMutation: "mutation { ... }" }); // OK
+useCustom({ gqlMutation: "mutation { ... }", gqlQuery: "query { ... }" }); // OK
+
+useCustom({ method: "GET", gqlQuery: "query { ... }" }); // Error: `method` prop type should be `never`.
+useCustom({ method: "GET", gqlMutation: "mutation { ... }" }); // Error: `method` prop type should be `never`.
+```


### PR DESCRIPTION

feat: The following changes implemented to improve `useCustom` hook's developer experience. #5600

- `url` prop is now optional. If not provided, the hook will use the data provider URL.

- From now on, at least one of the `gqlQuery`, `gqlMutation`, or `method` props must be required.
  - If user provides `method`, `gqlQuery` and `gqlMutation` props type will be `never`.
  - If user provides `gqlQuery`, or `gqlMutation`, `method` prop type will be `never`.

```tsx
import { useCustom } from "@refinedev/core";

useCustom({}); // Error: At least one of the `gqlQuery`, `gqlMutation`, or `method` props must be required.

useCustom({ method: "GET" }); // OK

useCustom({ gqlQuery: "query { ... }" }); // OK
useCustom({ gqlMutation: "mutation { ... }" }); // OK
useCustom({ gqlMutation: "mutation { ... }", gqlQuery: "query { ... }" }); // OK

useCustom({ method: "GET", gqlQuery: "query { ... }" }); // Error: `method` prop type should be `never`.
useCustom({ method: "GET", gqlMutation: "mutation { ... }" }); // Error: `method` prop type should be `never`.
```

### Closing issues

closes #5600

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
