### PR TITLE
fix(devtools-internal): fix noop return on hooks for production builds

### DIFF
--- a/.changeset/pretty-snails-shake.md
+++ b/.changeset/pretty-snails-shake.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/devtools-internal": patch
+---
+
+fix(devtools-internal): fix noop return on hooks for production builds
+
+Currently, `@refinedev/devtools-internal` returns noop function when bundled for production, yet the notation is not correctly interpreted by some bundlers. This PR fixes the issue by moving the empty return and noop functions to a separate definition.
+
+[Resolves #6030](https://github.com/refinedev/refine/issues/6030)

--- a/packages/devtools-internal/src/use-query-subscription.tsx
+++ b/packages/devtools-internal/src/use-query-subscription.tsx
@@ -7,11 +7,12 @@ import type { QueryClient } from "@tanstack/react-query";
 import React, { useContext } from "react";
 import { createQueryListener, createMutationListener } from "./listeners";
 
+const empty = {};
+const noop = () => empty;
+
 export const useQuerySubscription =
   __DEV_CONDITION__ !== "development"
-    ? () => {
-        return {};
-      }
+    ? noop
     : (queryClient: QueryClient) => {
         const { ws } = useContext(DevToolsContext);
         const queryCacheSubscription = React.useRef<() => void>();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

Currently, `@refinedev/devtools-internal` returns noop function when bundled for production, yet the notation is not correctly interpreted by some bundlers. This PR fixes the issue by moving the empty return and noop functions to a separate definition.

Resolves #6030