### PR TITLE
fix: lock `antd` version to `5.16.5`

### DIFF
--- a/.changeset/giant-tomatoes-love.md
+++ b/.changeset/giant-tomatoes-love.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/antd": patch
+---
+
+fix: lock `antd` version to `5.16.5` due to broken builds in `5.17.0`
+
+In the latest release of `antd` package, Next.js apps are failing to build or taking extremely long time to build. Until this issue is fixed in the `antd` package, we are locking the version to `5.16.5` to prevent any build issues.
+
+Related issue [antd/#48758](https://github.com/ant-design/ant-design/issues/48758)

--- a/examples/access-control-casbin/package.json
+++ b/examples/access-control-casbin/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "casbin": "^5.15.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/access-control-cerbos/package.json
+++ b/examples/access-control-cerbos/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/access-control-permify/package.json
+++ b/examples/access-control-permify/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/app-crm-minimal/package.json
+++ b/examples/app-crm-minimal/package.json
@@ -27,7 +27,7 @@
     "@refinedev/nestjs-query": "^1.1.3",
     "@refinedev/react-router-v6": "^4.5.7",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "classnames": "^2.3.2",
     "cross-env": "^7.0.3",
     "dayjs": "^1.10.7",

--- a/examples/app-crm/package.json
+++ b/examples/app-crm/package.json
@@ -33,7 +33,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@uiw/react-md-editor": "^3.19.5",
     "algoliasearch": "^4.19.1",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "axios": "^1.6.2",
     "classnames": "^2.3.2",
     "cross-env": "^7.0.3",

--- a/examples/auth-antd/package.json
+++ b/examples/auth-antd/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/auth-auth0/package.json
+++ b/examples/auth-auth0/package.json
@@ -31,7 +31,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "axios": "^1.6.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/auth-google-login/package.json
+++ b/examples/auth-google-login/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "axios": "^1.6.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/auth-keycloak/package.json
+++ b/examples/auth-keycloak/package.json
@@ -31,7 +31,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "axios": "^1.6.2",
     "keycloak-js": "^20.0.3",
     "react": "^18.0.0",

--- a/examples/auth-kinde/package.json
+++ b/examples/auth-kinde/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "axios": "^1.6.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/auth-otp/package.json
+++ b/examples/auth-otp/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/base-antd/package.json
+++ b/examples/base-antd/package.json
@@ -31,7 +31,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/blog-invoice-generator/package.json
+++ b/examples/blog-invoice-generator/package.json
@@ -30,7 +30,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/strapi-v4": "^6.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "axios": "^1.6.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/blog-issue-tracker/package.json
+++ b/examples/blog-issue-tracker/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^18.16.2",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "cross-env": "^7.0.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/blog-job-posting/package.json
+++ b/examples/blog-job-posting/package.json
@@ -31,7 +31,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "cross-env": "^7.0.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/blog-react-dnd/package.json
+++ b/examples/blog-react-dnd/package.json
@@ -35,7 +35,7 @@
     "@testing-library/user-event": "^14.1.1",
     "@types/jest": "^29.2.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "cross-env": "^7.0.3",
     "immutability-helper": "^3.1.1",
     "next": "^14.1.0",

--- a/examples/blog-refine-antd-dynamic-form/package.json
+++ b/examples/blog-refine-antd-dynamic-form/package.json
@@ -33,7 +33,7 @@
     "@testing-library/react": "^13.1.1",
     "@testing-library/user-event": "^14.1.1",
     "@types/jest": "^29.2.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1",

--- a/examples/blog-refine-digital-ocean/package.json
+++ b/examples/blog-refine-digital-ocean/package.json
@@ -31,7 +31,7 @@
     "@refinedev/kbar": "^1.3.8",
     "@refinedev/nestjs-query": "^1.1.3",
     "@refinedev/react-router-v6": "^4.5.7",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "dayjs": "^1.10.7",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/blog-refine-markdown/package.json
+++ b/examples/blog-refine-markdown/package.json
@@ -31,7 +31,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/calendar-app/package.json
+++ b/examples/calendar-app/package.json
@@ -27,7 +27,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/command-palette-kbar/package.json
+++ b/examples/command-palette-kbar/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/customization-footer/package.json
+++ b/examples/customization-footer/package.json
@@ -27,7 +27,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/customization-login/package.json
+++ b/examples/customization-login/package.json
@@ -31,7 +31,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "cross-env": "^7.0.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/customization-offlayout-area/package.json
+++ b/examples/customization-offlayout-area/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/customization-rtl/package.json
+++ b/examples/customization-rtl/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/customization-sider/package.json
+++ b/examples/customization-sider/package.json
@@ -27,7 +27,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/customization-theme-antd/package.json
+++ b/examples/customization-theme-antd/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/customization-top-menu-layout/package.json
+++ b/examples/customization-top-menu-layout/package.json
@@ -27,7 +27,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/data-provider-airtable/package.json
+++ b/examples/data-provider-airtable/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/data-provider-appwrite-tutorial-docs/package.json
+++ b/examples/data-provider-appwrite-tutorial-docs/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@types/uuid": "^9.0.6",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1",

--- a/examples/data-provider-appwrite/package.json
+++ b/examples/data-provider-appwrite/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/data-provider-hasura/package.json
+++ b/examples/data-provider-hasura/package.json
@@ -29,7 +29,7 @@
     "@refinedev/hasura": "^6.6.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "graphql": "^15.6.1",
     "graphql-tag": "^2.12.6",
     "react": "^18.0.0",

--- a/examples/data-provider-multiple/package.json
+++ b/examples/data-provider-multiple/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/data-provider-nestjs-query/package.json
+++ b/examples/data-provider-nestjs-query/package.json
@@ -29,7 +29,7 @@
     "@refinedev/nestjs-query": "^1.1.3",
     "@refinedev/react-router-v6": "^4.5.7",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "graphql": "^15.6.1",
     "graphql-tag": "^2.12.6",
     "graphql-ws": "^5.9.1",

--- a/examples/data-provider-nestjsx-crud/package.json
+++ b/examples/data-provider-nestjsx-crud/package.json
@@ -28,7 +28,7 @@
     "@refinedev/nestjsx-crud": "^5.0.4",
     "@refinedev/react-router-v6": "^4.5.7",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/data-provider-sanity/package.json
+++ b/examples/data-provider-sanity/package.json
@@ -30,7 +30,7 @@
     "@refinedev/simple-rest": "^5.0.4",
     "@sanity/client": "^6.6.0",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1",

--- a/examples/data-provider-strapi-v4/package.json
+++ b/examples/data-provider-strapi-v4/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/strapi-v4": "^6.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "axios": "^1.6.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/data-provider-strapi/package.json
+++ b/examples/data-provider-strapi/package.json
@@ -32,7 +32,7 @@
     "@testing-library/user-event": "^14.1.1",
     "@types/jest": "^29.2.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "axios": "^1.6.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/data-provider-supabase/package.json
+++ b/examples/data-provider-supabase/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/supabase": "^5.7.8",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1",

--- a/examples/field-antd-use-checkbox-group/package.json
+++ b/examples/field-antd-use-checkbox-group/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/field-antd-use-radio-group/package.json
+++ b/examples/field-antd-use-radio-group/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/field-antd-use-select-basic/package.json
+++ b/examples/field-antd-use-select-basic/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/field-antd-use-select-infinite/package.json
+++ b/examples/field-antd-use-select-infinite/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/finefoods-antd/package.json
+++ b/examples/finefoods-antd/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "antd-style": "^3.6.1",
     "dayjs": "^1.10.7",
     "google-map-react": "^2.1.10",

--- a/examples/form-antd-custom-validation/package.json
+++ b/examples/form-antd-custom-validation/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/form-antd-mutation-mode/package.json
+++ b/examples/form-antd-mutation-mode/package.json
@@ -33,7 +33,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/form-antd-use-drawer-form/package.json
+++ b/examples/form-antd-use-drawer-form/package.json
@@ -29,7 +29,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1",

--- a/examples/form-antd-use-form/package.json
+++ b/examples/form-antd-use-form/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/form-antd-use-modal-form/package.json
+++ b/examples/form-antd-use-modal-form/package.json
@@ -32,7 +32,7 @@
     "@types/node": "^18.16.2",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/form-antd-use-steps-form/package.json
+++ b/examples/form-antd-use-steps-form/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/i18n-nextjs/package.json
+++ b/examples/i18n-nextjs/package.json
@@ -18,7 +18,7 @@
     "@refinedev/kbar": "^1.3.8",
     "@refinedev/nextjs-router": "^6.0.2",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "cross-env": "^7.0.3",
     "i18next": "^20.1.0",
     "i18next-browser-languagedetector": "^6.1.1",

--- a/examples/i18n-react/package.json
+++ b/examples/i18n-react/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "i18next": "^20.1.0",
     "i18next-browser-languagedetector": "^6.1.1",
     "i18next-xhr-backend": "^3.2.2",

--- a/examples/import-export-antd/package.json
+++ b/examples/import-export-antd/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/inferencer-antd/package.json
+++ b/examples/inferencer-antd/package.json
@@ -32,7 +32,7 @@
     "@refinedev/kbar": "^1.3.8",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "i18next": "^20.1.0",
     "i18next-browser-languagedetector": "^6.1.1",
     "i18next-xhr-backend": "^3.2.2",

--- a/examples/inferencer-graphql-hasura/package.json
+++ b/examples/inferencer-graphql-hasura/package.json
@@ -32,7 +32,7 @@
     "@refinedev/inferencer": "^4.6.0",
     "@refinedev/kbar": "^1.3.8",
     "@refinedev/react-router-v6": "^4.5.7",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "graphql": "^15.6.1",
     "graphql-request": "^5.2.0",
     "react": "^18.0.0",

--- a/examples/input-custom/package.json
+++ b/examples/input-custom/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/input-date-picker/package.json
+++ b/examples/input-date-picker/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/live-provider-ably/package.json
+++ b/examples/live-provider-ably/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/loading-overtime/package.json
+++ b/examples/loading-overtime/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/monorepo-module-federation/apps/blog-posts/package.json
+++ b/examples/monorepo-module-federation/apps/blog-posts/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.1.0",
     "@refinedev/simple-rest": "^4.5.0",
     "@uiw/react-md-editor": "^3.23.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/monorepo-module-federation/apps/categories/package.json
+++ b/examples/monorepo-module-federation/apps/categories/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.1.0",
     "@refinedev/simple-rest": "^4.5.0",
     "@uiw/react-md-editor": "^3.23.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/monorepo-module-federation/apps/host/package.json
+++ b/examples/monorepo-module-federation/apps/host/package.json
@@ -28,7 +28,7 @@
     "@refinedev/kbar": "^1.1.0",
     "@refinedev/react-router-v6": "^4.1.0",
     "@refinedev/simple-rest": "^4.5.0",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/monorepo-with-lerna-bootstrap/apps/my-refine-app/package.json
+++ b/examples/monorepo-with-lerna-bootstrap/apps/my-refine-app/package.json
@@ -29,7 +29,7 @@
     "@refinedev/kbar": "^1.1.0",
     "@refinedev/react-router-v6": "^4.1.0",
     "@refinedev/simple-rest": "^4.5.0",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/monorepo-with-lerna/apps/my-refine-app/package.json
+++ b/examples/monorepo-with-lerna/apps/my-refine-app/package.json
@@ -29,7 +29,7 @@
     "@refinedev/kbar": "^1.1.0",
     "@refinedev/react-router-v6": "^4.1.0",
     "@refinedev/simple-rest": "^4.5.0",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/monorepo-with-turbo/apps/my-refine-app/package.json
+++ b/examples/monorepo-with-turbo/apps/my-refine-app/package.json
@@ -29,7 +29,7 @@
     "@refinedev/kbar": "^1.1.0",
     "@refinedev/react-router-v6": "^4.1.0",
     "@refinedev/simple-rest": "^4.5.0",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/multi-level-menu/package.json
+++ b/examples/multi-level-menu/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/multi-tenancy-appwrite/package.json
+++ b/examples/multi-tenancy-appwrite/package.json
@@ -28,7 +28,7 @@
     "@refinedev/cli": "^2.16.29",
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/multi-tenancy-strapi/package.json
+++ b/examples/multi-tenancy-strapi/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/strapi-v4": "^6.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "axios": "^1.6.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/new-routing-example/package.json
+++ b/examples/new-routing-example/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/pixels-admin/package.json
+++ b/examples/pixels-admin/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/supabase": "^5.7.8",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "casbin": "^5.15.2",
     "dotenv": "^16.0.3",
     "react": "^18.0.0",

--- a/examples/pixels/package.json
+++ b/examples/pixels/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/supabase": "^5.7.8",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "dotenv": "^16.0.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/refine-week-invoice-generator/package.json
+++ b/examples/refine-week-invoice-generator/package.json
@@ -31,7 +31,7 @@
     "@refinedev/kbar": "^1.3.8",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/strapi-v4": "^6.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "axios": "^1.6.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/search/package.json
+++ b/examples/search/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "lodash": "^4.17.21",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/server-side-form-validation-antd/package.json
+++ b/examples/server-side-form-validation-antd/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/table-antd-advanced/package.json
+++ b/examples/table-antd-advanced/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/table-antd-table-filter/package.json
+++ b/examples/table-antd-table-filter/package.json
@@ -31,7 +31,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "dayjs": "^1.10.7",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/table-antd-use-delete-many/package.json
+++ b/examples/table-antd-use-delete-many/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/table-antd-use-editable-table/package.json
+++ b/examples/table-antd-use-editable-table/package.json
@@ -29,7 +29,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/table-antd-use-table/package.json
+++ b/examples/table-antd-use-table/package.json
@@ -29,7 +29,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/table-antd-use-update-many/package.json
+++ b/examples/table-antd-use-update-many/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/theme-antd-demo/package.json
+++ b/examples/theme-antd-demo/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/tutorial-antd/package.json
+++ b/examples/tutorial-antd/package.json
@@ -29,7 +29,7 @@
     "@refinedev/inferencer": "^4.6.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1",

--- a/examples/upload-antd-base64/package.json
+++ b/examples/upload-antd-base64/package.json
@@ -27,7 +27,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/upload-antd-multipart/package.json
+++ b/examples/upload-antd-multipart/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/use-modal-antd/package.json
+++ b/examples/use-modal-antd/package.json
@@ -27,7 +27,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/use-simple-list-antd/package.json
+++ b/examples/use-simple-list-antd/package.json
@@ -27,7 +27,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "dayjs": "^1.10.7",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/with-custom-pages/package.json
+++ b/examples/with-custom-pages/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/with-javascript/package.json
+++ b/examples/with-javascript/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/with-meta-properties/package.json
+++ b/examples/with-meta-properties/package.json
@@ -15,7 +15,7 @@
     "@refinedev/core": "^4.49.0",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/with-nextjs-next-auth/package.json
+++ b/examples/with-nextjs-next-auth/package.json
@@ -21,7 +21,7 @@
     "@refinedev/kbar": "^1.3.8",
     "@refinedev/nextjs-router": "^6.0.2",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "cross-env": "^7.0.3",
     "js-cookie": "^3.0.1",
     "next": "^14.1.0",

--- a/examples/with-nextjs/package.json
+++ b/examples/with-nextjs/package.json
@@ -20,7 +20,7 @@
     "@refinedev/kbar": "^1.3.8",
     "@refinedev/nextjs-router": "^6.0.2",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "cross-env": "^7.0.3",
     "js-cookie": "^3.0.1",
     "next": "^14.1.0",

--- a/examples/with-nx/package.json
+++ b/examples/with-nx/package.json
@@ -30,7 +30,7 @@
     "@refinedev/kbar": "^1.3.8",
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1",

--- a/examples/with-remix-antd/package.json
+++ b/examples/with-remix-antd/package.json
@@ -19,7 +19,7 @@
     "@remix-run/node": "^2.4.0",
     "@remix-run/react": "^2.4.0",
     "@remix-run/serve": "^2.4.0",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "cookie": "^0.5.0",
     "js-cookie": "^3.0.1",
     "react": "^18.0.0",

--- a/examples/with-remix-auth/package.json
+++ b/examples/with-remix-auth/package.json
@@ -18,7 +18,7 @@
     "@remix-run/node": "^2.4.0",
     "@remix-run/react": "^2.4.0",
     "@remix-run/serve": "^2.4.0",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "cookie": "^0.5.0",
     "js-cookie": "^3.0.1",
     "react": "^18.0.0",

--- a/examples/with-storybook-antd/package.json
+++ b/examples/with-storybook-antd/package.json
@@ -41,7 +41,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1"

--- a/examples/with-web3/package.json
+++ b/examples/with-web3/package.json
@@ -28,7 +28,7 @@
     "@refinedev/react-router-v6": "^4.5.7",
     "@refinedev/simple-rest": "^5.0.4",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.8.1",

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -46,7 +46,7 @@
     "@ant-design/pro-layout": "7.17.12",
     "@refinedev/ui-types": "^1.22.5",
     "@tanstack/react-query": "^4.10.1",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "dayjs": "^1.10.7",
     "react-markdown": "^6.0.1",
     "remark-gfm": "^1.0.0",
@@ -81,7 +81,7 @@
     "@refinedev/core": "^4.46.1",
     "@types/react": "^17.0.0 || ^18.0.0",
     "@types/react-dom": "^17.0.0 || ^18.0.0",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "dayjs": "^1.10.7",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"

--- a/packages/live-previews/package.json
+++ b/packages/live-previews/package.json
@@ -49,7 +49,7 @@
     "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^3.19.5",
-    "antd": "^5.0.5",
+    "antd": "5.16.5",
     "axios": "^1.6.2",
     "base64url": "^3.0.1",
     "casbin": "^5.15.2",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

In the latest release of `antd` package, Next.js apps are failing to build or taking extremely long time to build. Until this issue is fixed in the `antd` package, we are locking the version to `5.16.5` to prevent any build issues.

Related issue [antd/#48758](https://github.com/ant-design/ant-design/issues/48758)
