### PR TITLE
fix(cli): type imports in swizzle command

### DIFF
--- a/.changeset/slow-cougars-sit.md
+++ b/.changeset/slow-cougars-sit.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/cli": patch
+---
+
+fix(cli): type imports are breaking the code structure on swizzle
+
+When exporting elements with `swizzle` command, it will try to replace and combine imports from Refine packages. This process was broken if the target file was using `import type` syntax. This PR updates swizzle command to handle `import type` syntax separately.
+
+Resolves [#6035](https://github.com/refinedev/refine/issues/6035)

--- a/packages/cli/src/utils/swizzle/import.test.ts
+++ b/packages/cli/src/utils/swizzle/import.test.ts
@@ -9,39 +9,60 @@ describe("getImports", () => {
                 import * as Antd from "antd";
                 import { Button as AntButton, TextInput } from "antd";
                 import { Button as AntButton, TextInput as AntTextInput } from "antd";
+                import type { IAuthProvider } from "@refinedev/core";
+                import { type BaseRecord } from "@refinedev/core";
+
         `;
 
     const expected = [
       {
+        isType: false,
         statement: 'import React from "react";',
         importPath: "react",
         defaultImport: "React",
       },
       {
+        isType: false,
         statement: 'import { Button } from "antd";',
         importPath: "antd",
         namedImports: " { Button }",
       },
       {
+        isType: false,
         statement: 'import { TextInput as AntTextInput } from "antd";',
         importPath: "antd",
         namedImports: " { TextInput as AntTextInput }",
       },
       {
+        isType: false,
         statement: 'import * as Antd from "antd";',
         importPath: "antd",
         namespaceImport: "Antd",
       },
       {
+        isType: false,
         statement: 'import { Button as AntButton, TextInput } from "antd";',
         importPath: "antd",
         namedImports: " { Button as AntButton, TextInput }",
       },
       {
+        isType: false,
         statement:
           'import { Button as AntButton, TextInput as AntTextInput } from "antd";',
         importPath: "antd",
         namedImports: " { Button as AntButton, TextInput as AntTextInput }",
+      },
+      {
+        isType: true,
+        statement: 'import type { IAuthProvider } from "@refinedev/core";',
+        importPath: "@refinedev/core",
+        namedImports: " { IAuthProvider }",
+      },
+      {
+        isType: false,
+        statement: 'import { type BaseRecord } from "@refinedev/core";',
+        importPath: "@refinedev/core",
+        namedImports: " { type BaseRecord }",
       },
     ];
 
@@ -52,7 +73,7 @@ describe("getImports", () => {
 describe("getNameChangeInImport", () => {
   it("should get all name changes", () => {
     const statement = `
-                { Button as AntButton, TextInput as AntTextInput }
+                { Button as AntButton, TextInput as AntTextInput, type ButtonProps, type TextInputProps as AntTextInputProps }
         `;
 
     const expected = [
@@ -63,10 +84,16 @@ describe("getNameChangeInImport", () => {
         afterCharacter: ",",
       },
       {
-        statement: " TextInput as AntTextInput ",
+        statement: " TextInput as AntTextInput,",
         fromName: "TextInput",
         toName: "AntTextInput",
+        afterCharacter: ",",
+      },
+      {
         afterCharacter: undefined,
+        fromName: "type TextInputProps",
+        statement: " type TextInputProps as AntTextInputProps ",
+        toName: "AntTextInputProps",
       },
     ];
 
@@ -196,6 +223,32 @@ import { Button, TextInput } from "antd";
 import React from "react";
 import { Button, TextInput } from "antd";
 import type { Layout } from "antd";
+`;
+
+    expect(reorderImports(content).trim()).toEqual(expected.trim());
+  });
+
+  it("should keep type imports with content", () => {
+    const content = `
+import type { AxiosInstance } from "axios";
+import { stringify } from "query-string";
+import type { DataProvider } from "@refinedev/core";
+import { axiosInstance, generateSort, generateFilter } from "./utils";
+
+type MethodTypes = "get" | "delete" | "head" | "options";
+type MethodTypesWithBody = "post" | "put" | "patch";
+`;
+
+    const expected = `
+import { axiosInstance, generateSort, generateFilter } from "./utils";
+import { stringify } from "query-string";
+import type { AxiosInstance } from "axios";
+import type { DataProvider } from "@refinedev/core";
+
+
+
+type MethodTypes = "get" | "delete" | "head" | "options";
+type MethodTypesWithBody = "post" | "put" | "patch";
 `;
 
     expect(reorderImports(content).trim()).toEqual(expected.trim());

--- a/packages/cli/src/utils/swizzle/import.test.ts
+++ b/packages/cli/src/utils/swizzle/import.test.ts
@@ -25,13 +25,13 @@ describe("getImports", () => {
         isType: false,
         statement: 'import { Button } from "antd";',
         importPath: "antd",
-        namedImports: " { Button }",
+        namedImports: "{ Button }",
       },
       {
         isType: false,
         statement: 'import { TextInput as AntTextInput } from "antd";',
         importPath: "antd",
-        namedImports: " { TextInput as AntTextInput }",
+        namedImports: "{ TextInput as AntTextInput }",
       },
       {
         isType: false,
@@ -43,26 +43,26 @@ describe("getImports", () => {
         isType: false,
         statement: 'import { Button as AntButton, TextInput } from "antd";',
         importPath: "antd",
-        namedImports: " { Button as AntButton, TextInput }",
+        namedImports: "{ Button as AntButton, TextInput }",
       },
       {
         isType: false,
         statement:
           'import { Button as AntButton, TextInput as AntTextInput } from "antd";',
         importPath: "antd",
-        namedImports: " { Button as AntButton, TextInput as AntTextInput }",
+        namedImports: "{ Button as AntButton, TextInput as AntTextInput }",
       },
       {
         isType: true,
         statement: 'import type { IAuthProvider } from "@refinedev/core";',
         importPath: "@refinedev/core",
-        namedImports: " { IAuthProvider }",
+        namedImports: "{ IAuthProvider }",
       },
       {
         isType: false,
         statement: 'import { type BaseRecord } from "@refinedev/core";',
         importPath: "@refinedev/core",
-        namedImports: " { type BaseRecord }",
+        namedImports: "{ type BaseRecord }",
       },
     ];
 

--- a/packages/cli/src/utils/swizzle/import.ts
+++ b/packages/cli/src/utils/swizzle/import.ts
@@ -1,5 +1,5 @@
 const packageRegex =
-  /import(?:\s{1}type)?(?:(?:(?:[ \n\t]+([^ *\n\t\{\},]+)[ \n\t]*(?:,|[ \n\t]+))?([ \n\t]*\{(?:[ \n\t]*[^ \n\t"'\{\}]+[ \n\t]*,?)+\})?[ \n\t]*)|[ \n\t]*\*[ \n\t]*as[ \n\t]+([^ \n\t\{\}]+)[ \n\t]+)from[ \n\t]*(?:['"])([^'"\n]+)(?:['"])(?:;?)/g;
+  /import(?:\s+(type))?\s*(?:([^\s\{\},]+)\s*(?:,\s*)?)?(\{[^}]+\})?\s*(?:\*\s*as\s+([^\s\{\}]+)\s*)?from\s*['"]([^'"]+)['"];?/g;
 
 const nameChangeRegex = /((?:\w|\s|_)*)( as )((?:\w|\s|_)*)( |,)?/g;
 
@@ -27,6 +27,7 @@ export const getImports = (content: string): Array<ImportMatch> => {
   for (const match of matches) {
     const [
       statement,
+      typePrefix,
       defaultImport,
       namedImports,
       namespaceImport,
@@ -34,7 +35,7 @@ export const getImports = (content: string): Array<ImportMatch> => {
     ] = match;
 
     imports.push({
-      isType: statement.includes("import type"),
+      isType: typePrefix === "type",
       statement,
       importPath,
       ...(defaultImport && { defaultImport }),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

When exporting elements with `swizzle` command, it will try to replace and combine imports from Refine packages. This process was broken if the target file was using `import type` syntax. This PR updates swizzle command to handle `import type` syntax separately.

Resolves #6035