### PR TITLE
fix(cli): demo access control provider's type is wrong.

### DIFF
--- a/.changeset/violet-games-exercise.md
+++ b/.changeset/violet-games-exercise.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/cli": patch
+---
+
+fix: demo access control provider typing.

--- a/documentation/docs/routing/integrations/next-js/provider-client-server.tsx
+++ b/documentation/docs/routing/integrations/next-js/provider-client-server.tsx
@@ -153,9 +153,9 @@ export const API_URL = "https://api.fake-rest.refine.dev";
 `;
 
 const AccessControlTsxCode = /* tsx */ `
-import { AccessControlBindings } from "@refinedev/core";
+import { AccessControlProvider } from "@refinedev/core";
 
-export const accessControlProvider: AccessControlBindings = {
+export const accessControlProvider: AccessControlProvider = {
     can: async ({ resource, action }) => {
         if (resource === "posts" && action === "edit") {
             return {

--- a/packages/cli/templates/provider/demo-access-control-provider.tsx
+++ b/packages/cli/templates/provider/demo-access-control-provider.tsx
@@ -1,11 +1,11 @@
-import { CanParams, IAccessControlContext } from "@refinedev/core";
+import { AccessControlProvider } from "@refinedev/core";
 
 /**
  * Check out the Access Control Provider documentation for detailed information
  * https://refine.dev/docs/api-reference/core/providers/accessControl-provider
  **/
-export const accessControlProvider: IAccessControlContext = {
-    can: async ({ resource, action, params }: CanParams) => {
+export const accessControlProvider: AccessControlProvider = {
+    can: async ({ resource, action, params }) => {
         console.log("can", {
             resource,
             action,

--- a/packages/cli/templates/provider/demo-data-provider.tsx
+++ b/packages/cli/templates/provider/demo-data-provider.tsx
@@ -6,7 +6,7 @@ import { DataProvider } from "@refinedev/core";
  **/
 export const dataProvider = (
     apiUrl: string,
-    httpClient: any, // TODO: replace `any` with your http client type
+    _httpClient: any, // TODO: replace `any` with your http client type
 ): DataProvider => ({
     getList: async ({ resource, pagination, filters, sorters, meta }) => {
         const url = `${apiUrl}/${resource}`;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

Currently, exported accessControlProvider object has wrong type, and also can params had to be set explicitly because of that.

## What is the new behavior?

Now accessControlProvider has `AccessControlProvider` type, also we don't need to have explicit CanParams.

fixes # (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
