### PR TITLE
fix(devtools): lodash imports in ESM builds

### DIFF
--- a/.changeset/popular-moose-dance.md
+++ b/.changeset/popular-moose-dance.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/devtools": patch
+"@refinedev/devtools-server": patch
+"@refinedev/devtools-ui": patch
+---
+
+fix: broken lodash imports in ESM builds
+
+Fixed lodash imports in ESM builds which requires `lodash-es` imports to use `.js` extension to work properly unless the bundler is configured to handle non-fully-specified imports.

--- a/.changeset/popular-moose-dance.md
+++ b/.changeset/popular-moose-dance.md
@@ -7,3 +7,5 @@
 fix: broken lodash imports in ESM builds
 
 Fixed lodash imports in ESM builds which requires `lodash-es` imports to use `.js` extension to work properly unless the bundler is configured to handle non-fully-specified imports.
+
+Resolves [#5822](https://github.com/refinedev/refine/issues/5822)

--- a/packages/devtools-server/package.json
+++ b/packages/devtools-server/package.json
@@ -61,6 +61,7 @@
     "http-proxy-middleware": "^2.0.6",
     "jscodeshift": "0.15.2",
     "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "marked": "^4.3.0",
     "node-fetch": "^2.6.7",
     "preferred-pm": "^3.0.3",

--- a/packages/devtools-server/tsup.config.ts
+++ b/packages/devtools-server/tsup.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "tsup";
 import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
+import { lodashReplacePlugin } from "../shared/lodash-replace-plugin";
 
 export default defineConfig((tsupOptions) => ({
   entry: ["src/index.ts", "src/cli.ts"],
@@ -17,6 +18,7 @@ export default defineConfig((tsupOptions) => ({
     };
   },
   esbuildPlugins: [
+    lodashReplacePlugin,
     NodeResolvePlugin({
       extensions: [".js", "ts", "tsx", "jsx"],
       onResolved: (resolved) => {

--- a/packages/devtools-ui/package.json
+++ b/packages/devtools-ui/package.json
@@ -51,6 +51,7 @@
     "clsx": "^1.1.1",
     "dayjs": "^1.10.7",
     "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "prism-react-renderer": "^1.3.5",
     "react-gravatar": "^2.6.3",
     "react-json-view": "^1.21.3",

--- a/packages/devtools-ui/tsup.config.ts
+++ b/packages/devtools-ui/tsup.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "tsup";
 import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
 import { dayJsEsmReplacePlugin } from "../shared/dayjs-esm-replace-plugin";
+import { lodashReplacePlugin } from "../shared/lodash-replace-plugin";
 
 export default defineConfig({
   entry: ["src/index.ts", "src/style.css"],
@@ -12,6 +13,7 @@ export default defineConfig({
   outExtension: ({ format }) => ({ js: format === "cjs" ? ".cjs" : ".mjs" }),
   platform: "browser",
   esbuildPlugins: [
+    lodashReplacePlugin,
     dayJsEsmReplacePlugin,
     NodeResolvePlugin({
       extensions: [".js", "ts", "tsx", "jsx"],

--- a/packages/devtools/tsup.config.ts
+++ b/packages/devtools/tsup.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "tsup";
 import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
+import { lodashReplacePlugin } from "../shared/lodash-replace-plugin";
 
 export default defineConfig({
   entry: ["src/index.ts"],
@@ -20,6 +21,7 @@ export default defineConfig({
     };
   },
   esbuildPlugins: [
+    lodashReplacePlugin,
     NodeResolvePlugin({
       extensions: [".js", "ts", "tsx", "jsx"],
       onResolved: (resolved) => {


### PR DESCRIPTION
- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the new behavior?

Fixed lodash imports in ESM builds which requires `lodash-es` imports to use `.js` extension to work properly unless the bundler is configured to handle non-fully-specified imports.

Resolves [#5822](https://github.com/refinedev/refine/issues/5822)
