### PR TITLE
docs(blog): add missing meta values in Refine + shadcn data table post

### DIFF
--- a/documentation/blog/2024-03-19-ts-shadcn.md
+++ b/documentation/blog/2024-03-19-ts-shadcn.md
@@ -1693,6 +1693,14 @@ export const BlogPostList: React.FC<IResourceComponentsProps> = () => {
     },
   });
 
+  tableProps?.setOptions((prev) => ({
+    ...prev,
+    meta: {
+      ...prev.meta,
+      categoryData,
+    },
+  }));
+
   return (
     <div className="p-2">
       <div className="flex justify-between items-center my-2 mx-2">


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

Added missing lines for setting relation data in table meta in reusable `<DataTable />` section of [Refine + Shadcn UI blog post](https://refine.dev/blog/shadcn-ui/#shadcn-select--components-in-refine)

These lines were included in the previous section but missed out in the next section.

Resolves #5838
