### PR TITLE
fix(mui): transformMuiOperatorToCrudOperator return type

### DIFF
--- a/.changeset/ninety-pots-smell.md
+++ b/.changeset/ninety-pots-smell.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/mui": patch
+---
+
+fix: `transformMuiOperatorToCrudOperator` return type is wrong.
+
+This PR fixes the return type of `transformMuiOperatorToCrudOperator` function. It has return type `Exclude<CrudOperators, "or">` but it also should exclude `and` operator to satisfy `LogicalFilter` type.

--- a/packages/mui/src/definitions/dataGrid/index.ts
+++ b/packages/mui/src/definitions/dataGrid/index.ts
@@ -34,7 +34,7 @@ export const transformCrudSortingToSortModel = (
 
 export const transformMuiOperatorToCrudOperator = (
   operatorValue?: string,
-): Exclude<CrudOperators, "or"> => {
+): Exclude<CrudOperators, "or" | "and"> => {
   if (!operatorValue) {
     return "eq";
   }
@@ -72,7 +72,7 @@ export const transformMuiOperatorToCrudOperator = (
     case "isNotEmpty":
       return "nnull";
     default:
-      return operatorValue as Exclude<CrudOperators, "or">;
+      return operatorValue as Exclude<CrudOperators, "or" | "and">;
   }
 };
 
@@ -81,11 +81,13 @@ export const transformFilterModelToCrudFilters = ({
   logicOperator,
 }: GridFilterModel): CrudFilters => {
   const filters = items.map(({ field, value, operator }) => {
-    return {
+    const filter: LogicalFilter = {
       field: field,
       value: ["isEmpty", "isNotEmpty"].includes(operator) ? true : value ?? "",
       operator: transformMuiOperatorToCrudOperator(operator),
     };
+
+    return filter;
   });
 
   if (logicOperator === GridLogicOperator.Or) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

`transformMuiOperatorToCrudOperator` return type is wrong.

## What is the new behavior?

Return type updated to `Exclude<CrudOperators, "or" | "and">` to satisfy `LogicalFilter` type.

