### PR TITLE
fix: release workflow can't update pnpm-lock.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: ./.github/workflows/scripts/update-lock.sh
-          publish: npm run changeset publish
+          version: pnpm version-packages
+          publish: pnpm changeset publish
           commit: "ci(changesets): version packages"
           title: "ci(changesets): version packages"
         env:

--- a/.github/workflows/scripts/update-lock.sh
+++ b/.github/workflows/scripts/update-lock.sh
@@ -1,1 +1,0 @@
-npm run changeset version && pnpm i --ignore-scripts --lockfile-only --frozen-lockfile false

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test": "lerna run test --stream",
     "test:all": "lerna run test --stream --scope @refinedev/* --scope create-refine-app",
     "test:all:coverage": "pnpm test:all -- -- --coverage",
-    "test:coverage": "pnpm test -- -- --coverage"
+    "test:coverage": "pnpm test -- -- --coverage",
+    "version-packages": "changeset version && pnpm i --ignore-scripts --lockfile-only"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json}": [


### PR DESCRIPTION
release workflow can't properly update `pnpm-lock.yaml` for every run. After running `changeset version` command, which updates package.json of all packages and examples, `pnpm-lock.yaml` file needs to be updated to have latest version.

Previously we had sh file to handle changeset version and running pnpm install but that doesn't seems to be working reliably.

Following the suggestions in [this issue](https://github.com/changesets/action/issues/203), added `version-packages` script to root package.json and updated release workflow's changeset job to run version-packages script instead.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
