### PR TITLE
refactor(react-table): allow conditional filters on `useTable`

### DIFF
--- a/.changeset/selfish-taxis-admire.md
+++ b/.changeset/selfish-taxis-admire.md
@@ -1,0 +1,11 @@
+---
+"@refinedev/react-table": patch
+---
+
+fix: updated column filter transformation logic to handle conditional filters
+
+`useTable` hook was ignoring the conditional filters with `"and"` and `"or"` operators, causing custom filtering logic inside the table to not work as expected and omitting the filters from the query. This PR enables working with conditionenal filters and fixes the disappearing filters issue.
+
+To customize the `key` value of the conditional filter, you can use the `filterKey` property in the column's `meta` property. This property will be used as the key for the filter when setting the filter value to the table from `@refinedev/core`'s filter state and when setting the filter value to the filter state from the table.
+
+Resolves [#5856](https://github.com/refinedev/refine/issues/5856)

--- a/.changeset/selfish-taxis-admire.md
+++ b/.changeset/selfish-taxis-admire.md
@@ -8,4 +8,21 @@ fix: updated column filter transformation logic to handle conditional filters
 
 To customize the `key` value of the conditional filter, you can use the `filterKey` property in the column's `meta` property. This property will be used as the key for the filter when setting the filter value to the table from `@refinedev/core`'s filter state and when setting the filter value to the filter state from the table.
 
+```tsx
+// An example of how to use the `filterKey` property in the column's `meta` property
+const columns: ColumnDef<IPost> = [
+  {
+    id: "title",
+    header: "Title",
+    accessorKey: "title",
+    meta: {
+      // This is optional, if not defined column id will be used as the key
+      filterKey: "titleFilter",
+      // If operator is not `'eq'` or `'in'`, make sure to set the `filterOperator` property
+      filterOperator: "and",
+    },
+  },
+];
+```
+
 Resolves [#5856](https://github.com/refinedev/refine/issues/5856)

--- a/documentation/docs/packages/tanstack-table/use-table/index.md
+++ b/documentation/docs/packages/tanstack-table/use-table/index.md
@@ -54,6 +54,10 @@ It also syncs the filtering state with the URL if you enable the [`syncWithLocat
 
 By default, filter operators are set to "eq" for all fields. You can specify which field will be filtered with which filter operator with the `filterOperator` property in the `meta` object. Just be aware that the `filterOperator` must be a [`CrudOperators`](/docs/core/interface-references#crudoperators) type.
 
+If you're going to use [logical filters](/docs/core/interface-references#logicalfilter) (`and`, `or`), you can set `filterOperator` to `and` or `or` in the `meta` object. By design, logical filters do not have `field` property, instead they have `key` property to differentiate between filters if there are multiple filters with the same operator.
+
+By default, `id` field of the column is used as the `key` property. If you want to use a different field as the `key`, you can set the `filterKey` property in the `meta` object.
+
 <FilteringLivePreview/>
 
 ## Realtime Updates

--- a/packages/react-table/src/useTable/index.ts
+++ b/packages/react-table/src/useTable/index.ts
@@ -168,7 +168,7 @@ export function useTable<
     if (crudFilters.length > 0 && isPaginationEnabled && !isFirstRender) {
       setCurrent(1);
     }
-  }, [columnFilters]);
+  }, [columnFilters, columns]);
 
   return {
     ...reactTableResult,

--- a/packages/react-table/src/useTable/index.ts
+++ b/packages/react-table/src/useTable/index.ts
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import {
   BaseRecord,
+  ConditionalFilter,
+  CrudFilter,
   CrudOperators,
   HttpError,
   LogicalFilter,
@@ -18,7 +20,12 @@ import {
   getFilteredRowModel,
 } from "@tanstack/react-table";
 
-import { useIsFirstRender } from "../utils";
+import {
+  useIsFirstRender,
+  columnFiltersToCrudFilters,
+  getRemovedFilters,
+  crudFiltersToColumnFilters,
+} from "../utils";
 
 export type UseTableReturnType<
   TData extends BaseRecord = BaseRecord,
@@ -80,17 +87,6 @@ export function useTable<
     pageCount,
   } = useTableResult;
 
-  const logicalFilters: LogicalFilter[] = [];
-  filtersCore.forEach((filter) => {
-    if (
-      filter.operator !== "or" &&
-      filter.operator !== "and" &&
-      "field" in filter
-    ) {
-      logicalFilters.push(filter);
-    }
-  });
-
   const reactTableResult = useReactTable<TData>({
     data: data?.data ?? [],
     getCoreRowModel: getCoreRowModel(),
@@ -109,11 +105,10 @@ export function useTable<
         id: sorting.field,
         desc: sorting.order === "desc",
       })),
-      columnFilters: logicalFilters.map((filter) => ({
-        id: filter.field,
-        operator: filter.operator as Exclude<CrudOperators, "or" | "and">,
-        value: filter.value,
-      })),
+      columnFilters: crudFiltersToColumnFilters({
+        columns: rest.columns,
+        crudFilters: filtersCore,
+      }),
       ...reactTableInitialState,
     },
     pageCount,
@@ -156,39 +151,17 @@ export function useTable<
   }, [sorting]);
 
   useEffect(() => {
-    const crudFilters: LogicalFilter[] = [];
-
-    columnFilters?.map((filter) => {
-      const operator =
-        (
-          filter as ColumnFilter & {
-            operator?: Exclude<CrudOperators, "or" | "and">;
-          }
-        ).operator ??
-        ((columns.find((c) => c.id === filter.id) as any)?.meta
-          ?.filterOperator as Exclude<CrudOperators, "or" | "and">);
-
-      crudFilters.push({
-        field: filter.id,
-        operator: operator ?? (Array.isArray(filter.value) ? "in" : "eq"),
-        value: filter.value,
-      });
+    const crudFilters: CrudFilter[] = columnFiltersToCrudFilters({
+      columns,
+      columnFilters,
     });
 
-    const filteredArray = logicalFilters.filter(
-      (value) =>
-        !crudFilters.some(
-          (b) => value.field === b.field && value.operator === b.operator,
-        ),
+    crudFilters.push(
+      ...getRemovedFilters({
+        nextFilters: crudFilters,
+        coreFilters: filtersCore,
+      }),
     );
-
-    filteredArray?.map((filter) => {
-      crudFilters.push({
-        field: filter.field,
-        operator: filter.operator,
-        value: undefined,
-      });
-    });
 
     setFilters(crudFilters);
 

--- a/packages/react-table/src/utils/column-filters-to-crud-filters/index.spec.ts
+++ b/packages/react-table/src/utils/column-filters-to-crud-filters/index.spec.ts
@@ -1,0 +1,221 @@
+import { ColumnDef, ColumnFilter } from "@tanstack/react-table";
+import { columnFiltersToCrudFilters } from ".";
+
+describe("columnFiltersToCrudFilters", () => {
+  it("should return with crud filters type", () => {
+    const columns: ColumnDef<any, any>[] = [
+      {
+        id: "name",
+        header: "Name",
+        accessorKey: "name",
+      },
+      {
+        header: "Age",
+        accessorKey: "age",
+      },
+    ];
+
+    const columnFilters: ColumnFilter[] = [
+      { id: "name", value: "John" },
+      { id: "age", value: 30 },
+    ];
+
+    const crudFilters = columnFiltersToCrudFilters({
+      columns,
+      columnFilters,
+    });
+
+    expect(crudFilters).toEqual([
+      { field: "name", value: "John", operator: "eq" },
+      { field: "age", value: 30, operator: "eq" },
+    ]);
+  });
+
+  it("should set operator to 'in' if value is an array", () => {
+    const columns: ColumnDef<any, any>[] = [
+      {
+        id: "name",
+        header: "Name",
+        accessorKey: "name",
+      },
+      {
+        header: "Age",
+        accessorKey: "age",
+      },
+    ];
+
+    const columnFilters: ColumnFilter[] = [
+      { id: "name", value: ["John", "Doe"] },
+      { id: "age", value: 30 },
+    ];
+
+    const crudFilters = columnFiltersToCrudFilters({
+      columns,
+      columnFilters,
+    });
+
+    expect(crudFilters).toEqual([
+      { field: "name", value: ["John", "Doe"], operator: "in" },
+      { field: "age", value: 30, operator: "eq" },
+    ]);
+  });
+
+  it("should respect filterOperator from column meta", () => {
+    const columns: ColumnDef<any, any>[] = [
+      {
+        id: "name",
+        header: "Name",
+        accessorKey: "name",
+        meta: {
+          filterOperator: "contains",
+        },
+      },
+      {
+        header: "Age",
+        accessorKey: "age",
+      },
+    ];
+
+    const columnFilters: ColumnFilter[] = [
+      { id: "name", value: "John" },
+      { id: "age", value: 30 },
+    ];
+
+    const crudFilters = columnFiltersToCrudFilters({
+      columns,
+      columnFilters,
+    });
+
+    expect(crudFilters).toEqual([
+      { field: "name", value: "John", operator: "contains" },
+      { field: "age", value: 30, operator: "eq" },
+    ]);
+  });
+
+  it("should transform and/or filters to conditional filters", () => {
+    const columns: ColumnDef<any, any>[] = [
+      {
+        id: "name",
+        header: "Name",
+        accessorKey: "name",
+        meta: {
+          filterOperator: "or",
+        },
+      },
+      {
+        id: "age",
+        header: "Age",
+        accessorKey: "age",
+        meta: {
+          filterOperator: "and",
+        },
+      },
+    ];
+
+    const columnFilters: ColumnFilter[] = [
+      {
+        id: "name",
+        value: [
+          { field: "name", operator: "eq", value: "John" },
+          { field: "name", operator: "eq", value: "Doe" },
+        ],
+      },
+
+      {
+        id: "age",
+        value: [
+          { field: "age", operator: "gte", value: 18 },
+          { field: "age", operator: "lte", value: 65 },
+        ],
+      },
+    ];
+
+    const crudFilters = columnFiltersToCrudFilters({
+      columns,
+      columnFilters,
+    });
+
+    expect(crudFilters).toEqual([
+      {
+        key: "name",
+        operator: "or",
+        value: [
+          { field: "name", operator: "eq", value: "John" },
+          { field: "name", operator: "eq", value: "Doe" },
+        ],
+      },
+      {
+        key: "age",
+        operator: "and",
+        value: [
+          { field: "age", operator: "gte", value: 18 },
+          { field: "age", operator: "lte", value: 65 },
+        ],
+      },
+    ]);
+  });
+
+  it("should respect custom filter key for conditional filters", () => {
+    const columns: ColumnDef<any, any>[] = [
+      {
+        id: "name",
+        header: "Name",
+        accessorKey: "name",
+        meta: {
+          filterOperator: "or",
+        },
+      },
+      {
+        id: "age",
+        header: "Age",
+        accessorKey: "age",
+        meta: {
+          filterOperator: "and",
+          filterKey: "customKey",
+        },
+      },
+    ];
+
+    const columnFilters: ColumnFilter[] = [
+      {
+        id: "name",
+        value: [
+          { field: "name", operator: "eq", value: "John" },
+          { field: "name", operator: "eq", value: "Doe" },
+        ],
+      },
+
+      {
+        id: "age",
+        value: [
+          { field: "age", operator: "gte", value: 18 },
+          { field: "age", operator: "lte", value: 65 },
+        ],
+      },
+    ];
+
+    const crudFilters = columnFiltersToCrudFilters({
+      columns,
+      columnFilters,
+    });
+
+    expect(crudFilters).toEqual([
+      {
+        key: "name",
+        operator: "or",
+        value: [
+          { field: "name", operator: "eq", value: "John" },
+          { field: "name", operator: "eq", value: "Doe" },
+        ],
+      },
+      {
+        key: "customKey",
+        operator: "and",
+        value: [
+          { field: "age", operator: "gte", value: 18 },
+          { field: "age", operator: "lte", value: 65 },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/react-table/src/utils/column-filters-to-crud-filters/index.ts
+++ b/packages/react-table/src/utils/column-filters-to-crud-filters/index.ts
@@ -1,0 +1,57 @@
+import {
+  ConditionalFilter,
+  CrudFilter,
+  CrudOperators,
+  LogicalFilter,
+} from "@refinedev/core";
+import {
+  ColumnDef,
+  ColumnFilter,
+  ColumnFiltersState,
+} from "@tanstack/react-table";
+
+type Params = {
+  columnFilters?: ColumnFiltersState;
+  columns: ColumnDef<any, any>[];
+};
+
+export const columnFiltersToCrudFilters = ({
+  columns,
+  columnFilters,
+}: Params): CrudFilter[] => {
+  return (
+    columnFilters?.map((filter) => {
+      const operator =
+        (filter as ColumnFilter & { operator?: CrudOperators }).operator ??
+        (
+          columns.find((col) => col.id === filter.id)?.meta as {
+            filterOperator?: string;
+          }
+        )?.filterOperator;
+
+      const isConditional = operator === "and" || operator === "or";
+
+      if (isConditional && Array.isArray(filter.value)) {
+        const filterKey =
+          (
+            columns.find((c) => c.id === filter.id)?.meta as {
+              filterKey?: string;
+            }
+          )?.filterKey ?? filter.id;
+
+        return {
+          key: filterKey,
+          operator: operator as ConditionalFilter["operator"],
+          value: filter.value,
+        };
+      }
+      const defaultOperator = Array.isArray(filter.value) ? "in" : "eq";
+
+      return {
+        field: filter.id,
+        operator: (operator as LogicalFilter["operator"]) ?? defaultOperator,
+        value: filter.value,
+      };
+    }) ?? []
+  );
+};

--- a/packages/react-table/src/utils/crud-filters-to-column-filters/index.spec.ts
+++ b/packages/react-table/src/utils/crud-filters-to-column-filters/index.spec.ts
@@ -1,0 +1,156 @@
+import { ColumnDef, ColumnFilter } from "@tanstack/react-table";
+import { crudFiltersToColumnFilters } from ".";
+import { CrudFilter } from "@refinedev/core";
+
+describe("crudFiltersToColumnFilters", () => {
+  it("should return with ColumnFilter type", () => {
+    const columns: ColumnDef<any, any>[] = [
+      {
+        id: "name",
+        header: "Name",
+        accessorKey: "name",
+      },
+      {
+        header: "Age",
+        accessorKey: "age",
+      },
+    ];
+
+    const crudFilters: CrudFilter[] = [
+      { field: "name", value: "John", operator: "eq" },
+      { field: "age", value: 30, operator: "eq" },
+    ];
+
+    const columnFilters = crudFiltersToColumnFilters({
+      columns,
+      crudFilters,
+    });
+
+    expect(columnFilters).toEqual([
+      { id: "name", value: "John", operator: "eq" },
+      { id: "age", value: 30, operator: "eq" },
+    ]);
+  });
+
+  it("should work with conditional filters", () => {
+    const columns: ColumnDef<any, any>[] = [
+      {
+        id: "name",
+        header: "Name",
+        accessorKey: "name",
+      },
+      {
+        id: "age",
+        header: "Age",
+        accessorKey: "age",
+      },
+    ];
+
+    const crudFilters: CrudFilter[] = [
+      {
+        operator: "and",
+        key: "name",
+        value: [
+          { field: "name", value: "John", operator: "eq" },
+          { field: "name", value: "Doe", operator: "eq" },
+        ],
+      },
+      {
+        operator: "and",
+        key: "age",
+        value: [
+          { field: "age", value: 30, operator: "eq" },
+          { field: "age", value: 40, operator: "eq" },
+        ],
+      },
+    ];
+
+    const columnFilters = crudFiltersToColumnFilters({
+      columns,
+      crudFilters,
+    });
+
+    expect(columnFilters).toEqual([
+      {
+        id: "name",
+        value: [
+          { field: "name", value: "John", operator: "eq" },
+          { field: "name", value: "Doe", operator: "eq" },
+        ],
+        operator: "and",
+      },
+      {
+        id: "age",
+        value: [
+          { field: "age", value: 30, operator: "eq" },
+          { field: "age", value: 40, operator: "eq" },
+        ],
+        operator: "and",
+      },
+    ]);
+  });
+
+  it("should respect custom filterKey", () => {
+    const columns: ColumnDef<any, any>[] = [
+      {
+        id: "name",
+        header: "Name",
+        accessorKey: "name",
+        meta: {
+          filterKey: "nameFilter",
+        },
+      },
+      {
+        id: "age",
+        header: "Age",
+        accessorKey: "age",
+        meta: {
+          filterKey: "ageFilter",
+        },
+      },
+    ];
+
+    const crudFilters: CrudFilter[] = [
+      {
+        operator: "and",
+        key: "nameFilter",
+        value: [
+          { field: "name", value: "John", operator: "eq" },
+          { field: "name", value: "Doe", operator: "eq" },
+        ],
+      },
+      {
+        operator: "and",
+        key: "ageFilter",
+        value: [
+          { field: "age", value: 30, operator: "eq" },
+          { field: "age", value: 40, operator: "eq" },
+        ],
+      },
+    ];
+
+    const columnFilters = crudFiltersToColumnFilters({
+      columns,
+      crudFilters,
+    });
+
+    expect(columnFilters).toEqual([
+      {
+        id: "name",
+        value: [
+          { field: "name", value: "John", operator: "eq" },
+          { field: "name", value: "Doe", operator: "eq" },
+        ],
+        operator: "and",
+      },
+      {
+        id: "age",
+        value: [
+          { field: "age", value: 30, operator: "eq" },
+          { field: "age", value: 40, operator: "eq" },
+        ],
+        operator: "and",
+      },
+    ]);
+  });
+});

--- a/packages/react-table/src/utils/crud-filters-to-column-filters/index.ts
+++ b/packages/react-table/src/utils/crud-filters-to-column-filters/index.ts
@@ -1,0 +1,38 @@
+import { CrudFilter, LogicalFilter } from "@refinedev/core";
+import { ColumnDef, ColumnFilter } from "@tanstack/react-table";
+
+type Params = {
+  columns: ColumnDef<any, any>[];
+  crudFilters: CrudFilter[];
+};
+
+export const crudFiltersToColumnFilters = ({
+  columns,
+  crudFilters,
+}: Params): ColumnFilter[] => {
+  return crudFilters
+    .map((filter) => {
+      if (filter.operator === "and" || filter.operator === "or") {
+        if (filter.key) {
+          const filterId: string =
+            columns.find(
+              (col) =>
+                (col.meta as { filterKey?: string })?.filterKey === filter.key,
+            )?.id ?? filter.key;
+
+          return {
+            id: filterId,
+            operator: filter.operator,
+            value: filter.value,
+          };
+        }
+        return undefined;
+      }
+      return {
+        id: (filter as LogicalFilter).field,
+        operator: (filter as LogicalFilter).operator,
+        value: filter.value,
+      };
+    })
+    .filter(Boolean) as ColumnFilter[];
+};

--- a/packages/react-table/src/utils/get-removed-filters/index.spec.ts
+++ b/packages/react-table/src/utils/get-removed-filters/index.spec.ts
@@ -1,0 +1,54 @@
+import { CrudFilter } from "@refinedev/core";
+import { getRemovedFilters } from ".";
+
+describe("getRemovedFilters", () => {
+  it("should return an empty array when no filters are removed", () => {
+    const nextFilters: CrudFilter[] = [
+      { field: "name", value: "John", operator: "eq" },
+      { field: "age", value: 30, operator: "eq" },
+    ];
+    const coreFilters: CrudFilter[] = [
+      { field: "name", value: "John", operator: "eq" },
+      { field: "age", value: 30, operator: "eq" },
+    ];
+    const removedFilters = getRemovedFilters({ nextFilters, coreFilters });
+    expect(removedFilters).toEqual([]);
+  });
+
+  it("should return an array of removed filters", () => {
+    const nextFilters: CrudFilter[] = [
+      { field: "name", value: "John", operator: "eq" },
+      { field: "age", value: 30, operator: "eq" },
+    ];
+    const coreFilters: CrudFilter[] = [
+      { field: "name", value: "John", operator: "eq" },
+      { field: "age", value: 30, operator: "eq" },
+      { field: "city", value: "New York", operator: "eq" },
+    ];
+    const removedFilters = getRemovedFilters({ nextFilters, coreFilters });
+    expect(removedFilters).toEqual([
+      { field: "city", value: undefined, operator: "eq" },
+    ]);
+  });
+
+  it("should remove and filter with empty value", () => {
+    const nextFilters: CrudFilter[] = [
+      { field: "name", value: "John", operator: "eq" },
+    ];
+    const coreFilters: CrudFilter[] = [
+      { field: "name", value: "John", operator: "eq" },
+      {
+        key: "createdAt",
+        operator: "and",
+        value: [
+          { field: "createdAt", operator: "gte", value: "2021-01-01" },
+          { field: "createdAt", operator: "lte", value: "2021-12-31" },
+        ],
+      },
+    ];
+    const removedFilters = getRemovedFilters({ nextFilters, coreFilters });
+    expect(removedFilters).toEqual([
+      { key: "createdAt", operator: "and", value: [] },
+    ]);
+  });
+});

--- a/packages/react-table/src/utils/get-removed-filters/index.ts
+++ b/packages/react-table/src/utils/get-removed-filters/index.ts
@@ -1,0 +1,48 @@
+import { CrudFilter, LogicalFilter } from "@refinedev/core";
+
+type Params = {
+  nextFilters: CrudFilter[];
+  coreFilters: CrudFilter[];
+};
+
+export const getRemovedFilters = ({
+  nextFilters,
+  coreFilters,
+}: Params): CrudFilter[] => {
+  const removedFilters = coreFilters.filter(
+    (filter) =>
+      !nextFilters.some((nextFilter) => {
+        const isFilterConditional =
+          filter.operator === "and" || filter.operator === "or";
+        const isCrudFilterConditional =
+          nextFilter.operator === "and" || nextFilter.operator === "or";
+        const hasSameOperator = filter.operator === nextFilter.operator;
+        const hasSameKey =
+          isFilterConditional &&
+          isCrudFilterConditional &&
+          filter.key === nextFilter.key;
+        const hasSameField =
+          !isFilterConditional &&
+          !isCrudFilterConditional &&
+          (filter as LogicalFilter).field ===
+            (nextFilter as LogicalFilter).field;
+
+        return hasSameOperator && (hasSameKey || hasSameField);
+      }),
+  );
+
+  return removedFilters.map((filter) => {
+    if (filter.operator === "and" || filter.operator === "or") {
+      return {
+        key: filter.key,
+        operator: filter.operator,
+        value: [],
+      };
+    }
+    return {
+      field: (filter as LogicalFilter).field,
+      operator: filter.operator,
+      value: undefined,
+    };
+  });
+};

--- a/packages/react-table/src/utils/index.ts
+++ b/packages/react-table/src/utils/index.ts
@@ -1,1 +1,4 @@
 export * from "./useIsFirstRender";
+export * from "./column-filters-to-crud-filters";
+export * from "./get-removed-filters";
+export * from "./crud-filters-to-column-filters";


### PR DESCRIPTION
`useTable` hook was ignoring the conditional filters with `"and"` and `"or"` operators, causing custom filtering logic inside the table to not work as expected and omitting the filters from the query. This PR enables working with conditional filters and fixes the disappearing filters issue.

To customize the `key` value of the conditional filter, you can use the `filterKey` property in the column's `meta` property. This property will be used as the key for the filter when setting the filter value to the table from `@refinedev/core`'s filter state and when setting the filter value to the filter state from the table.

```tsx
// An example of how to use the `filterKey` property in the column's `meta` property
const columns: ColumnDef<IPost> = [
  {
    id: "title",
    header: "Title",
    accessorKey: "title",
    meta: {
      // This is optional, if not defined column id will be used as the key
      filterKey: "titleFilter",
      // If operator is not `'eq'` or `'in'`, make sure to set the `filterOperator` property
      filterOperator: "and",
    },
  },
];
```

Resolves #5856
