### PR TITLE
fix(live-previews): fix replacement of the scoped default imports

### DIFF
--- a/packages/live-previews/src/scope/google.tsx
+++ b/packages/live-previews/src/scope/google.tsx
@@ -15,7 +15,7 @@ const MockGoogleButton = () => {
         background: "#3871E0",
         borderRadius: "4px",
         display: "flex",
-        justifyContent: "center",
+        justifyContent: "space-between",
         alignItems: "center",
         padding: "2px",
         paddingRight: "12px",

--- a/packages/live-previews/src/scope/map.tsx
+++ b/packages/live-previews/src/scope/map.tsx
@@ -62,9 +62,9 @@ export const packageMap: Record<string, string> = {
 };
 
 export const packageScopeMap: Record<string, RegExp> = {
-  "@mui/lab": /@mui\/lab\/.*/,
-  "@mui/material/styles": /@mui\/material\/styles\/.*/,
-  "@mui/material": /@mui\/material\/.*/,
-  "@mui/icons-material": /@mui\/icons-material\/.*/,
-  "@mui/x-data-grid": /@mui\/x-data-grid\/.*/,
+  "@mui/lab": /@mui\/lab\/(.*)/,
+  "@mui/material/styles": /@mui\/material\/styles\/(.*)/,
+  "@mui/material": /@mui\/material\/(.*)/,
+  "@mui/icons-material": /@mui\/icons-material\/(.*)/,
+  "@mui/x-data-grid": /@mui\/x-data-grid\/(.*)/,
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

In the live preview code we're replacing imports with provided scopes of packages.

Example:

```tsx
import { Button } from "@mui/material";
```

will be replaced with:

```tsx
const { Button } = MuiMaterial;
```

In some cases, imports may be made with subpaths/scopess of a package;

Example:

```tsx
import Button from "@mui/material/Button";
```

In this case we've been replacing it with the same structure:

```tsx
const { Button } = MuiMaterial;
```

This replacement was using the default import name (in this case `Button`) but it was flawed because the default import name don't have to match the actual export name.

Example: 


```tsx
import Button$1 from "@mui/material/Button";
```

In this case, a broken replacement is made:

```tsx
const { Button$1 } = MuiMaterial;
```

This caused `Button$1` to be `undefined` and break the preview.

In this PR, we've made a small change in this logic to use scope name and have a name change in the destructuring process.

Example:

```tsx
import Button$1 from "@mui/material/Button";
import { default as Button$2 } from "@mui/material/Button";
import { Button } from "@mui/material";
```

will be replaced with

```tsx
const {
  Button: Button$1,
  Button: Button$2,
  Button
} = MuiMaterial;
```