### PR TITLE
docs(docgen): replace dynamic import with require statement

### DIFF
--- a/documentation/src/components/props-table/index.tsx
+++ b/documentation/src/components/props-table/index.tsx
@@ -2,8 +2,8 @@ import React, { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import {
   type DeclarationType,
-  useDynamicImport,
-} from "../../hooks/use-dynamic-import";
+  requireDocgen,
+} from "../../utils/require-docgen";
 import PropTag from "../prop-tag";
 import Tooltip from "../tooltip";
 
@@ -212,7 +212,7 @@ const PropsTable: React.FC<React.PropsWithChildren<Props>> = ({
   children,
   ...overrides
 }) => {
-  const data = useDynamicImport(module);
+  const data = requireDocgen(module);
 
   const hideRowDefault = useMemo(() => {
     if (hideDefaults) return false;

--- a/documentation/src/utils/require-docgen.ts
+++ b/documentation/src/utils/require-docgen.ts
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import type { ComponentDoc, PropItem } from "react-docgen-typescript";
 
 export interface StringIndexedObject<T> {
@@ -18,30 +17,17 @@ export type DeclarationType = Omit<ComponentDoc, "methods"> &
     >;
   };
 
-export const useDynamicImport = (
+export const requireDocgen = (
   name: string,
   prefix = "@refinedev/",
 ): DeclarationType | null => {
-  const [props, setProps] = useState<DeclarationType>(null);
+  try {
+    const data = require(
+      `@docgen/${name.startsWith(prefix) ? name : `${prefix}${name}`}.json`,
+    );
 
-  useEffect(() => {
-    let resolved = false;
-
-    import(
-      `@docgen/${name.startsWith(prefix) ? name : `${prefix}${name}`}.json`
-    )
-      .then((props) => {
-        if (!resolved) {
-          resolved = true;
-          setProps(props.default);
-        }
-      })
-      .catch(console.warn);
-
-    return () => {
-      resolved = true;
-    };
-  }, [name]);
-
-  return props;
+    return data as DeclarationType;
+  } catch (err) {
+    return null;
+  }
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

Previously, `<PropsTable />` was using dynamic import inside an effect which was delaying its render and causing some bots to miss these information about the Refine API. Replaced the import statement with require and got rid of the effect to make it work with SSR.

Resolves #6123