### PR TITLE
docs(routing): add basic usage with `<RouterProvider>`

### DIFF
--- a/documentation/docs/routing/integrations/react-router/index.md
+++ b/documentation/docs/routing/integrations/react-router/index.md
@@ -30,6 +30,16 @@ You can define your routes the way you want, then pass the `routerProvider` prop
 
 We'll pass the `routerProvider` prop to the `Refine` component to instruct Refine on how to communicate with the router. We'll also define our resources and their action paths, this will inform Refine to use these paths when generating the breadcrumbs, menus, handling redirections and inferring the current resource and action.
 
+<Tabs
+defaultValue="browser-router"
+values={[
+{label: 'Using <BrowserRouter>', value: 'browser-router'},
+{label: 'Using <RouterProvider>', value: 'router-provider'},
+]}>
+<TabItem value="browser-router">
+
+This example uses the [`<BrowserRouter>`](https://reactrouter.com/en/main/router-components/browser-router) router component.
+
 ```tsx title=App.tsx
 import { Refine } from "@refinedev/core";
 import dataProvider from "@refinedev/simple-rest";
@@ -82,6 +92,93 @@ const App = () => {
   );
 };
 ```
+
+</TabItem>
+<TabItem value="router-provider">
+
+In their v6.4, React Router introduced Data APIs Router. It uses [`<RouterProvider>`](https://reactrouter.com/en/main/routers/router-provider) component coupled with a [`createBrowserRouter()`](https://reactrouter.com/en/main/routers/create-browser-router) function that live outside the DOM.
+
+The example below start from the `<BrowserRouter>` example and follow their [migration guide](https://reactrouter.com/en/main/upgrading/v6-data) to the `<RouterProvider>` component.
+
+:::caution Use cases
+
+While the basic usage of routing works out of the box, more advanced use cases of the Data APIs are not tested.
+
+You are welcome to [contribute][contributing] to help test and support the advanced use cases of the Data APIs.
+
+:::
+
+```tsx title=App.tsx
+import { Refine } from "@refinedev/core";
+import dataProvider from "@refinedev/simple-rest";
+import routerProvider from "@refinedev/react-router-v6";
+import { createBrowserRouter, RouterProvider, Outlet } from "react-router-dom";
+
+import { PostList, PostCreate } from "pages/posts";
+import { CategoryList, CategoryShow } from "pages/categories";
+
+const router = createBrowserRouter([
+  {
+    Component: RefineProvider,
+    children: [
+      // highlight-start
+      {
+        path: "posts",
+        children: [
+          { index: true, Component: PostList },
+          { path: "create", Component: PostCreate },
+        ],
+      },
+      {
+        path: "categories",
+        children: [
+          { index: true, Component: CategoryList },
+          { path: "show/:id", Component: CategoryShow },
+        ],
+      },
+      // highlight-end
+    ],
+  },
+]);
+
+const App = () => {
+  {
+    /* highlight-next-line*/
+  }
+  return <RouterProvider router={router} />;
+};
+
+const RefineProvider = () => {
+  return (
+    <Refine
+      dataProvider={dataProvider}
+      // highlight-next-line
+      routerProvider={routerProvider}
+      resources={[
+        {
+          name: "posts",
+          // highlight-start
+          list: "/posts",
+          create: "/posts/create",
+          // highlight-end
+        },
+        {
+          name: "categories",
+          // highlight-start
+          list: "/categories",
+          show: "/categories/show/:id",
+          // highlight-end
+        },
+      ]}
+    >
+      <Outlet />
+    </Refine>
+  );
+};
+```
+
+</TabItem>
+</Tabs>
 
 ### Usage with Authentication
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] (not applicable) Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

fixes #5797 

## Notes for reviewers

- I did not add changesets for docs change only.
- I added a caution about the more advance use cases of Data APIs that are not tested.
  - But that contribution are welcomed.
- Here how it looks testing using codespace.

![original-basic-usage](https://github.com/refinedev/refine/assets/8150191/4546a019-2a83-42e5-a1b1-066c03839d03)

![added-router-provider-basic-usage](https://github.com/refinedev/refine/assets/8150191/a9bf20e9-58e9-4aaa-9c45-08e3b8a6a942)

