### PR TITLE
Fix: Use Material UI notifications provider in documentation code sample

### DIFF
--- a/documentation/docs/ui-integrations/material-ui/introduction/index.md
+++ b/documentation/docs/ui-integrations/material-ui/introduction/index.md
@@ -154,7 +154,7 @@ Material UI has its own notification elements but lacks the notification managem
 
 ```tsx title="app.tsx"
 import { Refine } from "@refinedev/core";
-import { useNotificationProvider, notificationProvider } from "@refinedev/mui";
+import { useNotificationProvider } from "@refinedev/mui";
 
 const App = () => {
   return (

--- a/documentation/docs/ui-integrations/material-ui/introduction/index.md
+++ b/documentation/docs/ui-integrations/material-ui/introduction/index.md
@@ -154,14 +154,13 @@ Material UI has its own notification elements but lacks the notification managem
 
 ```tsx title="app.tsx"
 import { Refine } from "@refinedev/core";
-import { useNotificationProvider, RefineSnackbarProvider } from "@refinedev/antd";
+import { useNotificationProvider, notificationProvider } from "@refinedev/mui";
 
 const App = () => {
   return (
-    // `notistack` also requires a context provider to be used
-    <RefineSnackbarProvider>
-      <Refine notificationProvider={useNotificationProvider}>{/* ... */}</Refine>
-    </RefineSnackbarProvider>
+    <Refine notificationProvider={notificationProvider}>
+      {/* ... */}
+    </Refine>
   );
 };
 ```

--- a/documentation/docs/ui-integrations/material-ui/introduction/index.md
+++ b/documentation/docs/ui-integrations/material-ui/introduction/index.md
@@ -158,7 +158,7 @@ import { useNotificationProvider } from "@refinedev/mui";
 
 const App = () => {
   return (
-    <Refine notificationProvider={notificationProvider}>
+    <Refine notificationProvider={useNotificationProvider}>
       {/* ... */}
     </Refine>
   );


### PR DESCRIPTION
The documentation provided an incorrect code sample that utilized the notifications provider from the Ant Design UI package instead of the intended Material UI notifications provider. This commit updates the code sample to import and use the Material UI notifications provider from @refinedev/mui as recommended in the documentation.

Changes:
- Updated import statement to import the notification provider from @refinedev/mui.
- Updated the code sample to use the Material UI notifications provider in the <Refine /> component.

## What is the current behavior?
The current behavior is that the documentation provides an incorrect code sample using the notifications provider from the Ant Design UI package instead of the Material UI notifications provider.

## What is the new behavior?
The new behavior is that the documentation code sample is updated to import and use the Material UI notifications provider from @refinedev/mui as recommended.

fixes #5620 (issue)

Notes for reviewers
No additional notes. Everything should be straightforward.
