### PR TITLE
fix(mui): unnecessary margin on MUI ThemedSiderV2

### DIFF
--- a/.changeset/ten-readers-poke.md
+++ b/.changeset/ten-readers-poke.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/mui": patch
+---
+
+fix: issue with dropdown button on ThemedSiderV2 #5724
+
+There was unexpected margin on dropdown button at ThemedSiderV2.
+
+Fixes #5724

--- a/packages/mui/src/components/themedLayoutV2/sider/index.tsx
+++ b/packages/mui/src/components/themedLayoutV2/sider/index.tsx
@@ -138,7 +138,6 @@ export const ThemedSiderV2: React.FC<RefineThemedLayoutV2SiderProps> = ({
                   sx={{
                     pl: isNested ? 4 : 2,
                     justifyContent: "center",
-                    marginTop: "8px",
                   }}
                 >
                   <ListItemIcon


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

There is unexpected/unnecessary margin on ThemeSiderV2 (MUI). 

## What is the new behavior?

fixes #5724 (issue)

## Notes for reviewers

This 8px margin is really standing out when there are a lot of resources, images of margin are attached in #5724 issue.
