### PR TITLE
fix(docs): add missing dependency to mui tutorial

### DIFF
--- a/documentation/tutorial/ui-libraries/intro/material-ui/react-router/sandpack.tsx
+++ b/documentation/tutorial/ui-libraries/intro/material-ui/react-router/sandpack.tsx
@@ -239,6 +239,7 @@ export const dependencies = {
   "@mui/lab": "latest",
   "@mui/material": "latest",
   "@mui/x-data-grid": "latest",
+  "@mui/system": "latest",
   "@refinedev/mui": "latest",
   "@refinedev/react-hook-form": "latest",
   "react-hook-form": "latest",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention


## What is the current behavior?

Example at mui tutorial is failing at https://refine.dev/tutorial/ui-libraries/layout/material-ui/react-router/

![Screenshot 2024-03-20 at 10 53 00](https://github.com/refinedev/refine/assets/16444991/26a5727e-04db-4c71-97f0-b47f18dd8bcf)

## What is the new behavior?

Fixed.

