### PR TITLE
fix(inferencer): prism theme imports in ESM builds

### DIFF
--- a/.changeset/happy-poets-smash.md
+++ b/.changeset/happy-poets-smash.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/inferencer": patch
+---
+
+fix: inferencer now should work with ESM builds
+
+Fixed the issue with `prism-react-renderer` theme imports not being resolved correctly in ESM builds.

--- a/packages/inferencer/tsup.config.ts
+++ b/packages/inferencer/tsup.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "tsup";
 
 import { lodashReplacePlugin } from "../shared/lodash-replace-plugin";
+import { prismReactRendererThemeReplacePlugin } from "../shared/prism-react-renderer-theme-replace-plugin";
 import { markAsExternalPlugin } from "../shared/mark-as-external-plugin";
 import { removeTestIdsPlugin } from "../shared/remove-test-ids-plugin";
 import { tablerCjsReplacePlugin } from "../shared/tabler-cjs-replace-plugin";
@@ -26,6 +27,7 @@ export default defineConfig({
     tablerCjsReplacePlugin,
     removeTestIdsPlugin,
     lodashReplacePlugin,
+    prismReactRendererThemeReplacePlugin,
     markAsExternalPlugin,
   ],
   loader: {

--- a/packages/shared/prism-react-renderer-theme-replace-plugin.ts
+++ b/packages/shared/prism-react-renderer-theme-replace-plugin.ts
@@ -1,0 +1,29 @@
+import { Plugin } from "esbuild";
+
+export const prismReactRendererThemeReplacePlugin: Plugin = {
+  name: "prismReactRendererThemeReplace",
+  setup: (build) => {
+    if (build.initialOptions.format === "esm") {
+      build.onEnd(async (args) => {
+        const prismReactRendererThemeImportRegexp =
+          /from\s?"prism-react-renderer\/themes\/(\w*?)"/g;
+        const prismReactRendererThemeEsmImport =
+          'from "prism-react-renderer/themes/$1/index.js"';
+
+        const jsOutputFiles =
+          args.outputFiles?.filter(
+            (el) => el.path.endsWith(".mjs") || el.path.endsWith(".js"),
+          ) ?? [];
+
+        for (const jsOutputFile of jsOutputFiles) {
+          const str = new TextDecoder("utf-8").decode(jsOutputFile.contents);
+          const newStr = str.replace(
+            prismReactRendererThemeImportRegexp,
+            prismReactRendererThemeEsmImport,
+          );
+          jsOutputFile.contents = new TextEncoder().encode(newStr);
+        }
+      });
+    }
+  },
+};


### PR DESCRIPTION
There's an issue with `prism-react-renderer`'s themes when imported without an extension in ESM builds affecting `@refinedev/inferencer` and users with ESM environments. 

Added a small plugin to our esbuild setup to replace the imports with correct file and extension.

Resolves #5834