### PR TITLE
feat: add hash query param to live previews

### DIFF
--- a/packages/live-previews/pages/preview.tsx
+++ b/packages/live-previews/pages/preview.tsx
@@ -14,8 +14,15 @@ import { checkPackage } from "@/src/utils/check-package";
 
 const Preview: NextPage = () => {
   const [ready, setReady] = React.useState(false);
-  const { code, css, hasQuery, isReady, disableScroll, useTailwind } =
-    useCode();
+  const {
+    code,
+    css,
+    hasQuery,
+    isReady,
+    disableScroll,
+    useTailwind,
+    isLoading,
+  } = useCode();
   const [scope, setScope] = React.useState({ ...RefineCommonScope });
   const [scopeSettled, setScopeSettled] = React.useState(false);
 
@@ -60,7 +67,7 @@ const Preview: NextPage = () => {
     return <Error statusCode={404} />;
   }
 
-  if (isReady && hasQuery && !code) {
+  if (isReady && hasQuery && !code && !isLoading) {
     return <Error statusCode={400} />;
   }
 

--- a/packages/live-previews/src/utils/use-code.ts
+++ b/packages/live-previews/src/utils/use-code.ts
@@ -10,16 +10,45 @@ type UseCodeReturn = {
   hasQuery: boolean;
   disableScroll: boolean;
   useTailwind: boolean;
+  isLoading: boolean;
 };
 
 export const useCode = (): UseCodeReturn => {
   const { query, isReady } = useRouter();
   const {
-    code: compressed,
+    code: encoded,
+    hash,
     disableScroll,
     tailwind,
     css: cssCompressed,
   } = query ?? {};
+
+  const [isLoading, setIsLoading] = React.useState<boolean>(true);
+  const [compressed, setCompressed] = React.useState<string | undefined>();
+
+  React.useEffect(() => {
+    if (!isReady) return;
+    if (compressed) return;
+
+    if (encoded) {
+      setCompressed(encoded as string);
+      setIsLoading(false);
+      return;
+    }
+
+    if (hash) {
+      fetch(`${process.env.NEXT_PUBLIC_PREVIEW_BUCKET_URL}/${hash}`)
+        .then((body) =>
+          body.text().then((data) => {
+            setCompressed(data);
+            setIsLoading(false);
+          }),
+        )
+        .catch((e) => {
+          setIsLoading(false);
+        });
+    }
+  }, [isReady, compressed, encoded, hash]);
 
   const code = React.useMemo(() => {
     if (!isReady) return "";
@@ -61,8 +90,9 @@ export const useCode = (): UseCodeReturn => {
     code,
     css,
     isReady,
-    hasQuery: !!compressed,
+    hasQuery: !!encoded || !!hash,
     disableScroll: !!disableScroll,
     useTailwind: !!tailwind,
+    isLoading,
   };
 };

--- a/packages/live-previews/src/utils/use-code.ts
+++ b/packages/live-previews/src/utils/use-code.ts
@@ -37,7 +37,9 @@ export const useCode = (): UseCodeReturn => {
     }
 
     if (hash) {
-      fetch(`${process.env.NEXT_PUBLIC_PREVIEW_BUCKET_URL}/${hash}`)
+      fetch(
+        `https://${process.env.NEXT_PUBLIC_PREVIEWS_BUCKET_NAME}.fra1.cdn.digitaloceanspaces.com/preview-strings/${hash}`,
+      )
         .then((body) =>
           body.text().then((data) => {
             setCompressed(data);


### PR DESCRIPTION
Added option to handle `hash` query parameter for live previews. This will be used to fetch lzstring from the bucket with given hash to avoid 414 status code.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes # (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
