### PR TITLE
feat(docs): update landing showcase finefoods image names

### DIFF
--- a/documentation/src/refine-theme/landing-hero-showcase-section.tsx
+++ b/documentation/src/refine-theme/landing-hero-showcase-section.tsx
@@ -517,14 +517,14 @@ const ShowcaseECommerce = ({ className }: { className?: string }) => {
     return (
         <ShowcaseWrapper
             className={className}
-            render="https://refine.ams3.cdn.digitaloceanspaces.com/website/static/showcase-images/finefoods/base_render.png"
+            render="https://refine.ams3.cdn.digitaloceanspaces.com/website/static/showcase-images/finefoods/base_render-2.png"
             highlights={[
                 {
                     x: 811,
                     y: 10,
                     width: 108,
                     height: 44,
-                    render: "https://refine.ams3.cdn.digitaloceanspaces.com/website/static/showcase-images/finefoods/language.png",
+                    render: "https://refine.ams3.cdn.digitaloceanspaces.com/website/static/showcase-images/finefoods/language-2.png",
                     codePosition: "left",
                     code: `
                             import { useSetLocale, useGetLocale } from "@refinedev/core";
@@ -542,7 +542,7 @@ const ShowcaseECommerce = ({ className }: { className?: string }) => {
                     y: 168,
                     width: 616,
                     height: 360,
-                    render: "https://refine.ams3.cdn.digitaloceanspaces.com/website/static/showcase-images/finefoods/map.png",
+                    render: "https://refine.ams3.cdn.digitaloceanspaces.com/website/static/showcase-images/finefoods/map-2.png",
                     codePosition: "right",
                     codeClassName: "!pl-2",
                     overlap: true,
@@ -561,7 +561,7 @@ const ShowcaseECommerce = ({ className }: { className?: string }) => {
                     y: 92,
                     width: 204,
                     height: 48,
-                    render: "https://refine.ams3.cdn.digitaloceanspaces.com/website/static/showcase-images/finefoods/actions.png",
+                    render: "https://refine.ams3.cdn.digitaloceanspaces.com/website/static/showcase-images/finefoods/actions-2.png",
                     codePosition: "left",
                     code: `
                     import { useResource, useUpdate } from "@refinedev/core";
@@ -583,7 +583,7 @@ const ShowcaseECommerce = ({ className }: { className?: string }) => {
                     y: 216,
                     width: 152,
                     height: 120,
-                    render: "https://refine.ams3.cdn.digitaloceanspaces.com/website/static/showcase-images/finefoods/menu.png",
+                    render: "https://refine.ams3.cdn.digitaloceanspaces.com/website/static/showcase-images/finefoods/menu-2.png",
                     codePosition: "right",
                     code: `
                     


### PR DESCRIPTION

<img width="300" alt="image" src="https://github.com/refinedev/refine/assets/23058882/f656e8ab-feb7-4b1a-9db8-497aea82b7ba">


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

newly uploaded images remain in the local cache of some browsers, so the new ones do not show up.

## What is the new behavior?

new images are uploaded with a different name to prevent them from staying in the local cache.

fixes # (issue)

Some users see old images on landing pages because of CDN or local cache.

