### PR TITLE
feat(devtools): devtools improvements

### DIFF
--- a/.changeset/clean-dryers-grow.md
+++ b/.changeset/clean-dryers-grow.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+refactor: add resource name to devtools xray calls
+
+Added the resource name to the devtools xray calls to allow resource names to be displayed in the devtools even with custom query keys.

--- a/.changeset/clean-elephants-matter.md
+++ b/.changeset/clean-elephants-matter.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/devtools-server": patch
+---
+
+chore: move `@refinedev/devtools-ui` dependency
+
+Moved `@refinedev/devtools-ui` dependency to `devDependencies` since only the `vite` output is used in the server.

--- a/.changeset/cyan-wolves-cry.md
+++ b/.changeset/cyan-wolves-cry.md
@@ -1,0 +1,10 @@
+---
+"@refinedev/devtools-internal": patch
+"@refinedev/devtools-server": patch
+"@refinedev/devtools-shared": patch
+"@refinedev/devtools-ui": patch
+---
+
+feat: update resource name accessing logic
+
+Updated resource name displaying logic to use `resourceName` from activity records to make sure `resource` is correctly displayed with custom query keys.

--- a/.changeset/flat-suns-push.md
+++ b/.changeset/flat-suns-push.md
@@ -1,0 +1,10 @@
+---
+"@refinedev/devtools-internal": patch
+"@refinedev/devtools-server": patch
+"@refinedev/devtools-shared": patch
+"@refinedev/devtools-ui": patch
+---
+
+feat: add invalidate query button
+
+Added `Invalidate Query` button to settled queries in the devtools panel to allow users to manually invalidate queries for debugging purposes.

--- a/.changeset/forty-pianos-beam.md
+++ b/.changeset/forty-pianos-beam.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/devtools-ui": patch
+---
+
+refactor: replace `react-json-view` with `react-json-view-lite`
+
+Replaced outdated `react-json-view` package with `react-json-view-lite` for both performance and dependency resolution reasons.

--- a/.changeset/shiny-colts-nail.md
+++ b/.changeset/shiny-colts-nail.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+fix: exclude internal button hook calls from devtools trace
+
+Removed internal button hook calls from devtools trace to avoid crowding the trace with unnecessary information.

--- a/packages/core/src/hooks/accessControl/useCan/index.ts
+++ b/packages/core/src/hooks/accessControl/useCan/index.ts
@@ -75,7 +75,10 @@ export const useCan = ({
     ...mergedQueryOptions,
     meta: {
       ...mergedQueryOptions?.meta,
-      ...getXRay("useCan", preferLegacyKeys),
+      ...getXRay("useCan", preferLegacyKeys, resource, [
+        "useButtonCanAccess",
+        "useNavigationButton",
+      ]),
     },
     retry: false,
   });

--- a/packages/core/src/hooks/auditLog/useLogList/index.ts
+++ b/packages/core/src/hooks/auditLog/useLogList/index.ts
@@ -66,7 +66,7 @@ export const useLogList = <
     retry: false,
     meta: {
       ...queryOptions?.meta,
-      ...getXRay("useLogList", preferLegacyKeys),
+      ...getXRay("useLogList", preferLegacyKeys, resource),
     },
   });
 

--- a/packages/core/src/hooks/data/useInfiniteList.ts
+++ b/packages/core/src/hooks/data/useInfiniteList.ts
@@ -323,7 +323,7 @@ export const useInfiniteList = <
     },
     meta: {
       ...queryOptions?.meta,
-      ...getXRay("useInfiniteList", preferLegacyKeys),
+      ...getXRay("useInfiniteList", preferLegacyKeys, resource?.name),
     },
   });
 

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -330,7 +330,7 @@ export const useList = <
     },
     meta: {
       ...queryOptions?.meta,
-      ...getXRay("useList", preferLegacyKeys),
+      ...getXRay("useList", preferLegacyKeys, resource?.name),
     },
   });
 

--- a/packages/core/src/hooks/data/useMany.ts
+++ b/packages/core/src/hooks/data/useMany.ts
@@ -248,7 +248,7 @@ export const useMany = <
     },
     meta: {
       ...queryOptions?.meta,
-      ...getXRay("useMany", preferLegacyKeys),
+      ...getXRay("useMany", preferLegacyKeys, resource?.name),
     },
   });
 

