### PR TITLE
fix(devtools): failing auth status checks

### DIFF
--- a/.changeset/hip-ears-shave.md
+++ b/.changeset/hip-ears-shave.md
@@ -6,3 +6,5 @@
 fix(devtools-server): missing header check on auth requests
 
 Devtools was failing to determine the auth status and always end up redirecting to the login page regardless of the actual auth status. This was due to the missing check on the auth request that was causing all valid responses treated as unauthenticated.
+
+Resolves [#6047](https://github.com/refinedev/refine/issues/6047)

--- a/.changeset/hip-ears-shave.md
+++ b/.changeset/hip-ears-shave.md
@@ -1,0 +1,8 @@
+---
+"@refinedev/devtools-server": patch
+"@refinedev/devtools-ui": patch
+---
+
+fix(devtools-server): missing header check on auth requests
+
+Devtools was failing to determine the auth status and always end up redirecting to the login page regardless of the actual auth status. This was due to the missing check on the auth request that was causing all valid responses treated as unauthenticated.

--- a/.changeset/wet-pianos-arrive.md
+++ b/.changeset/wet-pianos-arrive.md
@@ -1,0 +1,8 @@
+---
+"@refinedev/cli": patch
+"@refinedev/devtools": patch
+---
+
+fix(devtools): failing authentication checks
+
+Devtools was failing on determining the auth status and always ended up redirecting to the login page or the onboarding step regardless of the actual authentication status.

--- a/.changeset/wet-pianos-arrive.md
+++ b/.changeset/wet-pianos-arrive.md
@@ -6,3 +6,5 @@
 fix(devtools): failing authentication checks
 
 Devtools was failing on determining the auth status and always ended up redirecting to the login page or the onboarding step regardless of the actual authentication status.
+
+Resolves [#6047](https://github.com/refinedev/refine/issues/6047)

--- a/packages/devtools-server/package.json
+++ b/packages/devtools-server/package.json
@@ -38,7 +38,7 @@
     "build": "pnpm build:client && tsup && node ../shared/generate-declarations.js",
     "build:client": "NODE_ENV=production tsc && vite build --config src/client/vite.config.ts",
     "dev": "pnpm dev:client & tsup --watch",
-    "dev:client": "vite build --watch --force --config src/client/vite.config.ts",
+    "dev:client": "vite build --watch --config src/client/vite.config.ts",
     "prepare": "pnpm -w build --scope @refinedev/devtools-server",
     "publint": "publint --strict=true --level=suggestion",
     "start:server": "node dist/cli.cjs",

--- a/packages/devtools-server/package.json
+++ b/packages/devtools-server/package.json
@@ -38,7 +38,7 @@
     "build": "pnpm build:client && tsup && node ../shared/generate-declarations.js",
     "build:client": "NODE_ENV=production tsc && vite build --config src/client/vite.config.ts",
     "dev": "pnpm dev:client & tsup --watch",
-    "dev:client": "vite build --watch --config src/client/vite.config.ts"
+    "dev:client": "vite build --watch --config src/client/vite.config.ts",
     "prepare": "pnpm build",
     "publint": "publint --strict=true --level=suggestion",
     "start:server": "node dist/cli.cjs",

--- a/packages/devtools-server/src/serve-proxy.ts
+++ b/packages/devtools-server/src/serve-proxy.ts
@@ -173,6 +173,7 @@ export const serveProxy = async (app: Express) => {
       if (proxyRes.statusCode === 401) {
         res.writeHead(200, {
           ...proxyRes.headers,
+          "Refine-Is-Authenticated": "false",
           "Access-Control-Expose-Headers": `Refine-Is-Authenticated, ${proxyRes.headers["Access-Control-Expose-Headers"]}`,
         });
       } else {

--- a/packages/devtools-ui/src/components/header-auth-status.tsx
+++ b/packages/devtools-ui/src/components/header-auth-status.tsx
@@ -68,6 +68,7 @@ export const HeaderAuthStatus = () => {
           <Gravatar
             email={me?.email ?? ""}
             size={32}
+            protocol="https://"
             style={{ borderRadius: "50%" }}
           />
           <div

--- a/packages/devtools-ui/src/utils/auth.ts
+++ b/packages/devtools-ui/src/utils/auth.ts
@@ -3,8 +3,11 @@ import { ory } from "./ory";
 export const isAuthenticated = async () => {
   try {
     const response = await ory.toSession();
-    const headerAuth = Boolean(response.headers["Refine-Is-Authenticated"]);
-    return headerAuth;
+    const authenticatedHeader = response.headers["refine-is-authenticated"];
+    if (authenticatedHeader === "false") {
+      return false;
+    }
+    return true;
   } catch (error: any) {
     return false;
   }

--- a/packages/devtools-ui/src/utils/me.ts
+++ b/packages/devtools-ui/src/utils/me.ts
@@ -8,9 +8,13 @@ export const getMe = async () => {
   try {
     const response = await fetch("/api/.refine/users/me");
 
-    const data = (await response.json()) as MeResponse;
+    if (response.ok) {
+      const data = (await response.json()) as MeResponse;
 
-    return data;
+      return data;
+    }
+
+    return null;
   } catch (_) {
     //
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

##Changes

Fixes #6047 

Devtools was failing to determine the auth status and always end up redirecting to the login page regardless of the actual auth status. This was due to the missing check on the auth request that was causing all valid responses treated as unauthenticated.