### PR TITLE
docs(blog): fix typo of react patterns

### DIFF
--- a/documentation/blog/2023-10-17-react-patterns.md
+++ b/documentation/blog/2023-10-17-react-patterns.md
@@ -279,16 +279,14 @@ After creating the provider, we will enclose components dependent on the data fr
 To obtain the data from context API, we call useContext hook, which accepts a context as a parameter(in this case, **ThemeContext**).
 
 ```tsx
-impor { useContext } from 'react';
+import { useContext } from "react";
 import { ThemeProvider, ThemeContext } from "../context";
-
 
 const HeaderSection = () => {
   <ThemeProvider>
     <TopNav />
   </ThemeProvider>;
 };
-
 
 const TopNav = () => {
   const { theme, setTheme } = useContext(ThemeContext);
@@ -299,7 +297,6 @@ const TopNav = () => {
     </div>
   );
 };
-
 ```
 
 ## Component enhancement with HOCs (higher-order components)


### PR DESCRIPTION
Hi, team. I'm new to React, and while reading [your team's very informative blog post](https://refine.dev/blog/react-design-patterns/#data-management-with-providers), 
I found a typo and just fix it.I apologize for this sudden pull request, and thank you in advance for taking your time to check this!

Best regards, 
shunmaruko

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset
     No, because no affect on any package.

## What is the current behavior?
typo & single quoted
https://refine.dev/blog/react-design-patterns/#data-management-with-providers
<img width="1012" src="https://github.com/refinedev/refine/assets/54808156/d3508d9a-b479-4775-9e4b-fad52ee256dc">

## What is the new behavior?

typo fixed & double quoted

<img width="1012" src="https://github.com/refinedev/refine/assets/54808156/1879ead7-4ef4-4a91-a901-843e726d1a48">


## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
