### PR TITLE
fix(app-crm): set resource of delete contact note button

### DIFF
--- a/examples/app-crm/src/routes/contacts/components/comment/comment-list.tsx
+++ b/examples/app-crm/src/routes/contacts/components/comment/comment-list.tsx
@@ -132,7 +132,7 @@ const ContactCommentListItem = ({ item }: { item: ContactNote }) => {
             </Typography.Link>
             <DeleteButton
               recordItemId={item.id}
-              meta={{ operation: "contactNote" }}
+              resource="contactNotes"
               size="small"
               type="link"
               successNotification={() => ({


### PR DESCRIPTION
Closes #5651

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

According to issue #5651 the app-crm example is trying to delete contacts instead of contact notes due to the delete button using the route resource (which is contact, as the notes widgets is inside the contact view),

## What is the new behavior?

After adding the resource (```contactNotes```) explicitly to the delete note button the example application `app-crm`  can now delete contact notes sucessfully.
