### PR TITLE
fix(react-router-v6): wrong type declaration for legacy router at `/legacy` imports

### DIFF
--- a/.changeset/tidy-bats-grow.md
+++ b/.changeset/tidy-bats-grow.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/react-router-v6": patch
+---
+
+Fixed the wrong type declaration for legacy router subexport at `/legacy`. Previously imports from `@refinedev/react-router-v6/legacy` used type declarations from new router, which caused type errors. Now it's fixed and the correct type declarations are used.

--- a/packages/react-router-v6/package.json
+++ b/packages/react-router-v6/package.json
@@ -18,7 +18,7 @@
       "require": "./dist/index.js"
     },
     "./legacy": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/legacy/index.d.ts",
       "import": "./dist/esm/legacy.js",
       "require": "./dist/legacy.js"
     }


### PR DESCRIPTION
Fixed the wrong type declaration for legacy router subexport at `/legacy`. Previously imports from `@refinedev/react-router-v6/legacy` used type declarations from new router, which caused type errors. Now it's fixed and the correct type declarations are used.