### PR TITLE
fix(devtools): devtools selector in the ESM builds

### DIFF
--- a/.changeset/tender-meals-explain.md
+++ b/.changeset/tender-meals-explain.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/devtools": patch
+---
+
+fix: devtools selector was breaking the esm builds
+
+Fixed the issue with `@aliemir/dom-to-fiber-utils` not being correctly interpreted as ESM in ESM environments, causing `@refinedev/devtools` to throw an unexpected error. Latest release of `@aliemir/dom-to-fiber-utils` (0.5.0) now correctly exports ESM and CJS builds fixing the issue.
+
+Resolves [#5831](https://github.com/refinedev/refine/issues/5831)

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -39,7 +39,7 @@
     "types": "node ../shared/generate-declarations.js"
   },
   "dependencies": {
-    "@aliemir/dom-to-fiber-utils": "^0.4.0",
+    "@aliemir/dom-to-fiber-utils": "^0.5.0",
     "@refinedev/devtools-shared": "1.1.5",
     "error-stack-parser": "^2.1.4",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Fixed the issue with `@aliemir/dom-to-fiber-utils` not being correctly interpreted as ESM in ESM environments, causing `@refinedev/devtools` to throw an unexpected error. Latest release of `@aliemir/dom-to-fiber-utils` (0.5.0) now correctly exports ESM and CJS builds fixing the issue.

Resolves #5831