### PR TITLE
fix: attw and publint scripts won't run

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,17 +47,14 @@ jobs:
           node-version: 18
           cache: "pnpm"
       - name: Install & Build
-        run: |
-          pnpm install
-      - name: Test
-        run: |
-          pnpm test:all --skip-nx-cache
+        run: pnpm install
       - name: Publint
-        run: |
-          pnpm publint:all
+        run: pnpm publint:all
       - name: Are The Types Wrong
-        run: |
-          pnpm attw:all
+        run: pnpm attw:all
+      - name: Test
+        run: pnpm test:all --skip-nx-cache
+
   tsdoc-check:
     runs-on: ubuntu-latest
     name: Check TSDoc Links

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,12 +41,12 @@ jobs:
         run: pnpm lint:ci
       - name: Syncpack
         run: pnpm sp lint
-      - name: Test
-        run: pnpm test:all
       - name: Publint
         run: pnpm publint:all
       - name: Are The Types Wrong
         run: pnpm attw:all
+      - name: Test
+        run: pnpm test:all
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1

--- a/nx.json
+++ b/nx.json
@@ -31,8 +31,12 @@
       "outputs": ["{projectRoot}/dist"]
     },
     "cypress:run": {},
-    "attw": {},
-    "publint": {}
+    "attw": {
+      "dependsOn": ["build"]
+    },
+    "publint": {
+      "dependsOn": ["build"]
+    }
   },
   "defaultProject": "@refinedev/core",
   "cli": {

--- a/nx.json
+++ b/nx.json
@@ -30,7 +30,9 @@
       "dependsOn": ["^types", "build"],
       "outputs": ["{projectRoot}/dist"]
     },
-    "cypress:run": {}
+    "cypress:run": {},
+    "attw": {},
+    "publint": {}
   },
   "defaultProject": "@refinedev/core",
   "cli": {


### PR DESCRIPTION
Since we were missing `attw` and `publint` scripts in `nx.json`, they weren't recognized by lerna and they weren't running in CI workflows.

Also moved `publint` and `attw` scripts above `test` step, since they run faster and we can get feedback earlier in case something is wrong.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
