### PR TITLE
refactor(core): omit `to` parameter at root on unauthenticated redirects

### DIFF
--- a/.changeset/ninety-cameras-give.md
+++ b/.changeset/ninety-cameras-give.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+refactor: omit `to` parameter if at root when unauthenticated
+
+If user is not authenticated, `<Authenticated />` redirects to the provided route and appends the current route to the `to` parameter. With this change, if the current route is the root (`/`), the `to` parameter will be omitted.

--- a/packages/core/src/components/authenticated/index.spec.tsx
+++ b/packages/core/src/components/authenticated/index.spec.tsx
@@ -517,4 +517,93 @@ describe("Authenticated", () => {
       ),
     );
   });
+
+  it("should redirect to `/login` without `to` query if at root", async () => {
+    const mockGo = jest.fn();
+
+    const { queryByText } = render(
+      <Authenticated key="should-redirect-custom-provider-check">
+        Custom Authenticated
+      </Authenticated>,
+      {
+        wrapper: TestWrapper({
+          dataProvider: MockJSONServer,
+          authProvider: {
+            ...mockAuthProvider,
+            check: async () => {
+              return {
+                authenticated: false,
+                redirectTo: "/login",
+              };
+            },
+          },
+          routerProvider: {
+            go: () => mockGo,
+          },
+          resources: [{ name: "posts", route: "posts" }],
+        }),
+      },
+    );
+
+    await act(async () => {
+      expect(queryByText("Custom Authenticated")).toBeNull();
+    });
+
+    await waitFor(() =>
+      expect(mockGo).toBeCalledWith(
+        expect.objectContaining({
+          to: "/login",
+          type: "replace",
+          query: undefined,
+        }),
+      ),
+    );
+  });
+
+  it("should redirect to `/login?to=/dashboard` if at /dashboard route", async () => {
+    const mockGo = jest.fn();
+
+    // Mocking first return value to simulate that user's location is at /dashboard
+    mockGo.mockReturnValueOnce("/dashboard");
+
+    const { queryByText } = render(
+      <Authenticated key="should-redirect-custom-provider-check">
+        Custom Authenticated
+      </Authenticated>,
+      {
+        wrapper: TestWrapper({
+          dataProvider: MockJSONServer,
+          authProvider: {
+            ...mockAuthProvider,
+            check: async () => {
+              return {
+                authenticated: false,
+                redirectTo: "/login",
+              };
+            },
+          },
+          routerProvider: {
+            go: () => mockGo,
+          },
+          resources: [{ name: "posts", route: "posts" }],
+        }),
+      },
+    );
+
+    await act(async () => {
+      expect(queryByText("Custom Authenticated")).toBeNull();
+    });
+
+    await waitFor(() =>
+      expect(mockGo).toBeCalledWith(
+        expect.objectContaining({
+          to: "/login",
+          type: "replace",
+          query: expect.objectContaining({
+            to: "/dashboard",
+          }),
+        }),
+      ),
+    );
+  });
 });

--- a/packages/core/src/components/authenticated/index.tsx
+++ b/packages/core/src/components/authenticated/index.tsx
@@ -175,21 +175,25 @@ export function Authenticated({
         : "";
       return <RedirectLegacy to={`${appliedRedirect}${toQuery}`} />;
     }
+
+    const queryToValue: string | undefined = parsed.params?.to
+      ? parsed.params.to
+      : go({
+          to: pathname,
+          options: { keepQuery: true },
+          type: "path",
+        });
+
     return (
       <Redirect
         config={{
           to: appliedRedirect,
-          query: appendCurrentPathToQuery
-            ? {
-                to: parsed.params?.to
-                  ? parsed.params.to
-                  : go({
-                      to: pathname,
-                      options: { keepQuery: true },
-                      type: "path",
-                    }),
-              }
-            : undefined,
+          query:
+            appendCurrentPathToQuery && (queryToValue ?? "").length > 1
+              ? {
+                  to: queryToValue,
+                }
+              : undefined,
           type: "replace",
         }}
       />


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

If user is not authenticated, `<Authenticated />` redirects to the provided route and appends the current route to the `to` parameter. With this change, if the current route is the root (`/`), the `to` parameter will be omitted.

RK-642