### PR TITLE
feat(docs): sidebar link color is wrong

### DIFF
--- a/documentation/src/refine-theme/doc-sidebar.tsx
+++ b/documentation/src/refine-theme/doc-sidebar.tsx
@@ -184,7 +184,9 @@ const SidebarCategory = ({
             )}
           />
         )}
-        <span className="z-[1]">{item.label}</span>
+        <span className="z-[1] text-refine-react-6 dark:text-refine-react-3">
+          {item.label}
+        </span>
         <div
           className={clsx(
             "absolute",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?


<img src="https://github.com/refinedev/refine/assets/23058882/feb4568d-bc39-4437-9c30-d6e6d9e975bc" alt="refine documentation screenshot" width="200"/>

## What is the new behavior?

<img src="https://github.com/refinedev/refine/assets/23058882/5da06f19-d173-4a48-bd5f-15017bad6fbd" alt="refine documentation screenshot" width="200"/>

 

