### PR TITLE
fix(live-previews): unresponsive keycloak sign in

### DIFF
--- a/packages/live-previews/src/scope/auth0.tsx
+++ b/packages/live-previews/src/scope/auth0.tsx
@@ -1,6 +1,6 @@
 import * as Auth0ReactScope from "@auth0/auth0-react";
-import { useGo } from "@refinedev/core";
 import React from "react";
+import { ExternalNavigationContext } from "./common";
 
 const Auth0Context = React.createContext<{
     isLoading: boolean;
@@ -21,7 +21,8 @@ const Auth0Context = React.createContext<{
 });
 
 const Auth0Provider = ({ children }: { children: React.ReactNode }) => {
-    const go = useGo();
+    const externalNavigator = React.useContext(ExternalNavigationContext);
+
     const [isAuthenticated, setIsAuthenticated] = React.useState(false);
 
     return (
@@ -39,7 +40,7 @@ const Auth0Provider = ({ children }: { children: React.ReactNode }) => {
                     if (isAuthenticated) {
                         setIsAuthenticated(false);
 
-                        go({ to: "/", type: "replace" });
+                        externalNavigator.go({ to: "/login", type: "replace" });
                     }
                 },
                 getIdTokenClaims: () => {
@@ -54,7 +55,7 @@ const Auth0Provider = ({ children }: { children: React.ReactNode }) => {
 
                     setIsAuthenticated(true);
 
-                    go({ to: "/", type: "replace" });
+                    externalNavigator.go({ to: "/", type: "replace" });
                 },
             }}
         >

--- a/packages/live-previews/src/scope/keycloak.tsx
+++ b/packages/live-previews/src/scope/keycloak.tsx
@@ -1,7 +1,7 @@
 import * as KeycloakScope from "keycloak-js";
 import * as ReactKeycloakWebScope from "@react-keycloak/web";
-import { useGo } from "@refinedev/core";
 import React from "react";
+import { ExternalNavigationContext } from "./common";
 
 const ReactKeycloakContext = React.createContext<{
     keycloak: {
@@ -22,7 +22,8 @@ const ReactKeycloakContext = React.createContext<{
 });
 
 const ReactKeycloakProvider = ({ children }: { children: React.ReactNode }) => {
-    const go = useGo();
+    const externalNavigator = React.useContext(ExternalNavigationContext);
+
     const [isAuthenticated, setIsAuthenticated] = React.useState(false);
 
     return (
@@ -35,13 +36,13 @@ const ReactKeycloakProvider = ({ children }: { children: React.ReactNode }) => {
 
                         setIsAuthenticated(true);
 
-                        go({ to: "/", type: "replace" });
+                        externalNavigator.go({ to: "/", type: "replace" });
                     },
                     logout: () => {
                         if (isAuthenticated) {
                             setIsAuthenticated(false);
 
-                            go({ to: "/", type: "replace" });
+                            externalNavigator.go({ to: "/", type: "replace" });
                         }
                     },
                     token: isAuthenticated ? "dummy-token" : undefined,

--- a/packages/live-previews/src/utils/use-code.ts
+++ b/packages/live-previews/src/utils/use-code.ts
@@ -39,7 +39,7 @@ export const useCode = (): UseCodeReturn => {
             content = fixed.replace(/render\(<App \/>\);?/, "");
             content = content.replace(
                 /createRoot\(container\);?/,
-                "{ render };",
+                "{ render: (children) => render(<RefineCore.ExternalNavigationProvider>{children}</RefineCore.ExternalNavigationProvider>) };",
             );
         }
 


### PR DESCRIPTION
Fixed the issue with keycloak Auth Provider when used inside the preview of the scaffolder.

Resolves #5625

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

Keycloak provider was mocked for preview purposes but it was accessing the hooks before they're initialized, causing navigations to not work properly.

## What is the new behavior?

Added a small context and an handler to pass navigation methods to outside of React and used them inside the mock.