### PR TITLE
chore(create-refine-app): suggest dev command instead of start

### DIFF
--- a/.changeset/early-pigs-add.md
+++ b/.changeset/early-pigs-add.md
@@ -1,0 +1,5 @@
+---
+"create-refine-app": patch
+---
+
+chore: update post create message to suggest "dev" command, instead of "start".

--- a/packages/create-refine-app/src/example/index.ts
+++ b/packages/create-refine-app/src/example/index.ts
@@ -192,7 +192,7 @@ const run = async (
                 chalk`Start using your new {bold refine} app by running:`,
                 "",
                 chalk`  {bold cd} {cyan ${cdPath}}`,
-                chalk`  {bold ${pm} ${pmRun}}{cyan start}`,
+                chalk`  {bold ${pm} ${pmRun}}{cyan dev}`,
             ].join("\n"),
             {
                 // title: `create-refine-app${version ? ` v${version}` : ""}`,


### PR DESCRIPTION
Updated post creation message to suggest "dev" command, instead of "start".

![Screenshot 2024-02-08 at 14 41 06](https://github.com/refinedev/refine/assets/16444991/8fa98062-8d12-4d72-8d26-669953740cff)
