### PR TITLE
chore: upgrade to `@tabler/icons-react@3` from `@tabler/icons@1`

### DIFF
--- a/.changeset/curvy-actors-itch.md
+++ b/.changeset/curvy-actors-itch.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/mantine": minor
+---
+
+Migrated from outdated `@tabler/icons@1` to `@tabler/icons-react@3` to make sure we're using the latest available version of the library without requiring users to pin to a deprecated version.
+
+If your project doesn't include `@tabler/icons` you won't be affected by this change. If you're using `@tabler/icons@1` in your project, you may need to update your dependency to latest version of `@tabler/icons-react` to avoid conflicting dependencies. Practically, this should not introduce any breaking changes to your project and all the icons in `@tabler/icons@1` should also be available in the latest version of `@tabler/icons-react`.

--- a/.changeset/three-rivers-invite.md
+++ b/.changeset/three-rivers-invite.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/inferencer": minor
+---
+
+Migrated from outdated `@tabler/icons@1` to `@tabler/icons-react@3` to make sure we're using the latest available version of the library without requiring users to pin to a deprecated version.
+
+If your project doesn't include `@tabler/icons` you won't be affected by this change. If you're using `@tabler/icons@1` in your project, you may need to update your dependency to latest version of `@tabler/icons-react` to avoid conflicting dependencies. Practically, this should not introduce any breaking changes to your project and all the icons in `@tabler/icons@1` should also be available in the latest version of `@tabler/icons-react`.

--- a/.changeset/tidy-dolphins-care.md
+++ b/.changeset/tidy-dolphins-care.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/chakra-ui": minor
+---
+
+Migrated from outdated `@tabler/icons@1` to `@tabler/icons-react@3` to make sure we're using the latest available version of the library without requiring users to pin to a deprecated version.
+
+If your project doesn't include `@tabler/icons` you won't be affected by this change. If you're using `@tabler/icons@1` in your project, you may need to update your dependency to latest version of `@tabler/icons-react` to avoid conflicting dependencies. Practically, this should not introduce any breaking changes to your project and all the icons in `@tabler/icons@1` should also be available in the latest version of `@tabler/icons-react`.

