### PR TITLE
chore(examples): add type "module" to all vite examples

### DIFF
--- a/examples/access-control-casbin/package.json
+++ b/examples/access-control-casbin/package.json
@@ -2,6 +2,7 @@
   "name": "access-control-casbin",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/access-control-cerbos/package.json
+++ b/examples/access-control-cerbos/package.json
@@ -2,6 +2,7 @@
   "name": "access-control-cerbos",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/access-control-permify/package.json
+++ b/examples/access-control-permify/package.json
@@ -2,6 +2,7 @@
   "name": "access-control-permify",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/app-crm-minimal/package.json
+++ b/examples/app-crm-minimal/package.json
@@ -2,6 +2,7 @@
   "name": "app-crm-minimal",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && cross-env NODE_OPTIONS=--max_old_space_size=4096 refine build",
     "codegen": "graphql-codegen",

--- a/examples/app-crm/package.json
+++ b/examples/app-crm/package.json
@@ -2,6 +2,7 @@
   "name": "app-crm",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && cross-env NODE_OPTIONS=--max_old_space_size=4096 refine build",
     "codegen": "graphql-codegen",

--- a/examples/audit-log-provider/package.json
+++ b/examples/audit-log-provider/package.json
@@ -2,6 +2,7 @@
   "name": "audit-log-provider",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/auth-antd/package.json
+++ b/examples/auth-antd/package.json
@@ -2,6 +2,7 @@
   "name": "auth-antd",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/auth-auth0/package.json
+++ b/examples/auth-auth0/package.json
@@ -2,6 +2,7 @@
   "name": "auth-auth0",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/auth-chakra-ui/package.json
+++ b/examples/auth-chakra-ui/package.json
@@ -2,6 +2,7 @@
   "name": "auth-chakra-ui",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/auth-google-login/package.json
+++ b/examples/auth-google-login/package.json
@@ -2,6 +2,7 @@
   "name": "auth-google-login",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/auth-headless/package.json
+++ b/examples/auth-headless/package.json
@@ -2,6 +2,7 @@
   "name": "auth-headless",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/auth-keycloak/package.json
+++ b/examples/auth-keycloak/package.json
@@ -2,6 +2,7 @@
   "name": "auth-keycloak",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/auth-kinde/package.json
+++ b/examples/auth-kinde/package.json
@@ -2,6 +2,7 @@
   "name": "auth-kinde",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/auth-mantine/package.json
+++ b/examples/auth-mantine/package.json
@@ -2,6 +2,7 @@
   "name": "auth-mantine",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/auth-material-ui/package.json
+++ b/examples/auth-material-ui/package.json
@@ -2,6 +2,7 @@
   "name": "auth-material-ui",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/auth-otp/package.json
+++ b/examples/auth-otp/package.json
@@ -2,6 +2,7 @@
   "name": "auth-otp",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/base-antd/package.json
+++ b/examples/base-antd/package.json
@@ -2,6 +2,7 @@
   "name": "base-antd",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/base-chakra-ui/package.json
+++ b/examples/base-chakra-ui/package.json
@@ -2,6 +2,7 @@
   "name": "base-chakra-ui",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/base-headless/package.json
+++ b/examples/base-headless/package.json
@@ -2,6 +2,7 @@
   "name": "base-headless",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/base-mantine/package.json
+++ b/examples/base-mantine/package.json
@@ -2,6 +2,7 @@
   "name": "base-mantine",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/base-material-ui/package.json
+++ b/examples/base-material-ui/package.json
@@ -2,6 +2,7 @@
   "name": "base-material-ui",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/blog-invoice-generator/package.json
+++ b/examples/blog-invoice-generator/package.json
@@ -2,6 +2,7 @@
   "name": "blog-invoice-generator",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "refine build",
     "dev": "refine dev",

