### PR TITLE
fix: replace lodash imports from root with subpath imports

### DIFF
--- a/.changeset/smooth-maps-arrive.md
+++ b/.changeset/smooth-maps-arrive.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/hasura": patch
+---
+
+fix(hasura): broken lodash import in bundle
+
+ESM bundle of `@refinedev/hasura` was broken due to incorrect lodash import. Import has been replaced with subdirectory import to get handled properly in the bundling process.
+
+Fixes [#6044](https://github.com/refinedev/refine/issues/6044)

--- a/.changeset/tall-geckos-help.md
+++ b/.changeset/tall-geckos-help.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/devtools-server": patch
+---
+
+fix(devtools-server): lodash import from root
+
+`@refinedev/devtools-server` was using `lodash` imports from root which are interpreted as CJS imports in the ESM bundle. To avoid any future issues, lodash imports have been replaced with subdirectory imports.

--- a/.changeset/twenty-insects-eat.md
+++ b/.changeset/twenty-insects-eat.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/inferencer": patch
+---
+
+fix(inferencer): broken lodash import in bundle
+
+ESM bundle of `@refinedev/inferencer` was broken due to incorrect lodash import. Import has been replaced with subdirectory import to get handled properly in the bundling process.

--- a/packages/devtools-server/src/reload-on-change.ts
+++ b/packages/devtools-server/src/reload-on-change.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import { DevtoolsEvent, send } from "@refinedev/devtools-shared";
 
 import type { Server } from "ws";

--- a/packages/hasura/src/utils/upperCaseValues.ts
+++ b/packages/hasura/src/utils/upperCaseValues.ts
@@ -1,4 +1,4 @@
-import { mapValues } from "lodash";
+import mapValues from "lodash/mapValues";
 
 export const upperCaseValues = (obj: any): any => {
   if (!obj) return undefined;

--- a/packages/inferencer/src/use-relation-fetch/index.ts
+++ b/packages/inferencer/src/use-relation-fetch/index.ts
@@ -13,7 +13,7 @@ import type {
   InferencerComponentProps,
   ResourceInferenceAttempt,
 } from "../types";
-import { get } from "lodash";
+import get from "lodash/get";
 import { pickMeta } from "../utilities/get-meta-props";
 
 type UseRelationFetchProps = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes


ESM bundle of `@refinedev/hasura` was broken due to incorrect lodash import. Import has been replaced with subdirectory import to get handled properly in the bundling process.

Fixes [#6044](https://github.com/refinedev/refine/issues/6044)

`@refinedev/devtools-server` was using `lodash` imports from root which are interpreted as CJS imports in the ESM bundle. To avoid any future issues, lodash imports have been replaced with subdirectory imports.

ESM bundle of `@refinedev/inferencer` was broken due to incorrect lodash import. Import has been replaced with subdirectory import to get handled properly in the bundling process.