### PR TITLE
fix(win95): genres filter should use `ina`

### DIFF
--- a/examples/win95/src/routes/video-club/tapes/select-title.tsx
+++ b/examples/win95/src/routes/video-club/tapes/select-title.tsx
@@ -125,7 +125,7 @@ export const VideoClubPageTapeSelectTitle = ({
             <TableFilterInputContainer>
               <TableFilterInputLabel>Category:</TableFilterInputLabel>
               <TableFilterInputText
-                defaultValue={getDefaultFilter("genres", filters, "contains")}
+                defaultValue={getDefaultFilter("genres", filters, "ina")}
                 onChange={(e) => {
                   const value = e.target?.value?.trim();
                   setCurrent(1);
@@ -133,7 +133,7 @@ export const VideoClubPageTapeSelectTitle = ({
                     {
                       field: "genres",
                       value: value.split(",").map((v) => v.trim()),
-                      operator: "contains",
+                      operator: "ina",
                     },
                   ]);
                 }}

--- a/examples/win95/src/routes/video-club/titles/list.tsx
+++ b/examples/win95/src/routes/video-club/titles/list.tsx
@@ -98,7 +98,7 @@ export const VideoClubPageBrowseTitles = () => {
           <FilterInputContainer>
             <FilterInputLabel>Category:</FilterInputLabel>
             <FilterInputText
-              defaultValue={getDefaultFilter("genres", filters, "contains")}
+              defaultValue={getDefaultFilter("genres", filters, "ina")}
               onChange={(e) => {
                 const value = e.target?.value?.trim();
                 setCurrent(1);
@@ -106,7 +106,7 @@ export const VideoClubPageBrowseTitles = () => {
                   {
                     field: "genres",
                     value: value.split(",").map((v) => v.trim()),
-                    operator: "contains",
+                    operator: "ina",
                   },
                 ]);
               }}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

---

fixed: `genres` filter operator