--- a/packages/core/src/hooks/data/useOne.ts
+++ b/packages/core/src/hooks/data/useOne.ts
@@ -246,7 +246,7 @@ export const useOne = <
     },
     meta: {
       ...queryOptions?.meta,
-      ...getXRay("useOne", preferLegacyKeys),
+      ...getXRay("useOne", preferLegacyKeys, resource?.name),
     },
   });
 

--- a/packages/devtools-internal/src/get-trace.ts
+++ b/packages/devtools-internal/src/get-trace.ts
@@ -4,7 +4,7 @@ import { isRefineStack } from "./is-refine-stack";
 import { getPackageNameFromFilename } from "./get-package-name-from-filename";
 import { TraceType } from "@refinedev/devtools-shared";
 
-export function getTrace() {
+export function getTrace(excludeFromTrace?: string[]) {
   if (__DEV_CONDITION__ !== "development") {
     return [];
   }
@@ -24,7 +24,8 @@ export function getTrace() {
             packageName: getPackageNameFromFilename(frame.fileName),
           }) as TraceType,
       )
-      .filter((trace) => trace.function);
+      .filter((trace) => trace.function)
+      .filter((trace) => !excludeFromTrace?.includes(trace.function ?? ""));
     return traces.slice(1);
   } catch (error) {
     return [];

--- a/packages/devtools-internal/src/get-xray.ts
+++ b/packages/devtools-internal/src/get-xray.ts
@@ -7,9 +7,14 @@ export type XRayResponse = {
   trace: TraceType[];
   resourcePath: string | null;
   legacyKey: boolean;
+  resourceName?: string;
 };
 
-export function getXRay(hookName: string, legacyKey: boolean): XRayResponse {
+export function getXRay(
+  hookName: string,
+  legacyKey: boolean,
+  resourceName?: string,
+): XRayResponse {
   if (__DEV_CONDITION__ !== "development") {
     return {
       hookName: "",
@@ -27,5 +32,6 @@ export function getXRay(hookName: string, legacyKey: boolean): XRayResponse {
     trace,
     resourcePath,
     legacyKey,
+    resourceName,
   };
 }

--- a/packages/devtools-internal/src/get-xray.ts
+++ b/packages/devtools-internal/src/get-xray.ts
@@ -14,6 +14,7 @@ export function getXRay(
   hookName: string,
   legacyKey: boolean,
   resourceName?: string,
+  excludeFromTrace?: string[],
 ): XRayResponse {
   if (__DEV_CONDITION__ !== "development") {
     return {
@@ -23,7 +24,7 @@ export function getXRay(
       legacyKey: false,
     };
   }
-  const trace = getTrace().slice(1);
+  const trace = getTrace(excludeFromTrace).slice(1);
 
   const resourcePath = getResourcePath(hookName as RefineHook, legacyKey);
 

--- a/packages/devtools-internal/src/listeners.ts
+++ b/packages/devtools-internal/src/listeners.ts
@@ -25,16 +25,6 @@ export const createMutationListener =
       });
       resolve();
     });
-
-    // console.table({
-    //     type: "mutation",
-    //     key: mutation?.options.mutationKey,
-    //     id: mutation?.mutationId,
-    //     status: mutation?.state.status,
-    //     trace: mutation?.meta?.trace,
-    //     state: mutation?.state,
-    //     variables: mutation?.state?.variables,
-    // });
   };
 
 export const createQueryListener = (ws: WebSocket) => (query: Query) => {
@@ -53,12 +43,4 @@ export const createQueryListener = (ws: WebSocket) => (query: Query) => {
     });
     resolve();
   });
-
-  // console.table({
-  //     type: "query",
-  //     key: query.queryKey,
-  //     status: query.state.status,
-  //     trace: query.meta?.trace,
-  //     state: query.state,
-  // });
 };

--- a/packages/devtools-internal/src/use-query-subscription.tsx
+++ b/packages/devtools-internal/src/use-query-subscription.tsx
@@ -1,4 +1,8 @@
-import { DevToolsContext } from "@refinedev/devtools-shared";
+import {
+  DevToolsContext,
+  DevtoolsEvent,
+  receive,
+} from "@refinedev/devtools-shared";
 import { QueryClient } from "@tanstack/react-query";
 import React, { useContext } from "react";
 import { createQueryListener, createMutationListener } from "./listeners";
@@ -48,6 +52,22 @@ export const useQuerySubscription =
           return () => {
             mutationCacheSubscription.current?.();
           };
+        }, [ws, queryClient]);
+
+        React.useEffect(() => {
+          if (!ws) return () => 0;
+
+          const cb = receive(
+            ws,
+            DevtoolsEvent.DEVTOOLS_INVALIDATE_QUERY_ACTION,
+            ({ queryKey }) => {
+              if (queryKey) {
+                queryClient.invalidateQueries(queryKey);
+              }
+            },
+          );
+
+          return cb;
         }, [ws, queryClient]);
 
         return {};

--- a/packages/devtools-server/package.json
+++ b/packages/devtools-server/package.json
@@ -37,17 +37,16 @@
     "build": "npm run build:client && tsup",
     "build:client": "NODE_ENV=production tsc && vite build --config src/client/vite.config.ts",
     "dev": "npm run dev:client & tsup --watch",
-    "dev:client": "vite build --watch --force --config src/client/vite.config.ts",
+    "dev:client": "vite build --watch --config src/client/vite.config.ts",
     "prepare": "npm run build",
     "publint": "publint --strict=true --level=suggestion",
-    "start:server": "node dist/cli.js",
+    "start:server": "node dist/cli.cjs",
     "test": "jest --passWithNoTests --runInBand",
     "types": "node ../shared/generate-declarations.js"
   },
   "dependencies": {
     "@ory/client": "^1.5.2",
     "@refinedev/devtools-shared": "1.1.5",
-    "@refinedev/devtools-ui": "1.1.20",
     "body-parser": "^1.20.2",
     "boxen": "^5.1.2",
     "chalk": "^4.1.2",
@@ -72,6 +71,7 @@
   },
   "devDependencies": {
     "@esbuild-plugins/node-resolve": "^0.1.4",
+    "@refinedev/devtools-ui": "1.1.20",
     "@testing-library/jest-dom": "^5.16.4",
     "@types/dedent": "^0.7.0",
     "@types/fs-extra": "^9.0.13",

--- a/packages/devtools-server/src/index.ts
+++ b/packages/devtools-server/src/index.ts
@@ -83,6 +83,18 @@ export const server = async ({ projectPath = process.cwd() }: Options = {}) => {
       },
     );
 
