### PR TITLE
fix: check cypress dir for e2e specs

### DIFF
--- a/.github/workflows/scripts/build-example-chunks.js
+++ b/.github/workflows/scripts/build-example-chunks.js
@@ -57,7 +57,7 @@ const hasPackageJson = (example) => {
 };
 
 const hasE2eTests = (example) => {
-  return fs.existsSync(path.join(EXAMPLES_DIR, example, "cypress.config.ts"));
+  return fs.existsSync(path.join("./cypress/e2e", example));
 };
 
 const isDirectory = (example) => {


### PR DESCRIPTION
Build example chunks script checks examples with e2e specs and balances chunks to have roughly same amount of e2e specs, since e2e specs takes longer to run, we don't want to have a chunk that takes 60 minutes while another takes 10.

Previously, we've moved cypress specs from examples directories to `cypress/e2e` folder and overlooked how this script checks e2e examples.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
