### PR TITLE
fix(auth page): i18n key in register page for "haveAccount" #5816

### DIFF
--- a/packages/antd/src/components/pages/auth/components/register/index.tsx
+++ b/packages/antd/src/components/pages/auth/components/register/index.tsx
@@ -208,7 +208,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                 }}
               >
                 {translate(
-                  "pages.login.buttons.haveAccount",
+                  "pages.register.buttons.haveAccount",
                   "Have an account?",
                 )}{" "}
                 <ActiveLink
@@ -251,7 +251,10 @@ export const RegisterPage: React.FC<RegisterProps> = ({
               fontSize: 12,
             }}
           >
-            {translate("pages.login.buttons.haveAccount", "Have an account?")}{" "}
+            {translate(
+              "pages.register.buttons.haveAccount",
+              "Have an account?",
+            )}{" "}
             <ActiveLink
               style={{
                 fontWeight: "bold",

--- a/packages/chakra-ui/src/components/pages/auth/components/register/index.tsx
+++ b/packages/chakra-ui/src/components/pages/auth/components/register/index.tsx
@@ -195,7 +195,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
             >
               <span>
                 {translate(
-                  "pages.login.buttons.haveAccount",
+                  "pages.register.buttons.haveAccount",
                   "Have an account?",
                 )}
               </span>

--- a/packages/core/src/components/pages/auth/components/register/index.tsx
+++ b/packages/core/src/components/pages/auth/components/register/index.tsx
@@ -140,7 +140,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                 <>
                   <span>
                     {translate(
-                      "pages.login.buttons.haveAccount",
+                      "pages.register.buttons.haveAccount",
                       "Have an account?",
                     )}{" "}
                     {renderLink(
@@ -156,7 +156,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
       )}
       {loginLink !== false && hideForm && (
         <div style={{ textAlign: "center" }}>
-          {translate("pages.login.buttons.haveAccount", "Have an account?")}{" "}
+          {translate("pages.register.buttons.haveAccount", "Have an account?")}{" "}
           {renderLink("/login", translate("pages.login.signin", "Sign in"))}
         </div>
       )}

--- a/packages/mui/src/components/pages/auth/components/register/index.tsx
+++ b/packages/mui/src/components/pages/auth/components/register/index.tsx
@@ -238,7 +238,10 @@ export const RegisterPage: React.FC<RegisterProps> = ({
             }}
           >
             <Typography variant="body2" component="span" fontSize="12px">
-              {translate("pages.login.buttons.haveAccount", "Have an account?")}
+              {translate(
+                "pages.register.buttons.haveAccount",
+                "Have an account?",
+              )}
             </Typography>
             <MuiLink
               ml="4px"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
Register pages use login pages' key for "haveAccount".  => `pages.login.buttons.haveAccount`

## What is the new behavior?
Register pages are now using register pages' key for "haveAccount".  => `pages.register.buttons.haveAccount`

fixes # (issue)
#5816 

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