--- a/examples/blog-ra-chakra-tutorial/package.json
+++ b/examples/blog-ra-chakra-tutorial/package.json
@@ -1,6 +1,7 @@
 {
   "name": "blog-ra-chakra-tutorial",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/blog-refine-airtable-crud/package.json
+++ b/examples/blog-refine-airtable-crud/package.json
@@ -2,6 +2,7 @@
   "name": "blog-refine-airtable-crud",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/blog-refine-antd-dynamic-form/package.json
+++ b/examples/blog-refine-antd-dynamic-form/package.json
@@ -2,6 +2,7 @@
   "name": "blog-refine-antd-dynamic-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/blog-refine-react-hook-form/package.json
+++ b/examples/blog-refine-react-hook-form/package.json
@@ -2,6 +2,7 @@
   "name": "blog-refine-react-hook-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/blog-refine-supabase-auth/package.json
+++ b/examples/blog-refine-supabase-auth/package.json
@@ -2,6 +2,7 @@
   "name": "blog-refine-supabase-auth",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/calendar-app/package.json
+++ b/examples/calendar-app/package.json
@@ -2,6 +2,7 @@
   "name": "calendar-app",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/command-palette-kbar/package.json
+++ b/examples/command-palette-kbar/package.json
@@ -2,6 +2,7 @@
   "name": "command-palette-kbar",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/core-use-import/package.json
+++ b/examples/core-use-import/package.json
@@ -2,6 +2,7 @@
   "name": "core-use-import",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/core-use-menu/package.json
+++ b/examples/core-use-menu/package.json
@@ -2,6 +2,7 @@
   "name": "core-use-menu",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/core-use-modal/package.json
+++ b/examples/core-use-modal/package.json
@@ -2,6 +2,7 @@
   "name": "core-use-modal",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/core-use-select/package.json
+++ b/examples/core-use-select/package.json
@@ -2,6 +2,7 @@
   "name": "core-use-select",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/customization-footer/package.json
+++ b/examples/customization-footer/package.json
@@ -2,6 +2,7 @@
   "name": "customization-footer",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/customization-offlayout-area/package.json
+++ b/examples/customization-offlayout-area/package.json
@@ -2,6 +2,7 @@
   "name": "customization-offlayout-area",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/customization-rtl/package.json
+++ b/examples/customization-rtl/package.json
@@ -2,6 +2,7 @@
   "name": "customization-rtl",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/customization-sider/package.json
+++ b/examples/customization-sider/package.json
@@ -2,6 +2,7 @@
   "name": "customization-sider",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/customization-theme-antd/package.json
+++ b/examples/customization-theme-antd/package.json
@@ -2,6 +2,7 @@
   "name": "customization-theme-antd",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/customization-theme-chakra-ui/package.json
+++ b/examples/customization-theme-chakra-ui/package.json
@@ -2,6 +2,7 @@
   "name": "customization-theme-chakra-ui",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/customization-theme-mantine/package.json
+++ b/examples/customization-theme-mantine/package.json
@@ -2,6 +2,7 @@
   "name": "customization-theme-mantine",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/customization-theme-material-ui/package.json
+++ b/examples/customization-theme-material-ui/package.json
@@ -2,6 +2,7 @@
   "name": "customization-theme-material-ui",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/customization-top-menu-layout/package.json
+++ b/examples/customization-top-menu-layout/package.json
@@ -2,6 +2,7 @@
   "name": "customization-top-menu-layout",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/data-provider-airtable/package.json
+++ b/examples/data-provider-airtable/package.json
@@ -2,6 +2,7 @@
   "name": "data-provider-airtable",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/data-provider-appwrite-tutorial-docs/package.json
+++ b/examples/data-provider-appwrite-tutorial-docs/package.json
@@ -2,6 +2,7 @@
   "name": "data-provider-appwrite-tutorial-docs",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/data-provider-appwrite/package.json
+++ b/examples/data-provider-appwrite/package.json
@@ -2,6 +2,7 @@
   "name": "data-provider-appwrite",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/data-provider-hasura/package.json
+++ b/examples/data-provider-hasura/package.json
@@ -2,6 +2,7 @@
   "name": "data-provider-hasura",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "codegen": "graphql-codegen",

--- a/examples/data-provider-multiple/package.json
+++ b/examples/data-provider-multiple/package.json
@@ -2,6 +2,7 @@
   "name": "data-provider-multiple",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/data-provider-nestjs-query/package.json
+++ b/examples/data-provider-nestjs-query/package.json
@@ -2,6 +2,7 @@
   "name": "data-provider-nestjs-query",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "codegen": "graphql-codegen",

--- a/examples/data-provider-nestjsx-crud/package.json
+++ b/examples/data-provider-nestjsx-crud/package.json
@@ -2,6 +2,7 @@
   "name": "data-provider-nestjsx-crud",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/data-provider-sanity/package.json
+++ b/examples/data-provider-sanity/package.json
@@ -2,6 +2,7 @@
   "name": "data-provider-sanity",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/data-provider-strapi-v4/package.json
+++ b/examples/data-provider-strapi-v4/package.json
@@ -2,6 +2,7 @@
   "name": "data-provider-strapi-v4",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/data-provider-strapi/package.json
+++ b/examples/data-provider-strapi/package.json
@@ -2,6 +2,7 @@
   "name": "data-provider-strapi",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/data-provider-supabase/package.json
+++ b/examples/data-provider-supabase/package.json
@@ -2,6 +2,7 @@
   "name": "data-provider-supabase",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/field-antd-use-checkbox-group/package.json
+++ b/examples/field-antd-use-checkbox-group/package.json
@@ -2,6 +2,7 @@
   "name": "field-antd-use-checkbox-group",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/field-antd-use-radio-group/package.json
+++ b/examples/field-antd-use-radio-group/package.json
@@ -2,6 +2,7 @@
   "name": "field-antd-use-radio-group",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/field-antd-use-select-basic/package.json
+++ b/examples/field-antd-use-select-basic/package.json
@@ -2,6 +2,7 @@
   "name": "field-antd-use-select-basic",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/field-antd-use-select-infinite/package.json
+++ b/examples/field-antd-use-select-infinite/package.json
@@ -2,6 +2,7 @@
   "name": "field-antd-use-select-infinite",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/field-material-ui-use-autocomplete/package.json
+++ b/examples/field-material-ui-use-autocomplete/package.json
@@ -2,6 +2,7 @@
   "name": "field-material-ui-use-autocomplete",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/finefoods-antd/package.json
+++ b/examples/finefoods-antd/package.json
@@ -2,6 +2,7 @@
   "name": "finefoods-antd",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/finefoods-material-ui/package.json
+++ b/examples/finefoods-material-ui/package.json
@@ -2,6 +2,7 @@
   "name": "finefoods-material-ui",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/form-antd-custom-validation/package.json
+++ b/examples/form-antd-custom-validation/package.json
@@ -2,6 +2,7 @@
   "name": "form-antd-custom-validation",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-antd-mutation-mode/package.json
+++ b/examples/form-antd-mutation-mode/package.json
@@ -2,6 +2,7 @@
   "name": "form-antd-mutation-mode",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-antd-use-drawer-form/package.json
+++ b/examples/form-antd-use-drawer-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-antd-use-drawer-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-antd-use-form/package.json
+++ b/examples/form-antd-use-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-antd-use-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-antd-use-modal-form/package.json
+++ b/examples/form-antd-use-modal-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-antd-use-modal-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-antd-use-steps-form/package.json
+++ b/examples/form-antd-use-steps-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-antd-use-steps-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-chakra-ui-mutation-mode/package.json
+++ b/examples/form-chakra-ui-mutation-mode/package.json
@@ -2,6 +2,7 @@
   "name": "form-chakra-ui-mutation-mode",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-chakra-ui-use-drawer-form/package.json
+++ b/examples/form-chakra-ui-use-drawer-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-chakra-ui-use-drawer-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-chakra-ui-use-form/package.json
+++ b/examples/form-chakra-ui-use-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-chakra-ui-use-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-chakra-use-modal-form/package.json
+++ b/examples/form-chakra-use-modal-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-chakra-use-modal-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-core-use-form/package.json
+++ b/examples/form-core-use-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-core-use-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/form-mantine-mutation-mode/package.json
+++ b/examples/form-mantine-mutation-mode/package.json
@@ -2,6 +2,7 @@
   "name": "form-mantine-mutation-mode",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-mantine-use-drawer-form/package.json
+++ b/examples/form-mantine-use-drawer-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-mantine-use-drawer-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-mantine-use-form/package.json
+++ b/examples/form-mantine-use-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-mantine-use-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-mantine-use-modal-form/package.json
+++ b/examples/form-mantine-use-modal-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-mantine-use-modal-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-mantine-use-steps-form/package.json
+++ b/examples/form-mantine-use-steps-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-mantine-use-steps-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-material-ui-mutation-mode/package.json
+++ b/examples/form-material-ui-mutation-mode/package.json
@@ -2,6 +2,7 @@
   "name": "form-material-ui-mutation-mode",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-material-ui-use-drawer-form/package.json
+++ b/examples/form-material-ui-use-drawer-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-material-ui-use-drawer-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-material-ui-use-form/package.json
+++ b/examples/form-material-ui-use-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-material-ui-use-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-material-ui-use-modal-form/package.json
+++ b/examples/form-material-ui-use-modal-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-material-ui-use-modal-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-material-ui-use-steps-form/package.json
+++ b/examples/form-material-ui-use-steps-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-material-ui-use-steps-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-react-hook-form-use-form/package.json
+++ b/examples/form-react-hook-form-use-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-react-hook-form-use-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-react-hook-form-use-modal-form/package.json
+++ b/examples/form-react-hook-form-use-modal-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-react-hook-form-use-modal-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-react-hook-form-use-steps-form/package.json
+++ b/examples/form-react-hook-form-use-steps-form/package.json
@@ -2,6 +2,7 @@
   "name": "form-react-hook-form-use-steps-form",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/form-save-and-continue/package.json
+++ b/examples/form-save-and-continue/package.json
@@ -2,6 +2,7 @@
   "name": "form-save-and-continue",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/i18n-react/package.json
+++ b/examples/i18n-react/package.json
@@ -2,6 +2,7 @@
   "name": "i18n-react",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/import-export-antd/package.json
+++ b/examples/import-export-antd/package.json
@@ -2,6 +2,7 @@
   "name": "import-export-antd",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/import-export-mantine/package.json
+++ b/examples/import-export-mantine/package.json
@@ -2,6 +2,7 @@
   "name": "import-export-mantine",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/import-export-material-ui/package.json
+++ b/examples/import-export-material-ui/package.json
@@ -2,6 +2,7 @@
   "name": "import-export-material-ui",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/input-custom/package.json
+++ b/examples/input-custom/package.json
@@ -2,6 +2,7 @@
   "name": "input-custom",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/input-date-picker/package.json
+++ b/examples/input-date-picker/package.json
@@ -2,6 +2,7 @@
   "name": "input-date-picker",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/live-provider-ably/package.json
+++ b/examples/live-provider-ably/package.json
@@ -2,6 +2,7 @@
   "name": "live-provider-ably",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/loading-overtime/package.json
+++ b/examples/loading-overtime/package.json
@@ -2,6 +2,7 @@
   "name": "loading-overtime",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/multi-level-menu/package.json
+++ b/examples/multi-level-menu/package.json
@@ -2,6 +2,7 @@
   "name": "multi-level-menu",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/multi-tenancy-appwrite/package.json
+++ b/examples/multi-tenancy-appwrite/package.json
@@ -2,6 +2,7 @@
   "name": "multi-tenancy-appwrite",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/multi-tenancy-strapi/package.json
+++ b/examples/multi-tenancy-strapi/package.json
@@ -2,6 +2,7 @@
   "name": "multi-tenancy-strapi",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/new-routing-example/package.json
+++ b/examples/new-routing-example/package.json
@@ -2,6 +2,7 @@
   "name": "new-routing-example",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/pixels-admin/package.json
+++ b/examples/pixels-admin/package.json
@@ -2,6 +2,7 @@
   "name": "pixels-admin",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/pixels/package.json
+++ b/examples/pixels/package.json
@@ -2,6 +2,7 @@
   "name": "pixels",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/refine-week-invoice-generator/package.json
+++ b/examples/refine-week-invoice-generator/package.json
@@ -2,6 +2,7 @@
   "name": "refine-week-invoice-generator",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/search/package.json
+++ b/examples/search/package.json
@@ -2,6 +2,7 @@
   "name": "search",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/server-side-form-validation-antd/package.json
+++ b/examples/server-side-form-validation-antd/package.json
@@ -2,6 +2,7 @@
   "name": "server-side-form-validation-antd",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/server-side-form-validation-chakra-ui/package.json
+++ b/examples/server-side-form-validation-chakra-ui/package.json
@@ -2,6 +2,7 @@
   "name": "server-side-form-validation-chakra-ui",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/server-side-form-validation-mantine/package.json
+++ b/examples/server-side-form-validation-mantine/package.json
@@ -2,6 +2,7 @@
   "name": "server-side-form-validation-mantine",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/server-side-form-validation-material-ui/package.json
+++ b/examples/server-side-form-validation-material-ui/package.json
@@ -2,6 +2,7 @@
   "name": "server-side-form-validation-material-ui",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-antd-advanced/package.json
+++ b/examples/table-antd-advanced/package.json
@@ -2,6 +2,7 @@
   "name": "table-antd-advanced",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-antd-table-filter/package.json
+++ b/examples/table-antd-table-filter/package.json
@@ -2,6 +2,7 @@
   "name": "table-antd-table-filter",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-antd-use-delete-many/package.json
+++ b/examples/table-antd-use-delete-many/package.json
@@ -2,6 +2,7 @@
   "name": "table-antd-use-delete-many",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-antd-use-editable-table/package.json
+++ b/examples/table-antd-use-editable-table/package.json
@@ -2,6 +2,7 @@
   "name": "table-antd-use-editable-table",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-antd-use-table/package.json
+++ b/examples/table-antd-use-table/package.json
@@ -2,6 +2,7 @@
   "name": "table-antd-use-table",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-antd-use-update-many/package.json
+++ b/examples/table-antd-use-update-many/package.json
@@ -2,6 +2,7 @@
   "name": "table-antd-use-update-many",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-chakra-ui-advanced/package.json
+++ b/examples/table-chakra-ui-advanced/package.json
@@ -2,6 +2,7 @@
   "name": "table-chakra-ui-advanced",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-chakra-ui-basic/package.json
+++ b/examples/table-chakra-ui-basic/package.json
@@ -2,6 +2,7 @@
   "name": "table-chakra-ui-basic",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-handson/package.json
+++ b/examples/table-handson/package.json
@@ -2,6 +2,7 @@
   "name": "table-handson",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-mantine-advanced/package.json
+++ b/examples/table-mantine-advanced/package.json
@@ -2,6 +2,7 @@
   "name": "table-mantine-advanced",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-mantine-basic/package.json
+++ b/examples/table-mantine-basic/package.json
@@ -2,6 +2,7 @@
   "name": "table-mantine-basic",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-material-ui-advanced/package.json
+++ b/examples/table-material-ui-advanced/package.json
@@ -2,6 +2,7 @@
   "name": "table-material-ui-advanced",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-material-ui-cursor-pagination/package.json
+++ b/examples/table-material-ui-cursor-pagination/package.json
@@ -2,6 +2,7 @@
   "name": "table-material-ui-cursor-pagination",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-material-ui-data-grid-pro/package.json
+++ b/examples/table-material-ui-data-grid-pro/package.json
@@ -2,6 +2,7 @@
   "name": "table-material-ui-data-grid-pro",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-material-ui-table-filter/package.json
+++ b/examples/table-material-ui-table-filter/package.json
@@ -2,6 +2,7 @@
   "name": "table-material-ui-table-filter",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-material-ui-use-data-grid/package.json
+++ b/examples/table-material-ui-use-data-grid/package.json
@@ -2,6 +2,7 @@
   "name": "table-material-ui-use-data-grid",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-material-ui-use-delete-many/package.json
+++ b/examples/table-material-ui-use-delete-many/package.json
@@ -2,6 +2,7 @@
   "name": "table-material-ui-use-delete-many",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-material-ui-use-update-many/package.json
+++ b/examples/table-material-ui-use-update-many/package.json
@@ -2,6 +2,7 @@
   "name": "table-material-ui-use-update-many",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-react-table-advanced/package.json
+++ b/examples/table-react-table-advanced/package.json
@@ -2,6 +2,7 @@
   "name": "table-react-table-advanced",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/table-react-table-basic/package.json
+++ b/examples/table-react-table-basic/package.json
@@ -2,6 +2,7 @@
   "name": "table-react-table-basic",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "cypress": "cypress open -C ./cypress.config.ts",

--- a/examples/template-chakra-ui/package.json
+++ b/examples/template-chakra-ui/package.json
@@ -2,6 +2,7 @@
   "name": "template-chakra-ui",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/template-headless/package.json
+++ b/examples/template-headless/package.json
@@ -2,6 +2,7 @@
   "name": "template-headless",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/template-mantine/package.json
+++ b/examples/template-mantine/package.json
@@ -2,6 +2,7 @@
   "name": "template-mantine",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/template-material-ui/package.json
+++ b/examples/template-material-ui/package.json
@@ -2,6 +2,7 @@
   "name": "template-material-ui",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/theme-antd-demo/package.json
+++ b/examples/theme-antd-demo/package.json
@@ -2,6 +2,7 @@
   "name": "theme-antd-demo",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/theme-chakra-ui-demo/package.json
+++ b/examples/theme-chakra-ui-demo/package.json
@@ -2,6 +2,7 @@
   "name": "theme-chakra-ui-demo",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/theme-mantine-demo/package.json
+++ b/examples/theme-mantine-demo/package.json
@@ -2,6 +2,7 @@
   "name": "theme-mantine-demo",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/theme-material-ui-demo/package.json
+++ b/examples/theme-material-ui-demo/package.json
@@ -2,6 +2,7 @@
   "name": "theme-material-ui-demo",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/tutorial-antd/package.json
+++ b/examples/tutorial-antd/package.json
@@ -2,6 +2,7 @@
   "name": "tutorial-antd",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/tutorial-chakra-ui/package.json
+++ b/examples/tutorial-chakra-ui/package.json
@@ -2,6 +2,7 @@
   "name": "tutorial-chakra-ui",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/tutorial-headless/package.json
+++ b/examples/tutorial-headless/package.json
@@ -2,6 +2,7 @@
   "name": "tutorial-headless",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/tutorial-mantine/package.json
+++ b/examples/tutorial-mantine/package.json
@@ -2,6 +2,7 @@
   "name": "tutorial-mantine",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/tutorial-material-ui/package.json
+++ b/examples/tutorial-material-ui/package.json
@@ -2,6 +2,7 @@
   "name": "tutorial-material-ui",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/upload-antd-base64/package.json
+++ b/examples/upload-antd-base64/package.json
@@ -2,6 +2,7 @@
   "name": "upload-antd-base64",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/upload-antd-multipart/package.json
+++ b/examples/upload-antd-multipart/package.json
@@ -2,6 +2,7 @@
   "name": "upload-antd-multipart",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/upload-chakra-ui-basic64/package.json
+++ b/examples/upload-chakra-ui-basic64/package.json
@@ -2,6 +2,7 @@
   "name": "upload-chakra-ui-basic64",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/upload-chakra-ui-multipart/package.json
+++ b/examples/upload-chakra-ui-multipart/package.json
@@ -2,6 +2,7 @@
   "name": "upload-chakra-ui-multipart",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/upload-mantine-base64/package.json
+++ b/examples/upload-mantine-base64/package.json
@@ -2,6 +2,7 @@
   "name": "upload-mantine-base64",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/upload-mantine-multipart/package.json
+++ b/examples/upload-mantine-multipart/package.json
@@ -2,6 +2,7 @@
   "name": "upload-mantine-multipart",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/upload-material-ui-base64/package.json
+++ b/examples/upload-material-ui-base64/package.json
@@ -2,6 +2,7 @@
   "name": "upload-material-ui-base64",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/upload-material-ui-multipart/package.json
+++ b/examples/upload-material-ui-multipart/package.json
@@ -2,6 +2,7 @@
   "name": "upload-material-ui-multipart",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/use-infinite-list/package.json
+++ b/examples/use-infinite-list/package.json
@@ -2,6 +2,7 @@
   "name": "use-infinite-list",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/use-modal-antd/package.json
+++ b/examples/use-modal-antd/package.json
@@ -2,6 +2,7 @@
   "name": "use-modal-antd",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/use-simple-list-antd/package.json
+++ b/examples/use-simple-list-antd/package.json
@@ -2,6 +2,7 @@
   "name": "use-simple-list-antd",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/with-custom-pages/package.json
+++ b/examples/with-custom-pages/package.json
@@ -2,6 +2,7 @@
   "name": "with-custom-pages",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/with-javascript/package.json
+++ b/examples/with-javascript/package.json
@@ -2,6 +2,7 @@
   "name": "with-javascript",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "refine build",
     "dev": "refine dev",

--- a/examples/with-meta-properties/package.json
+++ b/examples/with-meta-properties/package.json
@@ -2,6 +2,7 @@
   "name": "with-meta-properties",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/with-persist-query/package.json
+++ b/examples/with-persist-query/package.json
@@ -2,6 +2,7 @@
   "name": "with-persist-query",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/with-react-toastify/package.json
+++ b/examples/with-react-toastify/package.json
@@ -2,6 +2,7 @@
   "name": "with-react-toastify",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/with-storybook-antd/package.json
+++ b/examples/with-storybook-antd/package.json
@@ -2,6 +2,7 @@
   "name": "with-storybook-antd",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/with-storybook-material-ui/package.json
+++ b/examples/with-storybook-material-ui/package.json
@@ -2,6 +2,7 @@
   "name": "with-storybook-material-ui",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",

--- a/examples/with-web3/package.json
+++ b/examples/with-web3/package.json
@@ -2,6 +2,7 @@
   "name": "with-web3",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",


### PR DESCRIPTION
Since with Vite 5 the CJS Node API is deprecated we're using `type: "module"` in all our vite examples.

Check the troubleshooting guide in Vite docs: https://vitejs.dev/guide/troubleshooting#vite-cjs-node-api-deprecated