### PR TITLE
fix(core): ensure consistent casing in resource names for access control

### DIFF
--- a/documentation/docs/advanced-tutorials/real-time.md
+++ b/documentation/docs/advanced-tutorials/real-time.md
@@ -285,7 +285,7 @@ export const CustomSider: typeof Sider = ({ render }) => {
       return (
         <CanAccess
           key={route}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{ resource: item }}
         >
@@ -514,7 +514,7 @@ export const CustomSider: typeof Sider = ({ render }) => {
       return (
         <CanAccess
           key={key}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{ resource: item }}
         >

--- a/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/multi-tenancy/appwrite.md
+++ b/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/multi-tenancy/appwrite.md
@@ -242,7 +242,7 @@ export const CustomSider: React.FC = () => {
       const isSelected = route === selectedKey;
       const isRoute = !(parentName !== undefined && children.length === 0);
       return (
-        <CanAccess key={route} resource={name.toLowerCase()} action="list">
+        <CanAccess key={route} resource={name} action="list">
           <Menu.Item
             key={route}
             style={{

--- a/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/multi-tenancy/strapi.md
+++ b/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/multi-tenancy/strapi.md
@@ -346,7 +346,7 @@ export const CustomSider: React.FC = () => {
       const isSelected = route === selectedKey;
       const isRoute = !(parentName !== undefined && children.length === 0);
       return (
-        <CanAccess key={route} resource={name.toLowerCase()} action="list">
+        <CanAccess key={route} resource={name} action="list">
           <Menu.Item
             key={route}
             style={{

--- a/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/real-time.md
+++ b/documentation/versioned_docs/version-3.xx.xx/advanced-tutorials/real-time.md
@@ -226,7 +226,7 @@ export const CustomSider: React.FC = () => {
       const isSelected = route === selectedKey;
       const isRoute = !(parentName !== undefined && children.length === 0);
       return (
-        <CanAccess key={route} resource={name.toLowerCase()} action="list">
+        <CanAccess key={route} resource={name} action="list">
           <Menu.Item
             key={route}
             style={{
@@ -331,7 +331,7 @@ export const CustomSider: React.FC = () => {
       const isSelected = route === selectedKey;
       const isRoute = !(parentName !== undefined && children.length === 0);
       return (
-        <CanAccess key={route} resource={name.toLowerCase()} action="list">
+        <CanAccess key={route} resource={name} action="list">
           <Menu.Item
             key={route}
             style={{

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/antd/customization/sider.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/antd/customization/sider.md
@@ -172,7 +172,7 @@ const CustomSider: React.FC<RefineLayoutSiderProps> = ({ render }) => {
         return (
           <CanAccess
             key={route}
-            resource={name.toLowerCase()}
+            resource={name}
             action="list"
             params={{
               resource: item,
@@ -193,7 +193,7 @@ const CustomSider: React.FC<RefineLayoutSiderProps> = ({ render }) => {
       return (
         <CanAccess
           key={route}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{
             resource: item,

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/chakra-ui/customization/sider.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/chakra-ui/customization/sider.md
@@ -334,7 +334,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({ render }) => {
       return (
         <CanAccess
           key={route}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{
             resource: item,

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/customization/sider.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mantine/customization/sider.md
@@ -362,7 +362,7 @@ const CustomSider: React.FC<RefineLayoutSiderProps> = ({ render }) => {
       return (
         <CanAccess
           key={route}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{
             resource: item,
@@ -812,7 +812,7 @@ const CustomSider: React.FC<RefineLayoutSiderProps> = ({ render }) => {
       return (
         <CanAccess
           key={route}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{
             resource: item,

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/mui/customization/sider.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/mui/customization/sider.md
@@ -206,7 +206,7 @@ const CustomSider: React.FC<RefineLayoutSiderProps> = ({ render }) => {
         return (
           <CanAccess
             key={route}
-            resource={name.toLowerCase()}
+            resource={name}
             action="list"
             params={{
               resource: item,
@@ -276,7 +276,7 @@ const CustomSider: React.FC<RefineLayoutSiderProps> = ({ render }) => {
       return (
         <CanAccess
           key={route}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{ resource: item }}
         >

--- a/examples/app-crm/src/components/layout/sider.tsx
+++ b/examples/app-crm/src/components/layout/sider.tsx
@@ -64,7 +64,7 @@ export const Sider: React.FC = () => {
         return (
           <CanAccess
             key={item.key}
-            resource={name.toLowerCase()}
+            resource={name}
             action="list"
             params={{
               resource: item,
@@ -89,7 +89,7 @@ export const Sider: React.FC = () => {
       return (
         <CanAccess
           key={item.key}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{
             resource: item,

--- a/examples/customization-offlayout-area/src/components/sider/index.tsx
+++ b/examples/customization-offlayout-area/src/components/sider/index.tsx
@@ -48,7 +48,7 @@ export const FixedSider: React.FC = () => {
       return (
         <CanAccess
           key={route}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{ resource: item }}
         >

--- a/examples/customization-sider/src/components/sider/index.tsx
+++ b/examples/customization-sider/src/components/sider/index.tsx
@@ -66,7 +66,7 @@ export const CustomSider: typeof Sider = ({ render }) => {
       return (
         <CanAccess
           key={route}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{ resource: item }}
         >

--- a/examples/live-provider-ably/src/components/sider/index.tsx
+++ b/examples/live-provider-ably/src/components/sider/index.tsx
@@ -75,7 +75,7 @@ export const CustomSider: typeof Sider = ({ render }) => {
       return (
         <CanAccess
           key={key}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{ resource: item }}
         >

--- a/examples/mern-dashboard-client/src/components/layout/sider/index.tsx
+++ b/examples/mern-dashboard-client/src/components/layout/sider/index.tsx
@@ -86,7 +86,7 @@ export const Sider: typeof DefaultSider = ({ render }) => {
         return (
           <CanAccess
             key={route}
-            resource={name.toLowerCase()}
+            resource={name}
             action="list"
             params={{
               resource: item,
@@ -156,7 +156,7 @@ export const Sider: typeof DefaultSider = ({ render }) => {
       return (
         <CanAccess
           key={route}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{ resource: item }}
         >

--- a/packages/antd/src/components/layout/sider/index.tsx
+++ b/packages/antd/src/components/layout/sider/index.tsx
@@ -74,7 +74,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
         return (
           <CanAccess
             key={item.key}
-            resource={name.toLowerCase()}
+            resource={name}
             action="list"
             params={{
               resource: item,
@@ -98,7 +98,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
       return (
         <CanAccess
           key={item.key}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{
             resource: item,

--- a/packages/antd/src/components/themedLayout/sider/index.tsx
+++ b/packages/antd/src/components/themedLayout/sider/index.tsx
@@ -80,7 +80,7 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
         return (
           <CanAccess
             key={item.key}
-            resource={name.toLowerCase()}
+            resource={name}
             action="list"
             params={{
               resource: item,
@@ -105,7 +105,7 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
       return (
         <CanAccess
           key={item.key}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{
             resource: item,

--- a/packages/antd/src/components/themedLayoutV2/sider/index.tsx
+++ b/packages/antd/src/components/themedLayoutV2/sider/index.tsx
@@ -84,7 +84,7 @@ export const ThemedSiderV2: React.FC<RefineThemedLayoutV2SiderProps> = ({
         return (
           <CanAccess
             key={item.key}
-            resource={name.toLowerCase()}
+            resource={name}
             action="list"
             params={{
               resource: item,
@@ -112,7 +112,7 @@ export const ThemedSiderV2: React.FC<RefineThemedLayoutV2SiderProps> = ({
       return (
         <CanAccess
           key={item.key}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{
             resource: item,

--- a/packages/chakra-ui/src/components/layout/sider/index.tsx
+++ b/packages/chakra-ui/src/components/layout/sider/index.tsx
@@ -95,7 +95,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
       return (
         <CanAccess
           key={item.key}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{
             resource: item,

--- a/packages/chakra-ui/src/components/themedLayout/sider/index.tsx
+++ b/packages/chakra-ui/src/components/themedLayout/sider/index.tsx
@@ -97,7 +97,7 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
       return (
         <CanAccess
           key={item.key}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{
             resource: item,

--- a/packages/chakra-ui/src/components/themedLayoutV2/sider/index.tsx
+++ b/packages/chakra-ui/src/components/themedLayoutV2/sider/index.tsx
@@ -93,7 +93,7 @@ export const ThemedSiderV2: React.FC<RefineThemedLayoutV2SiderProps> = ({
       return (
         <CanAccess
           key={item.key}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{
             resource: item,

--- a/packages/mantine/src/components/layout/sider/index.tsx
+++ b/packages/mantine/src/components/layout/sider/index.tsx
@@ -124,7 +124,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
       return (
         <CanAccess
           key={item.key}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{
             resource: item,

--- a/packages/mantine/src/components/themedLayout/sider/index.tsx
+++ b/packages/mantine/src/components/themedLayout/sider/index.tsx
@@ -121,7 +121,7 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
       return (
         <CanAccess
           key={item.key}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{
             resource: item,

--- a/packages/mantine/src/components/themedLayoutV2/sider/index.tsx
+++ b/packages/mantine/src/components/themedLayoutV2/sider/index.tsx
@@ -116,7 +116,7 @@ export const ThemedSiderV2: React.FC<RefineThemedLayoutV2SiderProps> = ({
       return (
         <CanAccess
           key={item.key}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{
             resource: item,

--- a/packages/mui/src/components/layout/sider/index.tsx
+++ b/packages/mui/src/components/layout/sider/index.tsx
@@ -108,7 +108,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
         return (
           <CanAccess
             key={item.key}
-            resource={name.toLowerCase()}
+            resource={name}
             action="list"
             params={{
               resource: item,
@@ -182,7 +182,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
       return (
         <CanAccess
           key={item.key}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{ resource: item }}
         >

--- a/packages/mui/src/components/themedLayout/sider/index.tsx
+++ b/packages/mui/src/components/themedLayout/sider/index.tsx
@@ -111,7 +111,7 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
         return (
           <CanAccess
             key={item.key}
-            resource={name.toLowerCase()}
+            resource={name}
             action="list"
             params={{
               resource: item,
@@ -193,7 +193,7 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
       return (
         <CanAccess
           key={item.key}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{ resource: item }}
         >

--- a/packages/mui/src/components/themedLayoutV2/sider/index.tsx
+++ b/packages/mui/src/components/themedLayoutV2/sider/index.tsx
@@ -111,7 +111,7 @@ export const ThemedSiderV2: React.FC<RefineThemedLayoutV2SiderProps> = ({
         return (
           <CanAccess
             key={item.key}
-            resource={name.toLowerCase()}
+            resource={name}
             action="list"
             params={{
               resource: item,
@@ -195,7 +195,7 @@ export const ThemedSiderV2: React.FC<RefineThemedLayoutV2SiderProps> = ({
       return (
         <CanAccess
           key={item.key}
-          resource={name.toLowerCase()}
+          resource={name}
           action="list"
           params={{ resource: item }}
         >


### PR DESCRIPTION
## PR Checklist


- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

The current behavior intermittently lower cases resources due to inconsistent handling of resource names.

## What is the new behavior?

The new behavior ensures consistent casing of resource names, addressing the issue of intermittent lower casing.

fixes #6004

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
This PR addresses the intermittent issue where resource names were being lower-cased. The fix ensures consistent casing throughout the access control logic.
