### PR TITLE
feat(mui): editable Data Grid #5744

### DIFF
--- a/.changeset/honest-beds-rhyme.md
+++ b/.changeset/honest-beds-rhyme.md
@@ -1,0 +1,10 @@
+---
+"@refinedev/mui": minor
+---
+
+feat: editable feature for MUI Data Grid #5656
+
+It is now possible to make MUI Data Grid editable by
+setting editable property on specific column.
+
+Resolves #5656

--- a/documentation/docs/ui-integrations/material-ui/hooks/use-data-grid/index.md
+++ b/documentation/docs/ui-integrations/material-ui/hooks/use-data-grid/index.md
@@ -270,6 +270,40 @@ const MyComponent = () => {
 
 When the `useDataGrid` hook is mounted, it will call the `subscribe` method from the `liveProvider` with some parameters such as `channel`, `resource` etc. It is useful when you want to subscribe to live updates.
 
+## Editing
+
+The hook can further extend editing provided in [`<DataGrid>`](https://mui.com/x/react-data-grid/editing/) component. To enable column editing, set `editable: "true"` on specific column definition.
+
+`useDataGrid` will utilize `processRowUpdate` from `<DataGrid>` component, which in turn will call [`useForm`](https://refine.dev/docs/data/hooks/use-form/) to attempt updating the row with the new value.
+
+```tsx
+const columns = React.useMemo<GridColDef<IPost>[]>(
+  () => [
+    {
+      field: "title",
+      headerName: "Title",
+      minWidth: 400,
+      flex: 1,
+      editable: true,
+    },
+  ],
+  [],
+);
+```
+
+Properties from [`useForm`](https://refine.dev/docs/data/hooks/use-form/), with exception of `autoSave`, `action` and `redirect`, are available in `useDataGrid`.
+
+The hook returns `onFinish`, `setId`, `id` and `formLoading` from `useForm`, which can be used to extend functionality.
+
+```tsx
+const {
+  dataGridProps,
+  formProps: { onFinish, setId, id, formLoading },
+} = useDataGrid<IPost>();
+```
+
+By default, the `onCellEditStart` and `onRowEditStart` callbacks from `<DataGrid>` will set the `id` on the form, and `processRowUpdate` will call `onFinish`.
+
 ## Properties
 
 ### resource

--- a/examples/table-material-ui-use-data-grid/cypress/e2e/all.cy.ts
+++ b/examples/table-material-ui-use-data-grid/cypress/e2e/all.cy.ts
@@ -171,4 +171,52 @@ describe("table-material-ui-use-data-grid", () => {
 
     cy.url().should("include", "current=1");
   });
+
+  it("should update a cell", () => {
+    cy.getMaterialUILoadingCircular().should("not.exist");
+
+    cy.intercept("/posts/*").as("patchRequest");
+
+    cy.getMaterialUIColumnHeader(1).click();
+
+    cy.get(".MuiDataGrid-cell").eq(1).dblclick();
+
+    cy.get(
+      ".MuiDataGrid-cell--editing > .MuiInputBase-root > .MuiInputBase-input",
+    )
+      .clear()
+      .type("Lorem ipsum refine!")
+      .type("{enter}");
+
+    cy.wait("@patchRequest");
+
+    cy.get(".MuiDataGrid-cell").eq(1).should("contain", "Lorem ipsum refine!");
+  });
+
+  it("should not update a cell", () => {
+    cy.getMaterialUILoadingCircular().should("not.exist");
+
+    cy.intercept("PATCH", "/posts/*", (request) => {
+      request.reply({
+        statusCode: 500,
+      });
+    }).as("patchRequest");
+
+    cy.getMaterialUIColumnHeader(1).click();
+
+    cy.get(".MuiDataGrid-cell").eq(1).dblclick();
+
+    cy.get(
+      ".MuiDataGrid-cell--editing > .MuiInputBase-root > .MuiInputBase-input",
+    )
+      .clear()
+      .type("Lorem ipsum fail!")
+      .type("{enter}");
+
+    cy.wait("@patchRequest");
+
+    cy.get(".MuiDataGrid-cell")
+      .eq(1)
+      .should("not.contain", "Lorem ipsum fail!");
+  });
 });

--- a/examples/table-material-ui-use-data-grid/src/pages/posts/list.tsx
+++ b/examples/table-material-ui-use-data-grid/src/pages/posts/list.tsx
@@ -45,7 +45,13 @@ export const PostList: React.FC = () => {
         type: "number",
         width: 50,
       },
-      { field: "title", headerName: "Title", minWidth: 400, flex: 1 },
+      {
+        field: "title",
+        headerName: "Title",
+        minWidth: 400,
+        flex: 1,
+        editable: true,
+      },
       {
         field: "category.id",
         headerName: "Category",

--- a/packages/mui/src/hooks/useDataGrid/index.spec.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.spec.ts
@@ -5,6 +5,7 @@ import { MockJSONServer, TestWrapper } from "@test";
 import { useDataGrid } from "./";
 import { CrudFilters } from "@refinedev/core";
 import { act } from "react-dom/test-utils";
+import { posts } from "@test/dataMocks";
 
 describe("useDataGrid Hook", () => {
   it("controlled filtering with 'onSubmit' and 'onSearch'", async () => {
@@ -196,6 +197,80 @@ describe("useDataGrid Hook", () => {
     await waitFor(() => {
       expect(!result.current.tableQueryResult.isLoading).toBeTruthy();
       expect(result.current.overtime.elapsedTime).toBeUndefined();
+    });
+  });
+
+  it("when processRowUpdate is called, update data", async () => {
+    let postToUpdate: any = posts[0];
+
+    const { result } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+          formProps: {
+            resource: "posts",
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: {
+            ...MockJSONServer,
+            update: async (data) => {
+              const resolvedData = await Promise.resolve({ data });
+              postToUpdate = resolvedData.data.variables;
+            },
+          },
+        }),
+      },
+    );
+
+    const newPost = {
+      ...postToUpdate,
+      title: "New title",
+    };
+
+    await act(async () => {
+      await result.current.dataGridProps.processRowUpdate(
+        newPost,
+        postToUpdate,
+      );
+    });
+
+    expect(newPost).toEqual(postToUpdate);
+  });
+
+  it("when update fails, return old data to row", async () => {
+    const { result } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+          formProps: {
+            resource: "posts",
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: {
+            ...MockJSONServer,
+            update: () => Promise.reject(),
+          },
+        }),
+      },
+    );
+
+    const oldPost = posts[0];
+
+    const newPost = {
+      ...oldPost,
+      title: "New title",
+    };
+
+    await act(async () => {
+      const returnValue = await result.current.dataGridProps.processRowUpdate(
+        newPost,
+        oldPost,
+      );
+      expect(returnValue).toEqual(oldPost);
     });
   });
 });


### PR DESCRIPTION
## Bugs / Features
This PR introduces the ability to make MUI Data Grid columns editable by setting an editable property on specific column definitions.

## What is the current behavior?
Currently, the MUI Data Grid does not support inline editing directly through configuration.

## What is the new behavior?
With the changes in this PR, developers can now configure columns to be editable directly from the MUI Data Grid setup, enhancing the grid's flexibility for various use cases.

fixes # ([5656](https://github.com/refinedev/refine/issues/5656))

## Notes for reviewers
I have extensively tested the functionality introduced in this PR, primarily based on the initial implementation by @beg1c. After setting up a test project to integrate the enhanced dataGridHook, it has met the expected outcomes. I encourage a thorough review to ensure that all aspects of the new editable feature align with our project standards and user requirements. Please provide feedback or suggest improvements if you identify potential enhancements or adjustments. I am open to discussions and willing to make any necessary changes to perfect this feature.
