### PR TITLE
fix(nestjs-query): can specify `0` as filter value

### DIFF
--- a/.changeset/sharp-lies-wash.md
+++ b/.changeset/sharp-lies-wash.md
@@ -1,0 +1,19 @@
+---
+"@refinedev/nestjs-query": patch
+---
+
+fix: can specify 0 as filter value
+
+The following values do not apply to the filter.
+
+- null
+- undefined
+- NaN
+- Infinity / -Infinity
+
+The following values can apply to the filter.
+
+- 0
+- ""
+
+Resolves #6022

--- a/packages/nestjs-query/src/utils/index.ts
+++ b/packages/nestjs-query/src/utils/index.ts
@@ -161,8 +161,12 @@ export const generateFilters = (filters: LogicalFilter[]) => {
       if (Array.isArray(f.value) && f.value.length === 0) {
         return false;
       }
+      if (typeof f.value === "number") {
+        return Number.isFinite(f.value);
+      }
 
-      return !!f.value;
+      // If the value is null or undefined, it returns false.
+      return !(f.value == null);
     })
     .map((filter: LogicalFilter | CrudFilter) => {
       if (filter.operator === "and" || filter.operator === "or") {

--- a/packages/nestjs-query/test/utils/generateFilters.spec.ts
+++ b/packages/nestjs-query/test/utils/generateFilters.spec.ts
@@ -156,4 +156,49 @@ describe("generateFilters", () => {
       expect(result).toEqual(expected);
     });
   });
+  it("should generate filter when value is valid", () => {
+    const testCases: { filters: CrudFilter[]; expected: any }[] = [
+      {
+        filters: [{ operator: "eq", field: "name", value: "" }],
+        expected: { name: { eq: "" } },
+      },
+      {
+        filters: [{ operator: "eq", field: "name", value: null }],
+        expected: {},
+      },
+      {
+        filters: [{ operator: "eq", field: "name", value: undefined }],
+        expected: {},
+      },
+      {
+        filters: [{ operator: "eq", field: "age", value: 0 }],
+        expected: { age: { eq: 0 } },
+      },
+      {
+        filters: [{ operator: "eq", field: "age", value: Number.NaN }],
+        expected: {},
+      },
+      {
+        filters: [
+          { operator: "eq", field: "age", value: Number.POSITIVE_INFINITY },
+        ],
+        expected: {},
+      },
+      {
+        filters: [
+          { operator: "eq", field: "age", value: Number.NEGATIVE_INFINITY },
+        ],
+        expected: {},
+      },
+      {
+        filters: [{ operator: "between", field: "age", value: [] }],
+        expected: {},
+      },
+    ];
+
+    testCases.forEach(({ filters, expected }) => {
+      const result = generateFilters(filters as LogicalFilter[]);
+      expect(result).toEqual(expected);
+    });
+  });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] ~~Docs have been added / updated~~
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

- Cannot specify `0` as filter value
- Cannot specify `""` as filter value

## What is the new behavior?

- Can specify `0` as filter value
- Can specify `""` as filter value

fixes #6022

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