--- a/documentation/blog/2023-03-03-ra-chakra-tutorial.md
+++ b/documentation/blog/2023-03-03-ra-chakra-tutorial.md
@@ -559,7 +559,7 @@ Create a new file called `pagination.tsx` under the `components` folder. This fi
 ```tsx title="src/components/pagination/index.tsx"
 import { FC } from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";
@@ -1254,7 +1254,11 @@ we create a new folder named `components` under the `src` folder. Under that fol
 
 ```tsx title="src/components/ColumnSorter.tsx"
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 import { Column } from "@tanstack/react-table";
 
 export const ColumnSorter: React.FC<{ column: Column<any, any> }> = ({
@@ -1371,7 +1375,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 import { Column } from "@tanstack/react-table";
 
 export const ColumnFilter: React.FC<{ column: Column<any, any> }> = ({

--- a/documentation/docs/guides-concepts/authentication/auth-pages/chakra.tsx
+++ b/documentation/docs/guides-concepts/authentication/auth-pages/chakra.tsx
@@ -14,7 +14,7 @@ export function ChakraUIAuth() {
         "@refinedev/react-table": "latest",
         "react-router-dom": "latest",
         "react-router": "latest",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@chakra-ui/react": "^2.5.1",
       }}
       startRoute="/login"

--- a/documentation/docs/guides-concepts/authentication/auth-pages/mantine.tsx
+++ b/documentation/docs/guides-concepts/authentication/auth-pages/mantine.tsx
@@ -14,7 +14,7 @@ export function MantineAuth() {
         "@refinedev/react-table": "latest",
         "react-router-dom": "latest",
         "react-router": "latest",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@emotion/react": "^11.8.2",
         "@mantine/core": "^5.10.4",
         "@mantine/hooks": "^5.10.4",

--- a/documentation/docs/guides-concepts/forms/server-side-validation-chakra-ui.tsx
+++ b/documentation/docs/guides-concepts/forms/server-side-validation-chakra-ui.tsx
@@ -8,7 +8,7 @@ export default function ServerSideValidationChakraUi() {
       showOpenInCodeSandbox={false}
       dependencies={{
         "@refinedev/chakra-ui": "^2.26.17",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@refinedev/core": "^4.45.1",
         "@refinedev/react-router-v6": "^4.5.4",
         "@refinedev/simple-rest": "^4.5.4",

--- a/documentation/docs/guides-concepts/forms/server-side-validation-mantine.tsx
+++ b/documentation/docs/guides-concepts/forms/server-side-validation-mantine.tsx
@@ -13,7 +13,7 @@ export default function ServerSideValidationMantine() {
         "@refinedev/simple-rest": "^4.5.4",
         "@refinedev/react-table": "^5.6.4",
         "@tanstack/react-table": "^8.2.6",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@emotion/react": "^11.8.2",
         "@mantine/core": "^5.10.4",
         "@mantine/hooks": "^5.10.4",

--- a/documentation/docs/guides-concepts/forms/server-side-validation-react-hook-form.tsx
+++ b/documentation/docs/guides-concepts/forms/server-side-validation-react-hook-form.tsx
@@ -7,7 +7,7 @@ export default function ServerSideValidationReactHookForm() {
       height={460}
       showOpenInCodeSandbox={false}
       dependencies={{
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@refinedev/core": "^4.45.1",
         "@refinedev/react-router-v6": "^4.5.4",
         "@refinedev/simple-rest": "^4.5.4",

--- a/documentation/docs/guides-concepts/general-concepts/auth-pages/chakra.tsx
+++ b/documentation/docs/guides-concepts/general-concepts/auth-pages/chakra.tsx
@@ -14,7 +14,7 @@ export function ChakraUIAuth() {
         "@refinedev/react-table": "latest",
         "react-router-dom": "latest",
         "react-router": "latest",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@chakra-ui/react": "^2.5.1",
       }}
       startRoute="/login"

--- a/documentation/docs/guides-concepts/general-concepts/layout/chakra.tsx
+++ b/documentation/docs/guides-concepts/general-concepts/layout/chakra.tsx
@@ -15,7 +15,7 @@ export function ChakraUILayout() {
         "@refinedev/react-table": "latest",
         "react-router-dom": "latest",
         "react-router": "latest",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@chakra-ui/react": "^2.5.1",
       }}
       startRoute="/my-products"
@@ -115,7 +115,7 @@ import {
 } from "@chakra-ui/react";
 import { List, ShowButton, usePagination } from "@refinedev/chakra-ui";
 import { useTable } from "@refinedev/react-table";
-import { IconChevronLeft, IconChevronRight } from "@tabler/icons";
+import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
 import { ColumnDef, flexRender } from "@tanstack/react-table";
 
 export const ProductList = () => {

--- a/documentation/docs/guides-concepts/general-concepts/layout/mantine.tsx
+++ b/documentation/docs/guides-concepts/general-concepts/layout/mantine.tsx
@@ -15,7 +15,7 @@ export function MantineLayout() {
         "@refinedev/react-table": "latest",
         "react-router-dom": "latest",
         "react-router": "latest",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@emotion/react": "^11.8.2",
         "@mantine/core": "^5.10.4",
         "@mantine/hooks": "^5.10.4",

--- a/documentation/docs/guides-concepts/tables/example/chakra-ui.tsx
+++ b/documentation/docs/guides-concepts/tables/example/chakra-ui.tsx
@@ -11,7 +11,7 @@ export default function BaseCoreTable() {
         "@tanstack/react-table": "latest",
         "@refinedev/chakra-ui": "latest",
         "@chakra-ui/react": "^2.5.1",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
       }}
       startRoute="/"
       files={{
@@ -257,7 +257,7 @@ type PaginationProps = {
 export const ColumnSorterTsxCode = `
 import React, { useState } from "react";
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconChevronUp, IconSelector } from "@tabler/icons";
+import { IconChevronDown, IconChevronUp, IconSelector } from "@tabler/icons-react";
 
 import type { SortDirection } from "@tanstack/react-table";
 
@@ -304,7 +304,7 @@ import {
     VStack,
     HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 
 interface ColumnButtonProps {

--- a/documentation/docs/guides-concepts/tables/example/mantine.tsx
+++ b/documentation/docs/guides-concepts/tables/example/mantine.tsx
@@ -11,7 +11,7 @@ export default function BaseCoreTable() {
         "@refinedev/react-table": "latest",
         "@tanstack/react-table": "latest",
         "@mantine/core": "^5.10.4",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
       }}
       startRoute="/"
       files={{
@@ -188,7 +188,7 @@ interface IProduct {
 
 export const ColumnSorterTsxCode = `
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons-react";
 
 export interface ColumnButtonProps {
     column: Column<any, any>; // eslint-disable-line
@@ -224,7 +224,7 @@ export const ColumnFilterTsxCode = `
 import React, { useState } from "react";
 import { Column } from "@tanstack/react-table";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 interface ColumnButtonProps {
     column: Column<any, any>; // eslint-disable-line

--- a/documentation/docs/packages/tanstack-table/examples/chakra-ui.tsx
+++ b/documentation/docs/packages/tanstack-table/examples/chakra-ui.tsx
@@ -11,7 +11,7 @@ export default function BaseCoreTable() {
         "@tanstack/react-table": "latest",
         "@refinedev/chakra-ui": "latest",
         "@chakra-ui/react": "^2.5.1",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
       }}
       startRoute="/"
       files={{
@@ -257,7 +257,7 @@ type PaginationProps = {
 export const ColumnSorterTsxCode = `
 import React, { useState } from "react";
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconChevronUp, IconSelector } from "@tabler/icons";
+import { IconChevronDown, IconChevronUp, IconSelector } from "@tabler/icons-react";
 
 import type { SortDirection } from "@tanstack/react-table";
 
@@ -304,7 +304,7 @@ import {
     VStack,
     HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 
 interface ColumnButtonProps {

--- a/documentation/docs/packages/tanstack-table/examples/mantine.tsx
+++ b/documentation/docs/packages/tanstack-table/examples/mantine.tsx
@@ -11,7 +11,7 @@ export default function BaseCoreTable() {
         "@refinedev/react-table": "latest",
         "@tanstack/react-table": "latest",
         "@mantine/core": "^5.10.4",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
       }}
       startRoute="/"
       files={{
@@ -188,7 +188,7 @@ interface IProduct {
 
 export const ColumnSorterTsxCode = `
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons-react";
 
 export interface ColumnButtonProps {
     column: Column<any, any>; // eslint-disable-line
@@ -224,7 +224,7 @@ export const ColumnFilterTsxCode = `
 import React, { useState } from "react";
 import { Column } from "@tanstack/react-table";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 interface ColumnButtonProps {
     column: Column<any, any>; // eslint-disable-line

--- a/documentation/docs/ui-integrations/chakra-ui/components/basic-views/create/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/basic-views/create/index.md
@@ -304,7 +304,7 @@ import { CreateButton } from "@refinedev/chakra-ui";
 // visible-block-start
 import { Create } from "@refinedev/chakra-ui";
 /* highlight-next-line */
-import { IconMoodSmile } from "@tabler/icons";
+import { IconMoodSmile } from "@tabler/icons-react";
 
 const PostCreate: React.FC = () => {
   return (

--- a/documentation/docs/ui-integrations/chakra-ui/components/basic-views/edit/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/basic-views/edit/index.md
@@ -618,7 +618,7 @@ import dataProvider from "@refinedev/simple-rest";
 // visible-block-start
 import { Edit } from "@refinedev/chakra-ui";
 /* highlight-next-line */
-import { IconMoodSmile } from "@tabler/icons";
+import { IconMoodSmile } from "@tabler/icons-react";
 
 const PostEdit: React.FC = () => {
   return (

--- a/documentation/docs/ui-integrations/chakra-ui/components/basic-views/show/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/basic-views/show/index.md
@@ -470,7 +470,7 @@ import dataProvider from "@refinedev/simple-rest";
 // visible-block-start
 import { Show } from "@refinedev/chakra-ui";
 /* highlight-next-line */
-import { IconMoodSmile } from "@tabler/icons";
+import { IconMoodSmile } from "@tabler/icons-react";
 
 const PostShow: React.FC = () => {
   return (

--- a/documentation/docs/ui-integrations/chakra-ui/components/fields/boolean-field/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/fields/boolean-field/index.md
@@ -57,7 +57,7 @@ import {
 } from "@chakra-ui/react";
 import { useTable } from "@refinedev/react-table";
 import { ColumnDef, flexRender } from "@tanstack/react-table";
-import { IconX, IconCheck } from "@tabler/icons";
+import { IconX, IconCheck } from "@tabler/icons-react";
 
 const PostList: React.FC = () => {
   const columns = React.useMemo<ColumnDef<IPost>[]>(

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/index.md
@@ -12,7 +12,7 @@ import Example from "./previews/example.tsx";
 
 Installing the package is as simple as just by running the following command without any additional configuration:
 
-<InstallPackagesCommand args="@refinedev/chakra-ui @chakra-ui/react @refinedev/react-table @refinedev/react-hook-form @tanstack/react-table react-hook-form @tabler/icons@1"/>
+<InstallPackagesCommand args="@refinedev/chakra-ui @chakra-ui/react @refinedev/react-table @refinedev/react-hook-form @tanstack/react-table react-hook-form @tabler/icons-react"/>
 
 ## Usage
 

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/index.md
@@ -185,7 +185,7 @@ interface IProduct {
 ```tsx title="components/pagination.tsx"
 import React from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/auth-page.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/auth-page.tsx
@@ -9,7 +9,7 @@ export default function AuthPage() {
       initialPercentage={40}
       dependencies={{
         "@refinedev/chakra-ui": "^2.26.17",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@refinedev/core": "^4.45.1",
         "@refinedev/react-router-v6": "^4.5.4",
         "@refinedev/simple-rest": "^4.5.4",

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/basic-views.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/basic-views.tsx
@@ -8,7 +8,7 @@ export default function BasicViews() {
       initialPercentage={40}
       dependencies={{
         "@refinedev/chakra-ui": "^2.26.17",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@refinedev/core": "^4.45.1",
         "@refinedev/react-router-v6": "^4.5.4",
         "@refinedev/simple-rest": "^4.5.4",
@@ -62,7 +62,7 @@ export * from "./create";
 const PaginationTsxCode = /* jsx */ `
 import React from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/example.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/example.tsx
@@ -8,7 +8,7 @@ export default function Example() {
       previewOnly
       dependencies={{
         "@refinedev/chakra-ui": "^2.26.17",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@refinedev/core": "^4.45.1",
         "@refinedev/react-router-v6": "^4.5.4",
         "@refinedev/simple-rest": "^4.5.4",
@@ -189,7 +189,7 @@ export default App;
 const PaginationTsxCode = /* jsx */ `
 import React from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/layout-next-js.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/layout-next-js.tsx
@@ -8,7 +8,7 @@ export default function LayoutNextjs() {
       hidePreview
       dependencies={{
         "@refinedev/chakra-ui": "^2.26.17",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@refinedev/core": "^4.45.1",
         "@refinedev/react-router-v6": "^4.5.4",
         "@refinedev/simple-rest": "^4.5.4",

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/layout-react-router-dom.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/layout-react-router-dom.tsx
@@ -10,7 +10,7 @@ export default function LayoutReactRouterDom() {
       initialPercentage={35}
       dependencies={{
         "@refinedev/chakra-ui": "^2.26.17",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@refinedev/core": "^4.45.1",
         "@refinedev/react-router-v6": "^4.5.4",
         "@refinedev/simple-rest": "^4.5.4",
@@ -44,7 +44,7 @@ export default function LayoutReactRouterDom() {
 const PaginationTsxCode = /* jsx */ `
 import React from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/layout-remix.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/layout-remix.tsx
@@ -8,7 +8,7 @@ export default function LayoutRemix() {
       hidePreview
       dependencies={{
         "@refinedev/chakra-ui": "^2.26.17",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@refinedev/core": "^4.45.1",
         "@refinedev/react-router-v6": "^4.5.4",
         "@refinedev/simple-rest": "^4.5.4",

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/theming.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/theming.tsx
@@ -10,7 +10,7 @@ export default function Usage() {
       showOpenInCodeSandbox={false}
       dependencies={{
         "@refinedev/chakra-ui": "^2.26.17",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@refinedev/core": "^4.45.1",
         "@refinedev/react-router-v6": "^4.5.4",
         "@refinedev/simple-rest": "^4.5.4",
@@ -101,7 +101,7 @@ export default authProvider;
 const PaginationTsxCode = /* jsx */ `
 import React from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/usage-next-js.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/usage-next-js.tsx
@@ -9,7 +9,7 @@ export default function UsageNextjs() {
       showFiles
       dependencies={{
         "@refinedev/chakra-ui": "^2.26.17",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@refinedev/core": "^4.45.1",
         "@refinedev/react-router-v6": "^4.5.4",
         "@refinedev/simple-rest": "^4.5.4",
@@ -124,7 +124,7 @@ export const getServerSideProps = async () => {
 const PaginationTsxCode = /* jsx */ `
 import React from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/usage-react-router-dom.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/usage-react-router-dom.tsx
@@ -9,7 +9,7 @@ export default function UsageReactRouterDom() {
       showFiles
       dependencies={{
         "@refinedev/chakra-ui": "^2.26.17",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@refinedev/core": "^4.45.1",
         "@refinedev/react-router-v6": "^4.5.4",
         "@refinedev/simple-rest": "^4.5.4",
@@ -188,7 +188,7 @@ export default App;
 const PaginationTsxCode = /* jsx */ `
 import React from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/usage-remix.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/usage-remix.tsx
@@ -9,7 +9,7 @@ export default function UsageRemix() {
       showFiles
       dependencies={{
         "@refinedev/chakra-ui": "^2.26.17",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@refinedev/core": "^4.45.1",
         "@refinedev/react-router-v6": "^4.5.4",
         "@refinedev/simple-rest": "^4.5.4",

--- a/documentation/docs/ui-integrations/chakra-ui/theming/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/theming/index.md
@@ -293,7 +293,7 @@ import {
   extendTheme,
   // highlight-end
 } from "@chakra-ui/react";
-import { IconSun, IconMoonStars } from "@tabler/icons";
+import { IconSun, IconMoonStars } from "@tabler/icons-react";
 
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 

--- a/documentation/docs/ui-integrations/mantine/components/fields/boolean-field/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/fields/boolean-field/index.md
@@ -51,7 +51,7 @@ import { List, BooleanField } from "@refinedev/mantine";
 import { Table, Pagination } from "@mantine/core";
 import { useTable } from "@refinedev/react-table";
 import { ColumnDef, flexRender } from "@tanstack/react-table";
-import { IconX, IconCheck } from "@tabler/icons";
+import { IconX, IconCheck } from "@tabler/icons-react";
 
 const PostList: React.FC = () => {
   const columns = React.useMemo<ColumnDef<IPost>[]>(

--- a/documentation/docs/ui-integrations/mantine/introduction/index.md
+++ b/documentation/docs/ui-integrations/mantine/introduction/index.md
@@ -12,7 +12,7 @@ import Example from "./previews/example.tsx";
 
 Installing the package is as simple as just by running the following command without any additional configuration:
 
-<InstallPackagesCommand args="@refinedev/mantine @refinedev/react-table @mantine/core@5 @mantine/hooks@5 @mantine/form@5 @mantine/notifications@5 @emotion/react@11 @tabler/icons@1 @tanstack/react-table"/>
+<InstallPackagesCommand args="@refinedev/mantine @refinedev/react-table @mantine/core@5 @mantine/hooks@5 @mantine/form@5 @mantine/notifications@5 @emotion/react@11 @tabler/icons-react @tanstack/react-table"/>
 
 :::info Version Support
 Refine's Mantine integration currently uses Mantine v5.

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/auth-page.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/auth-page.tsx
@@ -14,7 +14,7 @@ export default function AuthPage() {
         "@refinedev/simple-rest": "^4.5.4",
         "@refinedev/react-table": "^5.6.4",
         "@tanstack/react-table": "^8.2.6",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@emotion/react": "^11.8.2",
         "@mantine/core": "^5.10.4",
         "@mantine/hooks": "^5.10.4",

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/basic-views.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/basic-views.tsx
@@ -13,7 +13,7 @@ export default function BasicViews() {
         "@refinedev/simple-rest": "^4.5.4",
         "@refinedev/react-table": "^5.6.4",
         "@tanstack/react-table": "^8.2.6",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@emotion/react": "^11.8.2",
         "@mantine/core": "^5.10.4",
         "@mantine/hooks": "^5.10.4",

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/example.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/example.tsx
@@ -13,7 +13,7 @@ export default function Example() {
         "@refinedev/simple-rest": "^4.5.4",
         "@refinedev/react-table": "^5.6.4",
         "@tanstack/react-table": "^8.2.6",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@emotion/react": "^11.8.2",
         "@mantine/core": "^5.10.4",
         "@mantine/hooks": "^5.10.4",

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/layout-next-js.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/layout-next-js.tsx
@@ -8,7 +8,7 @@ export default function LayoutNextjs() {
       hidePreview
       dependencies={{
         "@refinedev/chakra-ui": "^2.26.17",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@refinedev/core": "^4.45.1",
         "@refinedev/react-router-v6": "^4.5.4",
         "@refinedev/simple-rest": "^4.5.4",

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/layout-react-router-dom.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/layout-react-router-dom.tsx
@@ -15,7 +15,7 @@ export default function LayoutReactRouterDom() {
         "@refinedev/simple-rest": "^4.5.4",
         "@refinedev/react-table": "^5.6.4",
         "@tanstack/react-table": "^8.2.6",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@emotion/react": "^11.8.2",
         "@mantine/core": "^5.10.4",
         "@mantine/hooks": "^5.10.4",

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/layout-remix.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/layout-remix.tsx
@@ -12,7 +12,7 @@ export default function LayoutRemix() {
         "@refinedev/simple-rest": "^4.5.4",
         "@refinedev/react-table": "^5.6.4",
         "@tanstack/react-table": "^8.2.6",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@emotion/react": "^11.8.2",
         "@mantine/core": "^5.10.4",
         "@mantine/hooks": "^5.10.4",

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/theming.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/theming.tsx
@@ -15,7 +15,7 @@ export default function Usage() {
         "@refinedev/simple-rest": "^4.5.4",
         "@refinedev/react-table": "^5.6.4",
         "@tanstack/react-table": "^8.2.6",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@emotion/react": "^11.8.2",
         "@mantine/core": "^5.10.4",
         "@mantine/hooks": "^5.10.4",

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/usage-next-js.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/usage-next-js.tsx
@@ -13,7 +13,7 @@ export default function UsageNextjs() {
         "@refinedev/simple-rest": "^4.5.4",
         "@refinedev/react-table": "^5.6.4",
         "@tanstack/react-table": "^8.2.6",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@emotion/react": "^11.8.2",
         "@mantine/core": "^5.10.4",
         "@mantine/hooks": "^5.10.4",

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/usage-react-router-dom.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/usage-react-router-dom.tsx
@@ -13,7 +13,7 @@ export default function UsageReactRouterDom() {
         "@refinedev/simple-rest": "^4.5.4",
         "@refinedev/react-table": "^5.6.4",
         "@tanstack/react-table": "^8.2.6",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@emotion/react": "^11.8.2",
         "@mantine/core": "^5.10.4",
         "@mantine/hooks": "^5.10.4",

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/usage-remix.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/usage-remix.tsx
@@ -13,7 +13,7 @@ export default function UsageRemix() {
         "@refinedev/simple-rest": "^4.5.4",
         "@refinedev/react-table": "^5.6.4",
         "@tanstack/react-table": "^8.2.6",
-        "@tabler/icons": "^1.119.0",
+        "@tabler/icons-react": "^3.1.0",
         "@emotion/react": "^11.8.2",
         "@mantine/core": "^5.10.4",
         "@mantine/hooks": "^5.10.4",

--- a/documentation/docs/ui-integrations/mantine/theming/index.md
+++ b/documentation/docs/ui-integrations/mantine/theming/index.md
@@ -383,7 +383,7 @@ import { useLocalStorage } from "@mantine/hooks";
 
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 
-import { IconSun, IconMoonStars } from "@tabler/icons";
+import { IconSun, IconMoonStars } from "@tabler/icons-react";
 
 import { PostCreate, PostEdit, PostList } from "./pages";
 

--- a/examples/auth-chakra-ui/package.json
+++ b/examples/auth-chakra-ui/package.json
@@ -20,7 +20,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/auth-chakra-ui/src/App.tsx
+++ b/examples/auth-chakra-ui/src/App.tsx
@@ -20,7 +20,7 @@ import routerProvider, {
   DocumentTitleHandler,
 } from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
-import { IconBrandGoogle, IconBrandGithub } from "@tabler/icons";
+import { IconBrandGoogle, IconBrandGithub } from "@tabler/icons-react";
 
 import { PostCreate, PostEdit, PostList, PostShow } from "./pages";
 

--- a/examples/auth-chakra-ui/src/components/pagination/index.tsx
+++ b/examples/auth-chakra-ui/src/components/pagination/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/examples/auth-chakra-ui/src/components/table/columnFilter.tsx
+++ b/examples/auth-chakra-ui/src/components/table/columnFilter.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/auth-chakra-ui/src/components/table/columnSorter.tsx
+++ b/examples/auth-chakra-ui/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconChevronUp, IconSelector } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconChevronUp,
+  IconSelector,
+} from "@tabler/icons-react";
 
 import type { SortDirection } from "@tanstack/react-table";
 import { ColumnButtonProps } from "../../interfaces";

--- a/examples/auth-mantine/package.json
+++ b/examples/auth-mantine/package.json
@@ -23,7 +23,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",

--- a/examples/auth-mantine/src/App.tsx
+++ b/examples/auth-mantine/src/App.tsx
@@ -21,7 +21,7 @@ import routerProvider, {
   DocumentTitleHandler,
 } from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
-import { IconBrandGoogle, IconBrandGithub } from "@tabler/icons";
+import { IconBrandGoogle, IconBrandGithub } from "@tabler/icons-react";
 
 import { PostCreate, PostEdit, PostList, PostShow } from "./pages";
 

--- a/examples/auth-mantine/src/components/header/index.tsx
+++ b/examples/auth-mantine/src/components/header/index.tsx
@@ -8,7 +8,7 @@ import {
   useMantineTheme,
 } from "@mantine/core";
 import { useGetIdentity } from "@refinedev/core";
-import { IconMoonStars, IconSun } from "@tabler/icons";
+import { IconMoonStars, IconSun } from "@tabler/icons-react";
 
 type IUser = {
   id: number;

--- a/examples/auth-mantine/src/components/table/columnFilter.tsx
+++ b/examples/auth-mantine/src/components/table/columnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/auth-mantine/src/components/table/columnSorter.tsx
+++ b/examples/auth-mantine/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/base-chakra-ui/package.json
+++ b/examples/base-chakra-ui/package.json
@@ -20,7 +20,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/base-chakra-ui/src/components/pagination/index.tsx
+++ b/examples/base-chakra-ui/src/components/pagination/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/examples/base-chakra-ui/src/components/table/columnFilter.tsx
+++ b/examples/base-chakra-ui/src/components/table/columnFilter.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/base-chakra-ui/src/components/table/columnSorter.tsx
+++ b/examples/base-chakra-ui/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconChevronUp, IconSelector } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconChevronUp,
+  IconSelector,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 import type { SortDirection } from "@tanstack/react-table";

--- a/examples/base-mantine/package.json
+++ b/examples/base-mantine/package.json
@@ -23,7 +23,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",

--- a/examples/base-mantine/src/components/table/columnFilter.tsx
+++ b/examples/base-mantine/src/components/table/columnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/base-mantine/src/components/table/columnSorter.tsx
+++ b/examples/base-mantine/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/blog-ra-chakra-tutorial/package.json
+++ b/examples/blog-ra-chakra-tutorial/package.json
@@ -19,7 +19,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/strapi-v4": "^6.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "axios": "^1.6.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/blog-ra-chakra-tutorial/src/components/column-filter/index.tsx
+++ b/examples/blog-ra-chakra-tutorial/src/components/column-filter/index.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 import { Column } from "@tanstack/react-table";
 
 export const ColumnFilter: React.FC<{ column: Column<any, any> }> = ({

--- a/examples/blog-ra-chakra-tutorial/src/components/column-sorter/index.tsx
+++ b/examples/blog-ra-chakra-tutorial/src/components/column-sorter/index.tsx
@@ -1,5 +1,9 @@
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 import { Column } from "@tanstack/react-table";
 
 export const ColumnSorter: React.FC<{ column: Column<any, any> }> = ({

--- a/examples/blog-ra-chakra-tutorial/src/components/pagination/index.tsx
+++ b/examples/blog-ra-chakra-tutorial/src/components/pagination/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/examples/blog-refine-mantine-strapi/package.json
+++ b/examples/blog-refine-mantine-strapi/package.json
@@ -35,7 +35,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/strapi-v4": "^6.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "axios": "^1.6.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/blog-refine-mantine-strapi/src/components/header/index.tsx
+++ b/examples/blog-refine-mantine-strapi/src/components/header/index.tsx
@@ -14,7 +14,7 @@ import {
   HamburgerMenu,
   RefineThemedLayoutV2HeaderProps,
 } from "@refinedev/mantine";
-import { IconMoonStars, IconSun } from "@tabler/icons";
+import { IconMoonStars, IconSun } from "@tabler/icons-react";
 import React from "react";
 
 type IUser = {

--- a/examples/customization-theme-chakra-ui/package.json
+++ b/examples/customization-theme-chakra-ui/package.json
@@ -18,7 +18,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/customization-theme-chakra-ui/src/components/header/index.tsx
+++ b/examples/customization-theme-chakra-ui/src/components/header/index.tsx
@@ -1,6 +1,6 @@
 import { HamburgerMenu } from "@refinedev/chakra-ui";
 import { Box, IconButton, Icon, useColorMode } from "@chakra-ui/react";
-import { IconMoon, IconSun } from "@tabler/icons";
+import { IconMoon, IconSun } from "@tabler/icons-react";
 
 export const Header = () => {
   const { colorMode, toggleColorMode } = useColorMode();

--- a/examples/customization-theme-chakra-ui/src/components/pagination/index.tsx
+++ b/examples/customization-theme-chakra-ui/src/components/pagination/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/examples/customization-theme-chakra-ui/src/components/table/columnFilter.tsx
+++ b/examples/customization-theme-chakra-ui/src/components/table/columnFilter.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/customization-theme-chakra-ui/src/components/table/columnSorter.tsx
+++ b/examples/customization-theme-chakra-ui/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import type { SortDirection } from "@tanstack/react-table";
 import { ColumnButtonProps } from "../../interfaces";

--- a/examples/customization-theme-mantine/package.json
+++ b/examples/customization-theme-mantine/package.json
@@ -21,7 +21,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",

--- a/examples/customization-theme-mantine/src/components/header/index.tsx
+++ b/examples/customization-theme-mantine/src/components/header/index.tsx
@@ -4,7 +4,7 @@ import {
   Header as MantineHeader,
   useMantineColorScheme,
 } from "@mantine/core";
-import { IconSun, IconMoonStars } from "@tabler/icons";
+import { IconSun, IconMoonStars } from "@tabler/icons-react";
 import { HamburgerMenu } from "@refinedev/mantine";
 
 export const Header: React.FC = () => {

--- a/examples/customization-theme-mantine/src/components/table/columnFilter.tsx
+++ b/examples/customization-theme-mantine/src/components/table/columnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/customization-theme-mantine/src/components/table/columnSorter.tsx
+++ b/examples/customization-theme-mantine/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/form-chakra-ui-mutation-mode/package.json
+++ b/examples/form-chakra-ui-mutation-mode/package.json
@@ -20,7 +20,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/form-chakra-ui-mutation-mode/src/components/pagination/index.tsx
+++ b/examples/form-chakra-ui-mutation-mode/src/components/pagination/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/examples/form-chakra-ui-mutation-mode/src/components/table/columnFilter.tsx
+++ b/examples/form-chakra-ui-mutation-mode/src/components/table/columnFilter.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/form-chakra-ui-mutation-mode/src/components/table/columnSorter.tsx
+++ b/examples/form-chakra-ui-mutation-mode/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import type { SortDirection } from "@tanstack/react-table";
 import { ColumnButtonProps } from "../../interfaces";

--- a/examples/form-chakra-ui-use-drawer-form/package.json
+++ b/examples/form-chakra-ui-use-drawer-form/package.json
@@ -20,7 +20,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/form-chakra-ui-use-drawer-form/src/components/pagination/index.tsx
+++ b/examples/form-chakra-ui-use-drawer-form/src/components/pagination/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/examples/form-chakra-ui-use-drawer-form/src/components/table/columnFilter.tsx
+++ b/examples/form-chakra-ui-use-drawer-form/src/components/table/columnFilter.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/form-chakra-ui-use-drawer-form/src/components/table/columnSorter.tsx
+++ b/examples/form-chakra-ui-use-drawer-form/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 import type { SortDirection } from "@tanstack/react-table";

--- a/examples/form-chakra-ui-use-form/package.json
+++ b/examples/form-chakra-ui-use-form/package.json
@@ -20,7 +20,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/form-chakra-ui-use-form/src/components/pagination/index.tsx
+++ b/examples/form-chakra-ui-use-form/src/components/pagination/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/examples/form-chakra-ui-use-form/src/components/table/columnFilter.tsx
+++ b/examples/form-chakra-ui-use-form/src/components/table/columnFilter.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/form-chakra-ui-use-form/src/components/table/columnSorter.tsx
+++ b/examples/form-chakra-ui-use-form/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 import type { SortDirection } from "@tanstack/react-table";

--- a/examples/form-chakra-use-modal-form/package.json
+++ b/examples/form-chakra-use-modal-form/package.json
@@ -20,7 +20,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/form-chakra-use-modal-form/src/components/pagination/index.tsx
+++ b/examples/form-chakra-use-modal-form/src/components/pagination/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 type PaginationProps = {

--- a/examples/form-chakra-use-modal-form/src/components/table/columnFilter.tsx
+++ b/examples/form-chakra-use-modal-form/src/components/table/columnFilter.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/form-chakra-use-modal-form/src/components/table/columnSorter.tsx
+++ b/examples/form-chakra-use-modal-form/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 import type { SortDirection } from "@tanstack/react-table";

--- a/examples/form-mantine-mutation-mode/package.json
+++ b/examples/form-mantine-mutation-mode/package.json
@@ -24,7 +24,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",

--- a/examples/form-mantine-mutation-mode/src/components/table/columnFilter.tsx
+++ b/examples/form-mantine-mutation-mode/src/components/table/columnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/form-mantine-mutation-mode/src/components/table/columnSorter.tsx
+++ b/examples/form-mantine-mutation-mode/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/form-mantine-use-drawer-form/package.json
+++ b/examples/form-mantine-use-drawer-form/package.json
@@ -23,7 +23,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",

--- a/examples/form-mantine-use-drawer-form/src/components/table/columnFilter.tsx
+++ b/examples/form-mantine-use-drawer-form/src/components/table/columnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/form-mantine-use-drawer-form/src/components/table/columnSorter.tsx
+++ b/examples/form-mantine-use-drawer-form/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/form-mantine-use-form/package.json
+++ b/examples/form-mantine-use-form/package.json
@@ -24,7 +24,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",

--- a/examples/form-mantine-use-form/src/components/table/columnFilter.tsx
+++ b/examples/form-mantine-use-form/src/components/table/columnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/form-mantine-use-form/src/components/table/columnSorter.tsx
+++ b/examples/form-mantine-use-form/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/form-mantine-use-modal-form/package.json
+++ b/examples/form-mantine-use-modal-form/package.json
@@ -23,7 +23,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",

--- a/examples/form-mantine-use-modal-form/src/components/table/columnFilter.tsx
+++ b/examples/form-mantine-use-modal-form/src/components/table/columnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/form-mantine-use-modal-form/src/components/table/columnSorter.tsx
+++ b/examples/form-mantine-use-modal-form/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/form-mantine-use-steps-form/package.json
+++ b/examples/form-mantine-use-steps-form/package.json
@@ -24,7 +24,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",

--- a/examples/form-mantine-use-steps-form/src/components/table/columnFilter.tsx
+++ b/examples/form-mantine-use-steps-form/src/components/table/columnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/form-mantine-use-steps-form/src/components/table/columnSorter.tsx
+++ b/examples/form-mantine-use-steps-form/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/import-export-mantine/package.json
+++ b/examples/import-export-mantine/package.json
@@ -21,7 +21,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/import-export-mantine/src/components/table/columnFilter.tsx
+++ b/examples/import-export-mantine/src/components/table/columnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/import-export-mantine/src/components/table/columnSorter.tsx
+++ b/examples/import-export-mantine/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/inferencer-chakra-ui/package.json
+++ b/examples/inferencer-chakra-ui/package.json
@@ -34,7 +34,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "i18next": "^20.1.0",
     "i18next-browser-languagedetector": "^6.1.1",
     "i18next-xhr-backend": "^3.2.2",

--- a/examples/inferencer-chakra-ui/src/components/header/index.tsx
+++ b/examples/inferencer-chakra-ui/src/components/header/index.tsx
@@ -18,7 +18,7 @@ import {
   RefineThemedLayoutV2HeaderProps,
 } from "@refinedev/chakra-ui";
 import { useGetIdentity, useGetLocale, useSetLocale } from "@refinedev/core";
-import { IconLanguage, IconMoon, IconSun } from "@tabler/icons";
+import { IconLanguage, IconMoon, IconSun } from "@tabler/icons-react";
 import i18n from "i18next";
 import React from "react";
 

--- a/examples/inferencer-mantine/package.json
+++ b/examples/inferencer-mantine/package.json
@@ -37,7 +37,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "i18next": "^20.1.0",
     "i18next-browser-languagedetector": "^6.1.1",
     "i18next-xhr-backend": "^3.2.2",

--- a/examples/inferencer-mantine/src/components/header/index.tsx
+++ b/examples/inferencer-mantine/src/components/header/index.tsx
@@ -15,7 +15,7 @@ import {
   HamburgerMenu,
   RefineThemedLayoutV2HeaderProps,
 } from "@refinedev/mantine";
-import { IconLanguage, IconMoonStars, IconSun } from "@tabler/icons";
+import { IconLanguage, IconMoonStars, IconSun } from "@tabler/icons-react";
 import i18n from "i18next";
 import React from "react";
 

--- a/examples/server-side-form-validation-chakra-ui/package.json
+++ b/examples/server-side-form-validation-chakra-ui/package.json
@@ -20,7 +20,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/server-side-form-validation-chakra-ui/src/components/pagination/index.tsx
+++ b/examples/server-side-form-validation-chakra-ui/src/components/pagination/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/examples/server-side-form-validation-chakra-ui/src/components/table/columnFilter.tsx
+++ b/examples/server-side-form-validation-chakra-ui/src/components/table/columnFilter.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/server-side-form-validation-chakra-ui/src/components/table/columnSorter.tsx
+++ b/examples/server-side-form-validation-chakra-ui/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/server-side-form-validation-mantine/package.json
+++ b/examples/server-side-form-validation-mantine/package.json
@@ -23,7 +23,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",

--- a/examples/server-side-form-validation-mantine/src/components/table/columnFilter.tsx
+++ b/examples/server-side-form-validation-mantine/src/components/table/columnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/server-side-form-validation-mantine/src/components/table/columnSorter.tsx
+++ b/examples/server-side-form-validation-mantine/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/table-chakra-ui-advanced/package.json
+++ b/examples/table-chakra-ui-advanced/package.json
@@ -20,7 +20,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/table-chakra-ui-advanced/src/components/pagination/index.tsx
+++ b/examples/table-chakra-ui-advanced/src/components/pagination/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/examples/table-chakra-ui-advanced/src/components/table/columnFilter.tsx
+++ b/examples/table-chakra-ui-advanced/src/components/table/columnFilter.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/table-chakra-ui-advanced/src/components/table/columnSorter.tsx
+++ b/examples/table-chakra-ui-advanced/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 import type { SortDirection } from "@tanstack/react-table";

--- a/examples/table-chakra-ui-advanced/src/pages/posts/list.tsx
+++ b/examples/table-chakra-ui-advanced/src/pages/posts/list.tsx
@@ -34,7 +34,7 @@ import {
 } from "@chakra-ui/react";
 
 import { useForm } from "@refinedev/react-hook-form";
-import { IconChevronDown, IconChevronRight } from "@tabler/icons";
+import { IconChevronDown, IconChevronRight } from "@tabler/icons-react";
 
 import { ColumnFilter, ColumnSorter } from "../../components/table";
 import { Pagination } from "../../components/pagination";

--- a/examples/table-chakra-ui-basic/package.json
+++ b/examples/table-chakra-ui-basic/package.json
@@ -20,7 +20,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/table-chakra-ui-basic/src/components/pagination/index.tsx
+++ b/examples/table-chakra-ui-basic/src/components/pagination/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/examples/table-chakra-ui-basic/src/components/table/columnFilter.tsx
+++ b/examples/table-chakra-ui-basic/src/components/table/columnFilter.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/table-chakra-ui-basic/src/components/table/columnSorter.tsx
+++ b/examples/table-chakra-ui-basic/src/components/table/columnSorter.tsx
@@ -1,5 +1,5 @@
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconSelector } from "@tabler/icons";
+import { IconChevronDown, IconSelector } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/table-mantine-advanced/package.json
+++ b/examples/table-mantine-advanced/package.json
@@ -23,7 +23,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",

--- a/examples/table-mantine-advanced/src/components/table/columnFilter.tsx
+++ b/examples/table-mantine-advanced/src/components/table/columnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/table-mantine-advanced/src/components/table/columnSorter.tsx
+++ b/examples/table-mantine-advanced/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/table-mantine-advanced/src/pages/posts/list.tsx
+++ b/examples/table-mantine-advanced/src/pages/posts/list.tsx
@@ -27,7 +27,7 @@ import {
 } from "@mantine/core";
 
 import MDEditor from "@uiw/react-md-editor";
-import { IconChevronDown, IconChevronRight } from "@tabler/icons";
+import { IconChevronDown, IconChevronRight } from "@tabler/icons-react";
 
 import { ColumnFilter, ColumnSorter } from "../../components/table";
 import { IPost, ICategory } from "../../interfaces";

--- a/examples/table-mantine-basic/package.json
+++ b/examples/table-mantine-basic/package.json
@@ -23,7 +23,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/table-mantine-basic/src/components/table/columnFilter.tsx
+++ b/examples/table-mantine-basic/src/components/table/columnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/table-mantine-basic/src/components/table/columnSorter.tsx
+++ b/examples/table-mantine-basic/src/components/table/columnSorter.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector } from "@tabler/icons";
+import { IconChevronDown, IconSelector } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/template-chakra-ui/package.json
+++ b/examples/template-chakra-ui/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/template-mantine/package.json
+++ b/examples/template-mantine/package.json
@@ -33,7 +33,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/theme-chakra-ui-demo/package.json
+++ b/examples/theme-chakra-ui-demo/package.json
@@ -18,7 +18,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/theme-chakra-ui-demo/src/App.tsx
+++ b/examples/theme-chakra-ui-demo/src/App.tsx
@@ -15,7 +15,7 @@ import routerProvider, {
   DocumentTitleHandler,
 } from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
-import { IconBrandGoogle, IconBrandGithub } from "@tabler/icons";
+import { IconBrandGoogle, IconBrandGithub } from "@tabler/icons-react";
 
 import { PostCreate, PostEdit, PostList, PostShow } from "./pages";
 import { authProvider } from "./authProvider";

--- a/examples/theme-chakra-ui-demo/src/components/pagination/index.tsx
+++ b/examples/theme-chakra-ui-demo/src/components/pagination/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/examples/theme-chakra-ui-demo/src/components/table/columnFilter.tsx
+++ b/examples/theme-chakra-ui-demo/src/components/table/columnFilter.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/theme-chakra-ui-demo/src/components/table/columnSorter.tsx
+++ b/examples/theme-chakra-ui-demo/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 import type { SortDirection } from "@tanstack/react-table";

--- a/examples/theme-mantine-demo/package.json
+++ b/examples/theme-mantine-demo/package.json
@@ -21,7 +21,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",

--- a/examples/theme-mantine-demo/src/App.tsx
+++ b/examples/theme-mantine-demo/src/App.tsx
@@ -22,7 +22,7 @@ import routerProvider, {
   DocumentTitleHandler,
 } from "@refinedev/react-router-v6";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
-import { IconBrandGoogle, IconBrandGithub } from "@tabler/icons";
+import { IconBrandGoogle, IconBrandGithub } from "@tabler/icons-react";
 
 import { PostCreate, PostEdit, PostList, PostShow } from "./pages";
 import { authProvider } from "./authProvider";

--- a/examples/theme-mantine-demo/src/components/table/columnFilter.tsx
+++ b/examples/theme-mantine-demo/src/components/table/columnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/theme-mantine-demo/src/components/table/columnSorter.tsx
+++ b/examples/theme-mantine-demo/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/tutorial-chakra-ui/package.json
+++ b/examples/tutorial-chakra-ui/package.json
@@ -31,7 +31,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/tutorial-chakra-ui/src/components/table/ColumnFilter.tsx
+++ b/examples/tutorial-chakra-ui/src/components/table/ColumnFilter.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 import { Column } from "@tanstack/react-table";
 
 export const ColumnFilter: React.FC<{ column: Column<any, any> }> = ({

--- a/examples/tutorial-chakra-ui/src/components/table/ColumnSorter.tsx
+++ b/examples/tutorial-chakra-ui/src/components/table/ColumnSorter.tsx
@@ -1,5 +1,9 @@
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconChevronUp, IconSelector } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconChevronUp,
+  IconSelector,
+} from "@tabler/icons-react";
 import { Column } from "@tanstack/react-table";
 
 export const ColumnSorter: React.FC<{ column: Column<any, any> }> = ({

--- a/examples/tutorial-chakra-ui/src/pages/blog-posts/list.tsx
+++ b/examples/tutorial-chakra-ui/src/pages/blog-posts/list.tsx
@@ -25,7 +25,7 @@ import {
   Box,
   Text,
 } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { ColumnSorter } from "../../components/table/ColumnSorter";
 import { ColumnFilter } from "../../components/table/ColumnFilter";
 

--- a/examples/tutorial-mantine/package.json
+++ b/examples/tutorial-mantine/package.json
@@ -34,7 +34,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/tutorial-mantine/src/components/table/ColumnFilter.tsx
+++ b/examples/tutorial-mantine/src/components/table/ColumnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 import { Column } from "@tanstack/react-table";
 
 export const ColumnFilter: React.FC<{ column: Column<any, any> }> = ({

--- a/examples/tutorial-mantine/src/components/table/ColumnSorter.tsx
+++ b/examples/tutorial-mantine/src/components/table/ColumnSorter.tsx
@@ -1,5 +1,9 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconChevronUp, IconSelector } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconChevronUp,
+  IconSelector,
+} from "@tabler/icons-react";
 import { Column } from "@tanstack/react-table";
 
 export const ColumnSorter: React.FC<{ column: Column<any, any> }> = ({

--- a/examples/upload-chakra-ui-basic64/package.json
+++ b/examples/upload-chakra-ui-basic64/package.json
@@ -18,7 +18,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "rc-upload": "^4.3.4",
     "react": "^18.0.0",

--- a/examples/upload-chakra-ui-basic64/src/components/pagination/index.tsx
+++ b/examples/upload-chakra-ui-basic64/src/components/pagination/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/examples/upload-chakra-ui-basic64/src/components/table/columnFilter.tsx
+++ b/examples/upload-chakra-ui-basic64/src/components/table/columnFilter.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/upload-chakra-ui-basic64/src/components/table/columnSorter.tsx
+++ b/examples/upload-chakra-ui-basic64/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 import type { SortDirection } from "@tanstack/react-table";

--- a/examples/upload-chakra-ui-basic64/src/pages/posts/create.tsx
+++ b/examples/upload-chakra-ui-basic64/src/pages/posts/create.tsx
@@ -15,7 +15,7 @@ import {
 import { useSelect, file2Base64 } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import Upload from "rc-upload";
-import { IconFileUpload } from "@tabler/icons";
+import { IconFileUpload } from "@tabler/icons-react";
 
 import { IPost } from "../../interfaces";
 

--- a/examples/upload-chakra-ui-basic64/src/pages/posts/edit.tsx
+++ b/examples/upload-chakra-ui-basic64/src/pages/posts/edit.tsx
@@ -16,7 +16,7 @@ import {
 import { file2Base64, useSelect } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import Upload from "rc-upload";
-import { IconFileUpload } from "@tabler/icons";
+import { IconFileUpload } from "@tabler/icons-react";
 
 import { IPost } from "../../interfaces";
 

--- a/examples/upload-chakra-ui-multipart/package.json
+++ b/examples/upload-chakra-ui-multipart/package.json
@@ -18,7 +18,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "rc-upload": "^4.3.4",
     "react": "^18.0.0",

--- a/examples/upload-chakra-ui-multipart/src/components/pagination/index.tsx
+++ b/examples/upload-chakra-ui-multipart/src/components/pagination/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { HStack, Button, Box } from "@chakra-ui/react";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 import { usePagination } from "@refinedev/chakra-ui";
 
 import { IconButton } from "@chakra-ui/react";

--- a/examples/upload-chakra-ui-multipart/src/components/table/columnFilter.tsx
+++ b/examples/upload-chakra-ui-multipart/src/components/table/columnFilter.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
   HStack,
 } from "@chakra-ui/react";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/upload-chakra-ui-multipart/src/components/table/columnSorter.tsx
+++ b/examples/upload-chakra-ui-multipart/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { IconButton } from "@chakra-ui/react";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 import type { SortDirection } from "@tanstack/react-table";

--- a/examples/upload-chakra-ui-multipart/src/pages/posts/create.tsx
+++ b/examples/upload-chakra-ui-multipart/src/pages/posts/create.tsx
@@ -16,7 +16,7 @@ import {
 import { useApiUrl, useSelect } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import Upload from "rc-upload";
-import { IconFileUpload } from "@tabler/icons";
+import { IconFileUpload } from "@tabler/icons-react";
 
 import { IPost } from "../../interfaces";
 

--- a/examples/upload-chakra-ui-multipart/src/pages/posts/edit.tsx
+++ b/examples/upload-chakra-ui-multipart/src/pages/posts/edit.tsx
@@ -16,7 +16,7 @@ import {
 import { useApiUrl, useSelect } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import Upload from "rc-upload";
-import { IconFileUpload } from "@tabler/icons";
+import { IconFileUpload } from "@tabler/icons-react";
 
 import { IPost } from "../../interfaces";
 

--- a/examples/upload-mantine-base64/package.json
+++ b/examples/upload-mantine-base64/package.json
@@ -22,7 +22,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",

--- a/examples/upload-mantine-base64/src/components/table/columnFilter.tsx
+++ b/examples/upload-mantine-base64/src/components/table/columnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/upload-mantine-base64/src/components/table/columnSorter.tsx
+++ b/examples/upload-mantine-base64/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/upload-mantine-multipart/package.json
+++ b/examples/upload-mantine-multipart/package.json
@@ -22,7 +22,7 @@
     "@refinedev/react-router-v6": "^4.5.6",
     "@refinedev/react-table": "^5.6.7",
     "@refinedev/simple-rest": "^5.0.3",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",

--- a/examples/upload-mantine-multipart/src/components/table/columnFilter.tsx
+++ b/examples/upload-mantine-multipart/src/components/table/columnFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TextInput, Menu, ActionIcon, Stack, Group } from "@mantine/core";
-import { IconFilter, IconX, IconCheck } from "@tabler/icons";
+import { IconFilter, IconX, IconCheck } from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/examples/upload-mantine-multipart/src/components/table/columnSorter.tsx
+++ b/examples/upload-mantine-multipart/src/components/table/columnSorter.tsx
@@ -1,5 +1,9 @@
 import { ActionIcon } from "@mantine/core";
-import { IconChevronDown, IconSelector, IconChevronUp } from "@tabler/icons";
+import {
+  IconChevronDown,
+  IconSelector,
+  IconChevronUp,
+} from "@tabler/icons-react";
 
 import { ColumnButtonProps } from "../../interfaces";
 

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -21,7 +21,7 @@
     "@emotion/styled": "^11.8.1",
     "@refinedev/react-hook-form": "^4.8.15",
     "@refinedev/ui-types": "^1.22.4",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "dayjs": "^1.10.7",
     "framer-motion": "^7.5.3",
     "react-hook-form": "^7.30.0",

--- a/packages/chakra-ui/src/components/autoSaveIndicator/index.tsx
+++ b/packages/chakra-ui/src/components/autoSaveIndicator/index.tsx
@@ -10,7 +10,7 @@ import {
   IconRefresh,
   IconCircleCheck,
   IconExclamationCircle,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 export const AutoSaveIndicator: React.FC<AutoSaveIndicatorProps> = ({
   status,

--- a/packages/chakra-ui/src/components/breadcrumb/index.tsx
+++ b/packages/chakra-ui/src/components/breadcrumb/index.tsx
@@ -15,7 +15,7 @@ import {
   BreadcrumbItem,
   BreadcrumbLink,
 } from "@chakra-ui/react";
-import { IconHome } from "@tabler/icons";
+import { IconHome } from "@tabler/icons-react";
 
 export type BreadcrumbProps = RefineBreadcrumbProps<ChakraBreadcrumbProps>;
 

--- a/packages/chakra-ui/src/components/buttons/clone/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/clone/index.tsx
@@ -14,7 +14,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { Button, IconButton } from "@chakra-ui/react";
-import { IconSquarePlus } from "@tabler/icons";
+import { IconSquarePlus } from "@tabler/icons-react";
 
 import { CloneButtonProps } from "../types";
 

--- a/packages/chakra-ui/src/components/buttons/create/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/create/index.tsx
@@ -14,7 +14,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { Button, IconButton } from "@chakra-ui/react";
-import { IconSquarePlus } from "@tabler/icons";
+import { IconSquarePlus } from "@tabler/icons-react";
 
 import { CreateButtonProps } from "../types";
 

--- a/packages/chakra-ui/src/components/buttons/delete/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/delete/index.tsx
@@ -25,7 +25,7 @@ import {
   PopoverHeader,
   PopoverTrigger,
 } from "@chakra-ui/react";
-import { IconTrash } from "@tabler/icons";
+import { IconTrash } from "@tabler/icons-react";
 
 import { DeleteButtonProps } from "../types";
 

--- a/packages/chakra-ui/src/components/buttons/edit/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/edit/index.tsx
@@ -13,7 +13,7 @@ import {
   RefineButtonClassNames,
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
-import { IconPencil } from "@tabler/icons";
+import { IconPencil } from "@tabler/icons-react";
 import { Button, IconButton } from "@chakra-ui/react";
 
 import { EditButtonProps } from "../types";

--- a/packages/chakra-ui/src/components/buttons/export/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/export/index.tsx
@@ -5,7 +5,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { IconButton, Button } from "@chakra-ui/react";
-import { IconFileExport } from "@tabler/icons";
+import { IconFileExport } from "@tabler/icons-react";
 
 import { ExportButtonProps } from "../types";
 

--- a/packages/chakra-ui/src/components/buttons/import/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/import/index.tsx
@@ -5,7 +5,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { IconButton, Button } from "@chakra-ui/react";
-import { IconFileImport } from "@tabler/icons";
+import { IconFileImport } from "@tabler/icons-react";
 
 import { ImportButtonProps } from "../types";
 

--- a/packages/chakra-ui/src/components/buttons/list/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/list/index.tsx
@@ -16,7 +16,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { IconButton, Button } from "@chakra-ui/react";
-import { IconList } from "@tabler/icons";
+import { IconList } from "@tabler/icons-react";
 
 import { ListButtonProps } from "../types";
 

--- a/packages/chakra-ui/src/components/buttons/refresh/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/refresh/index.tsx
@@ -11,7 +11,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { IconButton, Button } from "@chakra-ui/react";
-import { IconRefresh } from "@tabler/icons";
+import { IconRefresh } from "@tabler/icons-react";
 
 import { RefreshButtonProps } from "../types";
 

--- a/packages/chakra-ui/src/components/buttons/save/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/save/index.tsx
@@ -5,7 +5,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { IconButton, Button } from "@chakra-ui/react";
-import { IconDeviceFloppy } from "@tabler/icons";
+import { IconDeviceFloppy } from "@tabler/icons-react";
 
 import { SaveButtonProps } from "../types";
 

--- a/packages/chakra-ui/src/components/buttons/show/index.tsx
+++ b/packages/chakra-ui/src/components/buttons/show/index.tsx
@@ -14,7 +14,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { IconButton, Button } from "@chakra-ui/react";
-import { IconEye } from "@tabler/icons";
+import { IconEye } from "@tabler/icons-react";
 
 import { ShowButtonProps } from "../types";
 

--- a/packages/chakra-ui/src/components/buttons/types.ts
+++ b/packages/chakra-ui/src/components/buttons/types.ts
@@ -12,13 +12,13 @@ import {
   RefineSaveButtonProps,
   RefineShowButtonProps,
 } from "@refinedev/ui-types";
-import { TablerIconProps } from "@tabler/icons";
+import { IconProps } from "@tabler/icons-react";
 
 export type ShowButtonProps = Omit<
   RefineShowButtonProps<
     ButtonProps,
     {
-      svgIconProps?: TablerIconProps;
+      svgIconProps?: Omit<IconProps, "ref">;
     }
   >,
   "ignoreAccessControlProvider"
@@ -27,14 +27,14 @@ export type ShowButtonProps = Omit<
 export type SaveButtonProps = RefineSaveButtonProps<
   ButtonProps,
   {
-    svgIconProps?: TablerIconProps;
+    svgIconProps?: Omit<IconProps, "ref">;
   }
 >;
 
 export type RefreshButtonProps = RefineRefreshButtonProps<
   ButtonProps,
   {
-    svgIconProps?: TablerIconProps;
+    svgIconProps?: Omit<IconProps, "ref">;
   }
 >;
 
@@ -42,7 +42,7 @@ export type ListButtonProps = Omit<
   RefineListButtonProps<
     ButtonProps,
     {
-      svgIconProps?: TablerIconProps;
+      svgIconProps?: Omit<IconProps, "ref">;
     }
   >,
   "ignoreAccessControlProvider"
@@ -52,14 +52,14 @@ export type ImportButtonProps = RefineImportButtonProps<
   ButtonProps,
   {
     inputProps: UseImportInputPropsType;
-    svgIconProps?: TablerIconProps;
+    svgIconProps?: Omit<IconProps, "ref">;
   }
 >;
 
 export type ExportButtonProps = RefineExportButtonProps<
   ButtonProps,
   {
-    svgIconProps?: TablerIconProps;
+    svgIconProps?: Omit<IconProps, "ref">;
   }
 >;
 
@@ -67,7 +67,7 @@ export type EditButtonProps = Omit<
   RefineEditButtonProps<
     ButtonProps,
     {
-      svgIconProps?: TablerIconProps;
+      svgIconProps?: Omit<IconProps, "ref">;
     }
   >,
   "ignoreAccessControlProvider"
@@ -77,7 +77,7 @@ export type DeleteButtonProps = Omit<
   RefineDeleteButtonProps<
     ButtonProps,
     {
-      svgIconProps?: TablerIconProps;
+      svgIconProps?: Omit<IconProps, "ref">;
     }
   >,
   "ignoreAccessControlProvider"
@@ -87,7 +87,7 @@ export type CloneButtonProps = Omit<
   RefineCloneButtonProps<
     ButtonProps,
     {
-      svgIconProps?: TablerIconProps;
+      svgIconProps?: Omit<IconProps, "ref">;
     }
   >,
   "ignoreAccessControlProvider"
@@ -97,7 +97,7 @@ export type CreateButtonProps = Omit<
   RefineCreateButtonProps<
     ButtonProps,
     {
-      svgIconProps?: TablerIconProps;
+      svgIconProps?: Omit<IconProps, "ref">;
     }
   >,
   "ignoreAccessControlProvider"

--- a/packages/chakra-ui/src/components/crud/create/index.tsx
+++ b/packages/chakra-ui/src/components/crud/create/index.tsx
@@ -11,7 +11,7 @@ import {
 import { Box, Heading, HStack, IconButton, Spinner } from "@chakra-ui/react";
 
 // We use @tabler/icons for icons but you can use any icon library you want.
-import { IconArrowLeft } from "@tabler/icons";
+import { IconArrowLeft } from "@tabler/icons-react";
 
 import { Breadcrumb, SaveButton, SaveButtonProps } from "@components";
 import { CreateProps } from "../types";

--- a/packages/chakra-ui/src/components/crud/edit/index.tsx
+++ b/packages/chakra-ui/src/components/crud/edit/index.tsx
@@ -16,7 +16,7 @@ import {
 import { Box, Heading, HStack, IconButton, Spinner } from "@chakra-ui/react";
 
 // We use @tabler/icons for icons but you can use any icon library you want.
-import { IconArrowLeft } from "@tabler/icons";
+import { IconArrowLeft } from "@tabler/icons-react";
 
 import {
   DeleteButton,

--- a/packages/chakra-ui/src/components/crud/show/index.tsx
+++ b/packages/chakra-ui/src/components/crud/show/index.tsx
@@ -13,7 +13,7 @@ import {
 import { Box, IconButton, HStack, Heading, Spinner } from "@chakra-ui/react";
 
 // We use @tabler/icons for icons but you can use any icon library you want.
-import { IconArrowLeft } from "@tabler/icons";
+import { IconArrowLeft } from "@tabler/icons-react";
 
 import {
   DeleteButton,

--- a/packages/chakra-ui/src/components/fields/boolean/index.tsx
+++ b/packages/chakra-ui/src/components/fields/boolean/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Tooltip } from "@chakra-ui/react";
-import { IconMinus, IconCheck } from "@tabler/icons";
+import { IconMinus, IconCheck } from "@tabler/icons-react";
 
 import { BooleanFieldProps } from "../types";
 

--- a/packages/chakra-ui/src/components/fields/types.ts
+++ b/packages/chakra-ui/src/components/fields/types.ts
@@ -11,13 +11,13 @@ import {
   RefineFieldTextProps,
   RefineFieldUrlProps,
 } from "@refinedev/ui-types";
-import { TablerIconProps } from "@tabler/icons";
+import type { IconProps } from "@tabler/icons-react";
 import { ConfigType } from "dayjs";
 
 export type BooleanFieldProps = RefineFieldBooleanProps<
   unknown,
   Omit<TooltipProps, "label" | "children">,
-  { svgIconProps?: TablerIconProps }
+  { svgIconProps?: Omit<IconProps, "ref"> }
 >;
 
 export type DateFieldProps = RefineFieldDateProps<ConfigType, TextProps>;

--- a/packages/chakra-ui/src/components/layout/sider/index.tsx
+++ b/packages/chakra-ui/src/components/layout/sider/index.tsx
@@ -37,7 +37,7 @@ import {
   IconDashboard,
   IconLogout,
   IconMenu2,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 import { Title as DefaultTitle } from "@components";
 import { RefineLayoutSiderProps } from "../types";

--- a/packages/chakra-ui/src/components/pages/error/index.tsx
+++ b/packages/chakra-ui/src/components/pages/error/index.tsx
@@ -17,7 +17,7 @@ import {
   useColorModeValue,
   Stack,
 } from "@chakra-ui/react";
-import { IconInfoCircle } from "@tabler/icons";
+import { IconInfoCircle } from "@tabler/icons-react";
 
 export const ErrorComponent: React.FC<RefineErrorPageProps> = () => {
   const [errorMessage, setErrorMessage] = useState<string>();

--- a/packages/chakra-ui/src/components/themedLayout/header/index.tsx
+++ b/packages/chakra-ui/src/components/themedLayout/header/index.tsx
@@ -13,7 +13,7 @@ import { RefineThemedLayoutHeaderProps } from "../types";
 import {
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 /**
  * @deprecated It is recommended to use the improved `ThemedLayoutV2`. Review migration guidelines. https://refine.dev/docs/api-reference/chakra-ui/components/chakra-ui-themed-layout/#migrate-themedlayout-to-themedlayoutv2

--- a/packages/chakra-ui/src/components/themedLayout/sider/index.tsx
+++ b/packages/chakra-ui/src/components/themedLayout/sider/index.tsx
@@ -31,7 +31,12 @@ import {
   useColorModeValue,
   VStack,
 } from "@chakra-ui/react";
-import { IconList, IconDashboard, IconPower, IconMenu2 } from "@tabler/icons";
+import {
+  IconList,
+  IconDashboard,
+  IconPower,
+  IconMenu2,
+} from "@tabler/icons-react";
 
 import { ThemedTitle as DefaultTitle } from "@components";
 import { RefineThemedLayoutSiderProps } from "../types";

--- a/packages/chakra-ui/src/components/themedLayoutV2/hamburgerMenu/index.tsx
+++ b/packages/chakra-ui/src/components/themedLayoutV2/hamburgerMenu/index.tsx
@@ -4,7 +4,7 @@ import {
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
   IconMenu2,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 import { useThemedLayoutContext } from "@hooks";
 

--- a/packages/chakra-ui/src/components/themedLayoutV2/sider/index.tsx
+++ b/packages/chakra-ui/src/components/themedLayoutV2/sider/index.tsx
@@ -30,7 +30,7 @@ import {
   useColorModeValue,
   VStack,
 } from "@chakra-ui/react";
-import { IconList, IconDashboard, IconPower } from "@tabler/icons";
+import { IconList, IconDashboard, IconPower } from "@tabler/icons-react";
 
 import { ThemedTitleV2 as DefaultTitle } from "../title";
 import { RefineThemedLayoutV2SiderProps } from "../types";

--- a/packages/chakra-ui/src/components/undoableNotification/index.tsx
+++ b/packages/chakra-ui/src/components/undoableNotification/index.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   useToast,
 } from "@chakra-ui/react";
-import { IconRotate2 } from "@tabler/icons";
+import { IconRotate2 } from "@tabler/icons-react";
 
 export type UndoableNotificationProps = {
   notificationKey: OpenNotificationParams["key"];

--- a/packages/devtools-server/src/packages/get-available-packages.ts
+++ b/packages/devtools-server/src/packages/get-available-packages.ts
@@ -102,7 +102,7 @@ export const AVAILABLE_PACKAGES: AvailablePackageType[] = [
     name: "@refinedev/chakra-ui",
     description: "Chakra UI integration for refine",
     install:
-      "npm install @refinedev/chakra-ui @chakra-ui/react @emotion/react @emotion/styled framer-motion",
+      "npm install @refinedev/chakra-ui @chakra-ui/react @emotion/react @emotion/styled framer-motion @tabler/icons-react",
     usage: dedent(
       `
             import { ThemedLayoutV2 } from "@refinedev/chakra-ui";
@@ -220,7 +220,7 @@ export const AVAILABLE_PACKAGES: AvailablePackageType[] = [
     name: "@refinedev/mantine",
     description: "Mantine UI integration for refine",
     install:
-      "npm install @refinedev/mantine @refinedev/react-table @mantine/core @mantine/hooks @mantine/form @mantine/notifications @emotion/react @tabler/icons",
+      "npm install @refinedev/mantine @refinedev/react-table @mantine/core @mantine/hooks @mantine/form @mantine/notifications @emotion/react @tabler/icons-react",
     usage: dedent(
       `
             import { ThemedLayoutV2 } from "@refinedev/mantine";

--- a/packages/inferencer/package.json
+++ b/packages/inferencer/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@aliemir/react-live": "^4.0.0",
     "@refinedev/core": "^4.48.0",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "dayjs": "^1.10.7",
     "graphql": "^15.6.1",
     "graphql-tag": "^2.12.6",

--- a/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/create.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/create.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`ChakraCreateInferencer should match the snapshot 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="icon icon-tabler icon-tabler-arrow-left"
+                class="tabler-icon tabler-icon-arrow-left "
                 fill="none"
                 focusable="false"
                 height="24"
@@ -35,27 +35,13 @@ exports[`ChakraCreateInferencer should match the snapshot 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
+                  d="M5 12l14 0"
                 />
-                <line
-                  x1="5"
-                  x2="19"
-                  y1="12"
-                  y2="12"
+                <path
+                  d="M5 12l6 6"
                 />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="18"
-                />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="6"
+                <path
+                  d="M5 12l6 -6"
                 />
               </svg>
             </button>
@@ -407,7 +393,7 @@ exports[`ChakraCreateInferencer should match the snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="icon icon-tabler icon-tabler-device-floppy"
+              class="tabler-icon tabler-icon-device-floppy "
               fill="none"
               focusable="false"
               height="20"
@@ -420,20 +406,13 @@ exports[`ChakraCreateInferencer should match the snapshot 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M0 0h24v24H0z"
-                fill="none"
-                stroke="none"
-              />
-              <path
                 d="M6 4h10l4 4v10a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2"
               />
-              <circle
-                cx="12"
-                cy="14"
-                r="2"
+              <path
+                d="M12 14m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0"
               />
-              <polyline
-                points="14 4 14 8 8 8 8 4"
+              <path
+                d="M14 4l0 4l-6 0l0 -4"
               />
             </svg>
           </span>

--- a/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/edit.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/edit.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`ChakraEditInferencer should match the snapshot 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="icon icon-tabler icon-tabler-arrow-left"
+                class="tabler-icon tabler-icon-arrow-left "
                 fill="none"
                 focusable="false"
                 height="24"
@@ -35,27 +35,13 @@ exports[`ChakraEditInferencer should match the snapshot 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
+                  d="M5 12l14 0"
                 />
-                <line
-                  x1="5"
-                  x2="19"
-                  y1="12"
-                  y2="12"
+                <path
+                  d="M5 12l6 6"
                 />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="18"
-                />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="6"
+                <path
+                  d="M5 12l6 -6"
                 />
               </svg>
             </button>
@@ -85,7 +71,7 @@ exports[`ChakraEditInferencer should match the snapshot 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="icon icon-tabler icon-tabler-list"
+                    class="tabler-icon tabler-icon-list "
                     fill="none"
                     focusable="false"
                     height="20"
@@ -98,45 +84,22 @@ exports[`ChakraEditInferencer should match the snapshot 1`] = `
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M0 0h24v24H0z"
-                      fill="none"
-                      stroke="none"
+                      d="M9 6l11 0"
                     />
-                    <line
-                      x1="9"
-                      x2="20"
-                      y1="6"
-                      y2="6"
+                    <path
+                      d="M9 12l11 0"
                     />
-                    <line
-                      x1="9"
-                      x2="20"
-                      y1="12"
-                      y2="12"
+                    <path
+                      d="M9 18l11 0"
                     />
-                    <line
-                      x1="9"
-                      x2="20"
-                      y1="18"
-                      y2="18"
+                    <path
+                      d="M5 6l0 .01"
                     />
-                    <line
-                      x1="5"
-                      x2="5"
-                      y1="6"
-                      y2="6.01"
+                    <path
+                      d="M5 12l0 .01"
                     />
-                    <line
-                      x1="5"
-                      x2="5"
-                      y1="12"
-                      y2="12.01"
-                    />
-                    <line
-                      x1="5"
-                      x2="5"
-                      y1="18"
-                      y2="18.01"
+                    <path
+                      d="M5 18l0 .01"
                     />
                   </svg>
                 </span>
@@ -152,7 +115,7 @@ exports[`ChakraEditInferencer should match the snapshot 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="icon icon-tabler icon-tabler-refresh"
+                  class="tabler-icon tabler-icon-refresh "
                   fill="none"
                   focusable="false"
                   height="20"
@@ -164,11 +127,6 @@ exports[`ChakraEditInferencer should match the snapshot 1`] = `
                   width="20"
                   xmlns="http://www.w3.org/2000/svg"
                 >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                    stroke="none"
-                  />
                   <path
                     d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4"
                   />
@@ -538,7 +496,7 @@ exports[`ChakraEditInferencer should match the snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="icon icon-tabler icon-tabler-device-floppy"
+              class="tabler-icon tabler-icon-device-floppy "
               fill="none"
               focusable="false"
               height="20"
@@ -551,20 +509,13 @@ exports[`ChakraEditInferencer should match the snapshot 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M0 0h24v24H0z"
-                fill="none"
-                stroke="none"
-              />
-              <path
                 d="M6 4h10l4 4v10a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2"
               />
-              <circle
-                cx="12"
-                cy="14"
-                r="2"
+              <path
+                d="M12 14m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0"
               />
-              <polyline
-                points="14 4 14 8 8 8 8 4"
+              <path
+                d="M14 4l0 4l-6 0l0 -4"
               />
             </svg>
           </span>

--- a/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/index.test.tsx.snap
@@ -1434,7 +1434,7 @@ exports[`ChakraUIInferencer should match the snapshot 1`] = `
                 class="token string"
                 style="color: rgb(206, 145, 120);"
               >
-                "@tabler/icons"
+                "@tabler/icons-react"
               </span>
               <span
                 class="token punctuation"
@@ -14583,7 +14583,7 @@ exports[`ChakraUIInferencer should match the snapshot 2`] = `
             >
               <svg
                 aria-hidden="true"
-                class="icon icon-tabler icon-tabler-arrow-left"
+                class="tabler-icon tabler-icon-arrow-left "
                 fill="none"
                 focusable="false"
                 height="24"
@@ -14596,27 +14596,13 @@ exports[`ChakraUIInferencer should match the snapshot 2`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
+                  d="M5 12l14 0"
                 />
-                <line
-                  x1="5"
-                  x2="19"
-                  y1="12"
-                  y2="12"
+                <path
+                  d="M5 12l6 6"
                 />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="18"
-                />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="6"
+                <path
+                  d="M5 12l6 -6"
                 />
               </svg>
             </button>
@@ -14968,7 +14954,7 @@ exports[`ChakraUIInferencer should match the snapshot 2`] = `
           >
             <svg
               aria-hidden="true"
-              class="icon icon-tabler icon-tabler-device-floppy"
+              class="tabler-icon tabler-icon-device-floppy "
               fill="none"
               focusable="false"
               height="20"
@@ -14981,20 +14967,13 @@ exports[`ChakraUIInferencer should match the snapshot 2`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M0 0h24v24H0z"
-                fill="none"
-                stroke="none"
-              />
-              <path
                 d="M6 4h10l4 4v10a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2"
               />
-              <circle
-                cx="12"
-                cy="14"
-                r="2"
+              <path
+                d="M12 14m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0"
               />
-              <polyline
-                points="14 4 14 8 8 8 8 4"
+              <path
+                d="M14 4l0 4l-6 0l0 -4"
               />
             </svg>
           </span>
@@ -25589,7 +25568,7 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
             >
               <svg
                 aria-hidden="true"
-                class="icon icon-tabler icon-tabler-arrow-left"
+                class="tabler-icon tabler-icon-arrow-left "
                 fill="none"
                 focusable="false"
                 height="24"
@@ -25602,27 +25581,13 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
+                  d="M5 12l14 0"
                 />
-                <line
-                  x1="5"
-                  x2="19"
-                  y1="12"
-                  y2="12"
+                <path
+                  d="M5 12l6 6"
                 />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="18"
-                />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="6"
+                <path
+                  d="M5 12l6 -6"
                 />
               </svg>
             </button>
@@ -25648,7 +25613,7 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="icon icon-tabler icon-tabler-refresh"
+                  class="tabler-icon tabler-icon-refresh "
                   fill="none"
                   focusable="false"
                   height="20"
@@ -25660,11 +25625,6 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
                   width="20"
                   xmlns="http://www.w3.org/2000/svg"
                 >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                    stroke="none"
-                  />
                   <path
                     d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4"
                   />
@@ -26034,7 +25994,7 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
           >
             <svg
               aria-hidden="true"
-              class="icon icon-tabler icon-tabler-device-floppy"
+              class="tabler-icon tabler-icon-device-floppy "
               fill="none"
               focusable="false"
               height="20"
@@ -26047,20 +26007,13 @@ exports[`ChakraUIInferencer should match the snapshot 3`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M0 0h24v24H0z"
-                fill="none"
-                stroke="none"
-              />
-              <path
                 d="M6 4h10l4 4v10a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2"
               />
-              <circle
-                cx="12"
-                cy="14"
-                r="2"
+              <path
+                d="M12 14m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0"
               />
-              <polyline
-                points="14 4 14 8 8 8 8 4"
+              <path
+                d="M14 4l0 4l-6 0l0 -4"
               />
             </svg>
           </span>
@@ -38324,7 +38277,7 @@ exports[`ChakraUIInferencer should match the snapshot 4`] = `
             >
               <svg
                 aria-hidden="true"
-                class="icon icon-tabler icon-tabler-arrow-left"
+                class="tabler-icon tabler-icon-arrow-left "
                 fill="none"
                 focusable="false"
                 height="24"
@@ -38337,27 +38290,13 @@ exports[`ChakraUIInferencer should match the snapshot 4`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
+                  d="M5 12l14 0"
                 />
-                <line
-                  x1="5"
-                  x2="19"
-                  y1="12"
-                  y2="12"
+                <path
+                  d="M5 12l6 6"
                 />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="18"
-                />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="6"
+                <path
+                  d="M5 12l6 -6"
                 />
               </svg>
             </button>
@@ -38380,7 +38319,7 @@ exports[`ChakraUIInferencer should match the snapshot 4`] = `
             >
               <svg
                 aria-hidden="true"
-                class="icon icon-tabler icon-tabler-refresh"
+                class="tabler-icon tabler-icon-refresh "
                 fill="none"
                 focusable="false"
                 height="20"
@@ -38392,11 +38331,6 @@ exports[`ChakraUIInferencer should match the snapshot 4`] = `
                 width="20"
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
-                />
                 <path
                   d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4"
                 />

--- a/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/list.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/list.test.tsx.snap
@@ -1428,7 +1428,7 @@ exports[`ChakraListInferencer should match the snapshot 1`] = `
                 class="token string"
                 style="color: rgb(206, 145, 120);"
               >
-                "@tabler/icons"
+                "@tabler/icons-react"
               </span>
               <span
                 class="token punctuation"

--- a/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/show.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/show.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`ChakraShowInferencer should match the snapshot 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="icon icon-tabler icon-tabler-arrow-left"
+                class="tabler-icon tabler-icon-arrow-left "
                 fill="none"
                 focusable="false"
                 height="24"
@@ -35,27 +35,13 @@ exports[`ChakraShowInferencer should match the snapshot 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
+                  d="M5 12l14 0"
                 />
-                <line
-                  x1="5"
-                  x2="19"
-                  y1="12"
-                  y2="12"
+                <path
+                  d="M5 12l6 6"
                 />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="18"
-                />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="6"
+                <path
+                  d="M5 12l6 -6"
                 />
               </svg>
             </button>
@@ -82,7 +68,7 @@ exports[`ChakraShowInferencer should match the snapshot 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="icon icon-tabler icon-tabler-list"
+                  class="tabler-icon tabler-icon-list "
                   fill="none"
                   focusable="false"
                   height="20"
@@ -95,45 +81,22 @@ exports[`ChakraShowInferencer should match the snapshot 1`] = `
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                    stroke="none"
+                    d="M9 6l11 0"
                   />
-                  <line
-                    x1="9"
-                    x2="20"
-                    y1="6"
-                    y2="6"
+                  <path
+                    d="M9 12l11 0"
                   />
-                  <line
-                    x1="9"
-                    x2="20"
-                    y1="12"
-                    y2="12"
+                  <path
+                    d="M9 18l11 0"
                   />
-                  <line
-                    x1="9"
-                    x2="20"
-                    y1="18"
-                    y2="18"
+                  <path
+                    d="M5 6l0 .01"
                   />
-                  <line
-                    x1="5"
-                    x2="5"
-                    y1="6"
-                    y2="6.01"
+                  <path
+                    d="M5 12l0 .01"
                   />
-                  <line
-                    x1="5"
-                    x2="5"
-                    y1="12"
-                    y2="12.01"
-                  />
-                  <line
-                    x1="5"
-                    x2="5"
-                    y1="18"
-                    y2="18.01"
+                  <path
+                    d="M5 18l0 .01"
                   />
                 </svg>
               </span>
@@ -149,7 +112,7 @@ exports[`ChakraShowInferencer should match the snapshot 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="icon icon-tabler icon-tabler-refresh"
+                class="tabler-icon tabler-icon-refresh "
                 fill="none"
                 focusable="false"
                 height="20"
@@ -161,11 +124,6 @@ exports[`ChakraShowInferencer should match the snapshot 1`] = `
                 width="20"
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
-                />
                 <path
                   d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4"
                 />

--- a/packages/inferencer/src/inferencers/chakra-ui/code-viewer.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/code-viewer.tsx
@@ -15,7 +15,7 @@ import {
   IconMessageCircle,
   IconCopy,
   IconCheck,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 import { prettierFormat } from "../../utilities";
 import { CreateInferencerConfig } from "../../types";

--- a/packages/inferencer/src/inferencers/chakra-ui/list.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/list.tsx
@@ -27,7 +27,7 @@ import {
 } from "@chakra-ui/react";
 import { useTable } from "@refinedev/react-table";
 import { flexRender } from "@tanstack/react-table";
-import { IconChevronRight, IconChevronLeft } from "@tabler/icons";
+import { IconChevronRight, IconChevronLeft } from "@tabler/icons-react";
 
 import { createInferencer } from "../../create-inferencer";
 import {
@@ -93,8 +93,8 @@ export const renderer = ({
     ["IconButton", "@chakra-ui/react"],
     ["usePagination", "@refinedev/chakra-ui"],
     ["Box", "@chakra-ui/react"],
-    ["IconChevronRight", "@tabler/icons"],
-    ["IconChevronLeft", "@tabler/icons"],
+    ["IconChevronRight", "@tabler/icons-react"],
+    ["IconChevronLeft", "@tabler/icons-react"],
   ];
 
   if (i18n) {
@@ -972,7 +972,11 @@ export const ListInferencer: InferencerResultComponent = createInferencer({
       },
     ],
     ["@refinedev/react-table", "RefineReactTable", { useTable }],
-    ["@tabler/icons", "TablerIcons", { IconChevronRight, IconChevronLeft }],
+    [
+      "@tabler/icons-react",
+      "TablerIcons",
+      { IconChevronRight, IconChevronLeft },
+    ],
     [
       "@chakra-ui/react",
       "ChakraUI",

--- a/packages/inferencer/src/inferencers/headless/code-viewer.tsx
+++ b/packages/inferencer/src/inferencers/headless/code-viewer.tsx
@@ -4,7 +4,7 @@ import {
   IconMessageCircle,
   IconCopy,
   IconCheck,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 import { prettierFormat } from "../../utilities";
 import { CreateInferencerConfig } from "../../types";

--- a/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/create.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/create.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`MantineCreateInferencer should match the snapshot 1`] = `
               type="button"
             >
               <svg
-                class="icon icon-tabler icon-tabler-arrow-left"
+                class="tabler-icon tabler-icon-arrow-left "
                 fill="none"
                 height="24"
                 stroke="currentColor"
@@ -32,27 +32,13 @@ exports[`MantineCreateInferencer should match the snapshot 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
+                  d="M5 12l14 0"
                 />
-                <line
-                  x1="5"
-                  x2="19"
-                  y1="12"
-                  y2="12"
+                <path
+                  d="M5 12l6 6"
                 />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="18"
-                />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="6"
+                <path
+                  d="M5 12l6 -6"
                 />
               </svg>
             </button>
@@ -570,7 +556,7 @@ exports[`MantineCreateInferencer should match the snapshot 1`] = `
               class="mantine-Button-icon mantine-Button-leftIcon mantine-1g4orza"
             >
               <svg
-                class="icon icon-tabler icon-tabler-device-floppy"
+                class="tabler-icon tabler-icon-device-floppy "
                 fill="none"
                 height="18"
                 stroke="currentColor"
@@ -582,20 +568,13 @@ exports[`MantineCreateInferencer should match the snapshot 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
-                />
-                <path
                   d="M6 4h10l4 4v10a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2"
                 />
-                <circle
-                  cx="12"
-                  cy="14"
-                  r="2"
+                <path
+                  d="M12 14m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0"
                 />
-                <polyline
-                  points="14 4 14 8 8 8 8 4"
+                <path
+                  d="M14 4l0 4l-6 0l0 -4"
                 />
               </svg>
             </span>

--- a/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/edit.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/edit.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`MantineEditInferencer should match the snapshot 1`] = `
               type="button"
             >
               <svg
-                class="icon icon-tabler icon-tabler-arrow-left"
+                class="tabler-icon tabler-icon-arrow-left "
                 fill="none"
                 height="24"
                 stroke="currentColor"
@@ -32,27 +32,13 @@ exports[`MantineEditInferencer should match the snapshot 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
+                  d="M5 12l14 0"
                 />
-                <line
-                  x1="5"
-                  x2="19"
-                  y1="12"
-                  y2="12"
+                <path
+                  d="M5 12l6 6"
                 />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="18"
-                />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="6"
+                <path
+                  d="M5 12l6 -6"
                 />
               </svg>
             </button>
@@ -83,7 +69,7 @@ exports[`MantineEditInferencer should match the snapshot 1`] = `
                   class="mantine-Button-icon mantine-Button-leftIcon mantine-1g4orza"
                 >
                   <svg
-                    class="icon icon-tabler icon-tabler-list"
+                    class="tabler-icon tabler-icon-list "
                     fill="none"
                     height="18"
                     stroke="currentColor"
@@ -95,45 +81,22 @@ exports[`MantineEditInferencer should match the snapshot 1`] = `
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M0 0h24v24H0z"
-                      fill="none"
-                      stroke="none"
+                      d="M9 6l11 0"
                     />
-                    <line
-                      x1="9"
-                      x2="20"
-                      y1="6"
-                      y2="6"
+                    <path
+                      d="M9 12l11 0"
                     />
-                    <line
-                      x1="9"
-                      x2="20"
-                      y1="12"
-                      y2="12"
+                    <path
+                      d="M9 18l11 0"
                     />
-                    <line
-                      x1="9"
-                      x2="20"
-                      y1="18"
-                      y2="18"
+                    <path
+                      d="M5 6l0 .01"
                     />
-                    <line
-                      x1="5"
-                      x2="5"
-                      y1="6"
-                      y2="6.01"
+                    <path
+                      d="M5 12l0 .01"
                     />
-                    <line
-                      x1="5"
-                      x2="5"
-                      y1="12"
-                      y2="12.01"
-                    />
-                    <line
-                      x1="5"
-                      x2="5"
-                      y1="18"
-                      y2="18.01"
+                    <path
+                      d="M5 18l0 .01"
                     />
                   </svg>
                 </span>
@@ -157,7 +120,7 @@ exports[`MantineEditInferencer should match the snapshot 1`] = `
                 class="mantine-Button-icon mantine-Button-leftIcon mantine-1g4orza"
               >
                 <svg
-                  class="icon icon-tabler icon-tabler-refresh"
+                  class="tabler-icon tabler-icon-refresh "
                   fill="none"
                   height="18"
                   stroke="currentColor"
@@ -168,11 +131,6 @@ exports[`MantineEditInferencer should match the snapshot 1`] = `
                   width="18"
                   xmlns="http://www.w3.org/2000/svg"
                 >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                    stroke="none"
-                  />
                   <path
                     d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4"
                   />
@@ -718,7 +676,7 @@ exports[`MantineEditInferencer should match the snapshot 1`] = `
               class="mantine-Button-icon mantine-Button-leftIcon mantine-1g4orza"
             >
               <svg
-                class="icon icon-tabler icon-tabler-device-floppy"
+                class="tabler-icon tabler-icon-device-floppy "
                 fill="none"
                 height="18"
                 stroke="currentColor"
@@ -730,20 +688,13 @@ exports[`MantineEditInferencer should match the snapshot 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
-                />
-                <path
                   d="M6 4h10l4 4v10a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2"
                 />
-                <circle
-                  cx="12"
-                  cy="14"
-                  r="2"
+                <path
+                  d="M12 14m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0"
                 />
-                <polyline
-                  points="14 4 14 8 8 8 8 4"
+                <path
+                  d="M14 4l0 4l-6 0l0 -4"
                 />
               </svg>
             </span>

--- a/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/index.test.tsx.snap
@@ -11968,7 +11968,7 @@ exports[`MantineInferencer should match the snapshot 2`] = `
               type="button"
             >
               <svg
-                class="icon icon-tabler icon-tabler-arrow-left"
+                class="tabler-icon tabler-icon-arrow-left "
                 fill="none"
                 height="24"
                 stroke="currentColor"
@@ -11980,27 +11980,13 @@ exports[`MantineInferencer should match the snapshot 2`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
+                  d="M5 12l14 0"
                 />
-                <line
-                  x1="5"
-                  x2="19"
-                  y1="12"
-                  y2="12"
+                <path
+                  d="M5 12l6 6"
                 />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="18"
-                />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="6"
+                <path
+                  d="M5 12l6 -6"
                 />
               </svg>
             </button>
@@ -12518,7 +12504,7 @@ exports[`MantineInferencer should match the snapshot 2`] = `
               class="mantine-Button-icon mantine-Button-leftIcon mantine-1g4orza"
             >
               <svg
-                class="icon icon-tabler icon-tabler-device-floppy"
+                class="tabler-icon tabler-icon-device-floppy "
                 fill="none"
                 height="18"
                 stroke="currentColor"
@@ -12530,20 +12516,13 @@ exports[`MantineInferencer should match the snapshot 2`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
-                />
-                <path
                   d="M6 4h10l4 4v10a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2"
                 />
-                <circle
-                  cx="12"
-                  cy="14"
-                  r="2"
+                <path
+                  d="M12 14m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0"
                 />
-                <polyline
-                  points="14 4 14 8 8 8 8 4"
+                <path
+                  d="M14 4l0 4l-6 0l0 -4"
                 />
               </svg>
             </span>
@@ -17582,7 +17561,7 @@ exports[`MantineInferencer should match the snapshot 3`] = `
               type="button"
             >
               <svg
-                class="icon icon-tabler icon-tabler-arrow-left"
+                class="tabler-icon tabler-icon-arrow-left "
                 fill="none"
                 height="24"
                 stroke="currentColor"
@@ -17594,27 +17573,13 @@ exports[`MantineInferencer should match the snapshot 3`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
+                  d="M5 12l14 0"
                 />
-                <line
-                  x1="5"
-                  x2="19"
-                  y1="12"
-                  y2="12"
+                <path
+                  d="M5 12l6 6"
                 />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="18"
-                />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="6"
+                <path
+                  d="M5 12l6 -6"
                 />
               </svg>
             </button>
@@ -17640,7 +17605,7 @@ exports[`MantineInferencer should match the snapshot 3`] = `
                 class="mantine-Button-icon mantine-Button-leftIcon mantine-1g4orza"
               >
                 <svg
-                  class="icon icon-tabler icon-tabler-refresh"
+                  class="tabler-icon tabler-icon-refresh "
                   fill="none"
                   height="18"
                   stroke="currentColor"
@@ -17651,11 +17616,6 @@ exports[`MantineInferencer should match the snapshot 3`] = `
                   width="18"
                   xmlns="http://www.w3.org/2000/svg"
                 >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                    stroke="none"
-                  />
                   <path
                     d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4"
                   />
@@ -18246,7 +18206,7 @@ exports[`MantineInferencer should match the snapshot 3`] = `
               class="mantine-Button-icon mantine-Button-leftIcon mantine-1g4orza"
             >
               <svg
-                class="icon icon-tabler icon-tabler-device-floppy"
+                class="tabler-icon tabler-icon-device-floppy "
                 fill="none"
                 height="18"
                 stroke="currentColor"
@@ -18258,20 +18218,13 @@ exports[`MantineInferencer should match the snapshot 3`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
-                />
-                <path
                   d="M6 4h10l4 4v10a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2"
                 />
-                <circle
-                  cx="12"
-                  cy="14"
-                  r="2"
+                <path
+                  d="M12 14m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0"
                 />
-                <polyline
-                  points="14 4 14 8 8 8 8 4"
+                <path
+                  d="M14 4l0 4l-6 0l0 -4"
                 />
               </svg>
             </span>
@@ -23735,7 +23688,7 @@ exports[`MantineInferencer should match the snapshot 4`] = `
               type="button"
             >
               <svg
-                class="icon icon-tabler icon-tabler-arrow-left"
+                class="tabler-icon tabler-icon-arrow-left "
                 fill="none"
                 height="24"
                 stroke="currentColor"
@@ -23747,27 +23700,13 @@ exports[`MantineInferencer should match the snapshot 4`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
+                  d="M5 12l14 0"
                 />
-                <line
-                  x1="5"
-                  x2="19"
-                  y1="12"
-                  y2="12"
+                <path
+                  d="M5 12l6 6"
                 />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="18"
-                />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="6"
+                <path
+                  d="M5 12l6 -6"
                 />
               </svg>
             </button>
@@ -23793,7 +23732,7 @@ exports[`MantineInferencer should match the snapshot 4`] = `
                 class="mantine-Button-icon mantine-Button-leftIcon mantine-1g4orza"
               >
                 <svg
-                  class="icon icon-tabler icon-tabler-refresh"
+                  class="tabler-icon tabler-icon-refresh "
                   fill="none"
                   height="18"
                   stroke="currentColor"
@@ -23804,11 +23743,6 @@ exports[`MantineInferencer should match the snapshot 4`] = `
                   width="18"
                   xmlns="http://www.w3.org/2000/svg"
                 >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                    stroke="none"
-                  />
                   <path
                     d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4"
                   />

--- a/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/show.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/show.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`MantineShowInferencer should match the snapshot 1`] = `
               type="button"
             >
               <svg
-                class="icon icon-tabler icon-tabler-arrow-left"
+                class="tabler-icon tabler-icon-arrow-left "
                 fill="none"
                 height="24"
                 stroke="currentColor"
@@ -32,27 +32,13 @@ exports[`MantineShowInferencer should match the snapshot 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                  stroke="none"
+                  d="M5 12l14 0"
                 />
-                <line
-                  x1="5"
-                  x2="19"
-                  y1="12"
-                  y2="12"
+                <path
+                  d="M5 12l6 6"
                 />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="18"
-                />
-                <line
-                  x1="5"
-                  x2="11"
-                  y1="12"
-                  y2="6"
+                <path
+                  d="M5 12l6 -6"
                 />
               </svg>
             </button>
@@ -83,7 +69,7 @@ exports[`MantineShowInferencer should match the snapshot 1`] = `
                   class="mantine-Button-icon mantine-Button-leftIcon mantine-1g4orza"
                 >
                   <svg
-                    class="icon icon-tabler icon-tabler-list"
+                    class="tabler-icon tabler-icon-list "
                     fill="none"
                     height="18"
                     stroke="currentColor"
@@ -95,45 +81,22 @@ exports[`MantineShowInferencer should match the snapshot 1`] = `
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M0 0h24v24H0z"
-                      fill="none"
-                      stroke="none"
+                      d="M9 6l11 0"
                     />
-                    <line
-                      x1="9"
-                      x2="20"
-                      y1="6"
-                      y2="6"
+                    <path
+                      d="M9 12l11 0"
                     />
-                    <line
-                      x1="9"
-                      x2="20"
-                      y1="12"
-                      y2="12"
+                    <path
+                      d="M9 18l11 0"
                     />
-                    <line
-                      x1="9"
-                      x2="20"
-                      y1="18"
-                      y2="18"
+                    <path
+                      d="M5 6l0 .01"
                     />
-                    <line
-                      x1="5"
-                      x2="5"
-                      y1="6"
-                      y2="6.01"
+                    <path
+                      d="M5 12l0 .01"
                     />
-                    <line
-                      x1="5"
-                      x2="5"
-                      y1="12"
-                      y2="12.01"
-                    />
-                    <line
-                      x1="5"
-                      x2="5"
-                      y1="18"
-                      y2="18.01"
+                    <path
+                      d="M5 18l0 .01"
                     />
                   </svg>
                 </span>
@@ -157,7 +120,7 @@ exports[`MantineShowInferencer should match the snapshot 1`] = `
                 class="mantine-Button-icon mantine-Button-leftIcon mantine-1g4orza"
               >
                 <svg
-                  class="icon icon-tabler icon-tabler-refresh"
+                  class="tabler-icon tabler-icon-refresh "
                   fill="none"
                   height="18"
                   stroke="currentColor"
@@ -168,11 +131,6 @@ exports[`MantineShowInferencer should match the snapshot 1`] = `
                   width="18"
                   xmlns="http://www.w3.org/2000/svg"
                 >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                    stroke="none"
-                  />
                   <path
                     d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4"
                   />

--- a/packages/inferencer/src/inferencers/mantine/code-viewer.tsx
+++ b/packages/inferencer/src/inferencers/mantine/code-viewer.tsx
@@ -6,7 +6,7 @@ import {
   IconX,
   IconCopy,
   IconCheck,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 import { prettierFormat } from "../../utilities";
 import { CreateInferencerConfig } from "../../types";

--- a/packages/inferencer/src/inferencers/mantine/error.tsx
+++ b/packages/inferencer/src/inferencers/mantine/error.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { Alert, Center } from "@mantine/core";
-import { IconAlertCircle } from "@tabler/icons";
+import { IconAlertCircle } from "@tabler/icons-react";
 
 import { CreateInferencerConfig } from "../../types";
 

--- a/packages/inferencer/src/inferencers/mui/code-viewer.tsx
+++ b/packages/inferencer/src/inferencers/mui/code-viewer.tsx
@@ -11,7 +11,7 @@ import {
   IconX,
   IconCopy,
   IconCheck,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 import { prettierFormat } from "../../utilities";
 import { CreateInferencerConfig } from "../../types";

--- a/packages/live-previews/package.json
+++ b/packages/live-previews/package.json
@@ -46,7 +46,7 @@
     "@refinedev/strapi-graphql": "^6.0.4",
     "@refinedev/strapi-v4": "^6.0.3",
     "@refinedev/supabase": "^5.7.7",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
     "antd": "^5.0.5",

--- a/packages/live-previews/src/scope/map.tsx
+++ b/packages/live-previews/src/scope/map.tsx
@@ -44,7 +44,9 @@ export const packageMap: Record<string, string> = {
   "@mui/material/styles": "MuiMaterialStyles",
   "@mui/icons-material": "MuiIconsMaterial",
   "@mui/x-data-grid": "MuiXDataGrid",
+  // To make sure we're still able to use the old package name, we're also mapping the old package name to the related scope
   "@tabler/icons": "TablerIcons",
+  "@tabler/icons-react": "TablerIcons",
   "@chakra-ui/react": "ChakraUI",
   "react-hook-form": "ReactHookForm",
   "@tanstack/react-table": "TanstackReactTable",

--- a/packages/live-previews/src/scope/tabler-icons.tsx
+++ b/packages/live-previews/src/scope/tabler-icons.tsx
@@ -20,7 +20,7 @@ import {
   IconMoon,
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 const TablerScope = {
   TablerIcons: {

--- a/packages/live-previews/src/utils/check-package.ts
+++ b/packages/live-previews/src/utils/check-package.ts
@@ -48,7 +48,8 @@ export const checkPackage = (code = "") => {
 
   const hasCasbin = code.includes("casbin");
   const hasI18n = code.includes("react-i18next") || code.includes("i18next");
-  const hasTablerIcons = code.includes("@tabler/icons");
+  const hasTablerIcons =
+    code.includes("@tabler/icons") || code.includes("@tabler/icons-react");
   const hasKbar = code.includes("@refinedev/kbar");
   const hasAirtable = code.includes("@refinedev/airtable");
   const hasAppwrite = code.includes("@refinedev/appwrite");

--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -27,7 +27,7 @@
     "@mantine/hooks": "^5.10.4",
     "@mantine/notifications": "^5.10.4",
     "@refinedev/ui-types": "^1.22.4",
-    "@tabler/icons": "^1.119.0",
+    "@tabler/icons-react": "^3.1.0",
     "dayjs": "^1.10.7",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",

--- a/packages/mantine/src/components/autoSaveIndicator/index.tsx
+++ b/packages/mantine/src/components/autoSaveIndicator/index.tsx
@@ -10,7 +10,7 @@ import {
   IconRefresh,
   IconCircleCheck,
   IconExclamationCircle,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 export const AutoSaveIndicator: React.FC<AutoSaveIndicatorProps> = ({
   status,

--- a/packages/mantine/src/components/breadcrumb/index.tsx
+++ b/packages/mantine/src/components/breadcrumb/index.tsx
@@ -17,7 +17,7 @@ import {
   Anchor,
   Group,
 } from "@mantine/core";
-import { IconHome } from "@tabler/icons";
+import { IconHome } from "@tabler/icons-react";
 
 export type BreadcrumbProps = RefineBreadcrumbProps<MantineBreadcrumbProps>;
 

--- a/packages/mantine/src/components/buttons/clone/index.tsx
+++ b/packages/mantine/src/components/buttons/clone/index.tsx
@@ -14,7 +14,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { ActionIcon, Anchor, Button } from "@mantine/core";
-import { IconSquarePlus } from "@tabler/icons";
+import { IconSquarePlus } from "@tabler/icons-react";
 
 import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { CloneButtonProps } from "../types";

--- a/packages/mantine/src/components/buttons/create/index.tsx
+++ b/packages/mantine/src/components/buttons/create/index.tsx
@@ -14,7 +14,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { ActionIcon, Anchor, Button } from "@mantine/core";
-import { IconSquarePlus } from "@tabler/icons";
+import { IconSquarePlus } from "@tabler/icons-react";
 
 import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { CreateButtonProps } from "../types";

--- a/packages/mantine/src/components/buttons/delete/index.tsx
+++ b/packages/mantine/src/components/buttons/delete/index.tsx
@@ -14,7 +14,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { Group, Text, Button, Popover, ActionIcon } from "@mantine/core";
-import { IconTrash } from "@tabler/icons";
+import { IconTrash } from "@tabler/icons-react";
 
 import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { DeleteButtonProps } from "../types";

--- a/packages/mantine/src/components/buttons/edit/index.tsx
+++ b/packages/mantine/src/components/buttons/edit/index.tsx
@@ -14,7 +14,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { ActionIcon, Anchor, Button } from "@mantine/core";
-import { IconPencil } from "@tabler/icons";
+import { IconPencil } from "@tabler/icons-react";
 
 import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { EditButtonProps } from "../types";

--- a/packages/mantine/src/components/buttons/export/index.tsx
+++ b/packages/mantine/src/components/buttons/export/index.tsx
@@ -5,7 +5,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { ActionIcon, Button } from "@mantine/core";
-import { IconFileExport } from "@tabler/icons";
+import { IconFileExport } from "@tabler/icons-react";
 
 import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { ExportButtonProps } from "../types";

--- a/packages/mantine/src/components/buttons/import/index.tsx
+++ b/packages/mantine/src/components/buttons/import/index.tsx
@@ -5,7 +5,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { ActionIcon, Button } from "@mantine/core";
-import { IconFileImport } from "@tabler/icons";
+import { IconFileImport } from "@tabler/icons-react";
 
 import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { ImportButtonProps } from "../types";

--- a/packages/mantine/src/components/buttons/list/index.tsx
+++ b/packages/mantine/src/components/buttons/list/index.tsx
@@ -16,7 +16,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { ActionIcon, Anchor, Button } from "@mantine/core";
-import { IconList } from "@tabler/icons";
+import { IconList } from "@tabler/icons-react";
 
 import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { ListButtonProps } from "../types";

--- a/packages/mantine/src/components/buttons/refresh/index.tsx
+++ b/packages/mantine/src/components/buttons/refresh/index.tsx
@@ -11,7 +11,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { ActionIcon, Button } from "@mantine/core";
-import { IconRefresh } from "@tabler/icons";
+import { IconRefresh } from "@tabler/icons-react";
 
 import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { RefreshButtonProps } from "../types";

--- a/packages/mantine/src/components/buttons/save/index.tsx
+++ b/packages/mantine/src/components/buttons/save/index.tsx
@@ -5,7 +5,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { ActionIcon, Button } from "@mantine/core";
-import { IconDeviceFloppy } from "@tabler/icons";
+import { IconDeviceFloppy } from "@tabler/icons-react";
 
 import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { SaveButtonProps } from "../types";

--- a/packages/mantine/src/components/buttons/show/index.tsx
+++ b/packages/mantine/src/components/buttons/show/index.tsx
@@ -14,7 +14,7 @@ import {
   RefineButtonTestIds,
 } from "@refinedev/ui-types";
 import { ActionIcon, Anchor, Button } from "@mantine/core";
-import { IconEye } from "@tabler/icons";
+import { IconEye } from "@tabler/icons-react";
 
 import { mapButtonVariantToActionIconVariant } from "@definitions/button";
 import { ShowButtonProps } from "../types";

--- a/packages/mantine/src/components/buttons/types.ts
+++ b/packages/mantine/src/components/buttons/types.ts
@@ -12,33 +12,33 @@ import {
   RefineSaveButtonProps,
   RefineShowButtonProps,
 } from "@refinedev/ui-types";
-import { TablerIconProps } from "@tabler/icons";
+import { IconProps } from "@tabler/icons-react";
 
 export type ShowButtonProps = RefineShowButtonProps<
   ButtonProps,
   {
-    svgIconProps?: TablerIconProps;
+    svgIconProps?: Omit<IconProps, "ref">;
   }
 >;
 
 export type SaveButtonProps = RefineSaveButtonProps<
   ButtonProps,
   {
-    svgIconProps?: TablerIconProps;
+    svgIconProps?: Omit<IconProps, "ref">;
   }
 >;
 
 export type RefreshButtonProps = RefineRefreshButtonProps<
   ButtonProps,
   {
-    svgIconProps?: TablerIconProps;
+    svgIconProps?: Omit<IconProps, "ref">;
   }
 >;
 
 export type ListButtonProps = RefineListButtonProps<
   ButtonProps,
   {
-    svgIconProps?: TablerIconProps;
+    svgIconProps?: Omit<IconProps, "ref">;
   }
 >;
 
@@ -46,41 +46,41 @@ export type ImportButtonProps = RefineImportButtonProps<
   ButtonProps,
   {
     inputProps: UseImportInputPropsType;
-    svgIconProps?: TablerIconProps;
+    svgIconProps?: Omit<IconProps, "ref">;
   }
 >;
 
 export type ExportButtonProps = RefineExportButtonProps<
   ButtonProps,
   {
-    svgIconProps?: TablerIconProps;
+    svgIconProps?: Omit<IconProps, "ref">;
   }
 >;
 
 export type EditButtonProps = RefineEditButtonProps<
   ButtonProps,
   {
-    svgIconProps?: TablerIconProps;
+    svgIconProps?: Omit<IconProps, "ref">;
   }
 >;
 
 export type DeleteButtonProps = RefineDeleteButtonProps<
   ButtonProps,
   {
-    svgIconProps?: TablerIconProps;
+    svgIconProps?: Omit<IconProps, "ref">;
   }
 >;
 
 export type CreateButtonProps = RefineCreateButtonProps<
   ButtonProps,
   {
-    svgIconProps?: TablerIconProps;
+    svgIconProps?: Omit<IconProps, "ref">;
   }
 >;
 
 export type CloneButtonProps = RefineCloneButtonProps<
   ButtonProps,
   {
-    svgIconProps?: TablerIconProps;
+    svgIconProps?: Omit<IconProps, "ref">;
   }
 >;

--- a/packages/mantine/src/components/crud/create/index.tsx
+++ b/packages/mantine/src/components/crud/create/index.tsx
@@ -17,7 +17,7 @@ import {
   useRouterType,
   useTranslate,
 } from "@refinedev/core";
-import { IconArrowLeft } from "@tabler/icons";
+import { IconArrowLeft } from "@tabler/icons-react";
 import { SaveButton, Breadcrumb, SaveButtonProps } from "@components";
 import { CreateProps } from "../types";
 import { RefinePageHeaderClassNames } from "@refinedev/ui-types";

--- a/packages/mantine/src/components/crud/edit/index.tsx
+++ b/packages/mantine/src/components/crud/edit/index.tsx
@@ -20,7 +20,7 @@ import {
   useToPath,
   useTranslate,
 } from "@refinedev/core";
-import { IconArrowLeft } from "@tabler/icons";
+import { IconArrowLeft } from "@tabler/icons-react";
 import {
   DeleteButton,
   ListButton,

--- a/packages/mantine/src/components/crud/show/index.tsx
+++ b/packages/mantine/src/components/crud/show/index.tsx
@@ -19,7 +19,7 @@ import {
   useToPath,
   useTranslate,
 } from "@refinedev/core";
-import { IconArrowLeft } from "@tabler/icons";
+import { IconArrowLeft } from "@tabler/icons-react";
 
 import {
   DeleteButton,

--- a/packages/mantine/src/components/fields/boolean/index.tsx
+++ b/packages/mantine/src/components/fields/boolean/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Tooltip } from "@mantine/core";
-import { IconX, IconCheck } from "@tabler/icons";
+import { IconX, IconCheck } from "@tabler/icons-react";
 
 import { BooleanFieldProps } from "../types";
 

--- a/packages/mantine/src/components/fields/types.ts
+++ b/packages/mantine/src/components/fields/types.ts
@@ -11,14 +11,14 @@ import {
   RefineFieldTextProps,
   RefineFieldUrlProps,
 } from "@refinedev/ui-types";
-import { TablerIconProps } from "@tabler/icons";
+import { IconProps } from "@tabler/icons-react";
 import { ConfigType } from "dayjs";
 import { ReactMarkdownOptions } from "react-markdown";
 
 export type BooleanFieldProps = RefineFieldBooleanProps<
   unknown,
   Omit<TooltipProps, "label" | "children">,
-  { svgIconProps?: TablerIconProps }
+  { svgIconProps?: Omit<IconProps, "ref"> }
 >;
 
 export type DateFieldProps = RefineFieldDateProps<ConfigType, TextProps>;

--- a/packages/mantine/src/components/layout/sider/index.tsx
+++ b/packages/mantine/src/components/layout/sider/index.tsx
@@ -36,7 +36,7 @@ import {
   IconChevronLeft,
   IconPower,
   IconDashboard,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 import { RefineLayoutSiderProps } from "../types";
 
 import { RefineTitle as DefaultTitle } from "@components";

--- a/packages/mantine/src/components/pages/error/index.tsx
+++ b/packages/mantine/src/components/pages/error/index.tsx
@@ -17,7 +17,7 @@ import {
   Button,
   Space,
 } from "@mantine/core";
-import { IconInfoCircle } from "@tabler/icons";
+import { IconInfoCircle } from "@tabler/icons-react";
 
 export const ErrorComponent: React.FC<RefineErrorPageProps> = () => {
   const [errorMessage, setErrorMessage] = useState<string>();

--- a/packages/mantine/src/components/themedLayout/sider/index.tsx
+++ b/packages/mantine/src/components/themedLayout/sider/index.tsx
@@ -38,7 +38,7 @@ import {
   IconIndentIncrease,
   IconPower,
   IconDashboard,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 import { RefineThemedLayoutSiderProps } from "../types";
 
 import { ThemedTitle as DefaultTitle } from "@components";

--- a/packages/mantine/src/components/themedLayoutV2/hamburgerMenu/index.tsx
+++ b/packages/mantine/src/components/themedLayoutV2/hamburgerMenu/index.tsx
@@ -4,7 +4,7 @@ import {
   IconMenu2,
   IconIndentDecrease,
   IconIndentIncrease,
-} from "@tabler/icons";
+} from "@tabler/icons-react";
 
 import { useThemedLayoutContext } from "@hooks";
 

--- a/packages/mantine/src/components/themedLayoutV2/sider/index.tsx
+++ b/packages/mantine/src/components/themedLayoutV2/sider/index.tsx
@@ -29,7 +29,7 @@ import {
   useMantineTheme,
   Flex,
 } from "@mantine/core";
-import { IconList, IconPower, IconDashboard } from "@tabler/icons";
+import { IconList, IconPower, IconDashboard } from "@tabler/icons-react";
 
 import { ThemedTitleV2 as DefaultTitle } from "@components";
 import { useThemedLayoutContext } from "@hooks";

--- a/packages/mantine/src/providers/notificationProvider.tsx
+++ b/packages/mantine/src/providers/notificationProvider.tsx
@@ -6,7 +6,7 @@ import {
   hideNotification,
 } from "@mantine/notifications";
 import { ActionIcon, Box, Group, Text } from "@mantine/core";
-import { IconCheck, IconRotate2, IconX } from "@tabler/icons";
+import { IconCheck, IconRotate2, IconX } from "@tabler/icons-react";
 
 import { RingCountdown } from "@components";
 


### PR DESCRIPTION
Migrated from outdated `@tabler/icons@1` to `@tabler/icons-react@3` to make sure we're using the latest available version of the library without requiring users to pin to a deprecated version.

If your project doesn't include `@tabler/icons` you won't be affected by this change.

If you're using `@tabler/icons@1` in your project, you may need to update your dependency to latest version of `@tabler/icons-react` to avoid conflicting dependencies. Practically, this should not introduce any breaking changes to your project and all the icons in `@tabler/icons@1` should also be available in the latest version of `@tabler/icons-react`.