### PR TITLE
fix(mui): broken `<DataGrid />` sizing in `<ThemedLayoutV2 />`

### DIFF
--- a/.changeset/cold-olives-allow.md
+++ b/.changeset/cold-olives-allow.md
@@ -1,0 +1,11 @@
+---
+"@refinedev/mui": patch
+---
+
+fix(mui): <DataGrid /> horizontal scroll is broken in <ThemedLayoutV2 />
+
+Due to the changes in CSS rendering in latest Google Chrome updates, `<DataGrid />` components are not properly sized when used inside `<ThemedLayoutV2 />` component. The `overflow: clip` property in the layout content is causing either miscalculations on the data grid width or causing an overflow on the container and overlapping with the sidebar.
+
+This change replaces the `overflow: clip` property with `min-height` and `min-width` properties to ensure the layout content is properly rendered and responsive to the content inside it.
+
+[Resolves #6077](https://github.com/refinedev/refine/issues/6077)

--- a/packages/mui/src/components/themedLayoutV2/index.tsx
+++ b/packages/mui/src/components/themedLayoutV2/index.tsx
@@ -29,10 +29,9 @@ export const ThemedLayoutV2: React.FC<RefineThemedLayoutV2Props> = ({
               display: "flex",
               flexDirection: "column",
               flex: 1,
-              minHeight: "100vh",
+              minWidth: "1px",
+              minHeight: "1px",
             },
-            { overflow: "auto" },
-            { overflow: "clip" },
           ]}
         >
           <HeaderToRender />


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

Due to the changes in CSS rendering in latest Google Chrome updates, `<DataGrid />` components are not properly sized when used inside `<ThemedLayoutV2 />` component. The `overflow: clip` property in the layout content is causing either miscalculations on the data grid width or causing an overflow on the container and overlapping with the sidebar.

This change replaces the `overflow: clip` property with `min-height` and `min-width` properties to ensure the layout content is properly rendered and responsive to the content inside it.

Resolves #6077

Preview for `finefoods-material-ui` example: https://deploy-preview-6144--finefoods-admin-mui.netlify.app
