### PR TITLE
docs(tutorial): fixed browser view crash

### DIFF
--- a/documentation/tutorial/ui-libraries/crud-components/material-ui/react-router/sandpack.tsx
+++ b/documentation/tutorial/ui-libraries/crud-components/material-ui/react-router/sandpack.tsx
@@ -69,7 +69,7 @@ export const ListProducts = () => {
         flex: 0.5,
         type: "singleSelect",
         valueOptions: categories,
-        valueFormatter: (params) => params.value,
+        valueFormatter: (params) => params?.value,
         renderCell: function render({ row }) {
           if (isLoading) {
             return "Loading...";

--- a/documentation/tutorial/ui-libraries/refactoring/material-ui/react-router/sandpack.tsx
+++ b/documentation/tutorial/ui-libraries/refactoring/material-ui/react-router/sandpack.tsx
@@ -166,7 +166,7 @@ export const ListProducts = () => {
         flex: 0.5,
         type: "singleSelect",
         valueOptions: categories,
-        valueFormatter: (params) => params.value,
+        valueFormatter: (params) => params?.value,
         renderCell: function render({ row }) {
           if (isLoading) {
             return "Loading...";


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
The browser view crashes on tutorial section of  `crud components` and `notifications`

## What is the new behavior?
Browser view does not crash

fixes #5871 

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
