### PR TITLE
fix(core): add fallback mutation function for `useOnError`

### DIFF
--- a/.changeset/dull-spies-sparkle.md
+++ b/.changeset/dull-spies-sparkle.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+fix: development errors being logged when `useOnError` is called without an auth provider
+
+When there's no `authProvider` set, the `useOnError` hook will log `"no mutationFn found"` to the console in development because of missing `onError` property. This PR fixes the issue by providing a dummy `onError` function when `authProvider` is not set.

--- a/packages/core/src/hooks/auth/useOnError/index.ts
+++ b/packages/core/src/hooks/auth/useOnError/index.ts
@@ -76,24 +76,30 @@ export function useOnError({
     v3LegacyAuthProviderCompatible: Boolean(v3LegacyAuthProviderCompatible),
   });
 
-  const mutation = useMutation({
+  const mutation = useMutation<OnErrorResponse, unknown, unknown, unknown>({
     mutationKey: keys().auth().action("onError").get(preferLegacyKeys),
-    mutationFn: onErrorFromContext,
-    onSuccess: ({ logout: shouldLogout, redirectTo }) => {
-      if (shouldLogout) {
-        logout({ redirectPath: redirectTo });
-        return;
-      }
+    ...(onErrorFromContext
+      ? {
+          mutationFn: onErrorFromContext,
+          onSuccess: ({ logout: shouldLogout, redirectTo }) => {
+            if (shouldLogout) {
+              logout({ redirectPath: redirectTo });
+              return;
+            }
 
-      if (redirectTo) {
-        if (routerType === "legacy") {
-          replace(redirectTo);
-        } else {
-          go({ to: redirectTo, type: "replace" });
+            if (redirectTo) {
+              if (routerType === "legacy") {
+                replace(redirectTo);
+              } else {
+                go({ to: redirectTo, type: "replace" });
+              }
+              return;
+            }
+          },
         }
-        return;
-      }
-    },
+      : {
+          mutationFn: () => ({}) as Promise<OnErrorResponse>,
+        }),
     meta: {
       ...getXRay("useOnError", preferLegacyKeys),
     },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

Currently when user doesn't define an `authProvider.onError` method, `useOnError` calls (made internally when a query or a mutation fails) will log an error to the console in development environments as `"no mutationFn found"`. 

Provided a fallback function to `useOnError` to prevent this error to be logged without changing any functionality of the hook.
