### PR TITLE
fix(docs): Changed type of options in translate function of i18nProvider

### DIFF
--- a/documentation/docs/guides-concepts/i18n/index.md
+++ b/documentation/docs/guides-concepts/i18n/index.md
@@ -131,13 +131,15 @@ import type { I18nProvider } from "@refinedev/core";
 import { Refine } from "@refinedev/core";
 // highlight-next-line
 import { useTranslation } from "react-i18next";
+// highlight-next-line
+import { $Dictionary } from "i18next/typescript/helpers";
 
 const App: React.FC = () => {
   // highlight-start
   const { t, i18n } = useTranslation();
 
   const i18nProvider: I18nProvider = {
-    translate: (key: string, options?: any) => t(key, options),
+    translate: (key: string, options?: $Dictionary<unknown>) => t(key, options),
     changeLocale: (lang: string) => i18n.changeLanguage(lang),
     getLocale: () => i18n.language,
   };
@@ -276,6 +278,7 @@ import { Refine, Resource } from "@refinedev/core";
 import { ThemedLayoutV2 } from "@refinedev/antd";
 
 import { useTranslation } from "react-i18next";
+import { $Dictionary } from "i18next/typescript/helpers";
 
 import "./i18n";
 
@@ -286,7 +289,7 @@ const App: React.FC = () => {
     const { t, i18n } = useTranslation();
 
     const i18nProvider = {
-        translate: (key: string, options?: any) => t(key, options),
+        translate: (key: string, options?: $Dictionary<unknown>) => t(key, options),
         changeLocale: (lang: string) => i18n.changeLanguage(lang),
         getLocale: () => i18n.language,
     };


### PR DESCRIPTION
Example with `options: any` gives me the following error:

```
Type '(key: string, options?: any) => string | TFunctionDetailedResult<string, any>' is not assignable to type 'TranslateFunction'.
  Type 'string | TFunctionDetailedResult<string, any>' is not assignable to type 'string'.
    Type 'TFunctionDetailedResult<string, any>' is not assignable to type 'string'.ts(2322)
```

I found solution in a following file that fixes the error:

https://github.com/Fgruntjes/WFK-Finance/blob/7b6c817b913f89db6197c705d34e260aaf7ed726/frontend/src/i18n-provider/useI18nProvider.ts#L5

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes # (issue)

## Notes for reviewers

I'm following the guide at [the page](https://refine.dev/docs/guides-concepts/i18n/#changing-the-locale) and getting error. The error is fixed when I change `options?: any` to `options?: $Dictionary<unknown>`. 

The screenshot of an error:

![image](https://github.com/refinedev/refine/assets/89320434/f7ae9587-66e2-4729-a7e7-69d916fe906c)

