### PR TITLE
refactor(ci): dont use dev server for e2e tests

### DIFF
--- a/.github/workflows/scripts/build-example-chunks.js
+++ b/.github/workflows/scripts/build-example-chunks.js
@@ -45,7 +45,7 @@ const isExampleAffected = (example, changedPackages) => {
 
 const isExampleModified = (example) => {
   const output = execSync(
-    `git diff --quiet HEAD origin/${BASE_REF} -- ${EXAMPLES_DIR}/${example} || echo changed`,
+    `git diff --quiet HEAD origin/${BASE_REF} -- ${EXAMPLES_DIR}/${example} cypress/e2e/${example} || echo changed`,
     { stdio: "pipe" },
   );
 

--- a/.github/workflows/scripts/e2e-examples.js
+++ b/.github/workflows/scripts/e2e-examples.js
@@ -214,12 +214,17 @@ const runTests = async () => {
 
     try {
       if (!failed) {
-        const params = `--record --group ${path}`;
-        const runner = `pnpm cypress:run --spec cypress/e2e/${path} ${params} --config baseUrl=http://localhost:${port}`;
+        const additionalParams = [
+          `--record --group ${path}`,
+          `--spec cypress/e2e/${path}`,
+          `--config baseUrl=http://localhost:${port}`,
+        ];
+
+        const runCommand = `pnpm cypress:run ${additionalParams.join(" ")} `;
 
         prettyLog("blue", `Running tests for ${path}`);
 
-        const { promise } = execPromise(runner);
+        const { promise } = execPromise(runCommand);
 
         await promise;
 

--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   viewportWidth: 1920,
   viewportHeight: 1080,
   e2e: {
+    baseUrl: "http://localhost:5173",
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress/e2e/auth-antd/all.cy.ts
+++ b/cypress/e2e/auth-antd/all.cy.ts
@@ -2,13 +2,11 @@
 /// <reference types="../../cypress/support" />
 
 describe("auth-antd", () => {
-  const BASE_URL = "http://localhost:5173";
-
   beforeEach(() => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   const submitAuthForm = () => {
@@ -32,7 +30,7 @@ describe("auth-antd", () => {
 
       cy.location("pathname").should("eq", "/");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls[BASE_URL]).to.have.property("email");
+        expect(ls).to.have.property("email");
       });
     });
 
@@ -48,7 +46,7 @@ describe("auth-antd", () => {
       login();
       cy.location("pathname").should("eq", "/");
 
-      cy.visit(`${BASE_URL}/test`);
+      cy.visit("/test");
       cy.location("pathname").should("eq", "/test");
       cy.clearAllLocalStorage();
       cy.reload();
@@ -60,7 +58,7 @@ describe("auth-antd", () => {
     });
 
     it("should redirect to /login?to= if user not authenticated", () => {
-      cy.visit(`${BASE_URL}/test-route`);
+      cy.visit("/test-route");
       cy.get(".ant-card-head-title > .ant-typography").contains(
         /sign in to your account/i,
       );
@@ -78,7 +76,7 @@ describe("auth-antd", () => {
       login();
       cy.location("pathname").should("eq", "/");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls[BASE_URL]).to.have.property("email");
+        expect(ls).to.have.property("email");
       });
     });
 
@@ -97,7 +95,7 @@ describe("auth-antd", () => {
 
   describe("forgot password", () => {
     it("should throw error if forgot password email is wrong", () => {
-      cy.visit(`${BASE_URL}/forgot-password`);
+      cy.visit("/forgot-password");
       cy.get("#email").clear().type("test@test.com");
       submitAuthForm();
       cy.getAntdNotification().contains(/invalid email/i);
@@ -107,7 +105,7 @@ describe("auth-antd", () => {
 
   describe("update password", () => {
     it("should throw error if update password is wrong", () => {
-      cy.visit(`${BASE_URL}/update-password`);
+      cy.visit("/update-password");
       cy.get("#password").clear().type("123456");
       cy.get("#confirmPassword").clear().type("123456");
       submitAuthForm();

--- a/cypress/e2e/auth-antd/all.cy.ts
+++ b/cypress/e2e/auth-antd/all.cy.ts
@@ -30,7 +30,7 @@ describe("auth-antd", () => {
 
       cy.location("pathname").should("eq", "/");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls).to.have.property("email");
+        expect(ls[Cypress.config("baseUrl")!]).to.have.property("email");
       });
     });
 
@@ -76,7 +76,7 @@ describe("auth-antd", () => {
       login();
       cy.location("pathname").should("eq", "/");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls).to.have.property("email");
+        expect(ls[Cypress.config("baseUrl")!]).to.have.property("email");
       });
     });
 

--- a/cypress/e2e/auth-auth0/all.cy.ts
+++ b/cypress/e2e/auth-auth0/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("auth-auth0", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const login = () => {
     cy.get("button")
       .contains(/sign in/i)
@@ -23,7 +21,7 @@ describe("auth-auth0", () => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   describe("login", () => {
@@ -36,7 +34,7 @@ describe("auth-auth0", () => {
       cy.location("pathname").should("eq", "/login");
       login();
       cy.location("pathname").should("eq", "/posts");
-      cy.visit(`${BASE_URL}/test-route`);
+      cy.visit("/test-route");
       cy.get(".ant-result-404").should("exist");
       cy.clearAllCookies();
       cy.clearAllSessionStorage();

--- a/cypress/e2e/auth-auth0/all.cy.ts
+++ b/cypress/e2e/auth-auth0/all.cy.ts
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 /// <reference types="../../cypress/support" />
 
-describe.skip("auth-auth0", () => {
+describe("auth-auth0", () => {
   const login = () => {
     cy.get("button")
       .contains(/sign in/i)

--- a/cypress/e2e/auth-auth0/all.cy.ts
+++ b/cypress/e2e/auth-auth0/all.cy.ts
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 /// <reference types="../../cypress/support" />
 
-describe("auth-auth0", () => {
+describe.skip("auth-auth0", () => {
   const login = () => {
     cy.get("button")
       .contains(/sign in/i)

--- a/cypress/e2e/auth-chakra-ui/all.cy.ts
+++ b/cypress/e2e/auth-chakra-ui/all.cy.ts
@@ -28,7 +28,7 @@ describe("auth-chakra-ui", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls).to.have.property("email");
+        expect(ls[Cypress.config("baseUrl")!]).to.have.property("email");
       });
     });
 
@@ -72,7 +72,7 @@ describe("auth-chakra-ui", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls).to.have.property("email");
+        expect(ls[Cypress.config("baseUrl")!]).to.have.property("email");
       });
     });
 

--- a/cypress/e2e/auth-chakra-ui/all.cy.ts
+++ b/cypress/e2e/auth-chakra-ui/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("auth-chakra-ui", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const submitAuthForm = () => {
     return cy.get("button[type=submit]").click();
   };
@@ -22,7 +20,7 @@ describe("auth-chakra-ui", () => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   describe("login", () => {
@@ -30,7 +28,7 @@ describe("auth-chakra-ui", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls[BASE_URL]).to.have.property("email");
+        expect(ls).to.have.property("email");
       });
     });
 
@@ -46,7 +44,7 @@ describe("auth-chakra-ui", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
 
-      cy.visit(`${BASE_URL}/test`);
+      cy.visit("/test");
       cy.location("pathname").should("eq", "/test");
       cy.clearAllLocalStorage();
       cy.reload();
@@ -58,7 +56,7 @@ describe("auth-chakra-ui", () => {
     });
 
     it("should redirect to /login?to= if user not authenticated", () => {
-      cy.visit(`${BASE_URL}/test-route`);
+      cy.visit("/test-route");
       cy.get(".chakra-heading").contains(/sign in to your account/i);
       cy.location("search").should("contains", "to=%2Ftest");
       cy.location("pathname").should("eq", "/login");
@@ -74,7 +72,7 @@ describe("auth-chakra-ui", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls[BASE_URL]).to.have.property("email");
+        expect(ls).to.have.property("email");
       });
     });
 
@@ -93,7 +91,7 @@ describe("auth-chakra-ui", () => {
 
   describe("forgot password", () => {
     it("should throw error if forgot password email is wrong", () => {
-      cy.visit(`${BASE_URL}/forgot-password`);
+      cy.visit("/forgot-password");
       cy.get("#email").clear().type("test@test.com");
       submitAuthForm();
       cy.getChakraUINotification().contains(/invalid email/i);
@@ -103,7 +101,7 @@ describe("auth-chakra-ui", () => {
 
   describe("update password", () => {
     it("should throw error if update password is wrong", () => {
-      cy.visit(`${BASE_URL}/update-password`);
+      cy.visit("/update-password");
       cy.get("#password").clear().type("123456");
       cy.get("#confirmPassword").clear().type("123456");
       submitAuthForm();

--- a/cypress/e2e/auth-google-login/all.cy.ts
+++ b/cypress/e2e/auth-google-login/all.cy.ts
@@ -2,13 +2,11 @@
 /// <reference types="../../cypress/support" />
 
 describe("auth-google-login", () => {
-  const BASE_URL = "http://localhost:5173";
-
   beforeEach(() => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("has google button", () => {

--- a/cypress/e2e/auth-headless/all.cy.ts
+++ b/cypress/e2e/auth-headless/all.cy.ts
@@ -28,7 +28,7 @@ describe("auth-headless", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls).to.have.property("email");
+        expect(ls[Cypress.config("baseUrl")!]).to.have.property("email");
       });
     });
 
@@ -61,7 +61,7 @@ describe("auth-headless", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls).to.have.property("email");
+        expect(ls[Cypress.config("baseUrl")!]).to.have.property("email");
       });
     });
   });

--- a/cypress/e2e/auth-headless/all.cy.ts
+++ b/cypress/e2e/auth-headless/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("auth-headless", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const submitAuthForm = () => {
     return cy.get("[type=submit]").click();
   };
@@ -22,7 +20,7 @@ describe("auth-headless", () => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   describe("login", () => {
@@ -30,7 +28,7 @@ describe("auth-headless", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls[BASE_URL]).to.have.property("email");
+        expect(ls).to.have.property("email");
       });
     });
 
@@ -38,7 +36,7 @@ describe("auth-headless", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
 
-      cy.visit(`${BASE_URL}/test`);
+      cy.visit("/test");
       cy.location("pathname").should("eq", "/test");
       cy.clearAllLocalStorage();
       cy.reload();
@@ -47,7 +45,7 @@ describe("auth-headless", () => {
     });
 
     it("should redirect to /login?to= if user not authenticated", () => {
-      cy.visit(`${BASE_URL}/test-route`);
+      cy.visit("/test-route");
       cy.get("h1").contains(/sign in to your account/i);
       cy.location("search").should("contains", "to=%2Ftest");
       cy.location("pathname").should("eq", "/login");
@@ -63,7 +61,7 @@ describe("auth-headless", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls[BASE_URL]).to.have.property("email");
+        expect(ls).to.have.property("email");
       });
     });
   });

--- a/cypress/e2e/auth-keycloak/all.cy.ts
+++ b/cypress/e2e/auth-keycloak/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("auth-keycloak", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const login = () => {
     cy.get("button")
       .contains(/sign in/i)
@@ -25,7 +23,7 @@ describe("auth-keycloak", () => {
     cy.interceptGETPosts();
     cy.interceptGETCategories();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   describe("login", () => {
@@ -36,7 +34,7 @@ describe("auth-keycloak", () => {
 
     it("should redirect to /login if user not authenticated", () => {
       login();
-      cy.visit(`${BASE_URL}/test-route`);
+      cy.visit("/test-route");
       cy.clearAllCookies();
       cy.reload();
       cy.location("pathname").should("eq", "/login");

--- a/cypress/e2e/auth-mantine/all.cy.ts
+++ b/cypress/e2e/auth-mantine/all.cy.ts
@@ -27,7 +27,7 @@ describe("auth-mantine", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls).to.have.property("email");
+        expect(ls[Cypress.config("baseUrl")!]).to.have.property("email");
       });
     });
 
@@ -76,7 +76,7 @@ describe("auth-mantine", () => {
 
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls).to.have.property("email");
+        expect(ls[Cypress.config("baseUrl")!]).to.have.property("email");
       });
     });
 

--- a/cypress/e2e/auth-mantine/all.cy.ts
+++ b/cypress/e2e/auth-mantine/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("auth-mantine", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const submitAuthForm = () => {
     return cy.get("button[type=submit]").click();
   };
@@ -21,7 +19,7 @@ describe("auth-mantine", () => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   describe("login", () => {
@@ -29,7 +27,7 @@ describe("auth-mantine", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls[BASE_URL]).to.have.property("email");
+        expect(ls).to.have.property("email");
       });
     });
 
@@ -45,7 +43,7 @@ describe("auth-mantine", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
 
-      cy.visit(`${BASE_URL}/test`);
+      cy.visit("/test");
       cy.location("pathname").should("eq", "/test");
       cy.clearAllLocalStorage();
       cy.reload();
@@ -57,7 +55,7 @@ describe("auth-mantine", () => {
     });
 
     it("should redirect to /login?to= if user not authenticated", () => {
-      cy.visit(`${BASE_URL}/test-route`);
+      cy.visit("/test-route");
       cy.get(".mantine-Title-root").contains(/sign in to your account/i);
       cy.location("search").should("contains", "to=%2Ftest");
       cy.location("pathname").should("eq", "/login");
@@ -78,7 +76,7 @@ describe("auth-mantine", () => {
 
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls[BASE_URL]).to.have.property("email");
+        expect(ls).to.have.property("email");
       });
     });
 
@@ -104,7 +102,7 @@ describe("auth-mantine", () => {
 
   describe("forgot password", () => {
     it("should throw error if forgot password email is wrong", () => {
-      cy.visit(`${BASE_URL}/forgot-password`);
+      cy.visit("/forgot-password");
       cy.get('input[name="email"]').clear().type("test@test.com");
       submitAuthForm();
       cy.getMantineNotification().contains(/invalid email/i);
@@ -114,7 +112,7 @@ describe("auth-mantine", () => {
 
   describe("update password", () => {
     it("should throw error if update password is wrong", () => {
-      cy.visit(`${BASE_URL}/update-password`);
+      cy.visit("/update-password");
       cy.get('input[name="password"]').clear().type("123456");
       cy.get('input[name="confirmPassword"]').clear().type("123456");
       submitAuthForm();

--- a/cypress/e2e/auth-material-ui/all.cy.ts
+++ b/cypress/e2e/auth-material-ui/all.cy.ts
@@ -29,7 +29,7 @@ describe("auth-material-ui", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls).to.have.property("email");
+        expect(ls[Cypress.config("baseUrl")!]).to.have.property("email");
       });
     });
 
@@ -73,7 +73,7 @@ describe("auth-material-ui", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls).to.have.property("email");
+        expect(ls[Cypress.config("baseUrl")!]).to.have.property("email");
       });
     });
 

--- a/cypress/e2e/auth-material-ui/all.cy.ts
+++ b/cypress/e2e/auth-material-ui/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("auth-material-ui", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const submitAuthForm = () => {
     return cy.get("button[type=submit]").click();
   };
@@ -23,7 +21,7 @@ describe("auth-material-ui", () => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   describe("login", () => {
@@ -31,7 +29,7 @@ describe("auth-material-ui", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls[BASE_URL]).to.have.property("email");
+        expect(ls).to.have.property("email");
       });
     });
 
@@ -47,7 +45,7 @@ describe("auth-material-ui", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
 
-      cy.visit(`${BASE_URL}/test`);
+      cy.visit("/test");
       cy.location("pathname").should("eq", "/test");
       cy.clearAllLocalStorage();
       cy.reload();
@@ -59,7 +57,7 @@ describe("auth-material-ui", () => {
     });
 
     it("should redirect to /login?to= if user not authenticated", () => {
-      cy.visit(`${BASE_URL}/test-route`);
+      cy.visit("/test-route");
       cy.get(".MuiTypography-root").contains(/sign in to your account/i);
       cy.location("search").should("contains", "to=%2Ftest");
       cy.location("pathname").should("eq", "/login");
@@ -75,7 +73,7 @@ describe("auth-material-ui", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls[BASE_URL]).to.have.property("email");
+        expect(ls).to.have.property("email");
       });
     });
 
@@ -94,7 +92,7 @@ describe("auth-material-ui", () => {
 
   describe("forgot password", () => {
     it("should throw error if forgot password email is wrong", () => {
-      cy.visit(`${BASE_URL}/forgot-password`);
+      cy.visit("/forgot-password");
       cy.get("#email").clear().type("test@test.com");
       submitAuthForm();
       cy.getMaterialUINotification().contains(/forgot password failed/i);
@@ -104,7 +102,7 @@ describe("auth-material-ui", () => {
 
   describe("update password", () => {
     it("should throw error if update password is wrong", () => {
-      cy.visit(`${BASE_URL}/update-password`);
+      cy.visit("/update-password");
       cy.get("#password").clear().type("123456");
       cy.get("#confirmPassword").clear().type("123456");
       submitAuthForm();

--- a/cypress/e2e/base-antd/all.cy.ts
+++ b/cypress/e2e/base-antd/all.cy.ts
@@ -6,15 +6,13 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("base-antd", () => {
-  const BASE_URL = "http://localhost:5173";
-
   beforeEach(() => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
     cy.interceptGETPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should list resource", () => {

--- a/cypress/e2e/base-chakra-ui/all.cy.ts
+++ b/cypress/e2e/base-chakra-ui/all.cy.ts
@@ -6,15 +6,13 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("base-chakra-ui", () => {
-  const BASE_URL = "http://localhost:5173";
-
   beforeEach(() => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
     cy.interceptGETPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should list resource", () => {

--- a/cypress/e2e/base-mantine/all.cy.ts
+++ b/cypress/e2e/base-mantine/all.cy.ts
@@ -6,15 +6,13 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("base-mantine", () => {
-  const BASE_URL = "http://localhost:5173";
-
   beforeEach(() => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
     cy.interceptGETPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should list resource", () => {

--- a/cypress/e2e/base-material-ui/all.cy.ts
+++ b/cypress/e2e/base-material-ui/all.cy.ts
@@ -6,15 +6,13 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("base-material-ui", () => {
-  const BASE_URL = "http://localhost:5173";
-
   beforeEach(() => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
     cy.interceptGETPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should list resource", () => {

--- a/cypress/e2e/data-provider-strapi-v4/all.cy.ts
+++ b/cypress/e2e/data-provider-strapi-v4/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("data-provider-strapi-v4", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const submitAuthForm = () => {
     return cy.get("button[type=submit]").click();
   };
@@ -33,7 +31,7 @@ describe("data-provider-strapi-v4", () => {
     cy.interceptStrapiV4GETCategories();
     cy.interceptStrapiV4GETCategory();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   describe("login", () => {
@@ -55,7 +53,7 @@ describe("data-provider-strapi-v4", () => {
       cy.location("pathname").should("eq", "/posts");
       cy.wait("@strapiV4GetPosts");
 
-      cy.visit(`${BASE_URL}/test`);
+      cy.visit("/test");
       cy.location("pathname").should("eq", "/test");
       cy.clearAllCookies();
       cy.clearAllLocalStorage();
@@ -66,7 +64,7 @@ describe("data-provider-strapi-v4", () => {
     });
 
     it("should redirect to /login?to= if user not authenticated", () => {
-      cy.visit(`${BASE_URL}/test-route`);
+      cy.visit("/test-route");
       cy.get(".ant-card-head-title > .ant-typography").contains(
         /sign in to your account/i,
       );

--- a/cypress/e2e/data-provider-supabase/all.cy.ts
+++ b/cypress/e2e/data-provider-supabase/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("data-provider-supabase", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const submitAuthForm = () => {
     return cy.get("button[type=submit]").click();
   };
@@ -30,7 +28,7 @@ describe("data-provider-supabase", () => {
     cy.interceptSupabaseDELETEPost();
     cy.interceptSupabaseGETCategories();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   describe("login", () => {
@@ -52,7 +50,7 @@ describe("data-provider-supabase", () => {
       cy.location("pathname").should("eq", "/blog-posts");
       cy.wait("@supabaseGetPosts");
 
-      cy.visit(`${BASE_URL}/test`);
+      cy.visit("/test");
       cy.location("pathname").should("eq", "/test");
       cy.clearAllCookies();
       cy.clearAllLocalStorage();
@@ -63,7 +61,7 @@ describe("data-provider-supabase", () => {
     });
 
     it("should redirect to /login?to= if user not authenticated", () => {
-      cy.visit(`${BASE_URL}/test-route`);
+      cy.visit("/test-route");
       cy.get(".ant-card-head-title > .ant-typography").contains(
         /sign in to your account/i,
       );

--- a/cypress/e2e/form-antd-custom-validation/all.cy.ts
+++ b/cypress/e2e/form-antd-custom-validation/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-antd-custom-validation", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const interceptUniqueCheck = (available: boolean) => {
     cy.intercept(
       {
@@ -34,7 +32,7 @@ describe("form-antd-custom-validation", () => {
 
   it("should render error", () => {
     interceptUniqueCheck(false);
-    cy.visit(`${BASE_URL}/posts/create`);
+    cy.visit("/posts/create");
 
     cy.get("#title").type("test title", { delay: 0 });
     cy.getSaveButton().click();
@@ -45,7 +43,7 @@ describe("form-antd-custom-validation", () => {
 
   it("should not render error", () => {
     interceptUniqueCheck(true);
-    cy.visit(`${BASE_URL}/posts/create`);
+    cy.visit("/posts/create");
 
     cy.get("#title").type("test title", { delay: 0 });
     cy.getSaveButton().click();

--- a/cypress/e2e/form-antd-mutation-mode/all.cy.ts
+++ b/cypress/e2e/form-antd-mutation-mode/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-antd-mutation-mode", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
@@ -65,7 +63,7 @@ describe("form-antd-mutation-mode", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should edit record when mutation mode is pessimistic", () => {

--- a/cypress/e2e/form-antd-use-drawer-form/all.cy.ts
+++ b/cypress/e2e/form-antd-use-drawer-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-antd-use-drawer-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry",
@@ -48,7 +46,7 @@ describe("form-antd-use-drawer-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should open and close drawer", () => {

--- a/cypress/e2e/form-antd-use-form/all.cy.ts
+++ b/cypress/e2e/form-antd-use-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-antd-use-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
@@ -31,7 +29,7 @@ describe("form-antd-use-form", () => {
     cy.clearAllSessionStorage();
 
     cy.interceptGETPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should create form render errors", () => {

--- a/cypress/e2e/form-antd-use-modal-form/all.cy.ts
+++ b/cypress/e2e/form-antd-use-modal-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-antd-use-modal-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
@@ -43,7 +41,7 @@ describe("form-antd-use-modal-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should open and close modal", () => {

--- a/cypress/e2e/form-antd-use-steps-form/all.cy.ts
+++ b/cypress/e2e/form-antd-use-steps-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-antd-use-steps-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
@@ -54,7 +52,7 @@ describe("form-antd-use-steps-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should create a new record", () => {

--- a/cypress/e2e/form-chakra-ui-mutation-mode/all.cy.ts
+++ b/cypress/e2e/form-chakra-ui-mutation-mode/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-chakra-ui-mutation-mode", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry",
@@ -51,7 +49,7 @@ describe("form-chakra-ui-mutation-mode", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should edit record when mutation mode is pessimistic", () => {

--- a/cypress/e2e/form-chakra-ui-use-drawer-form/all.cy.ts
+++ b/cypress/e2e/form-chakra-ui-use-drawer-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-chakra-use-drawer-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry",
@@ -59,7 +57,7 @@ describe("form-chakra-use-drawer-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should create record", () => {

--- a/cypress/e2e/form-chakra-ui-use-form/all.cy.ts
+++ b/cypress/e2e/form-chakra-ui-use-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-chakra-ui-use-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const submitForm = () => {
     return cy.getSaveButton().click();
   };
@@ -14,7 +12,7 @@ describe("form-chakra-ui-use-form", () => {
     cy.clearAllSessionStorage();
 
     cy.interceptGETPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should list resource", () => {

--- a/cypress/e2e/form-chakra-use-modal-form/all.cy.ts
+++ b/cypress/e2e/form-chakra-use-modal-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-chakra-use-modal-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry",
@@ -59,7 +57,7 @@ describe("form-chakra-use-modal-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should create record", () => {

--- a/cypress/e2e/form-core-use-form/all.cy.ts
+++ b/cypress/e2e/form-core-use-form/all.cy.ts
@@ -6,15 +6,13 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("form-core-use-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   beforeEach(() => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
     cy.interceptGETPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should edit resource with autosave", () => {

--- a/cypress/e2e/form-mantine-mutation-mode/all.cy.ts
+++ b/cypress/e2e/form-mantine-mutation-mode/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-mantine-mutation-mode", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry",
@@ -60,7 +58,7 @@ describe("form-mantine-mutation-mode", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should edit record when mutation mode is pessimistic", () => {

--- a/cypress/e2e/form-mantine-use-drawer-form/all.cy.ts
+++ b/cypress/e2e/form-mantine-use-drawer-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-mantine-use-drawer-form", () => {
-  const BASE_URL = "http://localhost:5173/";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry",
@@ -50,7 +48,7 @@ describe("form-mantine-use-drawer-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should create record", () => {

--- a/cypress/e2e/form-mantine-use-form/all.cy.ts
+++ b/cypress/e2e/form-mantine-use-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-mantine-use-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const submitForm = () => {
     return cy.getSaveButton().click();
   };
@@ -14,7 +12,7 @@ describe("form-mantine-use-form", () => {
     cy.clearAllSessionStorage();
 
     cy.interceptGETPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should list resource", () => {

--- a/cypress/e2e/form-mantine-use-modal-form/all.cy.ts
+++ b/cypress/e2e/form-mantine-use-modal-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-mantine-use-modal-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry",
@@ -50,7 +48,7 @@ describe("form-mantine-use-modal-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should create record", () => {

--- a/cypress/e2e/form-mantine-use-steps-form/all.cy.ts
+++ b/cypress/e2e/form-mantine-use-steps-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-mantine-use-steps-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry",
@@ -60,7 +58,7 @@ describe("form-mantine-use-steps-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should create record", () => {

--- a/cypress/e2e/form-material-ui-mutation-mode/all.cy.ts
+++ b/cypress/e2e/form-material-ui-mutation-mode/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-material-ui-mutation-mode", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
@@ -58,7 +56,7 @@ describe("form-material-ui-mutation-mode", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should edit record when mutation mode is pessimistic", () => {

--- a/cypress/e2e/form-material-ui-use-drawer-form/all.cy.ts
+++ b/cypress/e2e/form-material-ui-use-drawer-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-material-ui-use-drawer-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
@@ -68,7 +66,7 @@ describe("form-material-ui-use-drawer-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("open - close drawer", () => {

--- a/cypress/e2e/form-material-ui-use-form/all.cy.ts
+++ b/cypress/e2e/form-material-ui-use-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-material-ui-use-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const submitForm = () => {
     return cy.getSaveButton().click();
   };
@@ -14,7 +12,7 @@ describe("form-material-ui-use-form", () => {
     cy.clearAllSessionStorage();
 
     cy.interceptGETPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should list resource", () => {

--- a/cypress/e2e/form-material-ui-use-modal-form/all.cy.ts
+++ b/cypress/e2e/form-material-ui-use-modal-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-material-ui-use-modal-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
@@ -64,7 +62,7 @@ describe("form-material-ui-use-modal-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should create record", () => {

--- a/cypress/e2e/form-material-ui-use-steps-form/all.cy.ts
+++ b/cypress/e2e/form-material-ui-use-steps-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-material-ui-use-modal-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
@@ -73,7 +71,7 @@ describe("form-material-ui-use-modal-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should create record", () => {

--- a/cypress/e2e/form-react-hook-form-use-form/all.cy.ts
+++ b/cypress/e2e/form-react-hook-form-use-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-react-hook-form-use-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
@@ -59,7 +57,7 @@ describe("form-react-hook-form-use-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should create record", () => {

--- a/cypress/e2e/form-react-hook-form-use-modal-form/all.cy.ts
+++ b/cypress/e2e/form-react-hook-form-use-modal-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-react-hook-form-use-modal-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
@@ -63,7 +61,7 @@ describe("form-react-hook-form-use-modal-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should open - close modal", () => {

--- a/cypress/e2e/form-react-hook-form-use-steps-form/all.cy.ts
+++ b/cypress/e2e/form-react-hook-form-use-steps-form/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-react-hook-form-use-steps-form", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
@@ -87,7 +85,7 @@ describe("form-react-hook-form-use-steps-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should create record", () => {

--- a/cypress/e2e/form-save-and-continue/all.cy.ts
+++ b/cypress/e2e/form-save-and-continue/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("form-save-and-continue", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
@@ -51,7 +49,7 @@ describe("form-save-and-continue", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should create record", () => {

--- a/cypress/e2e/inferencer-antd/all.cy.ts
+++ b/cypress/e2e/inferencer-antd/all.cy.ts
@@ -6,8 +6,6 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("inferencer-antd", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const login = () => {
     cy.fixture("demo-auth-credentials").then((auth) => {
       cy.get("#email").clear();
@@ -27,7 +25,7 @@ describe("inferencer-antd", () => {
     cy.interceptGETCategory();
     cy.interceptGETCategories();
     cy.interceptGETBlogPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
 
     login();
   });
@@ -233,7 +231,7 @@ describe("inferencer-antd", () => {
     });
     // assert localStoage has changed
     cy.getAllLocalStorage().then((ls) => {
-      expect(ls[BASE_URL]["i18nextLng"]).to.eq("de");
+      expect(ls["i18nextLng"]).to.eq("de");
     });
 
     // reload the page and assert the language is persisted
@@ -253,7 +251,7 @@ describe("inferencer-antd", () => {
 
     // find initial  theme from localStorage
     cy.getAllLocalStorage().then((ls) => {
-      const initialTheme = ls[BASE_URL]["colorMode"]?.toString();
+      const initialTheme = ls["colorMode"]?.toString();
 
       // find the theme swtich
       cy.get(".ant-layout-header").within(() => {
@@ -269,10 +267,10 @@ describe("inferencer-antd", () => {
         cy.getAllLocalStorage().then((ls) => {
           if (initialTheme === "dark") {
             expect(cy.get(".ant-switch-checked").should("not.exist"));
-            expect(ls[BASE_URL]["colorMode"]).to.eq("light");
+            expect(ls["colorMode"]).to.eq("light");
           } else {
             expect(cy.get(".ant-switch-checked").should("exist"));
-            expect(ls[BASE_URL]["colorMode"]).to.eq("dark");
+            expect(ls["colorMode"]).to.eq("dark");
           }
         });
       });

--- a/cypress/e2e/inferencer-antd/all.cy.ts
+++ b/cypress/e2e/inferencer-antd/all.cy.ts
@@ -231,7 +231,7 @@ describe("inferencer-antd", () => {
     });
     // assert localStoage has changed
     cy.getAllLocalStorage().then((ls) => {
-      expect(ls["i18nextLng"]).to.eq("de");
+      expect(ls[Cypress.config("baseUrl")!]["i18nextLng"]).to.eq("de");
     });
 
     // reload the page and assert the language is persisted
@@ -251,7 +251,8 @@ describe("inferencer-antd", () => {
 
     // find initial  theme from localStorage
     cy.getAllLocalStorage().then((ls) => {
-      const initialTheme = ls["colorMode"]?.toString();
+      const initialTheme =
+        ls[Cypress.config("baseUrl")!]["colorMode"]?.toString();
 
       // find the theme swtich
       cy.get(".ant-layout-header").within(() => {
@@ -267,10 +268,10 @@ describe("inferencer-antd", () => {
         cy.getAllLocalStorage().then((ls) => {
           if (initialTheme === "dark") {
             expect(cy.get(".ant-switch-checked").should("not.exist"));
-            expect(ls["colorMode"]).to.eq("light");
+            expect(ls[Cypress.config("baseUrl")!]["colorMode"]).to.eq("light");
           } else {
             expect(cy.get(".ant-switch-checked").should("exist"));
-            expect(ls["colorMode"]).to.eq("dark");
+            expect(ls[Cypress.config("baseUrl")!]["colorMode"]).to.eq("dark");
           }
         });
       });

--- a/cypress/e2e/inferencer-chakra-ui/all.cy.ts
+++ b/cypress/e2e/inferencer-chakra-ui/all.cy.ts
@@ -209,7 +209,7 @@ describe("inferencer-chakra-ui", () => {
 
     // assert localStoage has changed
     cy.getAllLocalStorage().then((ls) => {
-      expect(ls["i18nextLng"]).to.eq("de");
+      expect(ls[Cypress.config("baseUrl")!]["i18nextLng"]).to.eq("de");
     });
 
     // reload the page and assert the language is persisted
@@ -236,7 +236,8 @@ describe("inferencer-chakra-ui", () => {
       const initialThemeFromHTML = $html.attr("data-theme")?.toString();
 
       cy.getAllLocalStorage().then((ls) => {
-        const initialThemeFromLS = ls["chakra-ui-color-mode"];
+        const initialThemeFromLS =
+          ls[Cypress.config("baseUrl")!]["chakra-ui-color-mode"];
 
         expect(initialThemeFromHTML).to.equal(initialThemeFromLS);
 
@@ -254,7 +255,7 @@ describe("inferencer-chakra-ui", () => {
 
         // assert theme is changed in local storage
         cy.getAllLocalStorage().then((ls) => {
-          const theme = ls["chakra-ui-color-mode"];
+          const theme = ls[Cypress.config("baseUrl")!]["chakra-ui-color-mode"];
           if (initialThemeFromLS === "dark") {
             expect(theme).to.equal("light");
           } else {
@@ -283,7 +284,7 @@ describe("inferencer-chakra-ui", () => {
 
         // assert theme is persisted in local storage
         cy.getAllLocalStorage().then((ls) => {
-          const theme = ls["chakra-ui-color-mode"];
+          const theme = ls[Cypress.config("baseUrl")!]["chakra-ui-color-mode"];
           if (initialThemeFromLS === "dark") {
             expect(theme).to.equal("light");
           } else {

--- a/cypress/e2e/inferencer-chakra-ui/all.cy.ts
+++ b/cypress/e2e/inferencer-chakra-ui/all.cy.ts
@@ -6,8 +6,6 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("inferencer-chakra-ui", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const login = () => {
     cy.fixture("demo-auth-credentials").then((auth) => {
       cy.get("#email").clear();
@@ -27,7 +25,7 @@ describe("inferencer-chakra-ui", () => {
     cy.interceptGETCategories();
     cy.interceptGETCategory();
     cy.interceptGETBlogPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
 
     login();
   });
@@ -211,7 +209,7 @@ describe("inferencer-chakra-ui", () => {
 
     // assert localStoage has changed
     cy.getAllLocalStorage().then((ls) => {
-      expect(ls[BASE_URL]["i18nextLng"]).to.eq("de");
+      expect(ls["i18nextLng"]).to.eq("de");
     });
 
     // reload the page and assert the language is persisted
@@ -238,7 +236,7 @@ describe("inferencer-chakra-ui", () => {
       const initialThemeFromHTML = $html.attr("data-theme")?.toString();
 
       cy.getAllLocalStorage().then((ls) => {
-        const initialThemeFromLS = ls[BASE_URL]["chakra-ui-color-mode"];
+        const initialThemeFromLS = ls["chakra-ui-color-mode"];
 
         expect(initialThemeFromHTML).to.equal(initialThemeFromLS);
 
@@ -256,7 +254,7 @@ describe("inferencer-chakra-ui", () => {
 
         // assert theme is changed in local storage
         cy.getAllLocalStorage().then((ls) => {
-          const theme = ls[BASE_URL]["chakra-ui-color-mode"];
+          const theme = ls["chakra-ui-color-mode"];
           if (initialThemeFromLS === "dark") {
             expect(theme).to.equal("light");
           } else {
@@ -285,7 +283,7 @@ describe("inferencer-chakra-ui", () => {
 
         // assert theme is persisted in local storage
         cy.getAllLocalStorage().then((ls) => {
-          const theme = ls[BASE_URL]["chakra-ui-color-mode"];
+          const theme = ls["chakra-ui-color-mode"];
           if (initialThemeFromLS === "dark") {
             expect(theme).to.equal("light");
           } else {

--- a/cypress/e2e/inferencer-graphql-hasura/all.cy.ts
+++ b/cypress/e2e/inferencer-graphql-hasura/all.cy.ts
@@ -104,7 +104,8 @@ describe("inferencer-antd", () => {
 
     // find initial  theme from localStorage
     cy.getAllLocalStorage().then((ls) => {
-      const initialTheme = ls["colorMode"]?.toString();
+      const initialTheme =
+        ls[Cypress.config("baseUrl")!]["colorMode"]?.toString();
 
       // find the theme swtich
       cy.get(".ant-layout-header").within(() => {
@@ -120,10 +121,10 @@ describe("inferencer-antd", () => {
         cy.getAllLocalStorage().then((ls) => {
           if (initialTheme === "dark") {
             expect(cy.get(".ant-switch-checked").should("not.exist"));
-            expect(ls["colorMode"]).to.eq("light");
+            expect(ls[Cypress.config("baseUrl")!]["colorMode"]).to.eq("light");
           } else {
             expect(cy.get(".ant-switch-checked").should("exist"));
-            expect(ls["colorMode"]).to.eq("dark");
+            expect(ls[Cypress.config("baseUrl")!]["colorMode"]).to.eq("dark");
           }
         });
       });

--- a/cypress/e2e/inferencer-graphql-hasura/all.cy.ts
+++ b/cypress/e2e/inferencer-graphql-hasura/all.cy.ts
@@ -6,15 +6,13 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("inferencer-antd", () => {
-  const BASE_URL = "http://localhost:5173";
-
   beforeEach(() => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
     cy.interceptHasura();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should list resource", () => {
@@ -106,7 +104,7 @@ describe("inferencer-antd", () => {
 
     // find initial  theme from localStorage
     cy.getAllLocalStorage().then((ls) => {
-      const initialTheme = ls[BASE_URL]["colorMode"]?.toString();
+      const initialTheme = ls["colorMode"]?.toString();
 
       // find the theme swtich
       cy.get(".ant-layout-header").within(() => {
@@ -122,10 +120,10 @@ describe("inferencer-antd", () => {
         cy.getAllLocalStorage().then((ls) => {
           if (initialTheme === "dark") {
             expect(cy.get(".ant-switch-checked").should("not.exist"));
-            expect(ls[BASE_URL]["colorMode"]).to.eq("light");
+            expect(ls["colorMode"]).to.eq("light");
           } else {
             expect(cy.get(".ant-switch-checked").should("exist"));
-            expect(ls[BASE_URL]["colorMode"]).to.eq("dark");
+            expect(ls["colorMode"]).to.eq("dark");
           }
         });
       });

--- a/cypress/e2e/inferencer-headless/all.cy.ts
+++ b/cypress/e2e/inferencer-headless/all.cy.ts
@@ -6,8 +6,6 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("inferencer-headless", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const waitForLoading = () => {
     cy.contains(/loading/).should("not.exist");
   };
@@ -31,7 +29,7 @@ describe("inferencer-headless", () => {
     cy.interceptGETCategory();
     cy.interceptGETCategories();
     cy.interceptGETBlogPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
 
     login();
   });

--- a/cypress/e2e/inferencer-mantine/all.cy.ts
+++ b/cypress/e2e/inferencer-mantine/all.cy.ts
@@ -215,7 +215,7 @@ describe("inferencer-mantine", () => {
 
     // assert localStoage has changed
     cy.getAllLocalStorage().then((ls) => {
-      expect(ls["i18nextLng"]).to.eq("de");
+      expect(ls[Cypress.config("baseUrl")!]["i18nextLng"]).to.eq("de");
     });
 
     // reload the page and assert the language is persisted
@@ -236,7 +236,8 @@ describe("inferencer-mantine", () => {
 
     // find initial  theme from localStorage
     cy.getAllLocalStorage().then((ls) => {
-      const initialTheme = ls["mantine-color-scheme"]?.toString();
+      const initialTheme =
+        ls[Cypress.config("baseUrl")!]["mantine-color-scheme"]?.toString();
 
       console.log(initialTheme);
 
@@ -253,10 +254,14 @@ describe("inferencer-mantine", () => {
         // assert the theme is changed, it should be reversed from initial theme
         if (initialTheme === "dark") {
           expect(cy.get(".tabler-icon-moon-stars").should("exist"));
-          expect(ls["mantine-color-scheme"]).to.contains("light");
+          expect(
+            ls[Cypress.config("baseUrl")!]["mantine-color-scheme"],
+          ).to.contains("light");
         } else {
           expect(cy.get(".tabler-icon-sun").should("exist"));
-          expect(ls["mantine-color-scheme"]).to.contains("dark");
+          expect(
+            ls[Cypress.config("baseUrl")!]["mantine-color-scheme"],
+          ).to.contains("dark");
         }
       });
 

--- a/cypress/e2e/inferencer-mantine/all.cy.ts
+++ b/cypress/e2e/inferencer-mantine/all.cy.ts
@@ -282,7 +282,6 @@ describe("inferencer-mantine", () => {
   it("should work with pagination", () => {
     cy.wait("@getBlogPosts");
     cy.wait("@getBlogPosts");
-    cy.wait("@getBlogPosts");
     cy.wait("@getCategories");
     cy.getMantineLoadingOverlay().should("not.exist");
 

--- a/cypress/e2e/inferencer-mantine/all.cy.ts
+++ b/cypress/e2e/inferencer-mantine/all.cy.ts
@@ -6,8 +6,6 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("inferencer-mantine", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const login = () => {
     cy.fixture("demo-auth-credentials").then((auth) => {
       cy.get("input[name=email]").clear();
@@ -27,7 +25,7 @@ describe("inferencer-mantine", () => {
     cy.interceptGETCategory();
     cy.interceptGETCategories();
     cy.interceptGETBlogPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
 
     login();
   });
@@ -217,7 +215,7 @@ describe("inferencer-mantine", () => {
 
     // assert localStoage has changed
     cy.getAllLocalStorage().then((ls) => {
-      expect(ls[BASE_URL]["i18nextLng"]).to.eq("de");
+      expect(ls["i18nextLng"]).to.eq("de");
     });
 
     // reload the page and assert the language is persisted
@@ -238,7 +236,7 @@ describe("inferencer-mantine", () => {
 
     // find initial  theme from localStorage
     cy.getAllLocalStorage().then((ls) => {
-      const initialTheme = ls[BASE_URL]["mantine-color-scheme"]?.toString();
+      const initialTheme = ls["mantine-color-scheme"]?.toString();
 
       console.log(initialTheme);
 
@@ -255,10 +253,10 @@ describe("inferencer-mantine", () => {
         // assert the theme is changed, it should be reversed from initial theme
         if (initialTheme === "dark") {
           expect(cy.get(".tabler-icon-moon-stars").should("exist"));
-          expect(ls[BASE_URL]["mantine-color-scheme"]).to.contains("light");
+          expect(ls["mantine-color-scheme"]).to.contains("light");
         } else {
           expect(cy.get(".tabler-icon-sun").should("exist"));
-          expect(ls[BASE_URL]["mantine-color-scheme"]).to.contains("dark");
+          expect(ls["mantine-color-scheme"]).to.contains("dark");
         }
       });
 

--- a/cypress/e2e/inferencer-material-ui/all.cy.ts
+++ b/cypress/e2e/inferencer-material-ui/all.cy.ts
@@ -236,7 +236,8 @@ describe("inferencer-material-ui", () => {
 
     // find initial theme from localStorage
     cy.getAllLocalStorage().then((ls) => {
-      const initialTheme = ls["colorMode"]?.toString() || "dark";
+      const initialTheme =
+        ls[Cypress.config("baseUrl")!]["colorMode"]?.toString() || "dark";
 
       // click the theme switch
       if (initialTheme === "dark") {
@@ -247,9 +248,9 @@ describe("inferencer-material-ui", () => {
 
       cy.getAllLocalStorage().then((ls) => {
         if (initialTheme === "dark") {
-          expect(ls["colorMode"]).to.eq("light");
+          expect(ls[Cypress.config("baseUrl")!]["colorMode"]).to.eq("light");
         } else {
-          expect(ls["colorMode"]).to.eq("dark");
+          expect(ls[Cypress.config("baseUrl")!]["colorMode"]).to.eq("dark");
         }
       });
 
@@ -279,7 +280,7 @@ describe("inferencer-material-ui", () => {
     cy.get("li[data-value=de]").click();
     // assert localStoage has changed
     cy.getAllLocalStorage().then((ls) => {
-      expect(ls["i18nextLng"]).to.eq("de");
+      expect(ls[Cypress.config("baseUrl")!]["i18nextLng"]).to.eq("de");
     });
 
     // reload the page and assert the language is persisted

--- a/cypress/e2e/inferencer-material-ui/all.cy.ts
+++ b/cypress/e2e/inferencer-material-ui/all.cy.ts
@@ -6,8 +6,6 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("inferencer-material-ui", () => {
-  const BASE_URL = "http://localhost:5173";
-
   const login = () => {
     cy.fixture("demo-auth-credentials").then((auth) => {
       cy.get("#email").clear();
@@ -27,7 +25,7 @@ describe("inferencer-material-ui", () => {
     cy.interceptGETCategory();
     cy.interceptGETCategories();
     cy.interceptGETBlogPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
 
     login();
   });
@@ -238,7 +236,7 @@ describe("inferencer-material-ui", () => {
 
     // find initial theme from localStorage
     cy.getAllLocalStorage().then((ls) => {
-      const initialTheme = ls[BASE_URL]["colorMode"]?.toString() || "dark";
+      const initialTheme = ls["colorMode"]?.toString() || "dark";
 
       // click the theme switch
       if (initialTheme === "dark") {
@@ -249,9 +247,9 @@ describe("inferencer-material-ui", () => {
 
       cy.getAllLocalStorage().then((ls) => {
         if (initialTheme === "dark") {
-          expect(ls[BASE_URL]["colorMode"]).to.eq("light");
+          expect(ls["colorMode"]).to.eq("light");
         } else {
-          expect(ls[BASE_URL]["colorMode"]).to.eq("dark");
+          expect(ls["colorMode"]).to.eq("dark");
         }
       });
 
@@ -281,7 +279,7 @@ describe("inferencer-material-ui", () => {
     cy.get("li[data-value=de]").click();
     // assert localStoage has changed
     cy.getAllLocalStorage().then((ls) => {
-      expect(ls[BASE_URL]["i18nextLng"]).to.eq("de");
+      expect(ls["i18nextLng"]).to.eq("de");
     });
 
     // reload the page and assert the language is persisted

--- a/cypress/e2e/server-side-form-validation-antd/all.cy.ts
+++ b/cypress/e2e/server-side-form-validation-antd/all.cy.ts
@@ -6,8 +6,6 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("server-side-form-validation-antd", () => {
-  const BASE_URL = "http://localhost:5173";
-
   beforeEach(() => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
@@ -15,7 +13,7 @@ describe("server-side-form-validation-antd", () => {
 
     cy.interceptGETCategories();
     cy.interceptGETPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should render edit form errors ", () => {

--- a/cypress/e2e/server-side-form-validation-chakra-ui/all.cy.ts
+++ b/cypress/e2e/server-side-form-validation-chakra-ui/all.cy.ts
@@ -6,8 +6,6 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("server-side-form-validation-chakra-ui", () => {
-  const BASE_URL = "http://localhost:5173";
-
   beforeEach(() => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
@@ -15,7 +13,7 @@ describe("server-side-form-validation-chakra-ui", () => {
 
     cy.interceptGETCategories();
     cy.interceptGETPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should render edit form errors ", () => {

--- a/cypress/e2e/server-side-form-validation-mantine/all.cy.ts
+++ b/cypress/e2e/server-side-form-validation-mantine/all.cy.ts
@@ -6,8 +6,6 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("server-side-form-validation-mantine", () => {
-  const BASE_URL = "http://localhost:5173";
-
   beforeEach(() => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
@@ -15,7 +13,7 @@ describe("server-side-form-validation-mantine", () => {
 
     cy.interceptGETCategories();
     cy.interceptGETPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should render edit form errors ", () => {

--- a/cypress/e2e/server-side-form-validation-material-ui/all.cy.ts
+++ b/cypress/e2e/server-side-form-validation-material-ui/all.cy.ts
@@ -6,8 +6,6 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("server-side-form-validation-material-ui", () => {
-  const BASE_URL = "http://localhost:5173";
-
   beforeEach(() => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
@@ -15,7 +13,7 @@ describe("server-side-form-validation-material-ui", () => {
 
     cy.interceptGETCategories();
     cy.interceptGETPosts();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   it("should render edit form errors ", () => {

--- a/cypress/e2e/table-antd-advanced/categories.cy.ts
+++ b/cypress/e2e/table-antd-advanced/categories.cy.ts
@@ -3,7 +3,7 @@
 
 describe("table-antd-advanced", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:5173/categories");
+    cy.visit("/categories");
   });
 
   it("expanded row should be display the table with the posts data", () => {

--- a/cypress/e2e/table-antd-advanced/posts.cy.ts
+++ b/cypress/e2e/table-antd-advanced/posts.cy.ts
@@ -4,7 +4,7 @@
 describe("table-antd-advanced", () => {
   beforeEach(() => {
     cy.interceptGETPosts();
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("should be view list page", () => {

--- a/cypress/e2e/table-antd-table-filter/all.cy.ts
+++ b/cypress/e2e/table-antd-table-filter/all.cy.ts
@@ -6,7 +6,7 @@ describe("table-antd-table-filter", () => {
     cy.interceptGETPosts();
     cy.interceptGETPosts();
     cy.interceptGETCategories();
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
     cy.wait("@getPosts");
     cy.wait("@getCategories");
   });

--- a/cypress/e2e/table-antd-use-delete-many/all.cy.ts
+++ b/cypress/e2e/table-antd-use-delete-many/all.cy.ts
@@ -6,7 +6,7 @@ describe("table-antd-use-delete-many", () => {
     cy.interceptGETPosts();
     cy.interceptGETCategories();
 
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("should be view list page", () => {

--- a/cypress/e2e/table-antd-use-editable-table/all.cy.ts
+++ b/cypress/e2e/table-antd-use-editable-table/all.cy.ts
@@ -3,7 +3,7 @@
 
 describe("table-antd-use-update-many", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("should be view list page", () => {

--- a/cypress/e2e/table-antd-use-table/all.cy.ts
+++ b/cypress/e2e/table-antd-use-table/all.cy.ts
@@ -3,7 +3,7 @@
 
 describe("table-antd-use-table", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("should be view list page", () => {

--- a/cypress/e2e/table-antd-use-update-many/all.cy.ts
+++ b/cypress/e2e/table-antd-use-update-many/all.cy.ts
@@ -6,7 +6,7 @@ describe("table-antd-use-update-many", () => {
     cy.interceptGETPosts();
     cy.interceptGETCategories();
 
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("should be view list page", () => {

--- a/cypress/e2e/table-chakra-ui-advanced/all.cy.ts
+++ b/cypress/e2e/table-chakra-ui-advanced/all.cy.ts
@@ -5,7 +5,7 @@ describe("table-chakra-ui-advanced", () => {
   beforeEach(() => {
     cy.interceptGETPosts();
 
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("the row should be expandable", () => {

--- a/cypress/e2e/table-chakra-ui-basic/all.cy.ts
+++ b/cypress/e2e/table-chakra-ui-basic/all.cy.ts
@@ -5,7 +5,7 @@ describe("table-chakra-ui-basic", () => {
   beforeEach(() => {
     cy.interceptGETPosts();
 
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("should work with sorter", () => {

--- a/cypress/e2e/table-handson/all.cy.ts
+++ b/cypress/e2e/table-handson/all.cy.ts
@@ -5,7 +5,7 @@ describe("table-handson", () => {
   beforeEach(() => {
     cy.interceptGETPosts();
 
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("the cell should be update", () => {

--- a/cypress/e2e/table-mantine-advanced/all.cy.ts
+++ b/cypress/e2e/table-mantine-advanced/all.cy.ts
@@ -5,7 +5,7 @@ describe("table-mantine-advanced", () => {
   beforeEach(() => {
     cy.interceptGETPosts();
 
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("the row should be expandable", () => {

--- a/cypress/e2e/table-mantine-basic/all.cy.ts
+++ b/cypress/e2e/table-mantine-basic/all.cy.ts
@@ -5,7 +5,7 @@ describe("table-mantine-basic", () => {
   beforeEach(() => {
     cy.interceptGETPosts();
 
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("should work with sorter", () => {

--- a/cypress/e2e/table-material-ui-advanced/data-grid.cy.ts
+++ b/cypress/e2e/table-material-ui-advanced/data-grid.cy.ts
@@ -5,7 +5,7 @@ describe("table-material-ui-advanced", () => {
   beforeEach(() => {
     cy.interceptGETPosts();
     cy.interceptGETCategories();
-    cy.visit("http://localhost:5173/posts/data-grid");
+    cy.visit("/posts/data-grid");
   });
 
   it("should work with filter", () => {

--- a/cypress/e2e/table-material-ui-advanced/react-table.cy.ts
+++ b/cypress/e2e/table-material-ui-advanced/react-table.cy.ts
@@ -5,7 +5,7 @@ describe("table-material-ui-advanced", () => {
   beforeEach(() => {
     cy.interceptGETPosts();
     cy.interceptGETCategories();
-    cy.visit("http://localhost:5173/posts/react-table");
+    cy.visit("/posts/react-table");
   });
 
   it("the row should be expandable", () => {

--- a/cypress/e2e/table-material-ui-cursor-pagination/all.cy.ts
+++ b/cypress/e2e/table-material-ui-cursor-pagination/all.cy.ts
@@ -3,7 +3,7 @@
 
 describe("table-material-ui-cursor-pagination", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("should work with pagination", () => {

--- a/cypress/e2e/table-material-ui-data-grid-pro/all.cy.ts
+++ b/cypress/e2e/table-material-ui-data-grid-pro/all.cy.ts
@@ -3,7 +3,7 @@
 
 describe("table-material-ui-data-grid-pro", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("should work with sorter", () => {

--- a/cypress/e2e/table-material-ui-table-filter/all.cy.ts
+++ b/cypress/e2e/table-material-ui-table-filter/all.cy.ts
@@ -6,7 +6,7 @@ describe("table-material-ui-table-filter", () => {
     cy.interceptGETPosts();
     cy.interceptGETCategories();
 
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("should be view list page", () => {

--- a/cypress/e2e/table-material-ui-use-data-grid/all.cy.ts
+++ b/cypress/e2e/table-material-ui-use-data-grid/all.cy.ts
@@ -3,7 +3,7 @@
 
 describe("table-material-ui-use-data-grid", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("should work with sorter", () => {

--- a/cypress/e2e/table-material-ui-use-delete-many/all.cy.ts
+++ b/cypress/e2e/table-material-ui-use-delete-many/all.cy.ts
@@ -3,7 +3,7 @@
 
 describe("table-material-ui-use-delete-many", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("should be view list page", () => {

--- a/cypress/e2e/table-material-ui-use-update-many/all.cy.ts
+++ b/cypress/e2e/table-material-ui-use-update-many/all.cy.ts
@@ -3,7 +3,7 @@
 
 describe("table-material-ui-use-update-many", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("should be view list page", () => {

--- a/cypress/e2e/table-react-table-advanced/all.cy.ts
+++ b/cypress/e2e/table-react-table-advanced/all.cy.ts
@@ -8,7 +8,7 @@ describe("table-react-table-advanced", () => {
     cy.interceptPATCHPost();
     cy.interceptGETCategories();
 
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("the row should be expandable", () => {

--- a/cypress/e2e/table-react-table-basic/all.cy.ts
+++ b/cypress/e2e/table-react-table-basic/all.cy.ts
@@ -5,7 +5,7 @@ describe("table-react-table-basic", () => {
   beforeEach(() => {
     cy.interceptGETPosts();
 
-    cy.visit("http://localhost:5173");
+    cy.visit("/");
   });
 
   it("should work with sorter", () => {

--- a/cypress/e2e/with-nextjs-next-auth/all.cy.ts
+++ b/cypress/e2e/with-nextjs-next-auth/all.cy.ts
@@ -28,7 +28,9 @@ describe("with-nextjs-next-auth", () => {
       login();
       cy.location("pathname").should("eq", "/blog-posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls).to.have.property("nextauth.message");
+        expect(ls[Cypress.config("baseUrl")!]).to.have.property(
+          "nextauth.message",
+        );
       });
     });
 

--- a/cypress/e2e/with-nextjs-next-auth/all.cy.ts
+++ b/cypress/e2e/with-nextjs-next-auth/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("with-nextjs-next-auth", () => {
-  const BASE_URL = "http://localhost:3000";
-
   const submitAuthForm = () => {
     return cy.get("button[type=submit]").click();
   };
@@ -22,7 +20,7 @@ describe("with-nextjs-next-auth", () => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
-    cy.visit(BASE_URL, { failOnStatusCode: false });
+    cy.visit("/", { failOnStatusCode: false });
   });
 
   describe("login", () => {
@@ -30,7 +28,7 @@ describe("with-nextjs-next-auth", () => {
       login();
       cy.location("pathname").should("eq", "/blog-posts");
       cy.getAllLocalStorage().then((ls) => {
-        expect(ls[BASE_URL]).to.have.property("nextauth.message");
+        expect(ls).to.have.property("nextauth.message");
       });
     });
 
@@ -39,7 +37,7 @@ describe("with-nextjs-next-auth", () => {
       login();
       cy.location("pathname").should("eq", "/blog-posts");
 
-      cy.visit(`${BASE_URL}/test`, { failOnStatusCode: false });
+      cy.visit("/test", { failOnStatusCode: false });
       cy.location("pathname").should("eq", "/test");
       cy.clearAllCookies();
       cy.reload();
@@ -54,7 +52,7 @@ describe("with-nextjs-next-auth", () => {
     });
 
     it("should redirect to /login?to= if user not authenticated", () => {
-      cy.visit(`${BASE_URL}/test-route`, { failOnStatusCode: false });
+      cy.visit("/test-route", { failOnStatusCode: false });
       cy.get(".ant-card-head-title > .ant-typography").contains(
         /sign in to your account/i,
       );

--- a/cypress/e2e/with-nextjs/all.cy.ts
+++ b/cypress/e2e/with-nextjs/all.cy.ts
@@ -2,8 +2,6 @@
 /// <reference types="../../cypress/support" />
 
 describe("with-nextjs", () => {
-  const BASE_URL = "http://localhost:3000";
-
   const fillForm = () => {
     cy.fixture("mock-post").then((mockPost) => {
       cy.get("#title").clear();
@@ -63,7 +61,7 @@ describe("with-nextjs", () => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
-    cy.visit(BASE_URL, {
+    cy.visit("/", {
       failOnStatusCode: false,
     });
   });
@@ -90,7 +88,7 @@ describe("with-nextjs", () => {
       login();
       cy.location("pathname").should("eq", "/");
 
-      cy.visit(`${BASE_URL}/test`, { failOnStatusCode: false });
+      cy.visit("/test", { failOnStatusCode: false });
       cy.location("pathname").should("eq", "/test");
       cy.clearAllCookies();
       cy.reload();
@@ -105,7 +103,7 @@ describe("with-nextjs", () => {
     });
 
     it("should redirect to /login?to= if user not authenticated", () => {
-      cy.visit(`${BASE_URL}/test-route`, { failOnStatusCode: false });
+      cy.visit("/test-route", { failOnStatusCode: false });
       cy.get(".ant-card-head-title > .ant-typography").contains(
         /sign in to your account/i,
       );
@@ -145,7 +143,7 @@ describe("with-nextjs", () => {
 
   describe("forgot password", () => {
     it("should throw error if forgot password email is wrong", () => {
-      cy.visit(`${BASE_URL}/forgot-password`, {
+      cy.visit("/forgot-password", {
         failOnStatusCode: false,
       });
       cy.get("#email").clear().type("test@test.com");
@@ -157,7 +155,7 @@ describe("with-nextjs", () => {
 
   describe("update password", () => {
     it("should throw error if update password is wrong", () => {
-      cy.visit(`${BASE_URL}/update-password`, {
+      cy.visit("/update-password", {
         failOnStatusCode: false,
       });
       cy.get("#password").clear().type("123456");

--- a/cypress/e2e/with-remix-antd/all.cy.ts
+++ b/cypress/e2e/with-remix-antd/all.cy.ts
@@ -6,8 +6,6 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe.skip("with-remix-antd", () => {
-  const BASE_URL = "http://localhost:3000";
-
   const mockPost = {
     title:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
@@ -51,7 +49,7 @@ describe.skip("with-remix-antd", () => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   const submitAuthForm = () => {
@@ -92,7 +90,7 @@ describe.skip("with-remix-antd", () => {
       login();
       cy.location("pathname").should("eq", "/");
 
-      cy.visit(`${BASE_URL}/test`);
+      cy.visit("/test");
       cy.location("pathname").should("eq", "/test");
       cy.clearAllCookies();
       cy.reload();
@@ -104,7 +102,7 @@ describe.skip("with-remix-antd", () => {
     });
 
     it("should redirect to /login?to= if user not authenticated", () => {
-      cy.visit(`${BASE_URL}/test-route`);
+      cy.visit("/test-route");
       cy.get(".ant-card-head-title > .ant-typography").contains(
         /sign in to your account/i,
       );
@@ -143,7 +141,7 @@ describe.skip("with-remix-antd", () => {
 
   describe("forgot password", () => {
     it("should throw error if forgot password email is wrong", () => {
-      cy.visit(`${BASE_URL}/forgot-password`);
+      cy.visit("/forgot-password");
       cy.get("#email").clear();
       cy.get("#email").type("test@test.com");
       submitAuthForm();
@@ -154,7 +152,7 @@ describe.skip("with-remix-antd", () => {
 
   describe("update password", () => {
     it("should throw error if update password is wrong", () => {
-      cy.visit(`${BASE_URL}/update-password`);
+      cy.visit("/update-password");
       cy.get("#password").clear();
       cy.get("#password").clear().type("123456");
       cy.get("#confirmPassword").clear();

--- a/cypress/e2e/with-remix-headless/all.cy.ts
+++ b/cypress/e2e/with-remix-headless/all.cy.ts
@@ -6,8 +6,6 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("with-remix-headless", () => {
-  const BASE_URL = "http://localhost:3000";
-
   const submitAuthForm = () => {
     return cy.get("[type=submit]").click();
   };
@@ -26,7 +24,7 @@ describe("with-remix-headless", () => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   describe("login", () => {
@@ -42,7 +40,7 @@ describe("with-remix-headless", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
 
-      cy.visit(`${BASE_URL}/test`);
+      cy.visit("/test");
       cy.location("pathname").should("eq", "/test");
       cy.clearAllCookies();
       cy.reload();
@@ -54,7 +52,7 @@ describe("with-remix-headless", () => {
     });
 
     it("should redirect to /login?to= if user not authenticated", () => {
-      cy.visit(`${BASE_URL}/test-route`);
+      cy.visit("/test-route");
       cy.get("h1").contains(/sign in to your account/i);
       cy.location("search").should("contains", "to=%2Ftest");
       cy.location("pathname").should("eq", "/login");

--- a/cypress/e2e/with-remix-material-ui/all.cy.ts
+++ b/cypress/e2e/with-remix-material-ui/all.cy.ts
@@ -6,8 +6,6 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("with-remix-material-ui", () => {
-  const BASE_URL = "http://localhost:3000";
-
   const submitAuthForm = () => {
     return cy.get("button[type=submit]").click();
   };
@@ -26,7 +24,7 @@ describe("with-remix-material-ui", () => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   describe("login", () => {
@@ -50,7 +48,7 @@ describe("with-remix-material-ui", () => {
       login();
       cy.location("pathname").should("eq", "/blog-posts");
 
-      cy.visit(`${BASE_URL}/test`);
+      cy.visit("/test");
       cy.location("pathname").should("eq", "/test");
       cy.clearAllCookies();
       cy.reload();
@@ -63,7 +61,7 @@ describe("with-remix-material-ui", () => {
     });
 
     it("should redirect to /login?to= if user not authenticated", () => {
-      cy.visit(`${BASE_URL}/test-route`);
+      cy.visit("/test-route");
       cy.get(".MuiTypography-root").contains(/sign in to your account/i);
       cy.location("search").should("contains", "to=%2Ftest");
       cy.location("pathname").should("eq", "/login");
@@ -116,7 +114,7 @@ describe("with-remix-material-ui", () => {
 
   describe("update password", () => {
     it("should throw error if update password is wrong", () => {
-      cy.visit(`${BASE_URL}/update-password`).wait(1000);
+      cy.visit("/update-password").wait(1000);
       cy.location("pathname").should("eq", "/update-password");
       cy.get("#password").type("123456");
       cy.get("#confirmPassword").type("123456");

--- a/cypress/e2e/with-remix-vite-headless/all.cy.ts
+++ b/cypress/e2e/with-remix-vite-headless/all.cy.ts
@@ -6,8 +6,6 @@ Cypress.on("uncaught:exception", () => {
 });
 
 describe("with-remix-vite-headless", () => {
-  const BASE_URL = "http://localhost:3000";
-
   const submitAuthForm = () => {
     return cy.get("[type=submit]").click();
   };
@@ -26,7 +24,7 @@ describe("with-remix-vite-headless", () => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
-    cy.visit(BASE_URL);
+    cy.visit("/");
   });
 
   describe("login", () => {
@@ -42,7 +40,7 @@ describe("with-remix-vite-headless", () => {
       login();
       cy.location("pathname").should("eq", "/posts");
 
-      cy.visit(`${BASE_URL}/test`);
+      cy.visit("/test");
       cy.location("pathname").should("eq", "/test");
       cy.clearAllCookies();
       cy.reload();
@@ -54,7 +52,7 @@ describe("with-remix-vite-headless", () => {
     });
 
     it("should redirect to /login?to= if user not authenticated", () => {
-      cy.visit(`${BASE_URL}/test-route`);
+      cy.visit("/test-route");
       cy.get("h1").contains(/sign in to your account/i);
       cy.location("search").should("contains", "to=%2Ftest");
       cy.location("pathname").should("eq", "/login");

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -4,7 +4,7 @@
     "resolveJsonModule": true,
     "esModuleInterop": false,
     "sourceMap": false,
-    "types": ["cypress", "chai"],
+    "types": ["cypress"],
     "target": "ESNext",
     "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],

--- a/examples/access-control-casbin/package.json
+++ b/examples/access-control-casbin/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/access-control-cerbos/package.json
+++ b/examples/access-control-cerbos/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/access-control-permify/package.json
+++ b/examples/access-control-permify/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/app-crm-minimal/package.json
+++ b/examples/app-crm-minimal/package.json
@@ -9,9 +9,8 @@
     "dev": "refine dev",
     "format": "prettier --write src",
     "lint": "eslint src --fix",
-    "preview": "refine start",
     "refine": "refine",
-    "start:prod": "refine start"
+    "start": "refine start"
   },
   "dependencies": {
     "@ant-design/cssinjs": "^1.17.2",

--- a/examples/app-crm/package.json
+++ b/examples/app-crm/package.json
@@ -9,8 +9,8 @@
     "dev": "refine dev",
     "format": "prettier src --write",
     "lint": "eslint src --fix",
-    "preview": "refine start",
     "refine": "refine",
+    "start": "refine start",
     "test": "jest --passWithNoTests --runInBand"
   },
   "dependencies": {

--- a/examples/audit-log-provider/package.json
+++ b/examples/audit-log-provider/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@refinedev/cli": "^2.16.36",

--- a/examples/auth-antd/package.json
+++ b/examples/auth-antd/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/auth-auth0/package.json
+++ b/examples/auth-auth0/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/auth-auth0/src/index.tsx
+++ b/examples/auth-auth0/src/index.tsx
@@ -11,8 +11,8 @@ const root = createRoot(container!);
 root.render(
   <React.StrictMode>
     <Auth0Provider
-      domain="dev-qg1ftdys736bk5i3.us.auth0.com"
-      clientId="Be5vsLunFvpzPf4xfXtaMxrZUVBjjNPO"
+      domain="dev-y38p834gjptooc4g.us.auth0.com"
+      clientId="AcinJvjWp1Dr41gPcJeQ20r5vcsteks4"
       redirectUri={window.location.origin}
     >
       <App />

--- a/examples/auth-chakra-ui/package.json
+++ b/examples/auth-chakra-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.5.1",

--- a/examples/auth-google-login/package.json
+++ b/examples/auth-google-login/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/auth-headless/package.json
+++ b/examples/auth-headless/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@refinedev/cli": "^2.16.36",

--- a/examples/auth-keycloak/package.json
+++ b/examples/auth-keycloak/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/auth-kinde/package.json
+++ b/examples/auth-kinde/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/auth-mantine/package.json
+++ b/examples/auth-mantine/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/examples/auth-material-ui/package.json
+++ b/examples/auth-material-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/auth-otp/package.json
+++ b/examples/auth-otp/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/base-antd/package.json
+++ b/examples/base-antd/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/base-chakra-ui/package.json
+++ b/examples/base-chakra-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.5.1",

--- a/examples/base-headless/package.json
+++ b/examples/base-headless/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/base-mantine/package.json
+++ b/examples/base-mantine/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/examples/base-material-ui/package.json
+++ b/examples/base-material-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/blog-ecommerce/package.json
+++ b/examples/blog-ecommerce/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "build": "refine build && rimraf .next/cache",
+    "dev": "cross-env NODE_OPTIONS=--max_old_space_size=4096 refine dev",
     "lint": "eslint '**/*.{js,jsx,ts,tsx}'",
-    "start": "cross-env NODE_OPTIONS=--max_old_space_size=4096 refine dev",
-    "start:prod": "refine start"
+    "start": "refine start"
   },
   "dependencies": {
     "@chakra-ui/icons": "^1.1.5",

--- a/examples/blog-invoice-generator/package.json
+++ b/examples/blog-invoice-generator/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "refine build",
     "dev": "refine dev",
-    "preview": "refine start",
     "refine": "refine",
+    "start": "refine start",
     "test": "jest --passWithNoTests --runInBand"
   },
   "browserslist": {

--- a/examples/blog-material-ui-datagrid/package.json
+++ b/examples/blog-material-ui-datagrid/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/blog-next-refine-pwa/package.json
+++ b/examples/blog-next-refine-pwa/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "build": "refine build && rimraf .next/cache",
+    "dev": "cross-env NODE_OPTIONS=--max_old_space_size=4096 refine dev",
     "lint": "eslint '**/*.{js,jsx,ts,tsx}'",
-    "start": "cross-env NODE_OPTIONS=--max_old_space_size=4096 refine dev",
-    "start:prod": "refine start"
+    "start": "refine start"
   },
   "dependencies": {
     "@refinedev/cli": "^2.16.36",

--- a/examples/blog-ra-chakra-tutorial/package.json
+++ b/examples/blog-ra-chakra-tutorial/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.5.1",

--- a/examples/blog-react-hot-toast/package.json
+++ b/examples/blog-react-hot-toast/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/blog-react-toastify/package.json
+++ b/examples/blog-react-toastify/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/blog-refine-airtable-crud/package.json
+++ b/examples/blog-refine-airtable-crud/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
     "refine": "refine",
+    "start": "refine start",
     "test": "jest"
   },
   "browserslist": {

--- a/examples/blog-refine-antd-dynamic-form/package.json
+++ b/examples/blog-refine-antd-dynamic-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
     "refine": "refine",
+    "start": "refine start",
     "test": "jest"
   },
   "browserslist": {

--- a/examples/blog-refine-daisyui/package.json
+++ b/examples/blog-refine-daisyui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/blog-refine-digital-ocean/package.json
+++ b/examples/blog-refine-digital-ocean/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/blog-refine-filtering/package.json
+++ b/examples/blog-refine-filtering/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/blog-refine-mantine-strapi/package.json
+++ b/examples/blog-refine-mantine-strapi/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/blog-refine-markdown/package.json
+++ b/examples/blog-refine-markdown/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/blog-refine-mui/package.json
+++ b/examples/blog-refine-mui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/blog-refine-nextui/package.json
+++ b/examples/blog-refine-nextui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/blog-refine-primereact/package.json
+++ b/examples/blog-refine-primereact/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/blog-refine-react-hook-form/package.json
+++ b/examples/blog-refine-react-hook-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/blog-refine-shadcn/package.json
+++ b/examples/blog-refine-shadcn/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/blog-refine-supabase-auth/package.json
+++ b/examples/blog-refine-supabase-auth/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
     "refine": "refine",
+    "start": "refine start",
     "test": "jest"
   },
   "browserslist": {

--- a/examples/blog-refine-tremor/package.json
+++ b/examples/blog-refine-tremor/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/blog-win95/package.json
+++ b/examples/blog-win95/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/calendar-app/package.json
+++ b/examples/calendar-app/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/command-palette-kbar/package.json
+++ b/examples/command-palette-kbar/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/core-use-import/package.json
+++ b/examples/core-use-import/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/core-use-menu/package.json
+++ b/examples/core-use-menu/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/core-use-modal/package.json
+++ b/examples/core-use-modal/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/core-use-select/package.json
+++ b/examples/core-use-select/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/customization-footer/package.json
+++ b/examples/customization-footer/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/customization-offlayout-area/package.json
+++ b/examples/customization-offlayout-area/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/customization-rtl/package.json
+++ b/examples/customization-rtl/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/customization-sider/package.json
+++ b/examples/customization-sider/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/customization-theme-antd/package.json
+++ b/examples/customization-theme-antd/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/customization-theme-chakra-ui/package.json
+++ b/examples/customization-theme-chakra-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.5.1",

--- a/examples/customization-theme-mantine/package.json
+++ b/examples/customization-theme-mantine/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/examples/customization-theme-material-ui/package.json
+++ b/examples/customization-theme-material-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/customization-top-menu-layout/package.json
+++ b/examples/customization-top-menu-layout/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/data-provider-airtable/package.json
+++ b/examples/data-provider-airtable/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/data-provider-appwrite-tutorial-docs/package.json
+++ b/examples/data-provider-appwrite-tutorial-docs/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/data-provider-appwrite/package.json
+++ b/examples/data-provider-appwrite/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/data-provider-hasura/package.json
+++ b/examples/data-provider-hasura/package.json
@@ -7,8 +7,8 @@
     "build": "tsc && refine build",
     "codegen": "graphql-codegen",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/data-provider-multiple/package.json
+++ b/examples/data-provider-multiple/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/data-provider-nestjs-query/package.json
+++ b/examples/data-provider-nestjs-query/package.json
@@ -7,8 +7,8 @@
     "build": "tsc && refine build",
     "codegen": "graphql-codegen",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/data-provider-nestjsx-crud/package.json
+++ b/examples/data-provider-nestjsx-crud/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/data-provider-sanity/package.json
+++ b/examples/data-provider-sanity/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/data-provider-strapi-v4/package.json
+++ b/examples/data-provider-strapi-v4/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/data-provider-strapi/package.json
+++ b/examples/data-provider-strapi/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/data-provider-supabase/package.json
+++ b/examples/data-provider-supabase/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/field-antd-use-checkbox-group/package.json
+++ b/examples/field-antd-use-checkbox-group/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/field-antd-use-radio-group/package.json
+++ b/examples/field-antd-use-radio-group/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/field-antd-use-select-basic/package.json
+++ b/examples/field-antd-use-select-basic/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/field-antd-use-select-infinite/package.json
+++ b/examples/field-antd-use-select-infinite/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/field-material-ui-use-autocomplete/package.json
+++ b/examples/field-material-ui-use-autocomplete/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/finefoods-antd/package.json
+++ b/examples/finefoods-antd/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": [
     ">0.2%",

--- a/examples/finefoods-client/package.json
+++ b/examples/finefoods-client/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "refine build && rimraf .next/cache",
     "dev": "refine dev",
-    "start:prod": "refine start"
+    "start": "refine start"
   },
   "dependencies": {
     "@refinedev/cli": "^2.16.36",

--- a/examples/finefoods-material-ui/package.json
+++ b/examples/finefoods-material-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-antd-custom-validation/package.json
+++ b/examples/form-antd-custom-validation/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-antd-mutation-mode/package.json
+++ b/examples/form-antd-mutation-mode/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-antd-use-drawer-form/package.json
+++ b/examples/form-antd-use-drawer-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-antd-use-form/package.json
+++ b/examples/form-antd-use-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-antd-use-modal-form/package.json
+++ b/examples/form-antd-use-modal-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-antd-use-steps-form/package.json
+++ b/examples/form-antd-use-steps-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-chakra-ui-mutation-mode/package.json
+++ b/examples/form-chakra-ui-mutation-mode/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.5.1",

--- a/examples/form-chakra-ui-use-drawer-form/package.json
+++ b/examples/form-chakra-ui-use-drawer-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.5.1",

--- a/examples/form-chakra-ui-use-form/package.json
+++ b/examples/form-chakra-ui-use-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.5.1",

--- a/examples/form-chakra-use-modal-form/package.json
+++ b/examples/form-chakra-use-modal-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.5.1",

--- a/examples/form-core-use-form/package.json
+++ b/examples/form-core-use-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-mantine-mutation-mode/package.json
+++ b/examples/form-mantine-mutation-mode/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/examples/form-mantine-use-drawer-form/package.json
+++ b/examples/form-mantine-use-drawer-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/examples/form-mantine-use-form/package.json
+++ b/examples/form-mantine-use-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/examples/form-mantine-use-modal-form/package.json
+++ b/examples/form-mantine-use-modal-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/examples/form-mantine-use-steps-form/package.json
+++ b/examples/form-mantine-use-steps-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/examples/form-material-ui-mutation-mode/package.json
+++ b/examples/form-material-ui-mutation-mode/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-material-ui-use-drawer-form/package.json
+++ b/examples/form-material-ui-use-drawer-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-material-ui-use-form/package.json
+++ b/examples/form-material-ui-use-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-material-ui-use-modal-form/package.json
+++ b/examples/form-material-ui-use-modal-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-material-ui-use-steps-form/package.json
+++ b/examples/form-material-ui-use-steps-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-react-hook-form-use-form/package.json
+++ b/examples/form-react-hook-form-use-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-react-hook-form-use-modal-form/package.json
+++ b/examples/form-react-hook-form-use-modal-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-react-hook-form-use-steps-form/package.json
+++ b/examples/form-react-hook-form-use-steps-form/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/form-save-and-continue/package.json
+++ b/examples/form-save-and-continue/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/i18n-nextjs/package.json
+++ b/examples/i18n-nextjs/package.json
@@ -6,7 +6,7 @@
     "build": "refine build",
     "dev": "cross-env NODE_OPTIONS=--max_old_space_size=4096 refine dev",
     "lint": "eslint '**/*.{js,jsx,ts,tsx}'",
-    "start:prod": "refine start"
+    "start": "refine start"
   },
   "dependencies": {
     "@ant-design/icons": "5.0.1",

--- a/examples/i18n-react/package.json
+++ b/examples/i18n-react/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/import-export-antd/package.json
+++ b/examples/import-export-antd/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/import-export-mantine/package.json
+++ b/examples/import-export-mantine/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/examples/import-export-material-ui/package.json
+++ b/examples/import-export-material-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/inferencer-antd/package.json
+++ b/examples/inferencer-antd/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/inferencer-chakra-ui/package.json
+++ b/examples/inferencer-chakra-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/inferencer-graphql-hasura/package.json
+++ b/examples/inferencer-graphql-hasura/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/inferencer-headless/package.json
+++ b/examples/inferencer-headless/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/inferencer-mantine/package.json
+++ b/examples/inferencer-mantine/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/inferencer-material-ui/package.json
+++ b/examples/inferencer-material-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/input-custom/package.json
+++ b/examples/input-custom/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/input-date-picker/package.json
+++ b/examples/input-date-picker/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/invoicer/package.json
+++ b/examples/invoicer/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/live-provider-ably/package.json
+++ b/examples/live-provider-ably/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/loading-overtime/package.json
+++ b/examples/loading-overtime/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/monorepo-module-federation/apps/blog-posts/package.json
+++ b/examples/monorepo-module-federation/apps/blog-posts/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/monorepo-module-federation/apps/categories/package.json
+++ b/examples/monorepo-module-federation/apps/categories/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/monorepo-module-federation/apps/host/package.json
+++ b/examples/monorepo-module-federation/apps/host/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/monorepo-with-lerna-bootstrap/apps/my-refine-app/package.json
+++ b/examples/monorepo-with-lerna-bootstrap/apps/my-refine-app/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/monorepo-with-lerna/apps/my-refine-app/package.json
+++ b/examples/monorepo-with-lerna/apps/my-refine-app/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/monorepo-with-turbo/apps/my-refine-app/package.json
+++ b/examples/monorepo-with-turbo/apps/my-refine-app/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/multi-level-menu/package.json
+++ b/examples/multi-level-menu/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/multi-tenancy-strapi/package.json
+++ b/examples/multi-tenancy-strapi/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/new-routing-example/package.json
+++ b/examples/new-routing-example/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/pixels-admin/package.json
+++ b/examples/pixels-admin/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/pixels/package.json
+++ b/examples/pixels/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/refine-week-invoice-generator/package.json
+++ b/examples/refine-week-invoice-generator/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/search/package.json
+++ b/examples/search/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/server-side-form-validation-antd/package.json
+++ b/examples/server-side-form-validation-antd/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/server-side-form-validation-chakra-ui/package.json
+++ b/examples/server-side-form-validation-chakra-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.5.1",

--- a/examples/server-side-form-validation-mantine/package.json
+++ b/examples/server-side-form-validation-mantine/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/examples/server-side-form-validation-material-ui/package.json
+++ b/examples/server-side-form-validation-material-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/starter-vite/package.json
+++ b/examples/starter-vite/package.json
@@ -7,8 +7,8 @@
     "build": "tsc && refine build",
     "dev": "refine dev",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@refinedev/cli": "^2.16.36",

--- a/examples/store/package.json
+++ b/examples/store/package.json
@@ -6,7 +6,7 @@
     "build": "next build && rimraf .next/cache",
     "dev": "cross-env NODE_OPTIONS=--max_old_space_size=4096 PORT=8000 next dev",
     "lint": "eslint '**/*.{js,jsx,ts,tsx}'",
-    "start:prod": "next start"
+    "start": "next start"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",

--- a/examples/table-antd-advanced/package.json
+++ b/examples/table-antd-advanced/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/table-antd-table-filter/package.json
+++ b/examples/table-antd-table-filter/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/table-antd-use-delete-many/package.json
+++ b/examples/table-antd-use-delete-many/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/table-antd-use-editable-table/package.json
+++ b/examples/table-antd-use-editable-table/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/table-antd-use-table/package.json
+++ b/examples/table-antd-use-table/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/table-antd-use-update-many/package.json
+++ b/examples/table-antd-use-update-many/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/table-chakra-ui-advanced/package.json
+++ b/examples/table-chakra-ui-advanced/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.5.1",

--- a/examples/table-chakra-ui-basic/package.json
+++ b/examples/table-chakra-ui-basic/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.5.1",

--- a/examples/table-handson/package.json
+++ b/examples/table-handson/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@handsontable/react": "^12.1.2",

--- a/examples/table-mantine-advanced/package.json
+++ b/examples/table-mantine-advanced/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/examples/table-mantine-basic/package.json
+++ b/examples/table-mantine-basic/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/examples/table-material-ui-advanced/package.json
+++ b/examples/table-material-ui-advanced/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/table-material-ui-cursor-pagination/package.json
+++ b/examples/table-material-ui-cursor-pagination/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/table-material-ui-data-grid-pro/package.json
+++ b/examples/table-material-ui-data-grid-pro/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/table-material-ui-table-filter/package.json
+++ b/examples/table-material-ui-table-filter/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/table-material-ui-use-data-grid/package.json
+++ b/examples/table-material-ui-use-data-grid/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/table-material-ui-use-delete-many/package.json
+++ b/examples/table-material-ui-use-delete-many/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/table-material-ui-use-update-many/package.json
+++ b/examples/table-material-ui-use-update-many/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/table-react-table-advanced/package.json
+++ b/examples/table-react-table-advanced/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/table-react-table-basic/package.json
+++ b/examples/table-react-table-basic/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/template-antd/package.json
+++ b/examples/template-antd/package.json
@@ -7,8 +7,8 @@
     "build": "tsc && refine build",
     "dev": "refine dev",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@refinedev/antd": "^5.42.0",

--- a/examples/template-chakra-ui/package.json
+++ b/examples/template-chakra-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/template-headless/package.json
+++ b/examples/template-headless/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/template-mantine/package.json
+++ b/examples/template-mantine/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/template-material-ui/package.json
+++ b/examples/template-material-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/theme-antd-demo/package.json
+++ b/examples/theme-antd-demo/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/theme-chakra-ui-demo/package.json
+++ b/examples/theme-chakra-ui-demo/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.5.1",

--- a/examples/theme-mantine-demo/package.json
+++ b/examples/theme-mantine-demo/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/examples/theme-material-ui-demo/package.json
+++ b/examples/theme-material-ui-demo/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/tutorial-antd/package.json
+++ b/examples/tutorial-antd/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/tutorial-chakra-ui/package.json
+++ b/examples/tutorial-chakra-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/tutorial-headless/package.json
+++ b/examples/tutorial-headless/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/tutorial-mantine/package.json
+++ b/examples/tutorial-mantine/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/tutorial-material-ui/package.json
+++ b/examples/tutorial-material-ui/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/upload-antd-base64/package.json
+++ b/examples/upload-antd-base64/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/upload-antd-multipart/package.json
+++ b/examples/upload-antd-multipart/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/upload-chakra-ui-basic64/package.json
+++ b/examples/upload-chakra-ui-basic64/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.5.1",

--- a/examples/upload-chakra-ui-multipart/package.json
+++ b/examples/upload-chakra-ui-multipart/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.5.1",

--- a/examples/upload-mantine-base64/package.json
+++ b/examples/upload-mantine-base64/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/examples/upload-mantine-multipart/package.json
+++ b/examples/upload-mantine-multipart/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/examples/upload-material-ui-base64/package.json
+++ b/examples/upload-material-ui-base64/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/upload-material-ui-multipart/package.json
+++ b/examples/upload-material-ui-multipart/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/use-infinite-list/package.json
+++ b/examples/use-infinite-list/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/use-modal-antd/package.json
+++ b/examples/use-modal-antd/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/use-simple-list-antd/package.json
+++ b/examples/use-simple-list-antd/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/win95/package.json
+++ b/examples/win95/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/with-custom-pages/package.json
+++ b/examples/with-custom-pages/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/with-javascript/package.json
+++ b/examples/with-javascript/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/with-material-ui-vite/package.json
+++ b/examples/with-material-ui-vite/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/with-meta-properties/package.json
+++ b/examples/with-meta-properties/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "dependencies": {
     "@refinedev/antd": "^5.42.0",

--- a/examples/with-nextjs-next-auth/package.json
+++ b/examples/with-nextjs-next-auth/package.json
@@ -6,7 +6,7 @@
     "build": "refine build && rimraf .next/cache",
     "dev": "cross-env NODE_OPTIONS=--max_old_space_size=4096 refine dev",
     "lint": "eslint '**/*.{js,jsx,ts,tsx}'",
-    "start:prod": "refine start"
+    "start": "refine start"
   },
   "dependencies": {
     "@ant-design/icons": "5.0.1",

--- a/examples/with-nextjs-next-auth/src/app/api/auth/[...nextauth]/options.ts
+++ b/examples/with-nextjs-next-auth/src/app/api/auth/[...nextauth]/options.ts
@@ -14,10 +14,10 @@ const authOptions = {
       clientSecret: "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",
     }),
     Auth0Provider({
-      clientId: "Be5vsLunFvpzPf4xfXtaMxrZUVBjjNPO",
+      clientId: "AcinJvjWp1Dr41gPcJeQ20r5vcsteks4",
       clientSecret:
-        "08F9X84FvzpsimV16CQvlQuwJOlqk-GqQgEdcq_3xzrn1K3UHnTCcRgMCwBW7api",
-      issuer: "https://dev-qg1ftdys736bk5i3.us.auth0.com",
+        "y3pj2KaTiNgING-5e8_JYmX_bIQSwvkp_XgDcA75sEPSSB2zmi0n-3UoTfH0pOTP",
+      issuer: "https://dev-y38p834gjptooc4g.us.auth0.com",
     }),
     KeycloakProvider({
       clientId: "refine-demo",

--- a/examples/with-nextjs/package.json
+++ b/examples/with-nextjs/package.json
@@ -6,7 +6,7 @@
     "build": "refine build",
     "dev": "cross-env NODE_OPTIONS=--max_old_space_size=4096 refine dev",
     "lint": "eslint '**/*.{js,jsx,ts,tsx}'",
-    "start:prod": "refine start"
+    "start": "refine start"
   },
   "dependencies": {
     "@ant-design/icons": "5.0.1",

--- a/examples/with-persist-query/package.json
+++ b/examples/with-persist-query/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/with-react-toastify/package.json
+++ b/examples/with-react-toastify/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/examples/with-remix-antd/package.json
+++ b/examples/with-remix-antd/package.json
@@ -7,7 +7,7 @@
     "build": "refine build",
     "dev": "refine dev",
     "refine": "refine",
-    "start:prod": "refine start"
+    "start": "refine start"
   },
   "dependencies": {
     "@refinedev/antd": "^5.42.0",

--- a/examples/with-remix-auth/app/utils/auth.server.ts
+++ b/examples/with-remix-auth/app/utils/auth.server.ts
@@ -14,10 +14,10 @@ const auth0Strategy = new Auth0Strategy(
   {
     // !!! Should be stored in .env file.
     callbackURL: "http://localhost:3000/auth/auth0/callback",
-    clientID: "Be5vsLunFvpzPf4xfXtaMxrZUVBjjNPO",
+    clientID: "AcinJvjWp1Dr41gPcJeQ20r5vcsteks4",
     clientSecret:
-      "08F9X84FvzpsimV16CQvlQuwJOlqk-GqQgEdcq_3xzrn1K3UHnTCcRgMCwBW7api",
-    domain: "dev-qg1ftdys736bk5i3.us.auth0.com",
+      "y3pj2KaTiNgING-5e8_JYmX_bIQSwvkp_XgDcA75sEPSSB2zmi0n-3UoTfH0pOTP",
+    domain: "dev-y38p834gjptooc4g.us.auth0.com",
   },
   async ({ accessToken, extraParams, profile, refreshToken }) => {
     const { id, displayName, photos } = profile;

--- a/examples/with-remix-auth/package.json
+++ b/examples/with-remix-auth/package.json
@@ -7,7 +7,7 @@
     "build": "refine build",
     "dev": "refine dev",
     "refine": "refine",
-    "start:prod": "refine start"
+    "start": "refine start"
   },
   "dependencies": {
     "@refinedev/antd": "^5.42.0",

--- a/examples/with-remix-headless/package.json
+++ b/examples/with-remix-headless/package.json
@@ -7,7 +7,7 @@
     "build": "refine build",
     "dev": "refine dev",
     "refine": "refine",
-    "start:prod": "refine start"
+    "start": "refine start"
   },
   "dependencies": {
     "@refinedev/cli": "^2.16.36",

--- a/examples/with-remix-material-ui/package.json
+++ b/examples/with-remix-material-ui/package.json
@@ -7,7 +7,7 @@
     "build": "refine build",
     "dev": "refine dev",
     "refine": "refine",
-    "start:prod": "refine start"
+    "start": "refine start"
   },
   "dependencies": {
     "@emotion/cache": "^11.11.0",

--- a/examples/with-remix-vite-headless/package.json
+++ b/examples/with-remix-vite-headless/package.json
@@ -8,7 +8,7 @@
     "build": "remix vite:build",
     "dev": "remix vite:dev",
     "refine": "refine",
-    "start:prod": "remix-serve ./build/server/index.js"
+    "start": "remix-serve ./build/server/index.js"
   },
   "dependencies": {
     "@refinedev/cli": "^2.16.36",

--- a/examples/with-web3/package.json
+++ b/examples/with-web3/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && refine build",
     "dev": "refine dev",
-    "preview": "refine start",
-    "refine": "refine"
+    "refine": "refine",
+    "start": "refine start"
   },
   "browserslist": {
     "production": [

--- a/nx.json
+++ b/nx.json
@@ -35,6 +35,9 @@
     },
     "publint": {
       "dependsOn": ["build"]
+    },
+    "start": {
+      "dependsOn": ["build"]
     }
   },
   "defaultProject": "@refinedev/core",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "publint": "lerna run publint --scope @refinedev/core",
     "publint:all": "lerna run publint --scope @refinedev/*",
     "sp": "syncpack",
+    "start": "lerna run start",
     "test": "lerna run test --stream",
     "test:all": "lerna run test --stream --scope @refinedev/* --scope create-refine-app",
     "test:all:coverage": "pnpm test:all -- -- --coverage",

--- a/packages/live-previews/package.json
+++ b/packages/live-previews/package.json
@@ -7,8 +7,7 @@
     "build": "next build && rimraf .next/cache",
     "dev": "NODE_OPTIONS='--max-http-header-size=32767' PORT=3030 next dev",
     "lint": "next lint",
-    "start": "PORT=3030 nodemon --watch ./node_modules --watch ./src --watch ./pages --ext ts,tsx,js,jsx --exec \"next build --no-lint && next start\"",
-    "start:prod": "NODE_OPTIONS='--max-http-header-size=32767' next start",
+    "start": "NODE_OPTIONS='--max-http-header-size=32767' next start",
     "test": "jest --passWithNoTests"
   },
   "dependencies": {

--- a/packages/live-previews/package.json
+++ b/packages/live-previews/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "next build && rimraf .next/cache",
     "dev": "NODE_OPTIONS='--max-http-header-size=32767' PORT=3030 next dev",
+    "dev:prod": "PORT=3030 nodemon --watch ./node_modules --watch ./src --watch ./pages --ext ts,tsx,js,jsx --exec \"next build --no-lint && next start\"",
     "lint": "next lint",
     "start": "NODE_OPTIONS='--max-http-header-size=32767' next start",
     "test": "jest --passWithNoTests"


### PR DESCRIPTION
## What is the current behavior?

Currently e2e vite examples are running dev server for e2e specs.
Also we have inconsistencies in example scripts.

## What is the new behavior?

Now examples are built and run from production build for e2e specs.
Also updated examples' scripts to be consistent.

- start:prod -> start
- preview -> start

Now build all examples action takes 16~ minutes, going down from 22~ minutes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset



fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
