### PR TITLE
fix(nestjs-query): implement unimplemented operators

### DIFF
--- a/.changeset/happy-parents-yawn.md
+++ b/.changeset/happy-parents-yawn.md
@@ -1,0 +1,17 @@
+---
+"@refinedev/nestjs-query": patch
+---
+
+fix: implement unimplemented operators
+
+The following filter operators have been implemented.
+
+- `containss`
+- `ncontainss`
+- `startswiths`
+- `nstartswiths`
+- `endswiths`
+- `nendswiths`
+- `nbetween`
+
+Resolves #6008

--- a/packages/nestjs-query/src/utils/index.ts
+++ b/packages/nestjs-query/src/utils/index.ts
@@ -78,6 +78,14 @@ const operatorMapper = (
     return { notILike: `%${value}%` };
   }
 
+  if (operator === "containss") {
+    return { like: `%${value}%` };
+  }
+
+  if (operator === "ncontainss") {
+    return { notLike: `%${value}%` };
+  }
+
   if (operator === "startswith") {
     return { iLike: `${value}%` };
   }
@@ -86,12 +94,28 @@ const operatorMapper = (
     return { notILike: `${value}%` };
   }
 
+  if (operator === "startswiths") {
+    return { like: `${value}%` };
+  }
+
+  if (operator === "nstartswiths") {
+    return { notLike: `${value}%` };
+  }
+
   if (operator === "endswith") {
     return { iLike: `%${value}` };
   }
 
   if (operator === "nendswith") {
     return { notILike: `%${value}` };
+  }
+
+  if (operator === "endswiths") {
+    return { like: `%${value}` };
+  }
+
+  if (operator === "nendswiths") {
+    return { notLike: `%${value}` };
   }
 
   if (operator === "null") {

--- a/packages/nestjs-query/src/utils/index.ts
+++ b/packages/nestjs-query/src/utils/index.ts
@@ -138,6 +138,18 @@ const operatorMapper = (
     return { between: { lower: value[0], upper: value[1] } };
   }
 
+  if (operator === "nbetween") {
+    if (!Array.isArray(value)) {
+      throw new Error("NBetween operator requires an array");
+    }
+
+    if (value.length !== 2) {
+      return {};
+    }
+
+    return { notBetween: { lower: value[0], upper: value[1] } };
+  }
+
   return { [operatorMap[operator]]: value };
 };
 

