### PR TITLE
feat(docs): add getDefaultFilter description

### DIFF
--- a/documentation/docs/data/hooks/use-table/index.md
+++ b/documentation/docs/data/hooks/use-table/index.md
@@ -68,6 +68,37 @@ If you are using `merge` behavior and want to remove one of the filters, you sho
 
 :::
 
+:::simple Finding the filter value
+
+Refine provides the [`getDefaultFilter`](https://github.com/refinedev/refine/blob/716656d9ad3deb169c32685cdebbfd46bac44beb/packages/core/src/definitions/table/index.ts#L166) function, You can use this function to find the filter value for the specific field.
+
+```tsx
+import { getDefaultFilter, useTable } from "@refinedev/core";
+
+const MyComponent = () => {
+  const { filters } = useTable({
+    filters: {
+      initial: [
+        {
+          field: "name",
+          operator: "contains",
+          value: "John Doe",
+        },
+      ],
+    },
+  });
+
+  const nameFilterValue = getDefaultFilter("name", filters, "contains");
+  console.log(nameFilterValue); // "John Doe"
+
+  return {
+    /** ... */
+  };
+};
+```
+
+:::
+
 <FilteringLivePreview/>
 
 ## Realtime Updates

--- a/documentation/docs/packages/tanstack-table/use-table/index.md
+++ b/documentation/docs/packages/tanstack-table/use-table/index.md
@@ -58,6 +58,42 @@ If you're going to use [logical filters](/docs/core/interface-references#logical
 
 By default, `id` field of the column is used as the `key` property. If you want to use a different field as the `key`, you can set the `filterKey` property in the `meta` object.
 
+:::simple Finding the filter value
+
+Refine provides the [`getDefaultFilter`](https://github.com/refinedev/refine/blob/716656d9ad3deb169c32685cdebbfd46bac44beb/packages/core/src/definitions/table/index.ts#L166) function, You can use this function to find the filter value for the specific field.
+
+```tsx
+import { getDefaultFilter } from "@refinedev/core";
+import { useTable } from "@refinedev/react-table";
+
+const MyComponent = () => {
+  const {
+    refineCore: { filters },
+  } = useTable({
+    refineCoreProps: {
+      filters: {
+        initial: [
+          {
+            field: "name",
+            operator: "contains",
+            value: "John Doe",
+          },
+        ],
+      },
+    },
+  });
+
+  const nameFilterValue = getDefaultFilter("name", filters, "contains");
+  console.log(nameFilterValue); // "John Doe"
+
+  return {
+    /** ... */
+  };
+};
+```
+
+:::
+
 <FilteringLivePreview/>
 
 ## Realtime Updates

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-table/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-table/index.md
@@ -127,6 +127,38 @@ const { tableProps, sorters, filters } = useTable({
 // ---
 ```
 
+:::simple Finding the filter value
+
+Refine provides the [`getDefaultFilter`](https://github.com/refinedev/refine/blob/716656d9ad3deb169c32685cdebbfd46bac44beb/packages/core/src/definitions/table/index.ts#L166) function, You can use this function to find the filter value for the specific field.
+
+```tsx
+import { getDefaultFilter } from "@refinedev/core";
+import { useTable } from "@refinedev/antd";
+
+const MyComponent = () => {
+  const { filters } = useTable({
+    filters: {
+      initial: [
+        {
+          field: "name",
+          operator: "contains",
+          value: "John Doe",
+        },
+      ],
+    },
+  });
+
+  const nameFilterValue = getDefaultFilter("name", filters, "contains");
+  console.log(nameFilterValue); // "John Doe"
+
+  return {
+    /** ... */
+  };
+};
+```
+
+:::
+
 ## Search
 
 We can use the [`onSearch`](#onsearch) and [`searchFormProps`](#searchformprops) properties to make custom filter form. `onSearch` is a function that is called when the form is submitted. `searchFormProps` is a property that is passed to the [`<Form>`](https://ant.design/components/form) component.

--- a/documentation/docs/ui-integrations/material-ui/hooks/use-data-grid/index.md
+++ b/documentation/docs/ui-integrations/material-ui/hooks/use-data-grid/index.md
@@ -232,6 +232,38 @@ return <DataGrid {...dataGridProps} filterModel={undefined} autoHeight />;
 
 When `filterModel` is not passed, it supports more than one criteria at a time, but cannot show which fields are filtered in `<DataGrid>` headers.
 
+:::simple Finding the filter value
+
+Refine provides the [`getDefaultFilter`](https://github.com/refinedev/refine/blob/716656d9ad3deb169c32685cdebbfd46bac44beb/packages/core/src/definitions/table/index.ts#L166) function, You can use this function to find the filter value for the specific field.
+
+```tsx
+import { getDefaultFilter } from "@refinedev/core";
+import { useDataGrid } from "@refinedev/mui";
+
+const MyComponent = () => {
+  const { filters } = useDataGrid({
+    filters: {
+      initial: [
+        {
+          field: "name",
+          operator: "contains",
+          value: "John Doe",
+        },
+      ],
+    },
+  });
+
+  const nameFilterValue = getDefaultFilter("name", filters, "contains");
+  console.log(nameFilterValue); // "John Doe"
+
+  return {
+    /** ... */
+  };
+};
+```
+
+:::
+
 ## Realtime Updates
 
 > [`LiveProvider`](/docs/realtime/live-provider) is required for this prop to work.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

We don't have a description of `getDefaultFilter` in the documentation.

## What is the new behavior?
 
`getDefaultFilter` description added.

pages:
- http://refine.dev/docs/data/hooks/use-table/#filtering
- http://refine.dev/docs/ui-integrations/ant-design/hooks/use-table/#initial-filter-and-sorter
- http://refine.dev/docs/ui-integrations/material-ui/hooks/use-data-grid/#filtering
- http://refine.dev/docs/packages/tanstack-table/use-table/#filtering
 
![image](https://github.com/refinedev/refine/assets/23058882/b1585a7e-9441-45f8-8fa0-6a1cfb864f42)

