### PR TITLE
feat: Passing selectedKey as props

### DIFF
--- a/packages/antd/src/components/themedLayoutV2/sider/index.tsx
+++ b/packages/antd/src/components/themedLayoutV2/sider/index.tsx
@@ -180,12 +180,14 @@ export const ThemedSiderV2: React.FC<RefineThemedLayoutV2SiderProps> = ({
         dashboard,
         items,
         logout,
+        selectedKey,
         collapsed: siderCollapsed,
       });
     }
     return (
       <>
         {dashboard}
+        {selectedKey}
         {items}
         {logout}
       </>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
* Users need to import the selectedKey from useMenu and pass in to modify menu items

## What is the new behavior?
* By passing it in render, it could be access via props, and could be passed accordingly.

fixes #5589

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