--- a/packages/nestjs-query/test/utils/generateFilters.spec.ts
+++ b/packages/nestjs-query/test/utils/generateFilters.spec.ts
@@ -1,0 +1,155 @@
+import { generateFilters } from "../../src/utils/index";
+import { CrudFilter, LogicalFilter } from "@refinedev/core";
+
+describe("generateFilters", () => {
+  it("should generate filter based on the specified operator", () => {
+    const testCases: { filters: CrudFilter[]; expected: any }[] = [
+      {
+        filters: [{ operator: "eq", field: "name", value: "John" }],
+        expected: { name: { eq: "John" } },
+      },
+      {
+        filters: [{ operator: "ne", field: "name", value: "John" }],
+        expected: { name: { neq: "John" } },
+      },
+      {
+        filters: [{ operator: "lt", field: "age", value: 20 }],
+        expected: { age: { lt: 20 } },
+      },
+      {
+        filters: [{ operator: "gt", field: "age", value: 20 }],
+        expected: { age: { gt: 20 } },
+      },
+      {
+        filters: [{ operator: "lte", field: "age", value: 20 }],
+        expected: { age: { lte: 20 } },
+      },
+      {
+        filters: [{ operator: "gte", field: "age", value: 20 }],
+        expected: { age: { gte: 20 } },
+      },
+      {
+        filters: [{ operator: "in", field: "name", value: "John" }],
+        expected: { name: { in: "John" } },
+      },
+      {
+        filters: [{ operator: "nin", field: "name", value: "John" }],
+        expected: { name: { notIn: "John" } },
+      },
+      {
+        filters: [{ operator: "contains", field: "name", value: "John" }],
+        expected: { name: { iLike: "%John%" } },
+      },
+      {
+        filters: [{ operator: "ncontains", field: "name", value: "John" }],
+        expected: { name: { notILike: "%John%" } },
+      },
+      {
+        filters: [{ operator: "containss", field: "name", value: "John" }],
+        expected: { name: { like: "%John%" } },
+      },
+      {
+        filters: [{ operator: "ncontainss", field: "name", value: "John" }],
+        expected: { name: { notLike: "%John%" } },
+      },
+      {
+        filters: [{ operator: "startswith", field: "name", value: "John" }],
+        expected: { name: { iLike: "John%" } },
+      },
+      {
+        filters: [{ operator: "nstartswith", field: "name", value: "John" }],
+        expected: { name: { notILike: "John%" } },
+      },
+      {
+        filters: [{ operator: "startswiths", field: "name", value: "John" }],
+        expected: { name: { like: "John%" } },
+      },
+      {
+        filters: [{ operator: "nstartswiths", field: "name", value: "John" }],
+        expected: { name: { notLike: "John%" } },
+      },
+      {
+        filters: [{ operator: "endswith", field: "name", value: "John" }],
+        expected: { name: { iLike: "%John" } },
+      },
+      {
+        filters: [{ operator: "nendswith", field: "name", value: "John" }],
+        expected: { name: { notILike: "%John" } },
+      },
+      {
+        filters: [{ operator: "endswiths", field: "name", value: "John" }],
+        expected: { name: { like: "%John" } },
+      },
+      {
+        filters: [{ operator: "nendswiths", field: "name", value: "John" }],
+        expected: { name: { notLike: "%John" } },
+      },
+      {
+        filters: [{ operator: "null", field: "name", value: true }],
+        expected: { name: { is: null } },
+      },
+      {
+        filters: [{ operator: "nnull", field: "name", value: true }],
+        expected: { name: { isNot: null } },
+      },
+      {
+        filters: [{ operator: "between", field: "age", value: [20, 30] }],
+        expected: { age: { between: { lower: 20, upper: 30 } } },
+      },
+    ];
+
+    testCases.forEach(({ filters, expected }) => {
+      const result = generateFilters(filters as LogicalFilter[]);
+      expect(result).toEqual(expected);
+    });
+  });
+  it("should generate filter with conditional operator", () => {
+    const testCases: { filters: CrudFilter[]; expected: any }[] = [
+      {
+        filters: [
+          {
+            operator: "and",
+            value: [
+              {
+                field: "name",
+                operator: "eq",
+                value: "John",
+              },
+              {
+                field: "age",
+                operator: "eq",
+                value: 20,
+              },
+            ],
+          },
+        ],
+        expected: { and: [{ name: { eq: "John" }, age: { eq: 20 } }] },
+      },
+      {
+        filters: [
+          {
+            operator: "or",
+            value: [
+              {
+                field: "name",
+                operator: "eq",
+                value: "John",
+              },
+              {
+                field: "age",
+                operator: "eq",
+                value: 20,
+              },
+            ],
+          },
+        ],
+        expected: { or: [{ name: { eq: "John" }, age: { eq: 20 } }] },
+      },
+    ];
+
+    testCases.forEach(({ filters, expected }) => {
+      const result = generateFilters(filters as LogicalFilter[]);
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/packages/nestjs-query/test/utils/generateFilters.spec.ts
+++ b/packages/nestjs-query/test/utils/generateFilters.spec.ts
@@ -96,6 +96,10 @@ describe("generateFilters", () => {
         filters: [{ operator: "between", field: "age", value: [20, 30] }],
         expected: { age: { between: { lower: 20, upper: 30 } } },
       },
+      {
+        filters: [{ operator: "nbetween", field: "age", value: [20, 30] }],
+        expected: { age: { notBetween: { lower: 20, upper: 30 } } },
+      },
     ];
 
     testCases.forEach(({ filters, expected }) => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] ~~Docs have been added / updated~~
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

The following filter operators do not work.

- `containss`
- `ncontainss`
- `startswiths`
- `nstartswiths`
- `endswiths`
- `nendswiths`
- `nbetween`

## What is the new behavior?

The following filter operators work correctly.

- `containss`
- `ncontainss`
- `startswiths`
- `nstartswiths`
- `endswiths`
- `nendswiths`
- `nbetween`

fixes #6008

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
