### PR TITLE
chore: update jscodeshift version to 0.15.2

### DIFF
--- a/.changeset/blue-roses-happen.md
+++ b/.changeset/blue-roses-happen.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/cli": patch
+"@refinedev/codemod": patch
+"@refinedev/devtools-server": patch
+---
+
+chore: update jscodeshift version to 0.15.2

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
     "http-proxy-middleware": "^2.0.6",
     "inquirer": "^8.2.5",
     "inquirer-autocomplete-prompt": "^2.0.0",
-    "jscodeshift": "0.13.1",
+    "jscodeshift": "0.15.2",
     "marked": "^4.3.0",
     "marked-terminal": "^6.0.0",
     "node-emoji": "^2.1.3",

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -30,7 +30,7 @@
     "globby": "^11.1.0",
     "inquirer": "^8.2.5",
     "is-git-clean": "1.1.0",
-    "jscodeshift": "0.13.1",
+    "jscodeshift": "0.15.2",
     "meow": "7.0.1",
     "semver": "7.5.2"
   },

--- a/packages/devtools-server/package.json
+++ b/packages/devtools-server/package.json
@@ -59,7 +59,7 @@
     "globby": "^11.1.0",
     "gray-matter": "^4.0.3",
     "http-proxy-middleware": "^2.0.6",
-    "jscodeshift": "0.13.1",
+    "jscodeshift": "0.15.2",
     "lodash": "^4.17.21",
     "marked": "^4.3.0",
     "node-fetch": "^2.6.7",


### PR DESCRIPTION
Current version `jscodeshift` has vulnerability reports. Updated to `0.15.2`. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

