### PR TITLE
feat(docs): scroll to active link in the sidebar

### DIFF
--- a/documentation/src/refine-theme/doc-sidebar.tsx
+++ b/documentation/src/refine-theme/doc-sidebar.tsx
@@ -68,6 +68,7 @@ const SidebarCategory = ({
   onLinkClick?: () => void;
   deferred?: boolean;
 }) => {
+  const location = useLocation();
   const isHeader = item.className?.includes("category-as-header");
   const isActive = isActiveSidebarItem(item, path);
 
@@ -99,6 +100,25 @@ const SidebarCategory = ({
       setSettled(false);
     }
   };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: we don't want to re-run this effect when the location changes
+  React.useEffect(() => {
+    // find <a> elements with href attribute value equal to the current path
+    const activeLink = document.querySelector(
+      `#refine-docs-sidebar a[href="${location.pathname}"]`,
+    );
+    if (!activeLink) return;
+
+    // get sidebar
+    const sidebar = document.querySelector("#refine-docs-sidebar");
+    if (!sidebar) return;
+
+    // scroll to active link in the sidebar
+    sidebar.scrollTo({
+      top: activeLink.getBoundingClientRect().top - 200,
+      behavior: "smooth",
+    });
+  }, []);
 
   const Comp = !isHeader && item.href && !isSame ? Link : "button";
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

for example, https://refine.dev/docs/authentication/auth-provider/ when we click on this link, the selected sidebar item is far below the visible screen area. Therefore it is very difficult to find the selected sidebar item.

## What is the new behavior?

the sidebar scrolls to the selected item after the page opens

https://github.com/refinedev/refine/assets/23058882/bafaac5b-cf3f-44ff-bac6-1b148846aa73

fixes # (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
