### PR TITLE
fix: reject Promise on error in mutation

### DIFF
--- a/packages/core/src/hooks/form/useForm.ts
+++ b/packages/core/src/hooks/form/useForm.ts
@@ -452,7 +452,7 @@ export const useForm = <
           },
           onError: (error: TResponseError, _, context) => {
             if (onMutationError) {
-              return onMutationError(error, values, context);
+              onMutationError(error, values, context);
             }
             reject();
           },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [X] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

The current behaviour is that the Promise of the `onFinish` handler never rejects because it returns early.

## What is the new behavior?

The Promise will be rejected if there was any error.

fixes https://github.com/refinedev/refine/issues/5667

## Notes for reviewers

Let me know if you are fine with the changes and I can see if I can implemented the corresponding test 😊 
