### PR TITLE
feat(mui): add a loading spinner to <Show> component

### DIFF
--- a/.changeset/lucky-balloons-relax.md
+++ b/.changeset/lucky-balloons-relax.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/mui": minor
+---
+
+feat(mui): add loading spinner to `<Show>` component [#5668](https://github.com/refinedev/refine/issues/5668)
+
+This change introduces a loading spinner to the `<Show>` component in the `@refinedev/mui` package. The spinner provides a visual indication that data is being loaded, improving the user experience by giving clear feedback during loading states.
+
+Resolves [#5668](https://github.com/refinedev/refine/issues/5668)

--- a/packages/mui/src/components/crud/show/index.spec.tsx
+++ b/packages/mui/src/components/crud/show/index.spec.tsx
@@ -34,6 +34,14 @@ const renderShow = (
 describe("Show", () => {
   crudShowTests.bind(this)(Show);
 
+  it("should display loading spinner when isLoading is true", async () => {
+    const { queryByRole } = renderShow(<Show isLoading />);
+
+    await waitFor(() => {
+      expect(queryByRole("progressbar")).not.toBeNull();
+    });
+  });
+
   it("depending on the accessControlProvider it should get the buttons successfully", async () => {
     const { getByText, getAllByText, queryByTestId } = renderShow(
       <Show

--- a/packages/mui/src/components/crud/show/index.tsx
+++ b/packages/mui/src/components/crud/show/index.tsx
@@ -34,6 +34,7 @@ import {
 } from "@components";
 import type { ShowProps } from "../types";
 import { RefinePageHeaderClassNames } from "@refinedev/ui-types";
+import { CircularProgress } from "@mui/material";
 
 /**
  * `<Show>` provides us a layout for displaying the page.
@@ -212,7 +213,17 @@ export const Show: React.FC<ShowProps> = ({
         }
         {...(headerProps ?? {})}
       />
-      <CardContent {...(contentProps ?? {})}>{children}</CardContent>
+      <CardContent {...(contentProps ?? {})}>
+        {isLoading ? (
+          <Box display="flex" justifyContent="center">
+            <CircularProgress
+              sx={{ border: (theme) => theme.palette.primary.main }}
+            />
+          </Box>
+        ) : (
+          children
+        )}
+      </CardContent>
       <CardActions sx={{ padding: "16px" }} {...(footerButtonProps ?? {})}>
         {footerButtons
           ? typeof footerButtons === "function"

--- a/packages/mui/src/components/crud/show/index.tsx
+++ b/packages/mui/src/components/crud/show/index.tsx
@@ -34,7 +34,7 @@ import {
 } from "@components";
 import type { ShowProps } from "../types";
 import { RefinePageHeaderClassNames } from "@refinedev/ui-types";
-import { CircularProgress } from "@mui/material";
+import CircularProgress from "@mui/material/CircularProgress";
 
 /**
  * `<Show>` provides us a layout for displaying the page.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
The `<Show>` component in the `@refinedev/mui package` currently does not display a loading spinner when data is being fetched or processed, leaving users without visual feedback during loading states.

## What is the new behavior?
The `<Show>` component now includes a loading spinner that appears when the `isLoading` prop is set to `true`. This provides users with a visual indication that data is being loaded during loading states. A test has been added to verify that the loading spinner renders when the `isLoading` prop is set to `true`.

fixes https://github.com/refinedev/refine/issues/5668

## Notes for reviewers
The loading spinner added to the `<Show>` component is based on the behavior and color of the spinner used in the `<List>` component. It utilizes the `<CircularProgress>` component with its color set to `theme.palette.primary.main`.

See testing when `isLoading` is set to `True`:

https://github.com/user-attachments/assets/1d25bac9-903d-4d19-b906-4dcdd74524d9

See testing of the actual behavior:

https://github.com/user-attachments/assets/6e598b7f-a808-494c-85d8-a05cd8c737fe

This is what the current loading spinner looks like in the `<List>` component:

https://github.com/user-attachments/assets/656bdb26-64c8-4549-91f9-2e850423e859


