### PR TITLE
fix(examples): type issues with `app-crm` and `app-crm-minimal`

### DIFF
--- a/examples/app-crm-minimal/README.MD
+++ b/examples/app-crm-minimal/README.MD
@@ -1287,8 +1287,6 @@ import {
 } from "@ant-design/icons";
 import { Button, Card, Input, Select, Space, Table } from "antd";
 
-import { Contact } from "@/graphql/schema.types";
-
 import { statusOptions } from "@/constants";
 import { COMPANY_CONTACTS_TABLE_QUERY } from "@/graphql/queries";
 
@@ -1296,6 +1294,8 @@ import { CompanyContactsTableQuery } from "@/graphql/types";
 import { Text } from "@/components/text";
 import CustomAvatar from "@/components/custom-avatar";
 import { ContactStatusTag } from "@/components/tags/contact-status-tag";
+
+type Contact = GetFieldsFromList<CompanyContactsTableQuery>;
 
 export const CompanyContactsTable = () => {
   // get params from the url
@@ -1307,71 +1307,69 @@ export const CompanyContactsTable = () => {
    * Under the hood it uses useList hook to fetch the data.
    * https://refine.dev/docs/packages/tanstack-table/use-table/#installation
    */
-  const { tableProps } = useTable<GetFieldsFromList<CompanyContactsTableQuery>>(
-    {
-      // specify the resource for which the table is to be used
-      resource: "contacts",
-      syncWithLocation: false,
-      // specify initial sorters
-      sorters: {
-        /**
-         * initial sets the initial value of sorters.
-         * it's not permanent
-         * it will be cleared when the user changes the sorting
-         * https://refine.dev/docs/ui-integrations/ant-design/hooks/use-table/#sortersinitial
-         */
-        initial: [
-          {
-            field: "createdAt",
-            order: "desc",
-          },
-        ],
-      },
-      // specify initial filters
-      filters: {
-        /**
-         * similar to initial in sorters
-         * https://refine.dev/docs/ui-integrations/ant-design/hooks/use-table/#filtersinitial
-         */
-        initial: [
-          {
-            field: "jobTitle",
-            value: "",
-            operator: "contains",
-          },
-          {
-            field: "name",
-            value: "",
-            operator: "contains",
-          },
-          {
-            field: "status",
-            value: undefined,
-            operator: "in",
-          },
-        ],
-        /**
-         * permanent filters are the filters that are always applied
-         * https://refine.dev/docs/ui-integrations/ant-design/hooks/use-table/#filterspermanent
-         */
-        permanent: [
-          {
-            field: "company.id",
-            operator: "eq",
-            value: params?.id as string,
-          },
-        ],
-      },
+  const { tableProps } = useTable<Contact>({
+    // specify the resource for which the table is to be used
+    resource: "contacts",
+    syncWithLocation: false,
+    // specify initial sorters
+    sorters: {
       /**
-       * used to provide any additional information to the data provider.
-       * https://refine.dev/docs/data/hooks/use-form/#meta-
+       * initial sets the initial value of sorters.
+       * it's not permanent
+       * it will be cleared when the user changes the sorting
+       * https://refine.dev/docs/ui-integrations/ant-design/hooks/use-table/#sortersinitial
        */
-      meta: {
-        // gqlQuery is used to specify the GraphQL query that should be used to fetch the data.
-        gqlQuery: COMPANY_CONTACTS_TABLE_QUERY,
-      },
+      initial: [
+        {
+          field: "createdAt",
+          order: "desc",
+        },
+      ],
     },
-  );
+    // specify initial filters
+    filters: {
+      /**
+       * similar to initial in sorters
+       * https://refine.dev/docs/ui-integrations/ant-design/hooks/use-table/#filtersinitial
+       */
+      initial: [
+        {
+          field: "jobTitle",
+          value: "",
+          operator: "contains",
+        },
+        {
+          field: "name",
+          value: "",
+          operator: "contains",
+        },
+        {
+          field: "status",
+          value: undefined,
+          operator: "in",
+        },
+      ],
+      /**
+       * permanent filters are the filters that are always applied
+       * https://refine.dev/docs/ui-integrations/ant-design/hooks/use-table/#filterspermanent
+       */
+      permanent: [
+        {
+          field: "company.id",
+          operator: "eq",
+          value: params?.id as string,
+        },
+      ],
+    },
+    /**
+     * used to provide any additional information to the data provider.
+     * https://refine.dev/docs/data/hooks/use-form/#meta-
+     */
+    meta: {
+      // gqlQuery is used to specify the GraphQL query that should be used to fetch the data.
+      gqlQuery: COMPANY_CONTACTS_TABLE_QUERY,
+    },
+  });
 
   return (
     <Card

--- a/examples/app-crm-minimal/src/routes/companies/edit/contacts-table.tsx
+++ b/examples/app-crm-minimal/src/routes/companies/edit/contacts-table.tsx
@@ -12,57 +12,56 @@ import {
 import { Button, Card, Input, Select, Space, Table } from "antd";
 
 import { ContactStatusTag, CustomAvatar, Text } from "@/components";
-import { Contact } from "@/graphql/schema.types";
 import { CompanyContactsTableQuery } from "@/graphql/types";
 
 import { COMPANY_CONTACTS_TABLE_QUERY } from "./queries";
 
+type Contact = GetFieldsFromList<CompanyContactsTableQuery>;
+
 export const CompanyContactsTable = () => {
   const params = useParams();
 
-  const { tableProps } = useTable<GetFieldsFromList<CompanyContactsTableQuery>>(
-    {
-      resource: "contacts",
-      syncWithLocation: false,
-      sorters: {
-        initial: [
-          {
-            field: "createdAt",
-            order: "desc",
-          },
-        ],
-      },
-      filters: {
-        initial: [
-          {
-            field: "jobTitle",
-            value: "",
-            operator: "contains",
-          },
-          {
-            field: "name",
-            value: "",
-            operator: "contains",
-          },
-          {
-            field: "status",
-            value: undefined,
-            operator: "in",
-          },
-        ],
-        permanent: [
-          {
-            field: "company.id",
-            operator: "eq",
-            value: params?.id as string,
-          },
-        ],
-      },
-      meta: {
-        gqlQuery: COMPANY_CONTACTS_TABLE_QUERY,
-      },
+  const { tableProps } = useTable<Contact>({
+    resource: "contacts",
+    syncWithLocation: false,
+    sorters: {
+      initial: [
+        {
+          field: "createdAt",
+          order: "desc",
+        },
+      ],
     },
-  );
+    filters: {
+      initial: [
+        {
+          field: "jobTitle",
+          value: "",
+          operator: "contains",
+        },
+        {
+          field: "name",
+          value: "",
+          operator: "contains",
+        },
+        {
+          field: "status",
+          value: undefined,
+          operator: "in",
+        },
+      ],
+      permanent: [
+        {
+          field: "company.id",
+          operator: "eq",
+          value: params?.id as string,
+        },
+      ],
+    },
+    meta: {
+      gqlQuery: COMPANY_CONTACTS_TABLE_QUERY,
+    },
+  });
 
   return (
     <Card

--- a/examples/app-crm-minimal/src/routes/companies/list/index.tsx
+++ b/examples/app-crm-minimal/src/routes/companies/list/index.tsx
@@ -15,20 +15,17 @@ import { SearchOutlined } from "@ant-design/icons";
 import { Input, Space, Table } from "antd";
 
 import { CustomAvatar, PaginationTotal, Text } from "@/components";
-import { Company } from "@/graphql/schema.types";
 import { CompaniesListQuery } from "@/graphql/types";
 import { currencyNumber } from "@/utilities";
 
 import { COMPANIES_LIST_QUERY } from "./queries";
 
+type Company = GetFieldsFromList<CompaniesListQuery>;
+
 export const CompanyListPage = ({ children }: React.PropsWithChildren) => {
   const go = useGo();
 
-  const { tableProps, filters } = useTable<
-    GetFieldsFromList<CompaniesListQuery>,
-    HttpError,
-    GetFieldsFromList<CompaniesListQuery>
-  >({
+  const { tableProps, filters } = useTable<Company, HttpError, Company>({
     resource: "companies",
     onSearch: (values) => {
       return [

--- a/examples/app-crm-minimal/vite.config.ts
+++ b/examples/app-crm-minimal/vite.config.ts
@@ -4,7 +4,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [tsconfigPaths(), react()],
+  plugins: [tsconfigPaths({ root: __dirname }), react()],
   build: {
     rollupOptions: {
       output: {

--- a/examples/app-crm/src/routes/administration/audit-log.tsx
+++ b/examples/app-crm/src/routes/administration/audit-log.tsx
@@ -12,11 +12,12 @@ import { SearchOutlined } from "@ant-design/icons";
 import { DatePicker, Input, Radio, Space, Table, Tag, TagProps } from "antd";
 
 import { CustomAvatar, PaginationTotal, Text } from "@/components";
-import { Audit } from "@/graphql/schema.types";
 import { AdministrationAuditLogsQuery } from "@/graphql/types";
 
 import { ActionCell } from "./components";
 import { ADMINISTRATION_AUDIT_LOGS_QUERY } from "./queries";
+
+export type Audit = GetFieldsFromList<AdministrationAuditLogsQuery>;
 
 const getActionColor = (action: string): TagProps["color"] => {
   switch (action) {
@@ -32,9 +33,7 @@ const getActionColor = (action: string): TagProps["color"] => {
 };
 
 export const AuditLogPage = () => {
-  const { tableProps, filters, sorters } = useTable<
-    GetFieldsFromList<AdministrationAuditLogsQuery>
-  >({
+  const { tableProps, filters, sorters } = useTable<Audit>({
     meta: {
       gqlQuery: ADMINISTRATION_AUDIT_LOGS_QUERY,
     },
@@ -131,10 +130,10 @@ export const AuditLogPage = () => {
           />
           <Table.Column dataIndex="targetEntity" title="Entity" />
           <Table.Column dataIndex="targetId" title="Entity ID" />
-          <Table.Column
+          <Table.Column<Audit>
             dataIndex="changes"
             title="Changes"
-            render={(_, record: Audit) => <ActionCell record={record} />}
+            render={(_, record) => <ActionCell record={record} />}
           />
           <Table.Column
             dataIndex="createdAt"

--- a/examples/app-crm/src/routes/administration/components/action-cell.tsx
+++ b/examples/app-crm/src/routes/administration/components/action-cell.tsx
@@ -5,12 +5,12 @@ import { Button, Modal, Table } from "antd";
 import type { ColumnsType } from "antd/es/table";
 
 import { Text } from "@/components";
-import { Audit, AuditChange } from "@/graphql/schema.types";
+import { Audit } from "..";
 
 export const ActionCell = ({ record }: { record: Audit }) => {
   const [opened, setOpened] = useState(false);
 
-  const columns: ColumnsType<AuditChange> = [
+  const columns: ColumnsType<Audit["changes"][0]> = [
     {
       title: "Field",
       dataIndex: "field",

--- a/examples/app-crm/src/routes/administration/settings.tsx
+++ b/examples/app-crm/src/routes/administration/settings.tsx
@@ -15,12 +15,13 @@ import { Card, Col, Input, Row, Select, Space, Table } from "antd";
 import cn from "classnames";
 
 import { CustomAvatar, Logo, Text } from "@/components";
-import { User } from "@/graphql/schema.types";
 import { AdministrationUsersQuery } from "@/graphql/types";
 
 import { RoleTag } from "./components";
 import { ADMINISTRATION_USERS_QUERY } from "./queries";
 import styles from "./settings.module.css";
+
+type User = GetFieldsFromList<AdministrationUsersQuery>;
 
 export const SettingsPage = () => {
   return (
@@ -88,9 +89,7 @@ const roleOptions: {
 ];
 
 const UsersTable = () => {
-  const { tableProps, filters } = useTable<
-    GetFieldsFromList<AdministrationUsersQuery>
-  >({
+  const { tableProps, filters } = useTable<User>({
     resource: "users",
     sorters: {
       initial: [

--- a/examples/app-crm/src/routes/calendar/components/calendar/index.tsx
+++ b/examples/app-crm/src/routes/calendar/components/calendar/index.tsx
@@ -9,13 +9,14 @@ import { Button, Card, Grid, Radio } from "antd";
 import dayjs from "dayjs";
 
 import { Text } from "@/components";
-import { Event } from "@/graphql/schema.types";
 import { CalendarEventsQuery } from "@/graphql/types";
 
 import styles from "./index.module.css";
 import { CALENDAR_EVENTS_QUERY } from "./queries";
 
 const FullCalendarWrapper = lazy(() => import("./full-calendar"));
+
+type Event = GetFieldsFromList<CalendarEventsQuery>;
 
 type View =
   | "dayGridMonth"
@@ -51,7 +52,7 @@ export const Calendar: React.FC<CalendarProps> = ({
     }
   }, [md]);
 
-  const { data } = useList<GetFieldsFromList<CalendarEventsQuery>>({
+  const { data } = useList<Event>({
     pagination: {
       mode: "off",
     },

--- a/examples/app-crm/src/routes/calendar/edit.tsx
+++ b/examples/app-crm/src/routes/calendar/edit.tsx
@@ -6,10 +6,12 @@ import { useNavigation, useResource } from "@refinedev/core";
 import { Modal } from "antd";
 import dayjs from "dayjs";
 
-import { Event } from "@/graphql/schema.types";
-
 import { CalendarForm } from "./components";
 import { CALENDAR_UPDATE_EVENT_MUTATION } from "./queries";
+import { GetFields } from "@refinedev/nestjs-query";
+import { UpdateEventMutation } from "../../graphql/types";
+
+type Event = GetFields<UpdateEventMutation>;
 
 export const CalendarEditPage: React.FC = () => {
   const [isAllDayEvent, setIsAllDayEvent] = useState(false);

--- a/examples/app-crm/src/routes/calendar/show.tsx
+++ b/examples/app-crm/src/routes/calendar/show.tsx
@@ -14,9 +14,12 @@ import { Button, Drawer, Skeleton, Space, Tag } from "antd";
 import dayjs from "dayjs";
 
 import { Text, UserTag } from "@/components";
-import { Event } from "@/graphql/schema.types";
 
 import { CALENDAR_GET_EVENT_QUERY } from "./queries";
+import { GetFields } from "@refinedev/nestjs-query";
+import { GetEventQuery } from "../../graphql/types";
+
+type Event = GetFields<GetEventQuery>;
 
 export const CalendarShowPage: React.FC = () => {
   const { id } = useResource();

--- a/examples/app-crm/src/routes/companies/components/card-view/index.tsx
+++ b/examples/app-crm/src/routes/companies/components/card-view/index.tsx
@@ -5,13 +5,14 @@ import { GetFieldsFromList } from "@refinedev/nestjs-query";
 import { List, ListProps, TableProps } from "antd";
 
 import { PaginationTotal } from "@/components";
-import { Company } from "@/graphql/schema.types";
 import { CompaniesTableQuery } from "@/graphql/types";
 
 import { CompanyCard, CompanyCardSkeleton } from "./card";
 
+type Company = GetFieldsFromList<CompaniesTableQuery>;
+
 type Props = {
-  tableProps: TableProps<GetFieldsFromList<CompaniesTableQuery>>;
+  tableProps: TableProps<Company>;
   setCurrent: (current: number) => void;
   setPageSize: (pageSize: number) => void;
 };

--- a/examples/app-crm/src/routes/companies/components/table-view.tsx
+++ b/examples/app-crm/src/routes/companies/components/table-view.tsx
@@ -8,13 +8,14 @@ import { EyeOutlined, SearchOutlined } from "@ant-design/icons";
 import { Input, Select, Space, Table, TableProps } from "antd";
 
 import { CustomAvatar, PaginationTotal, Text } from "@/components";
-import { Company } from "@/graphql/schema.types";
 import { CompaniesTableQuery } from "@/graphql/types";
 import { useContactsSelect } from "@/hooks/useContactsSelect";
 import { useUsersSelect } from "@/hooks/useUsersSelect";
 import { currencyNumber } from "@/utilities";
 
 import { AvatarGroup } from "./avatar-group";
+
+type Company = GetFieldsFromList<CompaniesTableQuery>;
 
 type Props = {
   tableProps: TableProps<GetFieldsFromList<CompaniesTableQuery>>;

--- a/examples/app-crm/src/routes/companies/create.tsx
+++ b/examples/app-crm/src/routes/companies/create.tsx
@@ -30,7 +30,6 @@ import {
 } from "antd";
 
 import { SelectOptionWithAvatar } from "@/components";
-import { Company } from "@/graphql/schema.types";
 import {
   CreateCompanyMutation,
   CreateCompanyMutationVariables,
@@ -38,6 +37,8 @@ import {
 import { useUsersSelect } from "@/hooks/useUsersSelect";
 
 import { COMPANY_CREATE_MUTATION } from "./queries";
+
+type Company = GetFields<CreateCompanyMutation>;
 
 type Props = {
   isOverModal?: boolean;
@@ -57,7 +58,7 @@ export const CompanyCreatePage = ({ isOverModal }: Props) => {
   const go = useGo();
 
   const { formProps, modalProps, close, onFinish } = useModalForm<
-    GetFields<CreateCompanyMutation>,
+    Company,
     HttpError,
     FormValues
   >({

--- a/examples/app-crm/src/routes/contacts/components/table-view.tsx
+++ b/examples/app-crm/src/routes/contacts/components/table-view.tsx
@@ -17,12 +17,13 @@ import {
   Text,
 } from "@/components";
 import { ContactStatusEnum } from "@/enums";
-import { Contact } from "@/graphql/schema.types";
 import { ContactsListQuery } from "@/graphql/types";
 import { useCompaniesSelect } from "@/hooks/useCompaniesSelect";
 
+type Contact = GetFieldsFromList<ContactsListQuery>;
+
 type Props = {
-  tableProps: TableProps<GetFieldsFromList<ContactsListQuery>>;
+  tableProps: TableProps<Contact>;
   filters: CrudFilters;
   sorters: CrudSorting;
 };

--- a/examples/app-crm/src/routes/quotes/components/show-description.tsx
+++ b/examples/app-crm/src/routes/quotes/components/show-description.tsx
@@ -59,7 +59,7 @@ export const ShowDescription = () => {
               bottom: "32px",
               right: "32px",
             }}
-            spinning={autoSaveProps?.status === "loading" ?? true}
+            spinning={autoSaveProps?.status === "loading"}
           />
         </div>
       </div>

--- a/examples/app-crm/src/routes/quotes/list.tsx
+++ b/examples/app-crm/src/routes/quotes/list.tsx
@@ -25,13 +25,15 @@ import {
   QuoteStatusTag,
   Text,
 } from "@/components";
-import { Quote, QuoteStatus } from "@/graphql/schema.types";
+import { QuoteStatus } from "@/graphql/schema.types";
 import { QuotesTableQuery } from "@/graphql/types";
 import { useCompaniesSelect } from "@/hooks/useCompaniesSelect";
 import { useUsersSelect } from "@/hooks/useUsersSelect";
 import { currencyNumber } from "@/utilities";
 
 import { QUOTES_TABLE_QUERY } from "./queries";
+
+type Quote = GetFieldsFromList<QuotesTableQuery>;
 
 const statusOptions: { label: string; value: QuoteStatus }[] = [
   {
@@ -52,45 +54,43 @@ export const QuotesListPage: FC<PropsWithChildren> = ({ children }) => {
   const screens = Grid.useBreakpoint();
 
   const { tableProps, searchFormProps, filters, sorters, tableQueryResult } =
-    useTable<GetFieldsFromList<QuotesTableQuery>, HttpError, { title: string }>(
-      {
-        resource: "quotes",
-        onSearch: (values) => {
-          return [
-            {
-              field: "title",
-              operator: "contains",
-              value: values.title,
-            },
-          ];
-        },
-        filters: {
-          initial: [
-            {
-              field: "title",
-              value: "",
-              operator: "contains",
-            },
-            {
-              field: "status",
-              value: undefined,
-              operator: "in",
-            },
-          ],
-        },
-        sorters: {
-          initial: [
-            {
-              field: "createdAt",
-              order: "desc",
-            },
-          ],
-        },
-        meta: {
-          gqlQuery: QUOTES_TABLE_QUERY,
-        },
+    useTable<Quote, HttpError, { title: string }>({
+      resource: "quotes",
+      onSearch: (values) => {
+        return [
+          {
+            field: "title",
+            operator: "contains",
+            value: values.title,
+          },
+        ];
       },
-    );
+      filters: {
+        initial: [
+          {
+            field: "title",
+            value: "",
+            operator: "contains",
+          },
+          {
+            field: "status",
+            value: undefined,
+            operator: "in",
+          },
+        ],
+      },
+      sorters: {
+        initial: [
+          {
+            field: "createdAt",
+            order: "desc",
+          },
+        ],
+      },
+      meta: {
+        gqlQuery: QUOTES_TABLE_QUERY,
+      },
+    });
 
   const { selectProps: selectPropsCompanies } = useCompaniesSelect();
 

--- a/examples/app-crm/src/routes/scrumboard/components/forms/description-form.tsx
+++ b/examples/app-crm/src/routes/scrumboard/components/forms/description-form.tsx
@@ -5,11 +5,13 @@ import { HttpError } from "@refinedev/core";
 
 import { Button, Form, Space } from "antd";
 
-import { Task } from "@/graphql/schema.types";
-
 import { KANBAN_UPDATE_TASK_MUTATION } from "../../kanban/queries";
+import { GetFields } from "@refinedev/nestjs-query";
+import { KanbanUpdateTaskMutation } from "../../../../graphql/types";
 
 const MDEditor = lazy(() => import("@uiw/react-md-editor"));
+
+type Task = GetFields<KanbanUpdateTaskMutation>;
 
 type Props = {
   initialValues: {

--- a/examples/app-crm/src/routes/scrumboard/components/forms/users-form.tsx
+++ b/examples/app-crm/src/routes/scrumboard/components/forms/users-form.tsx
@@ -3,10 +3,13 @@ import { HttpError } from "@refinedev/core";
 
 import { Button, Form, Select, Space } from "antd";
 
-import { Task } from "@/graphql/schema.types";
 import { useUsersSelect } from "@/hooks/useUsersSelect";
 
 import { KANBAN_UPDATE_TASK_MUTATION } from "../../kanban/queries";
+import { GetFields } from "@refinedev/nestjs-query";
+import { KanbanUpdateTaskMutation } from "../../../../graphql/types";
+
+type Task = GetFields<KanbanUpdateTaskMutation>;
 
 type Props = {
   initialValues: {

--- a/examples/app-crm/src/routes/scrumboard/sales/finalize-deal.tsx
+++ b/examples/app-crm/src/routes/scrumboard/sales/finalize-deal.tsx
@@ -6,9 +6,11 @@ import { HttpError, useInvalidate, useNavigation } from "@refinedev/core";
 import { DatePicker, Form, Input, Modal } from "antd";
 import dayjs from "dayjs";
 
-import { Deal } from "@/graphql/schema.types";
-
 import { SALES_FINALIZE_DEAL_MUTATION } from "./queries";
+import { GetFields } from "@refinedev/nestjs-query";
+import { SalesFinalizeDealMutation } from "../../../graphql/types";
+
+type Deal = GetFields<SalesFinalizeDealMutation>;
 
 type FormValues = {
   notes?: string;

--- a/examples/app-crm/vite.config.ts
+++ b/examples/app-crm/vite.config.ts
@@ -4,7 +4,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [tsconfigPaths(), react()],
+  plugins: [tsconfigPaths({ root: __dirname }), react()],
   build: {
     rollupOptions: {
       output: {

--- a/examples/blog-invoice-generator/vite.config.ts
+++ b/examples/blog-invoice-generator/vite.config.ts
@@ -3,5 +3,5 @@ import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [tsconfigPaths(), react()],
+  plugins: [tsconfigPaths({ root: __dirname }), react()],
 });

--- a/examples/monorepo-module-federation/apps/blog-posts/vite.config.ts
+++ b/examples/monorepo-module-federation/apps/blog-posts/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
         "antd",
       ],
     }),
-    tsconfigPaths(),
+    tsconfigPaths({ root: __dirname }),
   ],
   preview: {
     host: "localhost",

--- a/examples/monorepo-module-federation/apps/categories/vite.config.ts
+++ b/examples/monorepo-module-federation/apps/categories/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
         "antd",
       ],
     }),
-    tsconfigPaths(),
+    tsconfigPaths({ root: __dirname }),
   ],
   preview: {
     host: "localhost",

--- a/examples/monorepo-module-federation/apps/host/vite.config.ts
+++ b/examples/monorepo-module-federation/apps/host/vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
         "antd",
       ],
     }),
-    tsconfigPaths(),
+    tsconfigPaths({ root: __dirname }),
   ],
 
   preview: {

--- a/examples/with-remix-vite-headless/vite.config.ts
+++ b/examples/with-remix-vite-headless/vite.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
     remix({
       ignoredRouteFiles: ["**/.*"],
     }),
-    tsconfigPaths(),
+    tsconfigPaths({ root: __dirname }),
   ],
 });


### PR DESCRIPTION
`app-crm` and `app-crm-minimal` builds are throwing `JavaScript heap out of memory` error on build.

Also fixed the following error:


![Screenshot 2024-04-02 at 15 41 59](https://github.com/refinedev/refine/assets/16444991/07efe069-b57b-4db9-ae8f-886a5973dd17)


`vite-tsconfig-paths` plugin needs `root` path to search for `tsconfig.json`. Otherwise it's searching `tsconfig.json` in the root of the repository. Trying to use `documentation/tsconfig.json` to resolve paths.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention
