### PR TITLE
feat(mui): configurable `anchorOrigin` for `useNotificationProvider`

### DIFF
--- a/.changeset/few-terms-fetch.md
+++ b/.changeset/few-terms-fetch.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/mui": patch
+---
+
+feat: add ability to customize anchor origin from snackbar provider
+
+Previously, `useNotificationProvider` used hardcoded `anchorOrigin` and `disableWindowBlurListener` values, preventing users to customize these values. This change moves these values to `<RefineSnackbarProvider />` as default props to allow users to customize them when needed.
+
+Resolves [#5847](https://github.com/refinedev/refine/issues/5847)

--- a/packages/core/src/contexts/notification/types.ts
+++ b/packages/core/src/contexts/notification/types.ts
@@ -37,6 +37,12 @@ export type OpenNotificationParams = {
   description?: string;
   cancelMutation?: () => void;
   undoableTimeout?: number;
+  anchorOrigin?: {
+    vertical: "top" | "bottom";
+    horizontal: "left" | "center" | "right";
+  };
+  preventDuplicate?: boolean;
+  disableWindowBlurListener?: boolean;
 };
 
 export interface INotificationContext {

--- a/packages/core/src/contexts/notification/types.ts
+++ b/packages/core/src/contexts/notification/types.ts
@@ -37,12 +37,6 @@ export type OpenNotificationParams = {
   description?: string;
   cancelMutation?: () => void;
   undoableTimeout?: number;
-  anchorOrigin?: {
-    vertical: "top" | "bottom";
-    horizontal: "left" | "center" | "right";
-  };
-  preventDuplicate?: boolean;
-  disableWindowBlurListener?: boolean;
 };
 
 export interface INotificationContext {

--- a/packages/mui/src/providers/notificationProvider/index.spec.tsx
+++ b/packages/mui/src/providers/notificationProvider/index.spec.tsx
@@ -16,6 +16,12 @@ const mockNotification: OpenNotificationParams = {
   message: "Test Notification Message",
   type: "success",
   description: "Test Notification Description",
+  anchorOrigin: {
+    vertical: "top",
+    horizontal: "right",
+  },
+  disableWindowBlurListener: true,
+  preventDuplicate: true,
 };
 
 const mockNotificationUndoable: OpenNotificationParams = {
@@ -65,11 +71,12 @@ describe("Notistack notificationProvider", () => {
       {
         key: mockNotification.key,
         variant: "success",
-        anchorOrigin: {
+        anchorOrigin: mockNotification.anchorOrigin ?? {
           vertical: "top",
           horizontal: "right",
         },
-        disableWindowBlurListener: true,
+        disableWindowBlurListener: mockNotification.disableWindowBlurListener,
+        preventDuplicate: mockNotification.preventDuplicate,
       },
     );
   });
@@ -90,11 +97,12 @@ describe("Notistack notificationProvider", () => {
       {
         key: mockNotification.key,
         variant: "error",
-        anchorOrigin: {
+        anchorOrigin: mockNotification.anchorOrigin ?? {
           vertical: "top",
           horizontal: "right",
         },
-        disableWindowBlurListener: true,
+        disableWindowBlurListener: mockNotification.disableWindowBlurListener,
+        preventDuplicate: mockNotification.preventDuplicate,
       },
     );
   });
@@ -114,14 +122,15 @@ describe("Notistack notificationProvider", () => {
       </>,
       {
         action: expect.any(Function),
-        anchorOrigin: {
+        anchorOrigin: mockNotificationUndoable.anchorOrigin ?? {
           vertical: "top",
           horizontal: "right",
         },
-        preventDuplicate: true,
+        preventDuplicate: mockNotificationUndoable.preventDuplicate,
         key: "test-notification-undoable",
         autoHideDuration: 5000,
-        disableWindowBlurListener: true,
+        disableWindowBlurListener:
+          mockNotificationUndoable.disableWindowBlurListener,
       },
     );
   });

--- a/packages/mui/src/providers/notificationProvider/index.spec.tsx
+++ b/packages/mui/src/providers/notificationProvider/index.spec.tsx
@@ -104,6 +104,7 @@ describe("Notistack notificationProvider", () => {
       </>,
       {
         action: expect.any(Function),
+        preventDuplicate: true,
         key: "test-notification-undoable",
         autoHideDuration: 5000,
       },

--- a/packages/mui/src/providers/notificationProvider/index.spec.tsx
+++ b/packages/mui/src/providers/notificationProvider/index.spec.tsx
@@ -16,12 +16,6 @@ const mockNotification: OpenNotificationParams = {
   message: "Test Notification Message",
   type: "success",
   description: "Test Notification Description",
-  anchorOrigin: {
-    vertical: "top",
-    horizontal: "right",
-  },
-  disableWindowBlurListener: true,
-  preventDuplicate: true,
 };
 
 const mockNotificationUndoable: OpenNotificationParams = {
@@ -71,12 +65,6 @@ describe("Notistack notificationProvider", () => {
       {
         key: mockNotification.key,
         variant: "success",
-        anchorOrigin: mockNotification.anchorOrigin ?? {
-          vertical: "top",
-          horizontal: "right",
-        },
-        disableWindowBlurListener: mockNotification.disableWindowBlurListener,
-        preventDuplicate: mockNotification.preventDuplicate,
       },
     );
   });
@@ -97,12 +85,6 @@ describe("Notistack notificationProvider", () => {
       {
         key: mockNotification.key,
         variant: "error",
-        anchorOrigin: mockNotification.anchorOrigin ?? {
-          vertical: "top",
-          horizontal: "right",
-        },
-        disableWindowBlurListener: mockNotification.disableWindowBlurListener,
-        preventDuplicate: mockNotification.preventDuplicate,
       },
     );
   });
@@ -122,15 +104,8 @@ describe("Notistack notificationProvider", () => {
       </>,
       {
         action: expect.any(Function),
-        anchorOrigin: mockNotificationUndoable.anchorOrigin ?? {
-          vertical: "top",
-          horizontal: "right",
-        },
-        preventDuplicate: mockNotificationUndoable.preventDuplicate,
         key: "test-notification-undoable",
         autoHideDuration: 5000,
-        disableWindowBlurListener:
-          mockNotificationUndoable.disableWindowBlurListener,
       },
     );
   });

--- a/packages/mui/src/providers/notificationProvider/index.tsx
+++ b/packages/mui/src/providers/notificationProvider/index.tsx
@@ -21,6 +21,9 @@ export const useNotificationProvider = (): NotificationProvider => {
       key,
       cancelMutation,
       description,
+      anchorOrigin,
+      preventDuplicate,
+      disableWindowBlurListener,
     }) => {
       if (type === "progress") {
         const action = (key: any) => (
@@ -43,14 +46,14 @@ export const useNotificationProvider = (): NotificationProvider => {
           </>,
           {
             action,
-            anchorOrigin: {
+            key,
+            autoHideDuration: (undoableTimeout ?? 0) * 1000,
+            anchorOrigin: anchorOrigin ?? {
               vertical: "top",
               horizontal: "right",
             },
-            preventDuplicate: true,
-            key,
-            autoHideDuration: (undoableTimeout ?? 0) * 1000,
-            disableWindowBlurListener: true,
+            preventDuplicate,
+            disableWindowBlurListener,
           },
         );
       } else {
@@ -66,11 +69,12 @@ export const useNotificationProvider = (): NotificationProvider => {
           {
             key,
             variant: type,
-            anchorOrigin: {
+            anchorOrigin: anchorOrigin ?? {
               vertical: "top",
               horizontal: "right",
             },
-            disableWindowBlurListener: true,
+            preventDuplicate,
+            disableWindowBlurListener,
           },
         );
       }

--- a/packages/mui/src/providers/notificationProvider/index.tsx
+++ b/packages/mui/src/providers/notificationProvider/index.tsx
@@ -43,6 +43,7 @@ export const useNotificationProvider = (): NotificationProvider => {
           </>,
           {
             action,
+            preventDuplicate: true,
             key,
             autoHideDuration: (undoableTimeout ?? 0) * 1000,
           },

--- a/packages/mui/src/providers/notificationProvider/index.tsx
+++ b/packages/mui/src/providers/notificationProvider/index.tsx
@@ -21,9 +21,6 @@ export const useNotificationProvider = (): NotificationProvider => {
       key,
       cancelMutation,
       description,
-      anchorOrigin,
-      preventDuplicate,
-      disableWindowBlurListener,
     }) => {
       if (type === "progress") {
         const action = (key: any) => (
@@ -48,12 +45,6 @@ export const useNotificationProvider = (): NotificationProvider => {
             action,
             key,
             autoHideDuration: (undoableTimeout ?? 0) * 1000,
-            anchorOrigin: anchorOrigin ?? {
-              vertical: "top",
-              horizontal: "right",
-            },
-            preventDuplicate,
-            disableWindowBlurListener,
           },
         );
       } else {
@@ -69,12 +60,6 @@ export const useNotificationProvider = (): NotificationProvider => {
           {
             key,
             variant: type,
-            anchorOrigin: anchorOrigin ?? {
-              vertical: "top",
-              horizontal: "right",
-            },
-            preventDuplicate,
-            disableWindowBlurListener,
           },
         );
       }

--- a/packages/mui/src/providers/refineSnackbarProvider/index.tsx
+++ b/packages/mui/src/providers/refineSnackbarProvider/index.tsx
@@ -1,25 +1,43 @@
+import React from "react";
 import { styled } from "@mui/material/styles";
 import { SnackbarProvider } from "notistack";
 
-export const RefineSnackbarProvider = styled(SnackbarProvider)`
-    &.SnackbarItem-contentRoot {
-        background-color: ${(props) => props.theme.palette.background.default};
-        color: ${(props) => props.theme.palette.primary.main};
-    }
-    &.SnackbarItem-variantSuccess {
-        background-color: ${(props) => props.theme.palette.success.main};
-        color: ${(props) => props.theme.palette.success.contrastText};
-    }
-    &.SnackbarItem-variantError {
-        background-color: ${(props) => props.theme.palette.error.main};
-        color: ${(props) => props.theme.palette.error.contrastText};
-    }
-    &.SnackbarItem-variantInfo {
-        background-color: ${(props) => props.theme.palette.info.main};
-        color: ${(props) => props.theme.palette.info.contrastText};
-    }
-    &.SnackbarItem-variantWarning {
-        background-color: ${(props) => props.theme.palette.warning.main};
-        color: ${(props) => props.theme.palette.warning.contrastText};
-    }
+const SnackbarProviderWithDefaultValues = ({
+  anchorOrigin = {
+    vertical: "top",
+    horizontal: "right",
+  },
+  disableWindowBlurListener = true,
+  ...rest
+}: React.ComponentProps<typeof SnackbarProvider>) => {
+  return (
+    <SnackbarProvider
+      anchorOrigin={anchorOrigin}
+      disableWindowBlurListener={disableWindowBlurListener}
+      {...rest}
+    />
+  );
+};
+
+export const RefineSnackbarProvider = styled(SnackbarProviderWithDefaultValues)`
+&.SnackbarItem-contentRoot {
+    background-color: ${(props) => props.theme.palette.background.default};
+    color: ${(props) => props.theme.palette.primary.main};
+}
+&.SnackbarItem-variantSuccess {
+    background-color: ${(props) => props.theme.palette.success.main};
+    color: ${(props) => props.theme.palette.success.contrastText};
+}
+&.SnackbarItem-variantError {
+    background-color: ${(props) => props.theme.palette.error.main};
+    color: ${(props) => props.theme.palette.error.contrastText};
+}
+&.SnackbarItem-variantInfo {
+    background-color: ${(props) => props.theme.palette.info.main};
+    color: ${(props) => props.theme.palette.info.contrastText};
+}
+&.SnackbarItem-variantWarning {
+    background-color: ${(props) => props.theme.palette.warning.main};
+    color: ${(props) => props.theme.palette.warning.contrastText};
+}
 `;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
Anchor position,preventDuplicate,disableWindowBlurListener are hard coded in mui useNotificationsProvider

## What is the new behavior?
these values can now be provided as per usage

fixes #5847 

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
