### PR TITLE
docs(snippet): use correct constant in function iteration

### DIFF
--- a/documentation/docs/core/hooks/utilities/use-menu/index.md
+++ b/documentation/docs/core/hooks/utilities/use-menu/index.md
@@ -54,7 +54,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   const renderMenuItems = (items: ITreeMenu[]) => {
     return (
       <>
-        {menuItems.map(({ key, name, label, icon, route }) => {
+        {items.map(({ key, name, label, icon, route }) => {
           const isSelected = key === selectedKey;
           return (
             <li key={name}>

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/core/hooks/ui/useMenu.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/core/hooks/ui/useMenu.md
@@ -75,7 +75,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   const renderMenuItems = (items: ITreeMenu[]) => {
     return (
       <>
-        {menuItems.map(({ name, label, icon, route }) => {
+        {items.map(({ name, label, icon, route }) => {
           const isSelected = route === selectedKey;
           return (
             <li key={name}>
@@ -163,7 +163,7 @@ We created `<Layout>` with a header with a logo and a list of links to all menu 
 
 :::tip
 
-[Refer to Custom Layout guide for more detailed information on layout customization. &#8594](/docs/3.xx.xx/advanced-tutorials/custom-layout/)  
+[Refer to Custom Layout guide for more detailed information on layout customization. &#8594](/docs/3.xx.xx/advanced-tutorials/custom-layout/)
 :::
 
 After creating the `<Layout/>` component, we can use it in our application. We need to pass it to the `<Refine/>` component as a prop.

--- a/documentation/versioned_docs/version-3.xx.xx/api-reference/core/hooks/ui/useMenu.md
+++ b/documentation/versioned_docs/version-3.xx.xx/api-reference/core/hooks/ui/useMenu.md
@@ -163,7 +163,7 @@ We created `<Layout>` with a header with a logo and a list of links to all menu 
 
 :::tip
 
-[Refer to Custom Layout guide for more detailed information on layout customization. &#8594](/docs/3.xx.xx/advanced-tutorials/custom-layout/)
+[Refer to Custom Layout guide for more detailed information on layout customization. &#8594](/docs/3.xx.xx/advanced-tutorials/custom-layout/)  
 :::
 
 After creating the `<Layout/>` component, we can use it in our application. We need to pass it to the `<Refine/>` component as a prop.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
In useMenu, we have the renderMenuItems function that takes an array of items but doesn't make use of it, instead iterates over the state in the parent function. We can either remove the items that we pass to the function or actually use it. 

## What is the new behavior?
Uses the function parameter. 

fixes # (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
