### PR TITLE
fix(core): update debounce behavior on `onSearch` in `useSelect`

### DIFF
--- a/.changeset/thin-adults-complain.md
+++ b/.changeset/thin-adults-complain.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/core": minor
+---
+
+fix: update debounce behavior on `onSearch` in `useSelect`
+
+Now debounce behavior is working correctly on `onSearch` in `useSelect` when using inside `Controller` of react-hook-form.
+
+Resolves [#6096](https://github.com/refinedev/refine/issues/6096)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

Debounce behavior on `onSearch`  is not working correctly when use inside `Controller` of react-hook-form causing re-fechting  multiple times.

## What is the new behavior?

Update `onSearch` to memoized value to prevent from re-fetching instead on return as inlined.


## Notes for reviewers

fix(core): update debounce behavior on `onSearch` in `useSelect`

Fixes https://github.com/refinedev/refine/issues/6096