+    receive(
+      client as any,
+      DevtoolsEvent.DEVTOOLS_INVALIDATE_QUERY,
+      ({ queryKey }) => {
+        ws.clients.forEach((c) => {
+          send(c as any, DevtoolsEvent.DEVTOOLS_INVALIDATE_QUERY_ACTION, {
+            queryKey,
+          });
+        });
+      },
+    );
+
     receive(client as any, DevtoolsEvent.DEVTOOLS_LOGIN_SUCCESS, () => {
       ws.clients.forEach((c) => {
         send(c as any, DevtoolsEvent.DEVTOOLS_RELOAD_AFTER_LOGIN, {});

--- a/packages/devtools-server/tsconfig.declarations.json
+++ b/packages/devtools-server/tsconfig.declarations.json
@@ -8,7 +8,8 @@
     "**/*.spec.ts",
     "**/*.test.ts",
     "**/*.spec.tsx",
-    "**/*.test.tsx"
+    "**/*.test.tsx",
+    "src/client/**/*",
   ],
   "compilerOptions": {
     "outDir": "dist",

--- a/packages/devtools-server/tsconfig.declarations.json
+++ b/packages/devtools-server/tsconfig.declarations.json
@@ -9,7 +9,7 @@
     "**/*.test.ts",
     "**/*.spec.tsx",
     "**/*.test.tsx",
-    "src/client/**/*",
+    "src/client/**/*"
   ],
   "compilerOptions": {
     "outDir": "dist",

--- a/packages/devtools-server/tsconfig.json
+++ b/packages/devtools-server/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "include": ["src", "types"],
+  "exclude": [
+    "src/client/**/*",
+  ],
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "types": ["node", "jest", "@testing-library/jest-dom"],

--- a/packages/devtools-shared/src/event-types.ts
+++ b/packages/devtools-shared/src/event-types.ts
@@ -21,6 +21,8 @@ export enum DevtoolsEvent {
   DEVTOOLS_HIGHLIGHT_IN_MONITOR_ACTION = "devtools:highlight-in-monitor-action",
   DEVTOOLS_LOGIN_SUCCESS = "devtools:login-success",
   DEVTOOLS_RELOAD_AFTER_LOGIN = "devtools:reload-after-login",
+  DEVTOOLS_INVALIDATE_QUERY = "devtools:invalidate-query",
+  DEVTOOLS_INVALIDATE_QUERY_ACTION = "devtools:invalidate-query-action",
 }
 
 type Timestamps = {
@@ -68,4 +70,6 @@ export type DevtoolsEventPayloads = {
   [DevtoolsEvent.DEVTOOLS_HIGHLIGHT_IN_MONITOR_ACTION]: { name: string };
   [DevtoolsEvent.DEVTOOLS_LOGIN_SUCCESS]: {};
   [DevtoolsEvent.DEVTOOLS_RELOAD_AFTER_LOGIN]: {};
+  [DevtoolsEvent.DEVTOOLS_INVALIDATE_QUERY]: { queryKey: QueryKey };
+  [DevtoolsEvent.DEVTOOLS_INVALIDATE_QUERY_ACTION]: { queryKey: QueryKey };
 };

--- a/packages/devtools-shared/src/event-types.ts
+++ b/packages/devtools-shared/src/event-types.ts
@@ -41,6 +41,7 @@ type ActivityPayload =
       variables?: Mutation<any, any, any, any>["state"]["variables"];
       hookName: string;
       resourcePath: string | null;
+      resourceName?: string;
       legacyKey: boolean;
     }
   | {
@@ -52,6 +53,7 @@ type ActivityPayload =
       state: QueryState<any, any>;
       hookName: string;
       resourcePath: string | null;
+      resourceName?: string;
       legacyKey: boolean;
     };
 

--- a/packages/devtools-ui/package.json
+++ b/packages/devtools-ui/package.json
@@ -54,7 +54,7 @@
     "lodash-es": "^4.17.21",
     "prism-react-renderer": "^1.3.5",
     "react-gravatar": "^2.6.3",
-    "react-json-view": "^1.21.3",
+    "react-json-view-lite": "^1.3.0",
     "react-router-dom": "^6.8.1",
     "semver-diff": "^3.1.1"
   },

--- a/packages/devtools-ui/src/components/invalidate-button.tsx
+++ b/packages/devtools-ui/src/components/invalidate-button.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import type { Activity } from "../interfaces/activity";
+import { UpdateIcon } from "./icons/update";
+import clsx from "clsx";
+import {
+  DevToolsContext,
+  DevtoolsEvent,
+  send,
+} from "@refinedev/devtools-shared";
+
+export const InvalidateButton = ({ activity }: { activity: Activity }) => {
+  const { ws } = React.useContext(DevToolsContext);
+
+  if (activity.type !== "query") return null;
+
+  if (activity.status === "success" || activity.status === "error") {
+    const isFetching = activity.state.fetchStatus === "fetching";
+
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => {
+            if (!ws || !activity.key) return;
+            send(ws, DevtoolsEvent.DEVTOOLS_INVALIDATE_QUERY, {
+              queryKey: activity.key,
+            });
+          }}
+          className={clsx(
+            "re-ml-2",
+            "re-rounded-xl",
+            "re-py-0.5",
+            "re-pl-1",
+            "re-pr-1.5",
+            "re-text-[10px]",
+            "re-text-alt-blue",
+            "re-bg-alt-blue",
+            "re-bg-opacity-20",
+            "re-border",
+            "re-border-alt-blue",
+            "re-flex",
+            "re-items-center",
+            "re-gap-1",
+            "re-font-normal",
+            "hover:re-bg-opacity-30",
+            "active:re-bg-opacity-40",
+          )}
+        >
+          <UpdateIcon
+            className={clsx(
+              isFetching && "re-animate-spin",
+              "re-w-3",
+              "re-h-3",
+            )}
+          />
+          Invalidate Query
+        </button>
+      </>
+    );
+  }
+
+  return null;
+};

--- a/packages/devtools-ui/src/components/json-viewer.tsx
+++ b/packages/devtools-ui/src/components/json-viewer.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import React from "react";
-import ReactJson from "react-json-view";
+import { JsonView, darkStyles } from "react-json-view-lite";
 import { MaximizeIcon } from "./icons/maximize";
 import { Modal } from "./modal";
 
@@ -9,24 +9,61 @@ export const JsonViewer = ({ data, label }: { data: any; label: string }) => {
 
   return (
     <div className={clsx("re-relative")}>
-      <ReactJson
-        src={data}
-        enableClipboard={false}
-        displayDataTypes={false}
-        theme="flat"
+      <JsonView
+        data={data}
+        shouldExpandNode={(l) => l < 2}
         style={{
-          backgroundColor: "#303450",
-          padding: "8px",
-          borderRadius: "8px",
-          overflow: "auto",
-          maxHeight: "160px",
+          ...darkStyles,
+          container: clsx(
+            "re-bg-[#303450]",
+            "re-font-mono re-text-xs",
+            "[&>*:first-child]:!re-px-[12px]",
+            "re-py-1",
+            "re-overflow-auto",
+            "re-max-h-[160px]",
+            "re-rounded-lg",
+          ),
+          basicChildStyle: clsx(
+            "re-py-[3px]",
+            "re-pr-[5px]",
+            "re-pl-[20px]",
+            "re-leading-5",
+          ),
+          collapsedContent: clsx(
+            "re-text-amber-500",
+            "after:re-content-['...']",
+            "after:re-pr-[5px]",
+          ),
+          label: clsx("re-mr-[8px]", "re-text-neutral-200"),
+          stringValue: clsx("re-text-amber-500"),
+          numberValue: clsx("re-text-amber-500"),
+          undefinedValue: clsx("re-text-neutral-500"),
+          nullValue: clsx("re-text-neutral-500"),
+          expandIcon: clsx(
+            "after:re-transition-transform",
+            "after:re-duration-200",
+            "after:re-ease-in-out",
+            "after:re-content-['⏵']",
+            "after:re-mr-[8px]",
+            "after:re-inline-block",
+          ),
+          collapseIcon: clsx(
+            "after:re-transition-transform",
+            "after:re-duration-200",
+            "after:re-ease-in-out",
+            "after:re-content-['⏵']",
+            "after:re-mr-[8px]",
+            "after:re-inline-block",
+            "after:re-rotate-90",
+          ),
         }}
-        collapsed={2}
-        name={false}
       />
       <button
         type="button"
-        onClick={() => setModalVisible(true)}
+        onClick={(event) => {
+          event.preventDefault();
+          setModalVisible(true);
+        }}
         className={clsx(
           "re-group",
           "re-absolute",
@@ -69,21 +106,55 @@ export const JsonViewer = ({ data, label }: { data: any; label: string }) => {
         }
       >
         <div className={clsx("re-p-2")}>
-          <ReactJson
-            src={data}
-            enableClipboard={false}
-            displayDataTypes={false}
-            theme="flat"
+          <JsonView
+            data={data}
+            shouldExpandNode={(l) => l < 2}
             style={{
-              backgroundColor: "#303450",
-              padding: "8px",
-              borderRadius: "8px",
-              overflow: "auto",
-              maxHeight: "calc(100vh - 96px - 65px - 16px - 2px)",
-              minHeight: "calc(100vh - 96px - 65px - 16px - 2px)",
+              ...darkStyles,
+              container: clsx(
+                "re-bg-[#303450]",
+                "re-font-mono re-text-xs",
+                "[&>*:first-child]:!re-px-[12px]",
+                "re-py-1",
+                "re-overflow-auto",
+                "re-max-h-[calc(100vh-96px-65px-16px-2px)]",
+                "re-min-h-[calc(100vh-96px-65px-16px-2px)]",
+                "re-rounded-lg",
+              ),
+              basicChildStyle: clsx(
+                "re-py-[3px]",
+                "re-pr-[5px]",
+                "re-pl-[20px]",
+                "re-leading-5",
+              ),
+              collapsedContent: clsx(
+                "re-text-amber-500",
+                "after:re-content-['...']",
+                "after:re-pr-[5px]",
+              ),
+              label: clsx("re-mr-[8px]", "re-text-neutral-200"),
+              stringValue: clsx("re-text-amber-500"),
+              numberValue: clsx("re-text-amber-500"),
+              undefinedValue: clsx("re-text-neutral-500"),
+              nullValue: clsx("re-text-neutral-500"),
+              expandIcon: clsx(
+                "after:re-transition-transform",
+                "after:re-duration-200",
+                "after:re-ease-in-out",
+                "after:re-content-['⏵']",
+                "after:re-mr-[8px]",
+                "after:re-inline-block",
+              ),
+              collapseIcon: clsx(
+                "after:re-transition-transform",
+                "after:re-duration-200",
+                "after:re-ease-in-out",
+                "after:re-content-['⏵']",
+                "after:re-mr-[8px]",
+                "after:re-inline-block",
+                "after:re-rotate-90",
+              ),
             }}
-            collapsed={2}
-            name={false}
           />
         </div>
       </Modal>

--- a/packages/devtools-ui/src/components/monitor-details.tsx
+++ b/packages/devtools-ui/src/components/monitor-details.tsx
@@ -8,12 +8,19 @@ import dayjs from "dayjs";
 import { Owners } from "./owners";
 import { JsonViewer } from "./json-viewer";
 import { excludeKeys } from "src/utils/exclude-keys";
+import { InvalidateButton } from "./invalidate-button";
 import { getResourceValue } from "src/utils/get-resource-value";
 import { ResourceValue } from "./resource-value";
-import { RefineHook, scopes } from "@refinedev/devtools-shared";
+import {
+  DevToolsContext,
+  RefineHook,
+  scopes,
+} from "@refinedev/devtools-shared";
 import { getOwners } from "src/utils/get-owners";
 
 export const MonitorDetails = ({ activity }: { activity?: Activity }) => {
+  const { ws } = React.useContext(DevToolsContext);
+
   return (
     <div className={clsx("re-h-full", "re-text-gray-300", "re-relative")}>
       <div
@@ -327,9 +334,13 @@ export const MonitorDetails = ({ activity }: { activity?: Activity }) => {
                       "re-text-xs",
                       "re-font-semibold",
                       "re-text-gray-300",
+                      "re-flex",
+                      "re-items-center",
+                      "re-justify-between",
                     )}
                   >
-                    Data
+                    <span>Data</span>
+                    <InvalidateButton activity={activity} />
                   </div>
                   <JsonViewer data={activity.state.data ?? {}} label="Data" />
                 </div>
@@ -351,9 +362,13 @@ export const MonitorDetails = ({ activity }: { activity?: Activity }) => {
                       "re-text-xs",
                       "re-font-semibold",
                       "re-text-gray-300",
+                      "re-flex",
+                      "re-items-center",
+                      "re-justify-between",
                     )}
                   >
                     Error
+                    <InvalidateButton activity={activity} />
                   </div>
                   <JsonViewer data={activity.state.error ?? {}} label="Error" />
                 </div>

--- a/packages/devtools-ui/src/style.css
+++ b/packages/devtools-ui/src/style.css
@@ -79,3 +79,157 @@ body,
 *::-webkit-scrollbar {
     display: none;
 }
+
+/* json view */
+
+/* base styles */
+
+._GzYRV {
+    line-height: 1.2;
+    white-space: pre-wrap;
+    white-space: -moz-pre-wrap;
+    white-space: -pre-wrap;
+    white-space: -o-pre-wrap;
+    word-wrap: break-word;
+  }
+  
+  ._3eOF8 {
+    margin-right: 5px;
+    font-weight: bold;
+  }
+  
+  ._1MFti {
+    cursor: pointer;
+  }
+  
+  ._f10Tu {
+    font-size: 1.2em;
+    margin-right: 5px;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+            user-select: none;
+  }
+  
+  ._1UmXx::after {
+    content: '\25B8';
+  }
+  
+  ._1LId0::after {
+    content: '\25BE';
+  }
+  
+  ._1pNG9 {
+    margin-right: 5px;
+  }
+  
+  ._1pNG9::after {
+    content: '...';
+    font-size: 0.8em;
+  }
+  
+  ._2IvMF {
+    background: #eee;
+  }
+  
+  ._2bkNM {
+    margin: 0 10px;
+    padding: 0;
+  }
+  
+  /* default light style */
+  ._1MGIk {
+    font-weight: 600;
+    margin-right: 5px;
+    color: #000000;
+  }
+  
+  ._3uHL6 {
+    color: #000000;
+  }
+  
+  ._2T6PJ {
+    color: #df113a;
+  }
+  
+  ._1Gho6 {
+    color: #df113a;
+  }
+  
+  ._vGjyY {
+    color: rgb(42, 63, 60);
+  }
+  
+  ._1bQdo {
+    color: #0b75f5;
+  }
+  
+  ._3zQKs {
+    color: rgb(70, 144, 56);
+  }
+  
+  ._1xvuR {
+    color: #43413d;
+  }
+  
+  ._oLqym {
+    color: #000000;
+  }
+  
+  ._2AXVT {
+    color: #000000;
+  }
+  
+  ._2KJWg {
+    color: #000000;
+  }
+  
+  /* default dark style */
+  ._11RoI {
+    background: rgb(0, 43, 54);
+  }
+  
+  ._17H2C {
+    color: rgb(253, 246, 227);
+  }
+  
+  ._3QHg2 {
+    color: rgb(253, 246, 227);
+  }
+  
+  ._3fDAz {
+    color: rgb(253, 246, 227);
+  }
+  
+  ._2bSDX {
+    /* font-weight: bolder; */
+    margin-right: 5px;
+    color: rgb(253, 246, 227);
+  }
+  
+  ._gsbQL {
+    color: rgb(253, 246, 227);
+  }
+  
+  ._LaAZe {
+    color: rgb(129, 181, 172);
+  }
+  
+  ._GTKgm {
+    color: rgb(129, 181, 172);
+  }
+  
+  ._Chy1W {
+    color: rgb(203, 75, 22);
+  }
+  
+  ._2bveF {
+    color: rgb(211, 54, 130);
+  }
+  
+  ._2vRm- {
+    color: rgb(174, 129, 255);
+  }
+  
+  ._1prJR {
+    color: rgb(38, 139, 210);
+  }

--- a/packages/devtools-ui/src/utils/get-resource-value.ts
+++ b/packages/devtools-ui/src/utils/get-resource-value.ts
@@ -15,7 +15,7 @@ export const getResourceValue = (activity: Activity): string => {
     }
   }
 
-  if (resource) {
+  if (resource && typeof resource === "string") {
     resource = resource.charAt(0).toUpperCase() + resource.slice(1);
   }
 

--- a/packages/devtools-ui/src/utils/get-resource-value.ts
+++ b/packages/devtools-ui/src/utils/get-resource-value.ts
@@ -5,10 +5,14 @@ export const getResourceValue = (activity: Activity): string => {
   const { resourcePath } = activity;
   let resource: string | null = null;
 
-  if (resourcePath) {
-    resource = get(activity, resourcePath) ?? "-";
+  if (activity?.resourceName) {
+    resource = activity.resourceName;
   } else {
-    resource = "-";
+    if (resourcePath) {
+      resource = get(activity, resourcePath) ?? "-";
+    } else {
+      resource = "-";
+    }
   }
 
   if (resource) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

-  `@refinedev/devtools-ui` `@refinedev/devtools-shared` `@refinedev/devtools-internal` `@refinedev/core`
Added the resource name to the devtools xray calls to allow resource names to be displayed in the devtools even with custom query keys.
- `@refinedev/devtools-server`
Moved `@refinedev/devtools-ui` dependency to `devDependencies` since only the `vite` output is used in the server.
- `@refinedev/devtools-ui` `@refinedev/devtools-shared` `@refinedev/devtools-internal` `@refinedev/core`
Updated resource name displaying logic to use `resourceName` from activity records to make sure `resource` is correctly displayed with custom query keys.
- `@refinedev/devtools-internal` `@refinedev/devtools-shared` `@refinedev/devtools-server` @refinedev/devtools-ui`
Added `Invalidate Query` button to settled queries in the devtools panel to allow users to manually invalidate queries for debugging purposes.
- `@refinedev/devtools-ui`
Replaced outdated `react-json-view` package with `react-json-view-lite` for both performance and dependency resolution reasons.
- `@refinedev/core`
Removed internal button hook calls from devtools trace to avoid crowding the trace with unnecessary information.

![image](https://github.com/refinedev/refine/assets/11361964/ecbcd677-8d80-44d4-9fa3-0e72a47887d2)


