### PR TITLE
fix(core):  useMenu's default value of `hideOnMissingParameter` prop

### DIFF
--- a/.changeset/weak-impalas-relate.md
+++ b/.changeset/weak-impalas-relate.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+fix(core): `useMenu` `hideOnMissingParameter` prop default value set to `true`
+
+There was an error in the `useMenu` hook's `hideOnMissingParameter` prop. Its default value should be `true` but it was missed when props are passed partially. This PR fixes the issue by setting the default value to `true`.

--- a/packages/core/src/hooks/menu/useMenu.tsx
+++ b/packages/core/src/hooks/menu/useMenu.tsx
@@ -46,7 +46,7 @@ const getCleanPath = (pathname: string) => {
  * @see {@link https://refine.dev/docs/api-reference/core/hooks/ui/useMenu} for more details.
  */
 export const useMenu = (
-  { meta, hideOnMissingParameter }: UseMenuProps = {
+  { meta, hideOnMissingParameter = true }: UseMenuProps = {
     hideOnMissingParameter: true,
   },
 ): UseMenuReturnType => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Issues

Related with #5872

## Changes

Added missing default value `true` of `hideOnMissingParameter` prop of `useMenu` hook
