### PR TITLE
fix(cli): jscodeshift failing spec

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -81,7 +81,7 @@
     "@types/inquirer": "^8.2.5",
     "@types/inquirer-autocomplete-prompt": "^2.0.0",
     "@types/jest": "^29.2.4",
-    "@types/jscodeshift": "^0.11.5",
+    "@types/jscodeshift": "^0.11.11",
     "@types/marked-terminal": "^3.1.5",
     "@types/node-fetch": "^2.6.2",
     "@types/prettier": "^2.7.3",

--- a/packages/cli/src/utils/codeshift/index.ts
+++ b/packages/cli/src/utils/codeshift/index.ts
@@ -26,7 +26,13 @@ export const wrapElement = (
   const wrapperElement = j.jsxElement(
     j.jsxOpeningElement(j.jsxIdentifier(wrapper), wrapperAttributes),
     j.jsxClosingElement(j.jsxIdentifier(wrapper)),
-    [element.value],
+    [
+      j.jsxElement(
+        element.node.openingElement,
+        element.node.closingElement,
+        element.node.children,
+      ),
+    ],
   );
 
   j(element).replaceWith(wrapperElement);

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -38,7 +38,7 @@
     "@types/eslint": "^7.28.2",
     "@types/inquirer": "^8.2.5",
     "@types/jest": "^29.2.4",
-    "@types/jscodeshift": "^0.11.5",
+    "@types/jscodeshift": "^0.11.11",
     "jest": "^29.3.1",
     "ts-jest": "^29.1.2",
     "tslib": "^2.6.2",

--- a/packages/devtools-server/package.json
+++ b/packages/devtools-server/package.json
@@ -75,7 +75,7 @@
     "@types/dedent": "^0.7.0",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^29.2.4",
-    "@types/jscodeshift": "^0.11.5",
+    "@types/jscodeshift": "^0.11.11",
     "@types/marked": "^5.0.1",
     "@types/sanitize-html": "^2.9.0",
     "@types/ws": "^8.5.5",


### PR DESCRIPTION
After `jscodeshift` upgrade, CLI's antd transformer spec was failing because of extra parentheses.

![Screenshot 2024-04-02 at 12 50 39](https://github.com/refinedev/refine/assets/16444991/6989b48f-3e70-4bc9-b900-9f65be3323d9)

Fixed it by constructing a new jsxElement in `wrapElement` helper.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

