### PR TITLE
fix(devtools-server): broken auth flow in safari

### DIFF
--- a/.changeset/loud-toes-eat.md
+++ b/.changeset/loud-toes-eat.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/devtools-server": patch
+---
+
+fix: devtools authentication not working with safari
+
+Fixed the authentication flow and cookie handling for Safari. Now devtools users will be able to authenticate and use the devtools server using Safari.
+
+Resolves [#5753](https://github.com/refinedev/refine/issues/5753)

--- a/packages/devtools-server/package.json
+++ b/packages/devtools-server/package.json
@@ -40,7 +40,7 @@
     "dev:client": "vite build --watch --force --config src/client/vite.config.ts",
     "prepare": "npm run build",
     "publint": "publint --strict=true --level=suggestion",
-    "start:server": "node dist/cli.js",
+    "start:server": "node dist/cli.cjs",
     "test": "jest --passWithNoTests --runInBand",
     "types": "node ../shared/generate-declarations.js"
   },

--- a/packages/devtools-server/src/serve-proxy.ts
+++ b/packages/devtools-server/src/serve-proxy.ts
@@ -141,7 +141,7 @@ export const serveProxy = async (app: Express) => {
     changeOrigin: true,
     pathRewrite: { "^/api/.auth": "/.auth" },
     cookieDomainRewrite: {
-      "refine.dev": "",
+      "refine.dev": "localhost",
     },
     logLevel: __DEVELOPMENT__ ? "debug" : "silent",
     headers: {
@@ -156,6 +156,13 @@ export const serveProxy = async (app: Express) => {
       }
     },
     onProxyRes: (proxyRes, req, res) => {
+      const newSetCookie = proxyRes.headers["set-cookie"]?.map((cookie) =>
+        cookie
+          .replace("Domain=refine.dev;", "Domain=localhost;")
+          .replace(" HttpOnly; Secure; SameSite=Lax", ""),
+      );
+      if (newSetCookie) proxyRes.headers["set-cookie"] = newSetCookie;
+
       if (req.url.includes("self-service/methods/oidc/callback")) {
         return handleSignInCallbacks((_token, _jwt) => {
           token = _token;


### PR DESCRIPTION
Fixed the authentication flow and cookie handling for Safari. Flow was broken due to setting/accessing cookies with cross domain. Now devtools users will be able to authenticate and use the devtools server using Safari.

Resolves [#5753](https://github.com/refinedev/refine/issues/5753)
