### PR TITLE
fix(table-material-ui-use-data-grid): failing e2e example

### DIFF
--- a/examples/table-material-ui-use-data-grid/cypress/e2e/all.cy.ts
+++ b/examples/table-material-ui-use-data-grid/cypress/e2e/all.cy.ts
@@ -142,9 +142,24 @@ describe("table-material-ui-use-data-grid", () => {
   });
 
   it("should set current `1` when filter changed", () => {
+    cy.intercept(
+      {
+        url: "/posts*",
+        query: {
+          _start: "10",
+          _end: "20",
+        },
+      },
+      {
+        fixture: "posts.json",
+      },
+    ).as("getSecondPagePosts");
+
     cy.getMaterialUILoadingCircular().should("not.exist");
 
     cy.get("[title='Go to next page']").click();
+
+    cy.wait("@getSecondPagePosts");
 
     cy.getMaterialUIColumnHeader(2).within(() =>
       cy.get(".MuiDataGrid-menuIcon > button").click({ force: true }),


### PR DESCRIPTION
One of the e2e tests is failing for this example, guessing it's because we aren't waiting for the page load.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes # (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
