### PR TITLE
fix(docs): here section get started button double click issue

### DIFF
--- a/documentation/src/refine-theme/landing-hero-section.tsx
+++ b/documentation/src/refine-theme/landing-hero-section.tsx
@@ -83,7 +83,7 @@ export const LandingHeroSection = ({ className }: { className?: string }) => {
                         )}
                     >
                         <Link
-                            to="docs"
+                            to="/docs"
                             className={clsx(
                                 "self-start",
                                 "rounded-3xl",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
When the "Get Started" button is clicked twice, it results in a redirection to the URL "/docs/docs," which subsequently leads to a 404 error page.

## What is the new behavior?
Clicking the "Get Started" button should initiate a single redirection to the relevant destination without causing any navigational errors.

fixes # (issue)
[https://github.com/refinedev/refine/issues/5627](url)

## Notes for reviewers
Although this might not be considered a technical bug in the software, it's still frustrating for users when they accidentally click the "Get Started" button twice and end up being redirected unnecessarily.

<!-- Add any notes/questions you may have for reviewers -->
