### PR TITLE
chore(examples): update WelcomePage from core in examples

### DIFF
--- a/examples/template-antd/src/App.tsx
+++ b/examples/template-antd/src/App.tsx
@@ -1,7 +1,6 @@
-import { GitHubBanner, Refine } from "@refinedev/core";
+import { GitHubBanner, Refine, WelcomePage } from "@refinedev/core";
 import {
     useNotificationProvider,
-    WelcomePage,
     ErrorComponent,
     RefineThemes,
 } from "@refinedev/antd";

--- a/examples/template-chakra-ui/src/App.tsx
+++ b/examples/template-chakra-ui/src/App.tsx
@@ -1,8 +1,7 @@
-import { GitHubBanner, Refine } from "@refinedev/core";
+import { GitHubBanner, Refine, WelcomePage } from "@refinedev/core";
 import {
     useNotificationProvider,
     RefineThemes,
-    WelcomePage,
     ErrorComponent,
 } from "@refinedev/chakra-ui";
 import { BrowserRouter, Routes, Route } from "react-router-dom";

--- a/examples/template-mantine/src/App.tsx
+++ b/examples/template-mantine/src/App.tsx
@@ -1,8 +1,7 @@
-import { GitHubBanner, Refine } from "@refinedev/core";
+import { GitHubBanner, Refine, WelcomePage } from "@refinedev/core";
 import {
     useNotificationProvider,
     RefineThemes,
-    WelcomePage,
     ErrorComponent,
 } from "@refinedev/mantine";
 import dataProvider from "@refinedev/simple-rest";

--- a/examples/template-material-ui/src/App.tsx
+++ b/examples/template-material-ui/src/App.tsx
@@ -1,9 +1,8 @@
-import { GitHubBanner, Refine } from "@refinedev/core";
+import { GitHubBanner, Refine, WelcomePage } from "@refinedev/core";
 import {
     useNotificationProvider,
     RefineSnackbarProvider,
     RefineThemes,
-    WelcomePage,
     ErrorComponent,
 } from "@refinedev/mui";
 import { BrowserRouter, Routes, Route } from "react-router-dom";

--- a/examples/with-storybook-antd/src/App.tsx
+++ b/examples/with-storybook-antd/src/App.tsx
@@ -1,9 +1,5 @@
-import { GitHubBanner, Refine } from "@refinedev/core";
-import {
-    useNotificationProvider,
-    WelcomePage,
-    RefineThemes,
-} from "@refinedev/antd";
+import { GitHubBanner, Refine, WelcomePage } from "@refinedev/core";
+import { useNotificationProvider, RefineThemes } from "@refinedev/antd";
 import dataProvider from "@refinedev/simple-rest";
 import routerProvider, {
     UnsavedChangesNotifier,

--- a/examples/with-storybook-material-ui/src/App.tsx
+++ b/examples/with-storybook-material-ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { GitHubBanner, Refine } from "@refinedev/core";
+import { GitHubBanner, Refine, WelcomePage } from "@refinedev/core";
 import dataProvider from "@refinedev/simple-rest";
 import routerProvider, {
     UnsavedChangesNotifier,
@@ -9,7 +9,6 @@ import {
     RefineThemes,
     useNotificationProvider,
     RefineSnackbarProvider,
-    WelcomePage,
 } from "@refinedev/mui";
 import { ThemeProvider } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";


### PR DESCRIPTION
Some of the examples were using deprecated WelcomePage imports. 