### PR TITLE
fix(mui): add default values to RefineSnackbarProvider

### DIFF
--- a/documentation/tutorial/ui-libraries/crud-components/material-ui/react-router/sandpack.tsx
+++ b/documentation/tutorial/ui-libraries/crud-components/material-ui/react-router/sandpack.tsx
@@ -69,7 +69,7 @@ export const ListProducts = () => {
         flex: 0.5,
         type: "singleSelect",
         valueOptions: categories,
-        valueFormatter: (params) => params.value,
+        valueFormatter: (params) => params?.value,
         renderCell: function render({ row }) {
           if (isLoading) {
             return "Loading...";

--- a/documentation/tutorial/ui-libraries/refactoring/material-ui/react-router/sandpack.tsx
+++ b/documentation/tutorial/ui-libraries/refactoring/material-ui/react-router/sandpack.tsx
@@ -166,7 +166,7 @@ export const ListProducts = () => {
         flex: 0.5,
         type: "singleSelect",
         valueOptions: categories,
-        valueFormatter: (params) => params.value,
+        valueFormatter: (params) => params?.value,
         renderCell: function render({ row }) {
           if (isLoading) {
             return "Loading...";

--- a/packages/core/src/contexts/notification/types.ts
+++ b/packages/core/src/contexts/notification/types.ts
@@ -37,6 +37,12 @@ export type OpenNotificationParams = {
   description?: string;
   cancelMutation?: () => void;
   undoableTimeout?: number;
+  anchorOrigin?: {
+    vertical: "top" | "bottom";
+    horizontal: "left" | "center" | "right";
+  };
+  preventDuplicate?: boolean;
+  disableWindowBlurListener?: boolean;
 };
 
 export interface INotificationContext {

--- a/packages/mui/src/providers/notificationProvider/index.spec.tsx
+++ b/packages/mui/src/providers/notificationProvider/index.spec.tsx
@@ -16,6 +16,12 @@ const mockNotification: OpenNotificationParams = {
   message: "Test Notification Message",
   type: "success",
   description: "Test Notification Description",
+  anchorOrigin: {
+    vertical: "top",
+    horizontal: "right",
+  },
+  disableWindowBlurListener: true,
+  preventDuplicate: true,
 };
 
 const mockNotificationUndoable: OpenNotificationParams = {
@@ -65,11 +71,12 @@ describe("Notistack notificationProvider", () => {
       {
         key: mockNotification.key,
         variant: "success",
-        anchorOrigin: {
+        anchorOrigin: mockNotification.anchorOrigin ?? {
           vertical: "top",
           horizontal: "right",
         },
-        disableWindowBlurListener: true,
+        disableWindowBlurListener: mockNotification.disableWindowBlurListener,
+        preventDuplicate: mockNotification.preventDuplicate,
       },
     );
   });
@@ -90,11 +97,12 @@ describe("Notistack notificationProvider", () => {
       {
         key: mockNotification.key,
         variant: "error",
-        anchorOrigin: {
+        anchorOrigin: mockNotification.anchorOrigin ?? {
           vertical: "top",
           horizontal: "right",
         },
-        disableWindowBlurListener: true,
+        disableWindowBlurListener: mockNotification.disableWindowBlurListener,
+        preventDuplicate: mockNotification.preventDuplicate,
       },
     );
   });
@@ -114,14 +122,15 @@ describe("Notistack notificationProvider", () => {
       </>,
       {
         action: expect.any(Function),
-        anchorOrigin: {
+        anchorOrigin: mockNotificationUndoable.anchorOrigin ?? {
           vertical: "top",
           horizontal: "right",
         },
-        preventDuplicate: true,
+        preventDuplicate: mockNotificationUndoable.preventDuplicate,
         key: "test-notification-undoable",
         autoHideDuration: 5000,
-        disableWindowBlurListener: true,
+        disableWindowBlurListener:
+          mockNotificationUndoable.disableWindowBlurListener,
       },
     );
   });

--- a/packages/mui/src/providers/notificationProvider/index.tsx
+++ b/packages/mui/src/providers/notificationProvider/index.tsx
@@ -21,6 +21,9 @@ export const useNotificationProvider = (): NotificationProvider => {
       key,
       cancelMutation,
       description,
+      anchorOrigin,
+      preventDuplicate,
+      disableWindowBlurListener,
     }) => {
       if (type === "progress") {
         const action = (key: any) => (
@@ -43,14 +46,14 @@ export const useNotificationProvider = (): NotificationProvider => {
           </>,
           {
             action,
-            anchorOrigin: {
+            key,
+            autoHideDuration: (undoableTimeout ?? 0) * 1000,
+            anchorOrigin: anchorOrigin ?? {
               vertical: "top",
               horizontal: "right",
             },
-            preventDuplicate: true,
-            key,
-            autoHideDuration: (undoableTimeout ?? 0) * 1000,
-            disableWindowBlurListener: true,
+            preventDuplicate,
+            disableWindowBlurListener,
           },
         );
       } else {
@@ -66,11 +69,12 @@ export const useNotificationProvider = (): NotificationProvider => {
           {
             key,
             variant: type,
-            anchorOrigin: {
+            anchorOrigin: anchorOrigin ?? {
               vertical: "top",
               horizontal: "right",
             },
-            disableWindowBlurListener: true,
+            preventDuplicate,
+            disableWindowBlurListener,
           },
         );
       }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
Anchor position,preventDuplicate,disableWindowBlurListener are hard coded in mui useNotificationsProvider

## What is the new behavior?
these values can now be provided as per usage

fixes #5847 

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
