### PR TITLE
feat: refactor `tableQueryResult` name to `tableQuery`

### DIFF
--- a/.changeset/itchy-dancers-walk.md
+++ b/.changeset/itchy-dancers-walk.md
@@ -1,0 +1,12 @@
+---
+"@refinedev/core": minor
+---
+
+feat: [`useTable`](https://refine.dev/docs/data/hooks/use-table/)'s `tableQueryResult` is deprecated, use `tableQuery` instead. #6169
+
+```diff
+import { useTable } from '@refinedev/core';
+
+- const { tableQueryResult } = useTable();
++ const { tableQuery } = useTable();
+```

--- a/.changeset/rich-swans-prove.md
+++ b/.changeset/rich-swans-prove.md
@@ -1,0 +1,12 @@
+---
+"@refinedev/mui": minor
+---
+
+feat: [`useDataGrid`](https://refine.dev/docs/ui-integrations/material-ui/hooks/use-data-grid/)'s `tableQueryResult` is deprecated, use `tableQuery` instead. #6169
+
+```diff
+import { useDataGrid } from '@refinedev/mui';
+
+- const { tableQueryResult } = useDataGrid();
++ const { tableQuery } = useDataGrid();
+```

--- a/.changeset/sixty-countries-nail.md
+++ b/.changeset/sixty-countries-nail.md
@@ -1,0 +1,21 @@
+---
+"@refinedev/antd": minor
+---
+
+feat: [`useTable`](https://refine.dev/docs/ui-integrations/ant-design/hooks/use-table/)'s `tableQueryResult` is deprecated, use `tableQuery` instead. #6169
+
+```diff
+import { useTable } from '@refinedev/core';
+
+- const { tableQueryResult } = useTable();
++ const { tableQuery } = useTable();
+```
+
+feat: [`useSimpleList`](https://refine.dev/docs/ui-integrations/ant-design/hooks/use-simple-list/)'s `queryResult` is deprecated, use `query` instead. #6169
+
+```diff
+import { useSimpleList } from '@refinedev/antd';
+
+- const { queryResult } = useSimpleList();
++ const { query } = useSimpleList();
+```

--- a/documentation/blog/2022-03-22-refine-with-react95.md
+++ b/documentation/blog/2022-03-22-refine-with-react95.md
@@ -1055,7 +1055,7 @@ export const PostList = () => {
     setPageIndex,
     setPageSize,
     refineCore: {
-      tableQueryResult: { isLoading },
+      tableQuery: { isLoading },
     },
   } = useTable<IPost>({
     columns,

--- a/documentation/blog/2023-01-17-airtable-crud-app.md
+++ b/documentation/blog/2023-01-17-airtable-crud-app.md
@@ -329,7 +329,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
   const { push } = useNavigation();
 
   return (
-    <div className="py-4 pr-4 flex min-h-screen flex-col border md:flex-row">
+    <div className="flex min-h-screen flex-col border py-4 pr-4 md:flex-row">
       <div className="mb-2 border-b py-2 md:w-2/12">
         <div className="container mx-auto">
           <div className="flex flex-col items-center gap-2">
@@ -561,7 +561,7 @@ export const PostList: React.FC = () => {
                 <th
                   key={header.id}
                   colSpan={header.colSpan}
-                  className="py-3 px-6 text-left text-xs font-medium uppercase tracking-wider text-gray-700 "
+                  className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-700 "
                 >
                   {flexRender(
                     header.column.columnDef.header,
@@ -580,7 +580,7 @@ export const PostList: React.FC = () => {
                   return (
                     <td
                       key={cell.id}
-                      className="whitespace-nowrap py-2 px-6 text-sm font-medium text-gray-900"
+                      className="whitespace-nowrap px-6 py-2 text-sm font-medium text-gray-900"
                     >
                       {flexRender(
                         cell.column.columnDef.cell,
@@ -684,7 +684,7 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable<IPost>({ columns });
 
@@ -726,7 +726,7 @@ export const PostList: React.FC = () => {
                 <th
                   key={idx}
                   colSpan={header.colSpan}
-                  className="py-3 px-6 text-left text-xs font-medium uppercase tracking-wider text-gray-700 "
+                  className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-700 "
                 >
                   {flexRender(
                     header.column.columnDef.header,
@@ -745,7 +745,7 @@ export const PostList: React.FC = () => {
                   return (
                     <td
                       key={idx}
-                      className="whitespace-nowrap py-2 px-6 text-sm font-medium text-gray-900"
+                      className="whitespace-nowrap px-6 py-2 text-sm font-medium text-gray-900"
                     >
                       {flexRender(
                         cell.column.columnDef.cell,
@@ -1526,7 +1526,7 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
     getState,
     setPageIndex,

--- a/documentation/blog/2023-04-13-refine-invoicer-4.md
+++ b/documentation/blog/2023-04-13-refine-invoicer-4.md
@@ -867,7 +867,7 @@ Endowed a due patience, we can see this in action among many others in the `@ref
 
 ```tsx title="node_modules/@refinedev/antd/src/hooks/table/useTable/useTable.ts"
 const {
-  tableQueryResult,
+  tableQuery,
   current,
   setCurrent,
   pageSize,

--- a/documentation/blog/2023-07-02-refine-tremor-dashboard.md
+++ b/documentation/blog/2023-07-02-refine-tremor-dashboard.md
@@ -170,7 +170,7 @@ const currencyFormatter = Intl.NumberFormat("en-US", {
 });
 
 export default () => (
-  <Card className="max-w-xs mx-auto">
+  <Card className="mx-auto max-w-xs">
     <Text>Revenue</Text>
     <Metric>{currencyFormatter.format(3_500)}</Metric>
   </Card>
@@ -597,7 +597,7 @@ export const DashboardPage: React.FC = () => {
         </TabList>
         <TabPanels>
           <TabPanel>
-            <Grid numItemsMd={2} numItemsLg={3} className="gap-6 mt-6">
+            <Grid numItemsMd={2} numItemsLg={3} className="mt-6 gap-6">
               <Card>
                 <div className="h-28" />
               </Card>
@@ -842,7 +842,7 @@ export const DashboardPage: React.FC = () => {
         </TabList>
         <TabPanels>
           <TabPanel>
-            <Grid numItemsMd={2} numItemsLg={3} className="gap-6 mt-6">
+            <Grid numItemsMd={2} numItemsLg={3} className="mt-6 gap-6">
               //highlight-start
               <KpiCard
                 title="Weekly Revenue"
@@ -977,7 +977,7 @@ export function ChartView({ revenue, orders, customers }: IProps) {
 
   return (
     <Card>
-      <div className="md:flex justify-between">
+      <div className="justify-between md:flex">
         <div>
           <Flex
             justifyContent="start"
@@ -1014,7 +1014,7 @@ export function ChartView({ revenue, orders, customers }: IProps) {
         showLegend={true}
         valueFormatter={formatters[selectedKpi]}
         yAxisWidth={56}
-        className="h-96 mt-8"
+        className="mt-8 h-96"
       />
     </Card>
   );
@@ -1246,7 +1246,7 @@ export const Details = () => {
     getHeaderGroups,
     getRowModel,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
     getState,
     setPageIndex,
@@ -1402,7 +1402,7 @@ export const Details = () => {
         <TextInput
           type="text"
           placeholder="Enter Page"
-          className="max-w-xs w-1/8"
+          className="w-1/8 max-w-xs"
           defaultValue={`${getState().pagination.pageIndex + 1}`}
           onChange={(e) => {
             const { value } = e.target;

--- a/documentation/blog/2023-07-26-refine-primereact-dashboard.md
+++ b/documentation/blog/2023-07-26-refine-primereact-dashboard.md
@@ -220,7 +220,7 @@ import { Button } from "primereact/Button";
 
 export const Dashboard = () => {
   return (
-    <div className="flex justify-content-center">
+    <div className="justify-content-center flex">
       <Button label="Hello PrimeReact!" icon="pi pi-prime" />
     </div>
   );
@@ -338,14 +338,14 @@ export const KpiCard = ({
     if (total < trend) {
       return (
         <div className="text-green-500">
-          <span className="font-medium mr-2">+{calc}%</span>
+          <span className="mr-2 font-medium">+{calc}%</span>
         </div>
       );
     }
 
     return (
       <div className="text-pink-500">
-        <span className="font-medium mr-2">-{calc}%</span>
+        <span className="mr-2 font-medium">-{calc}%</span>
       </div>
     );
   };
@@ -354,15 +354,15 @@ export const KpiCard = ({
     <Card
       className={`shadow-1 border-left-3 border-${color}`}
       title={
-        <div className="flex justify-content-between">
+        <div className="justify-content-between flex">
           <div>
-            <span className="block font-bold text-xl mb-3">{title}</span>
-            <div className="text-900 font-medium text-2xl">
+            <span className="mb-3 block text-xl font-bold">{title}</span>
+            <div className="text-900 text-2xl font-medium">
               {formatTotal(total)}
             </div>
           </div>
           <div
-            className="flex align-items-center justify-content-center"
+            className="align-items-center justify-content-center flex"
             style={{ width: "2.5rem", height: "2.5rem" }}
           >
             <i className={`pi ${icon} text-${color} text-2xl`} />
@@ -797,7 +797,7 @@ import { IOrder, IOrderStatus } from "../../../interfaces";
 
 export const RecentSales = () => {
   const {
-    tableQueryResult,
+    tableQuery,
     pageCount,
     current,
     pageSize,
@@ -814,7 +814,7 @@ export const RecentSales = () => {
     },
   });
 
-  const orders = tableQueryResult?.data?.data;
+  const orders = tableQuery?.data?.data;
 
   const formatCurrency = (value: number) => {
     return value.toLocaleString("en-US", {
@@ -867,7 +867,7 @@ export const RecentSales = () => {
   };
 
   const header = (
-    <div className="flex justify-content-between">
+    <div className="justify-content-between flex">
       <Button
         type="button"
         icon="pi pi-filter-slash"
@@ -923,7 +923,7 @@ export const RecentSales = () => {
         }}
         sortField={sorters[0]?.field}
         sortOrder={sorters[0]?.order === "asc" ? 1 : -1}
-        loading={tableQueryResult?.isLoading}
+        loading={tableQuery?.isLoading}
         header={header}
       >
         <Column field="id" header="Id" sortable style={{ minWidth: "2rem" }} />
@@ -1126,7 +1126,7 @@ const formatCurrency = (value: number) => {
 
 export const ProductList = () => {
   const {
-    tableQueryResult,
+    tableQuery,
     pageCount,
     current,
     pageSize,
@@ -1140,7 +1140,7 @@ export const ProductList = () => {
   const { edit, show, create } = useNavigation();
   const { mutate: deleteProduct } = useDelete();
 
-  const products = tableQueryResult?.data?.data;
+  const products = tableQuery?.data?.data;
 
   const { data: categoryData } = useMany<ICategory>({
     resource: "categories",
@@ -1206,7 +1206,7 @@ export const ProductList = () => {
   };
 
   const header = (
-    <div className="flex justify-content-between">
+    <div className="justify-content-between flex">
       <Button
         type="button"
         icon="pi pi-filter-slash"
@@ -1241,7 +1241,7 @@ export const ProductList = () => {
     <Card
       className="shadow-1"
       title={
-        <div className="flex justify-content-between align-items-center">
+        <div className="justify-content-between align-items-center flex">
           <span className="p-card-title">Products</span>
           <Button
             icon="pi pi-plus"
@@ -1275,7 +1275,7 @@ export const ProductList = () => {
         }}
         sortField={sorters[0]?.field}
         sortOrder={sorters[0]?.order === "asc" ? 1 : -1}
-        loading={tableQueryResult?.isLoading}
+        loading={tableQuery?.isLoading}
         header={header}
       >
         <Column field="id" header="Id" sortable style={{ minWidth: "1rem" }} />
@@ -1474,7 +1474,7 @@ export const ProductCreate = () => {
     <Card
       className="shadow-1"
       title={
-        <div className="flex align-items-center">
+        <div className="align-items-center flex">
           <Button
             onClick={goBack}
             icon="pi pi-arrow-left"
@@ -1581,7 +1581,7 @@ export const ProductCreate = () => {
             )}
           />
         </div>
-        <div className="flex justify-content-end">
+        <div className="justify-content-end flex">
           <Button label="Save" type="submit" loading={formLoading} />
         </div>
       </form>
@@ -1713,8 +1713,8 @@ export const ProductEdit = () => {
     <Card
       className="shadow-1"
       title={
-        <div className="flex justify-content-between align-items-center">
-          <div className="flex align-items-center">
+        <div className="justify-content-between align-items-center flex">
+          <div className="align-items-center flex">
             <Button
               onClick={goBack}
               icon="pi pi-arrow-left"
@@ -1828,7 +1828,7 @@ export const ProductEdit = () => {
             )}
           />
         </div>
-        <div className="flex justify-content-end">
+        <div className="justify-content-end flex">
           <Button label="Save" type="submit" loading={formLoading} />
         </div>
       </form>
@@ -1941,7 +1941,7 @@ export const ProductShow = () => {
     <Card
       className="shadow-1"
       title={
-        <div className="flex align-items-center">
+        <div className="align-items-center flex">
           <Button
             onClick={goBack}
             icon="pi pi-arrow-left"
@@ -2164,7 +2164,7 @@ import { ICategory } from "../../interfaces";
 
 export const CategoryList = () => {
   const {
-    tableQueryResult,
+    tableQuery,
     pageCount,
     current,
     pageSize,
@@ -2182,7 +2182,7 @@ export const CategoryList = () => {
   const { edit, show, create } = useNavigation();
   const { mutate: deleteProduct } = useDelete();
 
-  const categories = tableQueryResult?.data?.data;
+  const categories = tableQuery?.data?.data;
 
   const confirmDeleteProduct = (id: number) => {
     confirmDialog({
@@ -2228,7 +2228,7 @@ export const CategoryList = () => {
   };
 
   const header = (
-    <div className="flex justify-content-between">
+    <div className="justify-content-between flex">
       <Button
         type="button"
         icon="pi pi-filter-slash"
@@ -2263,7 +2263,7 @@ export const CategoryList = () => {
     <Card
       className="shadow-1"
       title={
-        <div className="flex justify-content-between align-items-center">
+        <div className="justify-content-between align-items-center flex">
           <span className="p-card-title">Categories</span>
           <Button
             icon="pi pi-plus"
@@ -2297,7 +2297,7 @@ export const CategoryList = () => {
         }}
         sortField={sorters[0]?.field}
         sortOrder={sorters[0]?.order === "asc" ? 1 : -1}
-        loading={tableQueryResult?.isLoading}
+        loading={tableQuery?.isLoading}
         header={header}
       >
         <Column
@@ -2370,7 +2370,7 @@ export const CategoryCreate = () => {
     <Card
       className="shadow-1"
       title={
-        <div className="flex align-items-center">
+        <div className="align-items-center flex">
           <Button
             onClick={goBack}
             icon="pi pi-arrow-left"
@@ -2404,7 +2404,7 @@ export const CategoryCreate = () => {
             )}
           />
         </div>
-        <div className="flex justify-content-end">
+        <div className="justify-content-end flex">
           <Button label="Save" type="submit" loading={formLoading} />
         </div>
       </form>
@@ -2459,8 +2459,8 @@ export const CategoryEdit = () => {
     <Card
       className="shadow-1"
       title={
-        <div className="flex justify-content-between align-items-center">
-          <div className="flex align-items-center">
+        <div className="justify-content-between align-items-center flex">
+          <div className="align-items-center flex">
             <Button
               onClick={goBack}
               icon="pi pi-arrow-left"
@@ -2501,7 +2501,7 @@ export const CategoryEdit = () => {
             )}
           />
         </div>
-        <div className="flex justify-content-end">
+        <div className="justify-content-end flex">
           <Button label="Save" type="submit" loading={formLoading} />
         </div>
       </form>
@@ -2536,7 +2536,7 @@ export const CategoryShow = () => {
     <Card
       className="shadow-1"
       title={
-        <div className="flex align-items-center">
+        <div className="align-items-center flex">
           <Button
             onClick={goBack}
             icon="pi pi-arrow-left"
@@ -2838,7 +2838,7 @@ import { Breadcrumb } from "../breadcrumb";
 
 export const Layout: React.FC<PropsWithChildren> = ({ children }) => {
   return (
-    <div className="min-h-screen surface-ground">
+    <div className="surface-ground min-h-screen">
       <Menu />
       <div className="p-3">
         <Breadcrumb />
@@ -2882,7 +2882,7 @@ export const Menu = () => {
   }));
 
   return (
-    <div className="sticky top-0 z-5">
+    <div className="z-5 sticky top-0">
       <TabMenu model={items} />
     </div>
   );
@@ -2933,7 +2933,7 @@ export const Breadcrumb = () => {
   }));
 
   return (
-    <BreadCrumb className="surface-ground pl-0 border-none" model={items} />
+    <BreadCrumb className="surface-ground border-none pl-0" model={items} />
   );
 };
 ```

--- a/documentation/blog/2023-09-06-daisy-ui-panel.md
+++ b/documentation/blog/2023-09-06-daisy-ui-panel.md
@@ -1900,7 +1900,7 @@ export const ProductList = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
     getState,
     setPageIndex,

--- a/documentation/blog/2023-09-20-next-ui-panel.md
+++ b/documentation/blog/2023-09-20-next-ui-panel.md
@@ -464,7 +464,7 @@ export const KpiCard = ({
   return (
     <Card className="p-5">
       <div>
-        <div className="flex justify-between mb-10">
+        <div className="mb-10 flex justify-between">
           <div>
             <p>{title}</p>
             <h1 className="text-lg font-bold">{formattedTotal}</h1>
@@ -575,9 +575,9 @@ export const DashboardPage: React.FC = () => {
   });
 
   return (
-    <main className="flex w-full flex-col mt-5 gap-3">
+    <main className="mt-5 flex w-full flex-col gap-3">
       <h1 className="font-bold">Dashboards</h1>
-      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 justify-items-stretch">
+      <div className="grid grid-cols-2 justify-items-stretch gap-4 md:grid-cols-3">
         <KpiCard
           title="Weekly Revenue"
           total={dailyRevenue?.data.total ?? 0}
@@ -1002,7 +1002,7 @@ const getChipColor = (status: number) => {
 
 export const RecentSalesTable = () => {
   const {
-    tableQueryResult,
+    tableQuery,
     pageCount,
     current,
     pageSize,
@@ -1024,7 +1024,7 @@ export const RecentSalesTable = () => {
     direction: "ascending",
   });
 
-  const orders = tableQueryResult?.data?.data ?? [];
+  const orders = tableQuery?.data?.data ?? [];
 
   const getCellContents = useCallback((columnKey: string, item: IOrder) => {
     if (columnKey === "id") return item.id;
@@ -1076,7 +1076,7 @@ export const RecentSalesTable = () => {
       }}
       topContent={
         <div className="flex justify-between gap-3">
-          <h2 className="font-bold whitespace-nowrap">Recent sales</h2>
+          <h2 className="whitespace-nowrap font-bold">Recent sales</h2>
           <Input
             isClearable
             className="w-full sm:max-w-[20%]"
@@ -1107,7 +1107,7 @@ export const RecentSalesTable = () => {
         </div>
       }
       bottomContent={
-        <div className="flex w-full gap-2 justify-center">
+        <div className="flex w-full justify-center gap-2">
           <Pagination
             isCompact
             showControls
@@ -1340,7 +1340,7 @@ const columns = [
 
 export const ProductList = () => {
   const {
-    tableQueryResult,
+    tableQuery,
     pageCount,
     current,
     pageSize,
@@ -1359,7 +1359,7 @@ export const ProductList = () => {
     direction: "ascending",
   });
 
-  const products = tableQueryResult?.data?.data ?? [];
+  const products = tableQuery?.data?.data ?? [];
 
   const { data: categoryData } = useMany<ICategory>({
     resource: "categories",
@@ -1385,7 +1385,7 @@ export const ProductList = () => {
       if (columnKey === "actions") {
         return (
           <TableCell>
-            <div className="flex gap-4 items-center justify-end">
+            <div className="flex items-center justify-end gap-4">
               <Button
                 isIconOnly
                 size="sm"
@@ -1502,7 +1502,7 @@ export const ProductList = () => {
           </div>
         }
         bottomContent={
-          <div className="flex w-full gap-2 justify-center">
+          <div className="flex w-full justify-center gap-2">
             <Pagination
               isCompact
               showControls
@@ -1548,7 +1548,7 @@ export const ProductList = () => {
                 <TableColumn
                   allowsSorting={column.sortable}
                   key={column.key}
-                  className="text-end pr-16"
+                  className="pr-16 text-end"
                 >
                   {column.header}
                 </TableColumn>
@@ -1911,7 +1911,7 @@ export const ProductCreate = () => {
               }}
             />
           </div>
-          <div className="flex justify-content-end">
+          <div className="justify-content-end flex">
             <Button
               type="submit"
               isLoading={formLoading}
@@ -2138,7 +2138,7 @@ export const ProductEdit = () => {
               }}
             />
           </div>
-          <div className="flex justify-content-end">
+          <div className="justify-content-end flex">
             <Button
               type="submit"
               isLoading={formLoading}
@@ -2263,7 +2263,7 @@ export const ProductShow = () => {
           <h1 className="text-lg font-bold">Show product</h1>
         </div>
         <CardBody>
-          <CardHeader className="text-lg font-bold p-5">
+          <CardHeader className="p-5 text-lg font-bold">
             <h2>Product details</h2>
           </CardHeader>
           <CardBody>
@@ -2274,13 +2274,13 @@ export const ProductShow = () => {
                 alt={product.name}
               />
             ) : null}
-            <h2 className="text-base font-medium mt-3">Name</h2>
+            <h2 className="mt-3 text-base font-medium">Name</h2>
             <p>{product?.name}</p>
-            <h2 className="text-base font-medium mt-3">Price</h2>
+            <h2 className="mt-3 text-base font-medium">Price</h2>
             <p>{currencyFormatter.format(product?.price ?? 0)}</p>
-            <h2 className="text-base font-medium mt-3">Category</h2>
+            <h2 className="mt-3 text-base font-medium">Category</h2>
             <p>{categoryData?.data.title}</p>
-            <h2 className="text-base font-medium mt-3">Description</h2>
+            <h2 className="mt-3 text-base font-medium">Description</h2>
             <p>{product?.description}</p>
           </CardBody>
         </CardBody>
@@ -2415,7 +2415,7 @@ const columns = [
 
 export const CategoryList = () => {
   const {
-    tableQueryResult,
+    tableQuery,
     pageCount,
     current,
     pageSize,
@@ -2438,13 +2438,13 @@ export const CategoryList = () => {
     direction: "ascending",
   });
 
-  const categories = tableQueryResult?.data?.data ?? [];
+  const categories = tableQuery?.data?.data ?? [];
 
   const renderCell = useCallback((columnKey: string, item: IProduct) => {
     if (columnKey === "actions") {
       return (
         <TableCell>
-          <div className="flex gap-4 items-center justify-end">
+          <div className="flex items-center justify-end gap-4">
             <Button
               isIconOnly
               size="sm"
@@ -2523,7 +2523,7 @@ export const CategoryList = () => {
                 Create Category
               </Button>
             </div>
-            <div className="flex justify-end items-center">
+            <div className="flex items-center justify-end">
               <Input
                 isClearable
                 className="w-full sm:max-w-[20%]"
@@ -2555,7 +2555,7 @@ export const CategoryList = () => {
           </div>
         }
         bottomContent={
-          <div className="flex w-full gap-2 justify-center">
+          <div className="flex w-full justify-center gap-2">
             <Pagination
               isCompact
               showControls
@@ -2601,7 +2601,7 @@ export const CategoryList = () => {
                 <TableColumn
                   allowsSorting={column.sortable}
                   key={column.key}
-                  className="text-end pr-16"
+                  className="pr-16 text-end"
                 >
                   {column.header}
                 </TableColumn>
@@ -2731,7 +2731,7 @@ export const CategoryCreate = () => {
               }}
             />
           </div>
-          <div className="flex justify-content-end">
+          <div className="justify-content-end flex">
             <Button
               type="submit"
               isLoading={formLoading}
@@ -2833,7 +2833,7 @@ export const CategoryEdit = () => {
               }}
             />
           </div>
-          <div className="flex justify-content-end">
+          <div className="justify-content-end flex">
             <Button
               type="submit"
               isLoading={formLoading}
@@ -2902,16 +2902,16 @@ export const CategoryShow = () => {
           <h1 className="text-lg font-bold">Show Category</h1>
         </div>
         <CardBody>
-          <CardHeader className="text-lg font-bold p-5">
+          <CardHeader className="p-5 text-lg font-bold">
             <h2>Category details</h2>
           </CardHeader>
           <CardBody>
             {category?.cover ? (
               <Image src={category.cover} width={300} alt={category.title} />
             ) : null}
-            <h2 className="text-base font-medium mt-3">Id</h2>
+            <h2 className="mt-3 text-base font-medium">Id</h2>
             <p>{category?.id ?? 0}</p>
-            <h2 className="text-base font-medium mt-3">Title</h2>
+            <h2 className="mt-3 text-base font-medium">Title</h2>
             <p>{category?.title ?? ""}</p>
           </CardBody>
         </CardBody>
@@ -2968,16 +2968,16 @@ export const Menu = () => {
   const { menuItems } = useMenu();
   return (
     <nav className="mb-4">
-      <ul className="flex border-b-1 py-2">
+      <ul className="border-b-1 flex py-2">
         {menuItems.map((item) => (
           <li key={item.key} className="mr-4">
             <NavLink
               to={item.route ?? "/"}
               className={({ isActive, isPending }) => {
                 if (isActive) {
-                  return "text-center block text-blue-500 rounded hover:bg-gray-200 p-2";
+                  return "block rounded p-2 text-center text-blue-500 hover:bg-gray-200";
                 }
-                return "text-center block border-blue-500 rounded hover:bg-gray-200 p-2";
+                return "block rounded border-blue-500 p-2 text-center hover:bg-gray-200";
               }}
             >
               {item.label}
@@ -3005,7 +3005,7 @@ export const Breadcrumb = () => {
 
   return (
     <nav>
-      <ul className="breadcrumb flex gap-4 my-5">
+      <ul className="breadcrumb my-5 flex gap-4">
         {breadcrumbs.map((breadcrumb) => {
           return (
             <li key={`breadcrumb-${breadcrumb.label}`}>

--- a/documentation/blog/2023-10-31-react-table.md
+++ b/documentation/blog/2023-10-31-react-table.md
@@ -245,7 +245,7 @@ export const CategoryList = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,
@@ -342,7 +342,7 @@ export const CategoryList = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
     //highlight-start
     getState,

--- a/documentation/blog/2024-03-19-ts-shadcn.md
+++ b/documentation/blog/2024-03-19-ts-shadcn.md
@@ -290,7 +290,7 @@ export const BlogPostList: React.FC<IResourceComponentsProps> = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
     getState,
     setPageIndex,
@@ -1330,7 +1330,7 @@ export const BlogPostList: React.FC<IResourceComponentsProps> = () => {
     getHeaderGroups,
     getRowModel,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
     getState,
     setPageIndex,
@@ -1554,7 +1554,7 @@ export function DataTable({ ...tableProps }: any) {
     getHeaderGroups,
     getRowModel,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
     getState,
     setPageIndex,

--- a/documentation/blog/2024-06-25-next-refine-pwa.md
+++ b/documentation/blog/2024-06-25-next-refine-pwa.md
@@ -558,7 +558,7 @@ type ItemProp = {
 
 const ProductList: React.FC<ItemProp> = ({ products }) => {
   //highlight-start
-  const { tableQueryResult } = useTable<IProduct>({
+  const { tableQuery } = useTable<IProduct>({
     resource: "products",
     queryOptions: {
       initialData: products,
@@ -569,7 +569,7 @@ const ProductList: React.FC<ItemProp> = ({ products }) => {
   return (
     //highlight-start
     <div className="my-8 grid grid-cols-4 gap-6 px-24">
-      {tableQueryResult.data?.data.map((product) => {
+      {tableQuery.data?.data.map((product) => {
         return (
           <ProductCards
             key={product.id}
@@ -604,13 +604,13 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
 `useTable` is a Refine hook that uses helper hooks to simplify the process of fetching, interacting, and rendering data. To put things into perspective, we’ll use the `useTable` hook to process our response data from the `getServerSideProps` function.
 
-In the code above, we’re using `tableQueryResult` to map through the query results and passing them as props to the `ProductCards` component. Then we wrapped the component with the LayoutWrapper component.
+In the code above, we’re using `tableQuery` to map through the query results and passing them as props to the `ProductCards` component. Then we wrapped the component with the LayoutWrapper component.
 
 What we’re doing here is similar to what we did earlier with the resources prop, we specify which source (endpoint) to be fetched from the API by passing the resource option a string value. In this case, `products`.
 
-The only difference is that we added a `queryOptions` option and passed the products prop as its initial data. Then we destructed the `tableQueryResult` object from the `useTable` hook. This is what we’ll use to get the result of our query.
+The only difference is that we added a `queryOptions` option and passed the products prop as its initial data. Then we destructed the `tableQuery` object from the `useTable` hook. This is what we’ll use to get the result of our query.
 
-Also we created a `ProductCard` component and use it to render the query results using the `tableQueryResult` object.
+Also we created a `ProductCard` component and use it to render the query results using the `tableQuery` object.
 
 If you save your progress and go back to the browser, you should see a nicely rendered grid of product cards.
 

--- a/documentation/docs/data/hooks/use-table/_partial-basic-usage-live-preview.md
+++ b/documentation/docs/data/hooks/use-table/_partial-basic-usage-live-preview.md
@@ -21,10 +21,10 @@ interface IPost {
 }
 
 const PostList: React.FC = () => {
-  const { tableQueryResult } = useTable<IPost, HttpError>();
-  const posts = tableQueryResult?.data?.data ?? [];
+  const { tableQuery } = useTable<IPost, HttpError>();
+  const posts = tableQuery?.data?.data ?? [];
 
-  if (tableQueryResult?.isLoading) {
+  if (tableQuery?.isLoading) {
     return <div>Loading...</div>;
   }
 

--- a/documentation/docs/data/hooks/use-table/_partial-filtering-live-preview.md
+++ b/documentation/docs/data/hooks/use-table/_partial-filtering-live-preview.md
@@ -21,13 +21,10 @@ interface IPost {
 }
 
 const PostList: React.FC = () => {
-  const { tableQueryResult, filters, setFilters } = useTable<
-    IPost,
-    HttpError
-  >();
+  const { tableQuery, filters, setFilters } = useTable<IPost, HttpError>();
 
   // Fetches the posts for the current page
-  const posts = tableQueryResult?.data?.data ?? [];
+  const posts = tableQuery?.data?.data ?? [];
 
   // Gets the current filter values for the fields
   // highlight-start
@@ -124,7 +121,7 @@ const PostList: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data.map((post) => (
+          {tableQuery.data?.data.map((post) => (
             <tr key={post.id}>
               <td>{post.id}</td>
               <td>{post.title}</td>

--- a/documentation/docs/data/hooks/use-table/_partial-pagination-live-preview.md
+++ b/documentation/docs/data/hooks/use-table/_partial-pagination-live-preview.md
@@ -22,7 +22,7 @@ interface IPost {
 
 const PostList: React.FC = () => {
   const {
-    tableQueryResult,
+    tableQuery,
     // highlight-start
     current,
     setCurrent,
@@ -33,7 +33,7 @@ const PostList: React.FC = () => {
   } = useTable<IPost, HttpError>();
 
   // Fetches the posts for the current page
-  const posts = tableQueryResult?.data?.data ?? [];
+  const posts = tableQuery?.data?.data ?? [];
   // highlight-start
   // Checks if there is a next page available
   const hasNext = current < pageCount;
@@ -54,7 +54,7 @@ const PostList: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data.map((post) => (
+          {tableQuery.data?.data.map((post) => (
             <tr key={post.id}>
               <td>{post.id}</td>
               <td>{post.title}</td>

--- a/documentation/docs/data/hooks/use-table/_partial-relational-data-live-preview.md
+++ b/documentation/docs/data/hooks/use-table/_partial-relational-data-live-preview.md
@@ -38,8 +38,8 @@ interface IPost {
 }
 
 const PostList: React.FC = () => {
-  const { tableQueryResult } = useTable<IPost, HttpError>();
-  const posts = tableQueryResult?.data?.data ?? [];
+  const { tableQuery } = useTable<IPost, HttpError>();
+  const posts = tableQuery?.data?.data ?? [];
 
   // highlight-start
   // Fetches the category of each post. It uses the useMany hook to fetch the category data from the API.
@@ -57,7 +57,7 @@ const PostList: React.FC = () => {
   });
   // highlight-end
 
-  if (tableQueryResult?.isLoading) {
+  if (tableQuery?.isLoading) {
     return <div>Loading...</div>;
   }
 

--- a/documentation/docs/data/hooks/use-table/_partial-sorting-live-preview.md
+++ b/documentation/docs/data/hooks/use-table/_partial-sorting-live-preview.md
@@ -21,7 +21,7 @@ interface IPost {
 }
 
 const PostList: React.FC = () => {
-  const { tableQueryResult, sorter, setSorter } = useTable<IPost, HttpError>({
+  const { tableQuery, sorter, setSorter } = useTable<IPost, HttpError>({
     // highlight-start
     sorters: {
       initial: [
@@ -35,7 +35,7 @@ const PostList: React.FC = () => {
   });
 
   // Fetches the posts for the current page
-  const posts = tableQueryResult?.data?.data ?? [];
+  const posts = tableQuery?.data?.data ?? [];
 
   // Gets the current sort order for the fields
   // highlight-start
@@ -95,7 +95,7 @@ const PostList: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data.map((post) => (
+          {tableQuery.data?.data.map((post) => (
             <tr key={post.id}>
               <td>{post.id}</td>
               <td>{post.title}</td>

--- a/documentation/docs/data/hooks/use-table/index.md
+++ b/documentation/docs/data/hooks/use-table/index.md
@@ -529,7 +529,7 @@ Use `filters.defaultBehavior` instead.
 
 ## Return Values
 
-### tableQueryResult
+### tableQuery
 
 Returned values from [`useList`](/docs/data/hooks/use-list) hook.
 
@@ -612,6 +612,10 @@ Use `sorters` instead.
 
 Use `setSorters` instead.
 
+### ~~tableQueryResult~~ <PropTag deprecated />
+
+Use [`tableQuery`](#tablequery) instead.
+
 ## FAQ
 
 ### How can I handle relational data?
@@ -626,7 +630,7 @@ First, you need to set `filters.mode: "off"`
 
 ```tsx
 import { useTable } from "@refinedev/core";
-const { tableQueryResult, filters, setFilters } = useTable({
+const { tableQuery, filters, setFilters } = useTable({
   filters: {
     mode: "off",
   },
@@ -639,13 +643,13 @@ Then, you can use the `filters` state to filter your data.
 // ...
 
 const List = () => {
-  const { tableQueryResult, filters } = useTable();
+  const { tableQuery, filters } = useTable();
 
   // ...
 
   const filteredData = useMemo(() => {
     if (filters.length === 0) {
-      return tableQueryResult.data;
+      return tableQuery.data;
     }
 
     // Filters can be a LogicalFilter or a ConditionalFilter. ConditionalFilter not have field property. So we need to filter them.
@@ -661,7 +665,7 @@ const List = () => {
         }
       });
     });
-  }, [tableQueryResult.data, filters]);
+  }, [tableQuery.data, filters]);
 };
 
 return (
@@ -684,7 +688,7 @@ First, you need to set `sorters.mode: "off"`
 
 ```tsx
 import { useTable } from "@refinedev/core";
-const { tableQueryResult, sorters, setSorters } = useTable({
+const { tableQuery, sorters, setSorters } = useTable({
   sorters: {
     mode: "off",
   },
@@ -697,16 +701,16 @@ Then, you can use the `sorters` state to sort your data.
 // ...
 import { useTable } from "@refinedev/core";
 const List = () => {
-  const { tableQueryResult, sorters } = useTable();
+  const { tableQuery, sorters } = useTable();
 
   // ...
 
   const sortedData = useMemo(() => {
     if (sorters.length === 0) {
-      return tableQueryResult.data;
+      return tableQuery.data;
     }
 
-    return tableQueryResult.data.sort((a, b) => {
+    return tableQuery.data.sort((a, b) => {
       const sorter = sorters[0];
 
       if (sorter.order === "asc") {
@@ -715,7 +719,7 @@ const List = () => {
         return a[sorter.field] < b[sorter.field] ? 1 : -1;
       }
     });
-  }, [tableQueryResult.data, sorters]);
+  }, [tableQuery.data, sorters]);
 
   return (
     <div>
@@ -753,7 +757,7 @@ errorNotification-default='"There was an error creating resource (status code: `
 
 | Property                      | Description                                                                           | Type                                                                                                                                              |
 | ----------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| tableQueryResult              | Result of the `react-query`'s `useQuery`                                              | [` QueryObserverResult<{`` data: TData[];`` total: number; },`` TError> `][usequery]                                                              |
+| tableQuery                    | Result of the `react-query`'s `useQuery`                                              | [` QueryObserverResult<{`` data: TData[];`` total: number; },`` TError> `][usequery]                                                              |
 | current                       | Current page index state (returns `undefined` if pagination is disabled)              | `number` \| `undefined`                                                                                                                           |
 | pageCount                     | Total page count (returns `undefined` if pagination is disabled)                      | `number` \| `undefined`                                                                                                                           |
 | setCurrent                    | A function that changes the current (returns `undefined` if pagination is disabled)   | `React.Dispatch<React.SetStateAction<number>>` \| `undefined`                                                                                     |

--- a/documentation/docs/data/packages/supabase/index.md
+++ b/documentation/docs/data/packages/supabase/index.md
@@ -1621,7 +1621,7 @@ export const PostList = () => {
     channel: "categories",
     types: ["*"],
     onLiveEvent: () => {
-      table.tableQueryResult.refetch();
+      table.tableQuery.refetch();
     },
   });
 

--- a/documentation/docs/guides-concepts/faq/index.md
+++ b/documentation/docs/guides-concepts/faq/index.md
@@ -25,7 +25,7 @@ values={[
 import { useTable, useForm, useShow } from "@refinedev/core";
 
 // All "data" related hooks provided by Refine can use queryResult' refetch function
-const { tableQueryResult: { refetch } } = useTable();
+const { tableQuery: { refetch } } = useTable();
 const { queryResult: { refetch } } = useForm();
 ...
 ...

--- a/documentation/docs/guides-concepts/general-concepts/layout/mantine.tsx
+++ b/documentation/docs/guides-concepts/general-concepts/layout/mantine.tsx
@@ -153,7 +153,7 @@ export const ProductList = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/documentation/docs/guides-concepts/routing/index.md
+++ b/documentation/docs/guides-concepts/routing/index.md
@@ -383,10 +383,10 @@ const { ... } = useTable(
 And you will see a list of products, already **filtered**, **sorted** and **paginated** automatically based on the query parameters of the **current route**.
 
 ```ts
-const { tableQueryResult, current, pageSize, filters, sorters } = useTable();
+const { tableQuery, current, pageSize, filters, sorters } = useTable();
 
-console.log(tableQueryResult.data.data); // [{...}, {...}]
-console.log(tableQueryResult.data.total); // 32 - total number of unpaginated records
+console.log(tableQuery.data.data); // [{...}, {...}]
+console.log(tableQuery.data.total); // 32 - total number of unpaginated records
 console.log(current); // 1 - current page
 console.log(pageSize); // 2 - page size
 console.log(filters); // [{ field: "category.id", operator: "eq", value: "1" }]

--- a/documentation/docs/guides-concepts/routing/nextjs/use-table-usage.tsx
+++ b/documentation/docs/guides-concepts/routing/nextjs/use-table-usage.tsx
@@ -122,7 +122,7 @@ import React from "react";
 
 export const ProductList: React.FC = ({ tableProps }) => {
   const {
-    tableQueryResult,
+    tableQuery,
     isLoading,
     current,
     setCurrent,
@@ -148,7 +148,7 @@ export const ProductList: React.FC = ({ tableProps }) => {
           </tr>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data?.map((record) => (
+          {tableQuery.data?.data?.map((record) => (
             <tr key={record.id}>
               <td>{record.id}</td>
               <td>{record.name}</td>

--- a/documentation/docs/guides-concepts/routing/react-router/use-table-usage.tsx
+++ b/documentation/docs/guides-concepts/routing/react-router/use-table-usage.tsx
@@ -124,7 +124,7 @@ import React from "react";
 
 export const ProductList: React.FC = ({ tableProps }) => {
   const {
-    tableQueryResult,
+    tableQuery,
     isLoading,
     current,
     setCurrent,
@@ -150,7 +150,7 @@ export const ProductList: React.FC = ({ tableProps }) => {
           </tr>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data?.map((record) => (
+          {tableQuery.data?.data?.map((record) => (
             <tr key={record.id}>
               <td>{record.id}</td>
               <td>{record.name}</td>

--- a/documentation/docs/guides-concepts/routing/remix/use-table-usage.tsx
+++ b/documentation/docs/guides-concepts/routing/remix/use-table-usage.tsx
@@ -144,7 +144,7 @@ import React from "react";
 
 export const ProductList: React.FC = ({ tableProps }) => {
   const {
-    tableQueryResult,
+    tableQuery,
     isLoading,
     current,
     setCurrent,
@@ -170,7 +170,7 @@ export const ProductList: React.FC = ({ tableProps }) => {
           </tr>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data?.map((record) => (
+          {tableQuery.data?.data?.map((record) => (
             <tr key={record.id}>
               <td>{record.id}</td>
               <td>{record.name}</td>

--- a/documentation/docs/guides-concepts/tables/example/core.tsx
+++ b/documentation/docs/guides-concepts/tables/example/core.tsx
@@ -48,16 +48,16 @@ import { useTable, pageCount, pageSize, current, setCurrent } from "@refinedev/c
 
 
 export const ProductTable: React.FC = () => {
-    const { tableQueryResult, pageCount, pageSize, current, setCurrent } = useTable<IProduct>({
+    const { tableQuery, pageCount, pageSize, current, setCurrent } = useTable<IProduct>({
         resource: "products",
         pagination: {
             current: 1, 
             pageSize: 10,
         },
     });
-    const posts = tableQueryResult?.data?.data ?? [];
+    const posts = tableQuery?.data?.data ?? [];
 
-    if (tableQueryResult?.isLoading) {
+    if (tableQuery?.isLoading) {
         return <div>Loading...</div>;
     }
 

--- a/documentation/docs/guides-concepts/tables/example/filtering.tsx
+++ b/documentation/docs/guides-concepts/tables/example/filtering.tsx
@@ -48,7 +48,7 @@ import { useTable } from "@refinedev/core";
 
 
 export const ProductTable: React.FC = () => {
-  const { tableQueryResult, filters, setFilters } = useTable<IProduct>({
+  const { tableQuery, filters, setFilters } = useTable<IProduct>({
       resource: "products",
       filters: {
           permanent: [
@@ -61,7 +61,7 @@ export const ProductTable: React.FC = () => {
           initial: [{ field: "category.id", operator: "eq", value: "1" }],
       },
   });
-  const products = tableQueryResult?.data?.data ?? [];
+  const products = tableQuery?.data?.data ?? [];
 
   const getFilterByField = (field: string) => {
       return filters.find((filter) => {
@@ -76,7 +76,7 @@ export const ProductTable: React.FC = () => {
   };
 
 
-  if (tableQueryResult.isLoading) {
+  if (tableQuery.isLoading) {
       return <div>Loading...</div>;
   }
 

--- a/documentation/docs/guides-concepts/tables/example/pagination.tsx
+++ b/documentation/docs/guides-concepts/tables/example/pagination.tsx
@@ -47,7 +47,7 @@ import React from "react";
 import { useTable } from "@refinedev/core";
 
 export const ProductTable: React.FC = () => {
-  const { tableQueryResult, pageCount, pageSize, current, setCurrent } = useTable<IProduct>({
+  const { tableQuery, pageCount, pageSize, current, setCurrent } = useTable<IProduct>({
     resource: "products",
     pagination: {
         current: 1, 
@@ -55,9 +55,9 @@ export const ProductTable: React.FC = () => {
         mode: "server", // "client" or "server"
     },
   });
-  const posts = tableQueryResult?.data?.data ?? [];
+  const posts = tableQuery?.data?.data ?? [];
 
-  if (tableQueryResult?.isLoading) {
+  if (tableQuery?.isLoading) {
     return <div>Loading...</div>;
   }
 

--- a/documentation/docs/guides-concepts/tables/example/relationship.tsx
+++ b/documentation/docs/guides-concepts/tables/example/relationship.tsx
@@ -51,10 +51,10 @@ import React from "react";
 import { useTable, HttpError, useMany } from "@refinedev/core";
 
 export const HomePage: React.FC = () => {
-    const { tableQueryResult } = useTable<IPost, HttpError>({
+    const { tableQuery } = useTable<IPost, HttpError>({
         resource: "posts",
     });
-    const posts = tableQueryResult?.data?.data ?? [];
+    const posts = tableQuery?.data?.data ?? [];
 
     const categoryIds = posts.map((item) => item.category.id);
     const { data: categoriesData, isLoading } = useMany<ICategory>({
@@ -65,7 +65,7 @@ export const HomePage: React.FC = () => {
         },
     });
 
-    if (tableQueryResult?.isLoading) {
+    if (tableQuery?.isLoading) {
         return <div>Loading...</div>;
     }
 

--- a/documentation/docs/guides-concepts/tables/example/sorting.tsx
+++ b/documentation/docs/guides-concepts/tables/example/sorting.tsx
@@ -47,20 +47,20 @@ import React from "react";
 import { useTable } from "@refinedev/core";
 
 export const ProductTable: React.FC = () => {
-    const { tableQueryResult, sorters, setSorters } = useTable<IProduct>({
+    const { tableQuery, sorters, setSorters } = useTable<IProduct>({
         resource: "products",
         sorters: {
             initial: [{ field: "price", order: "asc" }],
         },
     });
-    const products = tableQueryResult?.data?.data ?? [];
+    const products = tableQuery?.data?.data ?? [];
 
     const findSorterByFieldName = (fieldName: string) => {
         return sorters.find((sorter) => sorter.field === fieldName);
     };
 
 
-    if (tableQueryResult.isLoading) {
+    if (tableQuery.isLoading) {
         return <div>Loading...</div>;
     }
     

--- a/documentation/docs/packages/react-hook-form/use-form/index.md
+++ b/documentation/docs/packages/react-hook-form/use-form/index.md
@@ -29,7 +29,7 @@ const Layout: React.FC = ({ children }) => {
 };
 
 const PostList: React.FC = () => {
-  const { tableQueryResult, current, setCurrent, pageSize, pageCount } =
+  const { tableQuery, current, setCurrent, pageSize, pageCount } =
     useTable<IPost>({
       sorters: {
         initial: [
@@ -55,7 +55,7 @@ const PostList: React.FC = () => {
           <td>Actions</td>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data.map((post) => (
+          {tableQuery.data?.data.map((post) => (
             <tr key={post.id}>
               <td>{post.id}</td>
               <td>{post.title}</td>

--- a/documentation/docs/packages/react-hook-form/use-modal-form/index.md
+++ b/documentation/docs/packages/react-hook-form/use-modal-form/index.md
@@ -118,7 +118,7 @@ import { useModalForm } from "@refinedev/react-hook-form";
 import { Modal } from "@components";
 
 const PostList = () => {
-  const { tableQueryResult } = useTable<IPost>({
+  const { tableQuery } = useTable<IPost>({
     sorters: {
       initial: [
         {
@@ -142,7 +142,7 @@ const PostList = () => {
   });
   // highlight-end
 
-  const loading = tableQueryResult?.isLoading;
+  const loading = tableQuery?.isLoading;
 
   if (loading) {
     return <div>Loading...</div>;
@@ -186,7 +186,7 @@ const PostList = () => {
           </tr>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data.map((post) => (
+          {tableQuery.data?.data.map((post) => (
             <tr key={post.id}>
               <td>{post.id}</td>
               <td>{post.title}</td>
@@ -232,7 +232,7 @@ import { useModalForm } from "@refinedev/react-hook-form";
 import { Modal } from "@components";
 
 const PostList = () => {
-  const { tableQueryResult } = useTable<IPost>({
+  const { tableQuery } = useTable<IPost>({
     sorters: {
       initial: [
         {
@@ -256,7 +256,7 @@ const PostList = () => {
   });
   // highlight-end
 
-  const loading = tableQueryResult?.isLoading;
+  const loading = tableQuery?.isLoading;
 
   if (loading) {
     return <div>Loading...</div>;
@@ -300,7 +300,7 @@ const PostList = () => {
           </tr>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data.map((post) => (
+          {tableQuery.data?.data.map((post) => (
             <tr key={post.id}>
               <td>{post.id}</td>
               <td>{post.title}</td>
@@ -369,7 +369,7 @@ import { useModalForm } from "@refinedev/react-hook-form";
 import { Modal } from "@components";
 
 const PostList = () => {
-  const { tableQueryResult } = useTable<IPost>({
+  const { tableQuery } = useTable<IPost>({
     initialSorter: [
       {
         field: "id",
@@ -391,7 +391,7 @@ const PostList = () => {
   });
   // highlight-end
 
-  const loading = tableQueryResult?.isLoading;
+  const loading = tableQuery?.isLoading;
 
   if (loading) {
     return <div>Loading...</div>;
@@ -435,7 +435,7 @@ const PostList = () => {
           </tr>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data.map((post) => (
+          {tableQuery.data?.data.map((post) => (
             <tr key={post.id}>
               <td>{post.id}</td>
               <td>{post.title}</td>

--- a/documentation/docs/packages/react-hook-form/use-steps-form/index.md
+++ b/documentation/docs/packages/react-hook-form/use-steps-form/index.md
@@ -35,7 +35,7 @@ interface IPost {
 const stepTitlesShared = ["Title", "Status", "Category and content"];
 
 const PostList: React.FC = () => {
-  const { tableQueryResult } = useTable<IPost>({
+  const { tableQuery } = useTable<IPost>({
     sorters: {
       initial: [
         {
@@ -48,7 +48,7 @@ const PostList: React.FC = () => {
   const { edit, create } = useNavigation();
 
   const categoryIds =
-    tableQueryResult?.data?.data.map((item) => item.category.id) ?? [];
+    tableQuery?.data?.data.map((item) => item.category.id) ?? [];
   const { data, isLoading } = useMany<ICategory>({
     resource: "categories",
     ids: categoryIds,
@@ -71,7 +71,7 @@ const PostList: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data.map((post) => (
+          {tableQuery.data?.data.map((post) => (
             <tr key={post.id}>
               <td>{post.id}</td>
               <td>{post.title}</td>

--- a/documentation/docs/packages/tanstack-table/examples/_partial-relational-live-preview.md
+++ b/documentation/docs/packages/tanstack-table/examples/_partial-relational-live-preview.md
@@ -79,7 +79,7 @@ const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable<IPost, HttpError>({
     columns,

--- a/documentation/docs/packages/tanstack-table/use-table/index.md
+++ b/documentation/docs/packages/tanstack-table/use-table/index.md
@@ -523,7 +523,7 @@ It also have all return values of [TanStack Table](https://tanstack.com/table/v8
 
 ### refineCore
 
-#### tableQueryResult
+#### tableQuery
 
 Returned values from [`useList`](/docs/data/hooks/use-list) hook.
 

--- a/documentation/docs/routing/integrations/next-js/index.md
+++ b/documentation/docs/routing/integrations/next-js/index.md
@@ -107,7 +107,7 @@ export default function PostList() {
   // `posts` resource will be inferred from the route.
   // Because we've defined `/posts` as the `list` action of the `posts` resource.
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
   } = useTable<IPost>();
 
   const tableData = data?.data;
@@ -174,7 +174,7 @@ export default function CategoryList() {
   // `categories` resource will be inferred from the route.
   // Because we've defined `/categories` as the `list` action of the `categories` resource.
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
   } = useTable<ICategory>();
 
   const tableData = data?.data;
@@ -320,7 +320,7 @@ export default function PostList() {
   // `posts` resource will be inferred from the route.
   // Because we've defined `/posts` as the `list` action of the `posts` resource.
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
   } = useTable<IPost>();
 
   const tableData = data?.data;
@@ -383,7 +383,7 @@ export default function CategoryList() {
   // `categories` resource will be inferred from the route.
   // Because we've defined `/categories` as the `list` action of the `categories` resource.
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
   } = useTable<ICategory>();
 
   const tableData = data?.data;
@@ -1086,7 +1086,7 @@ export const getServerSideProps = async () => {
 
 export default function Posts({ posts }: { posts: GetListResponse<IPost> }) {
   const {
-    tableQueryResult: { data },
+    tableQuery: { data },
   } = useTable<IPost>({
     queryOptions: {
       initialData: posts,

--- a/documentation/docs/routing/integrations/remix/index.md
+++ b/documentation/docs/routing/integrations/remix/index.md
@@ -129,7 +129,7 @@ export default function PostList() {
   // `posts` resource will be inferred from the route.
   // Because we've defined `/posts` as the `list` action of the `posts` resource.
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
   } = useTable<IPost>();
 
   const getToPath = useGetToPath();
@@ -202,7 +202,7 @@ export default function CategoryList() {
   // `categories` resource will be inferred from the route.
   // Because we've defined `/categories` as the `list` action of the `categories` resource.
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
   } = useTable<ICategory>();
 
   const getToPath = useGetToPath();
@@ -882,7 +882,7 @@ export default function Posts() {
   const initialPosts = useLoaderData<typeof loader>();
 
   const {
-    tableQueryResult: { data },
+    tableQuery: { data },
   } = useTable<IPost>({
     queryOptions: {
       initialData: initialPosts,

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-editable-table/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-editable-table/index.md
@@ -340,7 +340,7 @@ Takes a `id` as a parameter and returns `true` if the given `BaseKey` is equal t
 | ----------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | searchFormProps   | Ant Design [`<Form>`][form] props                       | [`FormProps<TSearchVariables>`][form]                                                |
 | tableProps        | Ant Design [`<Table>`][table] props                     | [`TableProps<TData>`][table]                                                         |
-| tableQueryResult  | Result of the `react-query`'s `useQuery`                | [` QueryObserverResult<{`` data: TData[];`` total: number; },`` TError> `][usequery] |
+| tableQuery        | Result of the `react-query`'s `useQuery`                | [` QueryObserverResult<{`` data: TData[];`` total: number; },`` TError> `][usequery] |
 | sorter            | Current sorting state                                   | [`CrudSorting`][crudsorting]                                                         |
 | filters           | Current filters state                                   | [`CrudFilters`][crudfilters]                                                         |
 | form              | Ant Design [`<Form>`][form] instance                    | [`FormInstance`][forminstance]                                                       |

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-simple-list/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-simple-list/index.md
@@ -115,15 +115,9 @@ interface ICategory {
 }
 
 export const ProductList: React.FC = () => {
-  const { tableQueryResult: productsQueryResult } = useSimpleList<
-    IProduct,
-    HttpError
-  >();
+  const { query: productsQuery } = useSimpleList<IProduct, HttpError>();
 
-  const { tableQueryResult: categoriesQueryResult } = useSimpleList<
-    ICategory,
-    HttpError
-  >({
+  const { query: categoriesQuery } = useSimpleList<ICategory, HttpError>({
     resource: "categories",
   });
 
@@ -535,9 +529,9 @@ console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 
 ## Return Values
 
-### queryResult
+### query
 
-`queryResult` is the returned values from [`useList`](/docs/data/hooks/use-list) hook.
+`query` is the returned values from [`useList`](/docs/data/hooks/use-list) hook.
 
 ### searchFormProps
 
@@ -680,6 +674,10 @@ Use `sorters` instead.
 
 Use `setSorters` instead.
 
+### ~~queryResult~~ <PropTag deprecated />
+
+Use [`query`](#query) instead.
+
 ## API
 
 ### Properties
@@ -699,7 +697,7 @@ Use `setSorters` instead.
 
 | Property        | Description                                                                           | Type                                                                                                                                                    |
 | --------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| queryResult     | Result of the query of a record                                                       | [`QueryObserverResult<{ data: TData }>`][usequery]                                                                                                      |
+| query           | Result of the query of a record                                                       | [`QueryObserverResult<{ data: TData }>`][usequery]                                                                                                      |
 | searchFormProps | Ant design Form props                                                                 | [`Form`][form]                                                                                                                                          |
 | listProps       | Ant design List props                                                                 | [`List`][list]                                                                                                                                          |
 | totalPage       | Total page count (returns `undefined` if pagination is disabled)                      | `number` \| `undefined`                                                                                                                                 |

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-table/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-table/index.md
@@ -705,9 +705,9 @@ const PostList: React.FC = () => {
 };
 ```
 
-### tableQueryResult
+### tableQuery
 
-`tableQueryResult` are the returned values from [`useList`](/docs/data/hooks/use-list) hook.
+`tableQuery` are the returned values from [`useList`](/docs/data/hooks/use-list) hook.
 
 ### sorters
 
@@ -786,6 +786,10 @@ Use `sorters` instead.
 ### ~~setSorter~~ <PropTag deprecated />
 
 Use `setSorters` instead.
+
+### ~~tableQueryResult~~ <PropTag deprecated />
+
+Use [`tableQuery`](#tablequery) instead.
 
 ## FAQ
 
@@ -878,23 +882,23 @@ const ListPage = () => {
 
 ### Return values
 
-| Property         | Description                                                                           | Type                                                                                                                                              |
-| ---------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| searchFormProps  | Ant Design [`<Form>`][form] props                                                     | [`FormProps<TSearchVariables>`][form]                                                                                                             |
-| tableProps       | Ant Design [`<Table>`][table] props                                                   | [`TableProps<TData>`][table]                                                                                                                      |
-| tableQueryResult | Result of the `react-query`'s `useQuery`                                              | [` QueryObserverResult<{`` data: TData[];`` total: number; },`` TError> `][usequery]                                                              |
-| totalPage        | Total page count (returns `undefined` if pagination is disabled)                      | `number` \| `undefined`                                                                                                                           |
-| current          | Current page index state (returns `undefined` if pagination is disabled)              | `number` \| `undefined`                                                                                                                           |
-| setCurrent       | A function that changes the current (returns `undefined` if pagination is disabled)   | `React.Dispatch<React.SetStateAction<number>>` \| `undefined`                                                                                     |
-| pageSize         | Current pageSize state (returns `undefined` if pagination is disabled)                | `number` \| `undefined`                                                                                                                           |
-| setPageSize      | A function that changes the pageSize. (returns `undefined` if pagination is disabled) | `React.Dispatch<React.SetStateAction<number>>` \| `undefined`                                                                                     |
-| sorters          | Current sorting state                                                                 | [`CrudSorting`][crudsorting]                                                                                                                      |
-| setSorters       | A function that accepts a new sorters state.                                          | `(sorters: CrudSorting) => void`                                                                                                                  |
-| ~~sorter~~       | Current sorting state                                                                 | [`CrudSorting`][crudsorting]                                                                                                                      |
-| ~~setSorter~~    | A function that accepts a new sorters state.                                          | `(sorters: CrudSorting) => void`                                                                                                                  |
-| filters          | Current filters state                                                                 | [`CrudFilters`][crudfilters]                                                                                                                      |
-| setFilters       | A function that accepts a new filter state                                            | - `(filters: CrudFilters, behavior?: "merge" \| "replace" = "merge") => void` - `(setter: (previousFilters: CrudFilters) => CrudFilters) => void` |
-| overtime         | Overtime loading props                                                                | `{ elapsedTime?: number }`                                                                                                                        |
+| Property        | Description                                                                           | Type                                                                                                                                              |
+| --------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| searchFormProps | Ant Design [`<Form>`][form] props                                                     | [`FormProps<TSearchVariables>`][form]                                                                                                             |
+| tableProps      | Ant Design [`<Table>`][table] props                                                   | [`TableProps<TData>`][table]                                                                                                                      |
+| tableQuery      | Result of the `react-query`'s `useQuery`                                              | [` QueryObserverResult<{`` data: TData[];`` total: number; },`` TError> `][usequery]                                                              |
+| totalPage       | Total page count (returns `undefined` if pagination is disabled)                      | `number` \| `undefined`                                                                                                                           |
+| current         | Current page index state (returns `undefined` if pagination is disabled)              | `number` \| `undefined`                                                                                                                           |
+| setCurrent      | A function that changes the current (returns `undefined` if pagination is disabled)   | `React.Dispatch<React.SetStateAction<number>>` \| `undefined`                                                                                     |
+| pageSize        | Current pageSize state (returns `undefined` if pagination is disabled)                | `number` \| `undefined`                                                                                                                           |
+| setPageSize     | A function that changes the pageSize. (returns `undefined` if pagination is disabled) | `React.Dispatch<React.SetStateAction<number>>` \| `undefined`                                                                                     |
+| sorters         | Current sorting state                                                                 | [`CrudSorting`][crudsorting]                                                                                                                      |
+| setSorters      | A function that accepts a new sorters state.                                          | `(sorters: CrudSorting) => void`                                                                                                                  |
+| ~~sorter~~      | Current sorting state                                                                 | [`CrudSorting`][crudsorting]                                                                                                                      |
+| ~~setSorter~~   | A function that accepts a new sorters state.                                          | `(sorters: CrudSorting) => void`                                                                                                                  |
+| filters         | Current filters state                                                                 | [`CrudFilters`][crudfilters]                                                                                                                      |
+| setFilters      | A function that accepts a new filter state                                            | - `(filters: CrudFilters, behavior?: "merge" \| "replace" = "merge") => void` - `(setter: (previousFilters: CrudFilters) => CrudFilters) => void` |
+| overtime        | Overtime loading props                                                                | `{ elapsedTime?: number }`                                                                                                                        |
 
 <br />
 

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/index.md
@@ -113,7 +113,7 @@ export const ProductList = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable<IProduct>({
     columns,

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/auth-page.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/auth-page.tsx
@@ -200,7 +200,7 @@ export const ProductList = () => {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/basic-views.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/basic-views.tsx
@@ -281,7 +281,7 @@ export const ProductList = () => {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/example.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/example.tsx
@@ -341,7 +341,7 @@ export const ProductList = () => {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/layout-next-js.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/layout-next-js.tsx
@@ -127,7 +127,7 @@ export default function ProductList() {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/layout-react-router-dom.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/layout-react-router-dom.tsx
@@ -218,7 +218,7 @@ export const ProductList = () => {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/layout-remix.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/layout-remix.tsx
@@ -161,7 +161,7 @@ export default function ProductList() {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/theming.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/theming.tsx
@@ -365,7 +365,7 @@ export const ProductList = () => {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/usage-next-js.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/usage-next-js.tsx
@@ -338,7 +338,7 @@ export default function ProductList() {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/usage-react-router-dom.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/usage-react-router-dom.tsx
@@ -340,7 +340,7 @@ export const ProductList = () => {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/usage-remix.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/usage-remix.tsx
@@ -301,7 +301,7 @@ export default function ProductList() {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/mantine/hooks/use-drawer-form/index.md
+++ b/documentation/docs/ui-integrations/mantine/hooks/use-drawer-form/index.md
@@ -115,7 +115,7 @@ const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,
@@ -346,7 +346,7 @@ const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/documentation/docs/ui-integrations/mantine/hooks/use-modal-form/index.md
+++ b/documentation/docs/ui-integrations/mantine/hooks/use-modal-form/index.md
@@ -109,7 +109,7 @@ const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,
@@ -327,7 +327,7 @@ const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,
@@ -584,7 +584,7 @@ const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/documentation/docs/ui-integrations/mantine/hooks/use-steps-form/index.md
+++ b/documentation/docs/ui-integrations/mantine/hooks/use-steps-form/index.md
@@ -135,7 +135,7 @@ const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/documentation/docs/ui-integrations/mantine/introduction/index.md
+++ b/documentation/docs/ui-integrations/mantine/introduction/index.md
@@ -101,7 +101,7 @@ export const ProductList = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable<IProduct>({ columns });
 

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/auth-page.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/auth-page.tsx
@@ -219,7 +219,7 @@ export const ProductList = () => {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/basic-views.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/basic-views.tsx
@@ -203,7 +203,7 @@ export const ProductList = () => {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/example.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/example.tsx
@@ -263,7 +263,7 @@ export const ProductList = () => {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/layout-next-js.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/layout-next-js.tsx
@@ -137,7 +137,7 @@ export default function ProductList() {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/layout-react-router-dom.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/layout-react-router-dom.tsx
@@ -145,7 +145,7 @@ export const ProductList = () => {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/layout-remix.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/layout-remix.tsx
@@ -158,7 +158,7 @@ export default function ProductList() {
           setCurrent,
           pageCount,
           current,
-          tableQueryResult: { data: tableData },
+          tableQuery: { data: tableData },
       },
   } = useTable({
       columns,

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/theming.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/theming.tsx
@@ -287,7 +287,7 @@ export const ProductList = () => {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/usage-next-js.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/usage-next-js.tsx
@@ -262,7 +262,7 @@ export default function ProductList() {
           setCurrent,
           pageCount,
           current,
-          tableQueryResult: { data: tableData },
+          tableQuery: { data: tableData },
       },
   } = useTable({
       columns,

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/usage-react-router-dom.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/usage-react-router-dom.tsx
@@ -264,7 +264,7 @@ export const ProductList = () => {
             setCurrent,
             pageCount,
             current,
-            tableQueryResult: { data: tableData },
+            tableQuery: { data: tableData },
         },
     } = useTable({
         columns,

--- a/documentation/docs/ui-integrations/mantine/introduction/previews/usage-remix.tsx
+++ b/documentation/docs/ui-integrations/mantine/introduction/previews/usage-remix.tsx
@@ -294,7 +294,7 @@ export default function ProductList() {
           setCurrent,
           pageCount,
           current,
-          tableQueryResult: { data: tableData },
+          tableQuery: { data: tableData },
       },
   } = useTable({
       columns,

--- a/documentation/docs/ui-integrations/material-ui/components/buttons/delete-button/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/buttons/delete-button/index.md
@@ -256,9 +256,9 @@ import {
 } from "@mui/x-data-grid";
 
 export const PostList: React.FC = () => {
-  const { tableQueryResult } = useTable<IPost>();
+  const { tableQuery } = useTable<IPost>();
 
-  const { data } = tableQueryResult;
+  const { data } = tableQuery;
 
   return (
     <List>

--- a/documentation/docs/ui-integrations/material-ui/hooks/use-data-grid/index.md
+++ b/documentation/docs/ui-integrations/material-ui/hooks/use-data-grid/index.md
@@ -827,7 +827,7 @@ Indicates whether the data is being fetched.
 
 Returns pagination configuration values(pageSize, current, setCurrent, etc.).
 
-### tableQueryResult
+### tableQuery
 
 Returned values from [`useList`](/docs/data/hooks/use-list) hook.
 
@@ -909,6 +909,10 @@ Use `sorters` instead.
 
 Use `setSorters` instead.
 
+### ~~tableQueryResult~~ <PropTag deprecated />
+
+Use [`tableQuery`](#tablequery) instead.
+
 ## FAQ
 
 ### How can I handle relational data?
@@ -961,7 +965,7 @@ useDataGrid({
 | Property                      | Description                                                                                        | Type                                                                                 |
 | ----------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | dataGridProps                 | MUI X [`<DataGrid>`][data-grid] props                                                              | `DataGridPropsType`\*                                                                |
-| tableQueryResult              | Result of the `react-query`'s `useQuery`                                                           | [` QueryObserverResult<{`` data: TData[];`` total: number; },`` TError> `][usequery] |
+| tableQuery                    | Result of the `react-query`'s `useQuery`                                                           | [` QueryObserverResult<{`` data: TData[];`` total: number; },`` TError> `][usequery] |
 | search                        | It sends the parameters it receives to its `onSearch` function                                     | `(value: TSearchVariables) => Promise<void>`                                         |
 | current                       | Current page index state (returns `undefined` if pagination is disabled)                           | `number` \| `undefined`                                                              |
 | totalPage                     | Total page count (returns `undefined` if pagination is disabled)                                   | `number` \| `undefined`                                                              |

--- a/documentation/tutorial/authentication/data-provider-integration/index.md
+++ b/documentation/tutorial/authentication/data-provider-integration/index.md
@@ -150,7 +150,7 @@ import { useTable, useMany } from "@refinedev/core";
 
 export const ListProducts = () => {
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
     current,
     setCurrent,
     pageCount,

--- a/documentation/tutorial/authentication/data-provider-integration/sandpack.tsx
+++ b/documentation/tutorial/authentication/data-provider-integration/sandpack.tsx
@@ -138,7 +138,7 @@ import { useTable, useMany } from "@refinedev/core";
 
 export const ListProducts = () => {
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
     current,
     setCurrent,
     pageCount,

--- a/documentation/tutorial/essentials/tables/index.md
+++ b/documentation/tutorial/essentials/tables/index.md
@@ -58,7 +58,7 @@ import { useTable } from "@refinedev/core";
 export const ListProducts = () => {
   // highlight-start
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
   } = useTable({
     resource: "products",
     pagination: { current: 1, pageSize: 10 },
@@ -116,7 +116,7 @@ import { useTable, useMany } from "@refinedev/core";
 
 export const ListProducts = () => {
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
   } = useTable({
     resource: "products",
     pagination: { current: 1, pageSize: 10 },
@@ -318,7 +318,7 @@ import { useTable, useMany } from "@refinedev/core";
 
 export const ListProducts = () => {
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
     // highlight-start
     current,
     setCurrent,
@@ -431,7 +431,7 @@ import { useTable, useMany } from "@refinedev/core";
 
 export const ListProducts = () => {
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
     current,
     setCurrent,
     pageCount,

--- a/documentation/tutorial/essentials/tables/sandpack.tsx
+++ b/documentation/tutorial/essentials/tables/sandpack.tsx
@@ -116,7 +116,7 @@ const ListProductsWithUseTableTsxCode = /* tsx */ `
 import { useTable } from "@refinedev/core";
 
 export const ListProducts = () => {
-  const { tableQueryResult: { data, isLoading } } = useTable({
+  const { tableQuery: { data, isLoading } } = useTable({
     resource: "products",
     pagination: { current: 1, pageSize: 10 },
     sorters: { initial: [{ field: "id", order: "asc" }] },
@@ -161,7 +161,7 @@ import { useTable, useMany } from "@refinedev/core";
 
 export const ListProducts = () => {
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
   } = useTable({
     resource: "products",
     pagination: { current: 1, pageSize: 10 },
@@ -422,7 +422,7 @@ import { useTable, useMany } from "@refinedev/core";
 
 export const ListProducts = () => {
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
     current,
     setCurrent,
     pageCount,
@@ -511,7 +511,7 @@ import { useTable, useMany } from "@refinedev/core";
 
 export const ListProducts = () => {
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
     current,
     setCurrent,
     pageCount,

--- a/documentation/tutorial/routing/inferring-parameters/react-router/index.md
+++ b/documentation/tutorial/routing/inferring-parameters/react-router/index.md
@@ -27,7 +27,7 @@ import { useTable, useMany } from "@refinedev/core";
 
 export const ListProducts = () => {
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
     current,
     setCurrent,
     pageCount,

--- a/documentation/tutorial/routing/inferring-parameters/react-router/sandpack.tsx
+++ b/documentation/tutorial/routing/inferring-parameters/react-router/sandpack.tsx
@@ -29,7 +29,7 @@ import { Link } from "react-router-dom";
 
 export const ListProducts = () => {
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
     current,
     setCurrent,
     pageCount,

--- a/documentation/tutorial/routing/navigation/react-router/index.md
+++ b/documentation/tutorial/routing/navigation/react-router/index.md
@@ -72,7 +72,7 @@ import { Link } from "react-router-dom";
 
 export const ListProducts = () => {
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
     current,
     setCurrent,
     pageCount,

--- a/documentation/tutorial/routing/navigation/react-router/sandpack.tsx
+++ b/documentation/tutorial/routing/navigation/react-router/sandpack.tsx
@@ -59,7 +59,7 @@ import { Link } from "react-router-dom";
 
 export const ListProducts = () => {
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
     current,
     setCurrent,
     pageCount,

--- a/documentation/tutorial/routing/syncing-state/react-router/index.md
+++ b/documentation/tutorial/routing/syncing-state/react-router/index.md
@@ -21,7 +21,7 @@ import { useTable, useMany, useNavigation } from "@refinedev/core";
 
 export const ListProducts = () => {
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
     current,
     setCurrent,
     pageCount,

--- a/documentation/tutorial/routing/syncing-state/react-router/sandpack.tsx
+++ b/documentation/tutorial/routing/syncing-state/react-router/sandpack.tsx
@@ -27,7 +27,7 @@ import { useTable, useMany, useNavigation } from "@refinedev/core";
 
 export const ListProducts = () => {
   const {
-    tableQueryResult: { data, isLoading },
+    tableQuery: { data, isLoading },
     current,
     setCurrent,
     pageCount,

--- a/examples/app-crm/src/routes/companies/list.tsx
+++ b/examples/app-crm/src/routes/companies/list.tsx
@@ -26,7 +26,7 @@ export const CompanyListPage: FC<PropsWithChildren> = ({ children }) => {
 
   const {
     tableProps,
-    tableQueryResult,
+    tableQuery,
     searchFormProps,
     filters,
     sorters,
@@ -110,10 +110,7 @@ export const CompanyListPage: FC<PropsWithChildren> = ({ children }) => {
                     // @ts-expect-error Ant Design Icon's v5.0.1 has an issue with @types/react@^18.2.66
                     prefix={<SearchOutlined className="anticon tertiary" />}
                     suffix={
-                      <Spin
-                        size="small"
-                        spinning={tableQueryResult.isFetching}
-                      />
+                      <Spin size="small" spinning={tableQuery.isFetching} />
                     }
                     placeholder="Search by name"
                     onChange={debouncedOnChange}

--- a/examples/app-crm/src/routes/contacts/list.tsx
+++ b/examples/app-crm/src/routes/contacts/list.tsx
@@ -33,7 +33,7 @@ export const ContactsListPage: React.FC<Props> = ({ children }) => {
     filters,
     sorters,
     setFilters,
-    tableQueryResult,
+    tableQuery,
   } = useTable<
     GetFieldsFromList<ContactsListQuery>,
     HttpError,
@@ -131,10 +131,7 @@ export const ContactsListPage: React.FC<Props> = ({ children }) => {
                     // @ts-expect-error Ant Design Icon's v5.0.1 has an issue with @types/react@^18.2.66
                     prefix={<SearchOutlined className="anticon tertiary" />}
                     suffix={
-                      <Spin
-                        size="small"
-                        spinning={tableQueryResult.isFetching}
-                      />
+                      <Spin size="small" spinning={tableQuery.isFetching} />
                     }
                     placeholder="Search by name"
                     onChange={debouncedOnChange}

--- a/examples/app-crm/src/routes/quotes/list.tsx
+++ b/examples/app-crm/src/routes/quotes/list.tsx
@@ -53,7 +53,7 @@ const statusOptions: { label: string; value: QuoteStatus }[] = [
 export const QuotesListPage: FC<PropsWithChildren> = ({ children }) => {
   const screens = Grid.useBreakpoint();
 
-  const { tableProps, searchFormProps, filters, sorters, tableQueryResult } =
+  const { tableProps, searchFormProps, filters, sorters, tableQuery } =
     useTable<Quote, HttpError, { title: string }>({
       resource: "quotes",
       onSearch: (values) => {
@@ -127,10 +127,7 @@ export const QuotesListPage: FC<PropsWithChildren> = ({ children }) => {
                     // @ts-expect-error Ant Design Icon's v5.0.1 has an issue with @types/react@^18.2.66
                     prefix={<SearchOutlined className="anticon tertiary" />}
                     suffix={
-                      <Spin
-                        size="small"
-                        spinning={tableQueryResult.isFetching}
-                      />
+                      <Spin size="small" spinning={tableQuery.isFetching} />
                     }
                     placeholder="Search by name"
                     onChange={debouncedOnChange}

--- a/examples/audit-log-provider/src/pages/posts/list.tsx
+++ b/examples/audit-log-provider/src/pages/posts/list.tsx
@@ -8,7 +8,7 @@ import type { IPost } from "../../interfaces";
 export const PostList: React.FC = () => {
   const { show, close, visible } = useModal();
   const [historyId, setHistoryId] = useState<number>();
-  const { tableQueryResult } = useTable<IPost>({
+  const { tableQuery } = useTable<IPost>({
     initialSorter: [
       {
         field: "id",
@@ -32,7 +32,7 @@ export const PostList: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data.map((post) => (
+          {tableQuery.data?.data.map((post) => (
             <tr key={post.id}>
               <td>{post.id}</td>
               <td>{post.title}</td>

--- a/examples/auth-chakra-ui/src/pages/posts/list.tsx
+++ b/examples/auth-chakra-ui/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/auth-mantine/src/pages/posts/list.tsx
+++ b/examples/auth-mantine/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/base-chakra-ui/src/pages/posts/list.tsx
+++ b/examples/base-chakra-ui/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/base-mantine/src/pages/posts/list.tsx
+++ b/examples/base-mantine/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/blog-ecommerce/pages/index.tsx
+++ b/examples/blog-ecommerce/pages/index.tsx
@@ -13,7 +13,7 @@ type ItemProps = {
 };
 
 export const ProductList: React.FC<ItemProps> = ({ products, stores }) => {
-  const { tableQueryResult, setFilters, current, setCurrent, pageSize } =
+  const { tableQuery, setFilters, current, setCurrent, pageSize } =
     useTable<IProduct>({
       resource: "products",
       queryOptions: {
@@ -23,9 +23,7 @@ export const ProductList: React.FC<ItemProps> = ({ products, stores }) => {
       metaData: { populate: ["image"] },
     });
 
-  const totalPageCount = Math.ceil(
-    (tableQueryResult.data?.total ?? 0) / pageSize,
-  );
+  const totalPageCount = Math.ceil((tableQuery.data?.total ?? 0) / pageSize);
 
   return (
     <>
@@ -74,7 +72,7 @@ export const ProductList: React.FC<ItemProps> = ({ products, stores }) => {
       </Flex>
 
       <SimpleGrid columns={[1, 2, 3]} mt={6} spacing={3}>
-        {tableQueryResult.data?.data.map((item) => (
+        {tableQuery.data?.data.map((item) => (
           <ProductCard
             key={item.id}
             id={item.id}

--- a/examples/blog-next-refine-pwa/pages/index.tsx
+++ b/examples/blog-next-refine-pwa/pages/index.tsx
@@ -17,7 +17,7 @@ type ItemProp = {
 };
 
 const ProductList: React.FC<ItemProp> = ({ products }) => {
-  const { tableQueryResult } = useTable<IProduct>({
+  const { tableQuery } = useTable<IProduct>({
     resource: "products",
     queryOptions: {
       initialData: products,
@@ -26,7 +26,7 @@ const ProductList: React.FC<ItemProp> = ({ products }) => {
 
   return (
     <div className="my-8 grid grid-cols-4 gap-6 px-24">
-      {tableQueryResult.data?.data.map((product) => {
+      {tableQuery.data?.data.map((product) => {
         return (
           <ProductCards
             key={product.id}

--- a/examples/blog-refine-airtable-crud/src/pages/post/list.tsx
+++ b/examples/blog-refine-airtable-crud/src/pages/post/list.tsx
@@ -94,7 +94,7 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
     getState,
     setPageIndex,

--- a/examples/blog-refine-nextui/src/components/table/RecentSalesTable.tsx
+++ b/examples/blog-refine-nextui/src/components/table/RecentSalesTable.tsx
@@ -64,7 +64,7 @@ const getChipColor = (status: number) => {
 
 export const RecentSalesTable = () => {
   const {
-    tableQueryResult,
+    tableQuery,
     pageCount,
     current,
     pageSize,
@@ -86,7 +86,7 @@ export const RecentSalesTable = () => {
     direction: "ascending",
   });
 
-  const orders = tableQueryResult?.data?.data ?? [];
+  const orders = tableQuery?.data?.data ?? [];
 
   const getCellContents = useCallback((columnKey: string, item: IOrder) => {
     if (columnKey === "id") return item.id;

--- a/examples/blog-refine-nextui/src/pages/categories/list.tsx
+++ b/examples/blog-refine-nextui/src/pages/categories/list.tsx
@@ -44,7 +44,7 @@ const columns = [
 
 export const CategoryList = () => {
   const {
-    tableQueryResult,
+    tableQuery,
     pageCount,
     current,
     pageSize,
@@ -67,7 +67,7 @@ export const CategoryList = () => {
     direction: "ascending",
   });
 
-  const categories = tableQueryResult?.data?.data ?? [];
+  const categories = tableQuery?.data?.data ?? [];
 
   const renderCell = useCallback((columnKey: string, item: IProduct) => {
     if (columnKey === "actions") {

--- a/examples/blog-refine-nextui/src/pages/products/list.tsx
+++ b/examples/blog-refine-nextui/src/pages/products/list.tsx
@@ -49,7 +49,7 @@ const columns = [
 
 export const ProductList = () => {
   const {
-    tableQueryResult,
+    tableQuery,
     pageCount,
     current,
     pageSize,
@@ -68,7 +68,7 @@ export const ProductList = () => {
     direction: "ascending",
   });
 
-  const products = tableQueryResult?.data?.data ?? [];
+  const products = tableQuery?.data?.data ?? [];
 
   const { data: categoryData } = useMany<ICategory>({
     resource: "categories",

--- a/examples/blog-refine-primereact/src/components/dashboard/recentSales/index.tsx
+++ b/examples/blog-refine-primereact/src/components/dashboard/recentSales/index.tsx
@@ -11,7 +11,7 @@ import type { IOrder, IOrderStatus } from "../../../interfaces";
 
 export const RecentSales = () => {
   const {
-    tableQueryResult,
+    tableQuery,
     pageCount,
     current,
     pageSize,
@@ -28,7 +28,7 @@ export const RecentSales = () => {
     },
   });
 
-  const orders = tableQueryResult?.data?.data;
+  const orders = tableQuery?.data?.data;
 
   const formatCurrency = (value: number) => {
     return value.toLocaleString("en-US", {
@@ -137,7 +137,7 @@ export const RecentSales = () => {
         }}
         sortField={sorters[0]?.field}
         sortOrder={sorters[0]?.order === "asc" ? 1 : -1}
-        loading={tableQueryResult?.isLoading}
+        loading={tableQuery?.isLoading}
         header={header}
       >
         <Column field="id" header="Id" sortable style={{ minWidth: "2rem" }} />

--- a/examples/blog-refine-primereact/src/pages/categories/list.tsx
+++ b/examples/blog-refine-primereact/src/pages/categories/list.tsx
@@ -16,7 +16,7 @@ import type { ICategory } from "../../interfaces";
 
 export const CategoryList = () => {
   const {
-    tableQueryResult,
+    tableQuery,
     pageCount,
     current,
     pageSize,
@@ -34,7 +34,7 @@ export const CategoryList = () => {
   const { edit, show, create } = useNavigation();
   const { mutate: deleteProduct } = useDelete();
 
-  const categories = tableQueryResult?.data?.data;
+  const categories = tableQuery?.data?.data;
 
   const confirmDeleteProduct = (id: number) => {
     confirmDialog({
@@ -149,7 +149,7 @@ export const CategoryList = () => {
         }}
         sortField={sorters[0]?.field}
         sortOrder={sorters[0]?.order === "asc" ? 1 : -1}
-        loading={tableQueryResult?.isLoading}
+        loading={tableQuery?.isLoading}
         header={header}
       >
         <Column

--- a/examples/blog-refine-primereact/src/pages/products/list.tsx
+++ b/examples/blog-refine-primereact/src/pages/products/list.tsx
@@ -24,7 +24,7 @@ const formatCurrency = (value: number) => {
 
 export const ProductList = () => {
   const {
-    tableQueryResult,
+    tableQuery,
     pageCount,
     current,
     pageSize,
@@ -38,7 +38,7 @@ export const ProductList = () => {
   const { edit, show, create } = useNavigation();
   const { mutate: deleteProduct } = useDelete();
 
-  const products = tableQueryResult?.data?.data;
+  const products = tableQuery?.data?.data;
 
   const { data: categoryData } = useMany<ICategory>({
     resource: "categories",
@@ -173,7 +173,7 @@ export const ProductList = () => {
         }}
         sortField={sorters[0]?.field}
         sortOrder={sorters[0]?.order === "asc" ? 1 : -1}
-        loading={tableQueryResult?.isLoading}
+        loading={tableQuery?.isLoading}
         header={header}
       >
         <Column field="id" header="Id" sortable style={{ minWidth: "1rem" }} />

--- a/examples/blog-refine-shadcn/src/components/table/data-table.tsx
+++ b/examples/blog-refine-shadcn/src/components/table/data-table.tsx
@@ -38,7 +38,7 @@ export function DataTable({ ...tableProps }: any) {
     getHeaderGroups,
     getRowModel,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
     getState,
     setPageIndex,

--- a/examples/blog-refine-shadcn/src/pages/blog-posts/list.tsx
+++ b/examples/blog-refine-shadcn/src/pages/blog-posts/list.tsx
@@ -110,7 +110,7 @@ export const BlogPostList: React.FC<IResourceComponentsProps> = () => {
     },
   });
 
-  const tableData = tableProps?.refineCore?.tableQueryResult?.data;
+  const tableData = tableProps?.refineCore?.tableQuery?.data;
   const catList =
     tableData?.data?.map((item: IBlogPost) => item?.category?.id) ?? [];
 

--- a/examples/blog-refine-tremor/src/pages/dashboard/details/index.tsx
+++ b/examples/blog-refine-tremor/src/pages/dashboard/details/index.tsx
@@ -126,7 +126,7 @@ export const Details = () => {
     getHeaderGroups,
     getRowModel,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
     getState,
     setPageIndex,

--- a/examples/blog-win95/src/pages/categories/list.tsx
+++ b/examples/blog-win95/src/pages/categories/list.tsx
@@ -16,7 +16,7 @@ import {
 import type { ICategory } from "../../interfaces";
 
 export const CategoryList = () => {
-  const { tableQueryResult } = useTable<ICategory>({
+  const { tableQuery } = useTable<ICategory>({
     resource: "categories",
   });
 
@@ -35,7 +35,7 @@ export const CategoryList = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {tableQueryResult.data?.data.map((item) => {
+            {tableQuery.data?.data.map((item) => {
               return (
                 <TableRow key={item.id}>
                   <TableDataCell>{item.id}</TableDataCell>
@@ -60,7 +60,7 @@ export const CategoryList = () => {
             })}
           </TableBody>
         </Table>
-        {tableQueryResult.isLoading && (
+        {tableQuery.isLoading && (
           <div
             style={{
               display: "flex",

--- a/examples/blog-win95/src/pages/posts/list.tsx
+++ b/examples/blog-win95/src/pages/posts/list.tsx
@@ -97,7 +97,7 @@ export const PostList = () => {
     setPageIndex,
     setPageSize,
     refineCore: {
-      tableQueryResult: { isLoading },
+      tableQuery: { isLoading },
     },
   } = useTable<IPost>({
     columns,

--- a/examples/customization-theme-chakra-ui/src/pages/posts/list.tsx
+++ b/examples/customization-theme-chakra-ui/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/customization-theme-mantine/src/pages/posts/list.tsx
+++ b/examples/customization-theme-mantine/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/finefoods-material-ui/src/components/dashboard/orderTimeline/index.tsx
+++ b/examples/finefoods-material-ui/src/components/dashboard/orderTimeline/index.tsx
@@ -15,21 +15,19 @@ export const OrderTimeline: React.FC = () => {
 
   const { show } = useNavigation();
 
-  const { tableQueryResult, current, setCurrent, pageCount } = useTable<IOrder>(
-    {
-      resource: "orders",
-      initialSorter: [
-        {
-          field: "createdAt",
-          order: "desc",
-        },
-      ],
-      initialPageSize: 7,
-      syncWithLocation: false,
-    },
-  );
+  const { tableQuery, current, setCurrent, pageCount } = useTable<IOrder>({
+    resource: "orders",
+    initialSorter: [
+      {
+        field: "createdAt",
+        order: "desc",
+      },
+    ],
+    initialPageSize: 7,
+    syncWithLocation: false,
+  });
 
-  const { data } = tableQueryResult;
+  const { data } = tableQuery;
 
   return (
     <Box

--- a/examples/finefoods-material-ui/src/components/product/list-card/index.tsx
+++ b/examples/finefoods-material-ui/src/components/product/list-card/index.tsx
@@ -28,7 +28,7 @@ export const ProductListCard = (props: Props) => {
   const { pathname } = useLocation();
   const { editUrl } = useNavigation();
   const t = useTranslate();
-  const products = props.tableQueryResult?.data?.data || [];
+  const products = props.tableQuery?.data?.data || [];
 
   const categoryFilters = useMemo(() => {
     const filter = props.filters.find((filter) => {

--- a/examples/form-chakra-ui-mutation-mode/src/pages/posts/list.tsx
+++ b/examples/form-chakra-ui-mutation-mode/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-chakra-ui-use-drawer-form/src/pages/posts/list.tsx
+++ b/examples/form-chakra-ui-use-drawer-form/src/pages/posts/list.tsx
@@ -136,7 +136,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-chakra-ui-use-form/src/pages/posts/list.tsx
+++ b/examples/form-chakra-ui-use-form/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-chakra-use-modal-form/src/pages/posts/list.tsx
+++ b/examples/form-chakra-use-modal-form/src/pages/posts/list.tsx
@@ -135,7 +135,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-mantine-mutation-mode/src/pages/posts/list.tsx
+++ b/examples/form-mantine-mutation-mode/src/pages/posts/list.tsx
@@ -104,7 +104,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-mantine-use-drawer-form/src/pages/posts/list.tsx
+++ b/examples/form-mantine-use-drawer-form/src/pages/posts/list.tsx
@@ -157,7 +157,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-mantine-use-form/src/pages/posts/list.tsx
+++ b/examples/form-mantine-use-form/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-mantine-use-modal-form/src/pages/posts/list.tsx
+++ b/examples/form-mantine-use-modal-form/src/pages/posts/list.tsx
@@ -157,7 +157,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-mantine-use-steps-form/src/pages/posts/list.tsx
+++ b/examples/form-mantine-use-steps-form/src/pages/posts/list.tsx
@@ -104,7 +104,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-react-hook-form-use-form/src/pages/posts/list.tsx
+++ b/examples/form-react-hook-form-use-form/src/pages/posts/list.tsx
@@ -3,7 +3,7 @@ import { useTable, useNavigation } from "@refinedev/core";
 import type { IPost } from "../../interfaces";
 
 export const PostList: React.FC = () => {
-  const { tableQueryResult } = useTable<IPost>({
+  const { tableQuery } = useTable<IPost>({
     initialSorter: [
       {
         field: "id",
@@ -23,7 +23,7 @@ export const PostList: React.FC = () => {
           <td>Actions</td>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data.map((post) => (
+          {tableQuery.data?.data.map((post) => (
             <tr key={post.id}>
               <td>{post.id}</td>
               <td>{post.title}</td>

--- a/examples/form-react-hook-form-use-modal-form/src/pages/posts/list.tsx
+++ b/examples/form-react-hook-form-use-modal-form/src/pages/posts/list.tsx
@@ -5,7 +5,7 @@ import { CreatePost, EditPost } from "../../components";
 import type { IPost } from "../../interfaces";
 
 export const PostList: React.FC = () => {
-  const { tableQueryResult } = useTable<IPost>({
+  const { tableQuery } = useTable<IPost>({
     initialSorter: [
       {
         field: "id",
@@ -45,7 +45,7 @@ export const PostList: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data.map((post) => (
+          {tableQuery.data?.data.map((post) => (
             <tr key={post.id}>
               <td>{post.id}</td>
               <td>{post.title}</td>

--- a/examples/form-react-hook-form-use-steps-form/src/pages/posts/list.tsx
+++ b/examples/form-react-hook-form-use-steps-form/src/pages/posts/list.tsx
@@ -3,7 +3,7 @@ import { useTable, useNavigation, useMany } from "@refinedev/core";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostList: React.FC = () => {
-  const { tableQueryResult } = useTable<IPost>({
+  const { tableQuery } = useTable<IPost>({
     initialSorter: [
       {
         field: "id",
@@ -14,7 +14,7 @@ export const PostList: React.FC = () => {
   const { edit, create } = useNavigation();
 
   const categoryIds =
-    tableQueryResult?.data?.data.map((item) => item.category.id) ?? [];
+    tableQuery?.data?.data.map((item) => item.category.id) ?? [];
   const { data, isLoading } = useMany<ICategory>({
     resource: "categories",
     ids: categoryIds,
@@ -37,7 +37,7 @@ export const PostList: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data.map((post) => (
+          {tableQuery.data?.data.map((post) => (
             <tr key={post.id}>
               <td>{post.id}</td>
               <td>{post.title}</td>

--- a/examples/form-save-and-continue/src/pages/posts/list.tsx
+++ b/examples/form-save-and-continue/src/pages/posts/list.tsx
@@ -3,7 +3,7 @@ import { useTable, useNavigation } from "@refinedev/core";
 import type { IPost } from "../../interfaces";
 
 export const PostList: React.FC = () => {
-  const { tableQueryResult } = useTable<IPost>({
+  const { tableQuery } = useTable<IPost>({
     initialSorter: [
       {
         field: "id",
@@ -25,7 +25,7 @@ export const PostList: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {tableQueryResult.data?.data.map((post) => (
+          {tableQuery.data?.data.map((post) => (
             <tr key={post.id}>
               <td>{post.id}</td>
               <td>{post.title}</td>

--- a/examples/import-export-mantine/src/pages/posts/list.tsx
+++ b/examples/import-export-mantine/src/pages/posts/list.tsx
@@ -115,7 +115,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/mern-dashboard-client/src/pages/all-properties.tsx
+++ b/examples/mern-dashboard-client/src/pages/all-properties.tsx
@@ -15,7 +15,7 @@ const AllProperties = () => {
   const navigate = useNavigate();
 
   const {
-    tableQueryResult: { data, isLoading, isError },
+    tableQuery: { data, isLoading, isError },
     current,
     setCurrent,
     setPageSize,

--- a/examples/multi-tenancy-strapi/src/components/product/product-cards.tsx
+++ b/examples/multi-tenancy-strapi/src/components/product/product-cards.tsx
@@ -19,8 +19,8 @@ type ProductCardsProps = {
 export const ProductCards = ({ useTableResult }: ProductCardsProps) => {
   const { styles } = useStyles();
 
-  const products = useTableResult.tableQueryResult?.data?.data || [];
-  const isLoading = useTableResult.tableQueryResult.isLoading;
+  const products = useTableResult.tableQuery?.data?.data || [];
+  const isLoading = useTableResult.tableQuery.isLoading;
 
   return (
     <>

--- a/examples/server-side-form-validation-chakra-ui/src/pages/posts/list.tsx
+++ b/examples/server-side-form-validation-chakra-ui/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/server-side-form-validation-mantine/src/pages/posts/list.tsx
+++ b/examples/server-side-form-validation-mantine/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/store/pages/index.tsx
+++ b/examples/store/pages/index.tsx
@@ -59,7 +59,7 @@ const Home = ({
   const selectedCategoryId = selectedCategory?.id;
 
   const {
-    tableQueryResult: { data: products, isLoading, isFetching },
+    tableQuery: { data: products, isLoading, isFetching },
     filters,
     setFilters,
   } = useTable<Product>({

--- a/examples/table-chakra-ui-advanced/src/pages/posts/list.tsx
+++ b/examples/table-chakra-ui-advanced/src/pages/posts/list.tsx
@@ -229,7 +229,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/table-chakra-ui-basic/src/pages/posts/list.tsx
+++ b/examples/table-chakra-ui-basic/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/table-handson/src/pages/posts/list.tsx
+++ b/examples/table-handson/src/pages/posts/list.tsx
@@ -25,7 +25,7 @@ export const PostList = () => {
   });
 
   const {
-    tableQueryResult: {
+    tableQuery: {
       data: { data } = { data: [] },
     },
   } = useTable<IPost>({

--- a/examples/table-mantine-advanced/src/pages/posts/list.tsx
+++ b/examples/table-mantine-advanced/src/pages/posts/list.tsx
@@ -194,7 +194,7 @@ export const PostList: React.FC = () => {
     getRowModel,
     resetRowSelection,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
       setCurrent,
       pageCount,
       current,

--- a/examples/table-mantine-basic/src/pages/posts/list.tsx
+++ b/examples/table-mantine-basic/src/pages/posts/list.tsx
@@ -103,7 +103,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/table-material-ui-advanced/src/pages/table/index.tsx
+++ b/examples/table-material-ui-advanced/src/pages/table/index.tsx
@@ -182,7 +182,7 @@ export const PostList: React.FC = () => {
     getSelectedRowModel,
     resetRowSelection,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable<IPost>({
     columns,

--- a/examples/table-material-ui-cursor-pagination/src/pages/posts/list.tsx
+++ b/examples/table-material-ui-cursor-pagination/src/pages/posts/list.tsx
@@ -7,7 +7,7 @@ import type { ICommit } from "../../interfaces";
 
 export const PostList: React.FC = () => {
   const [next, setNext] = React.useState<string | undefined>(undefined);
-  const { dataGridProps, tableQueryResult } = useDataGrid<ICommit>({
+  const { dataGridProps, tableQuery } = useDataGrid<ICommit>({
     initialPageSize: 5,
     metaData: {
       cursor: {
@@ -16,7 +16,7 @@ export const PostList: React.FC = () => {
     },
   });
 
-  const { data } = tableQueryResult;
+  const { data } = tableQuery;
 
   const columns: GridColDef<ICommit>[] = [
     {

--- a/examples/table-react-table-advanced/src/pages/posts/list.tsx
+++ b/examples/table-react-table-advanced/src/pages/posts/list.tsx
@@ -193,7 +193,7 @@ export const PostList: React.FC = () => {
     previousPage,
     resetRowSelection,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable<IPost>({
     columns,

--- a/examples/theme-chakra-ui-demo/src/pages/posts/list.tsx
+++ b/examples/theme-chakra-ui-demo/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/theme-mantine-demo/src/pages/posts/list.tsx
+++ b/examples/theme-mantine-demo/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/tutorial-chakra-ui/src/pages/blog-posts/list.tsx
+++ b/examples/tutorial-chakra-ui/src/pages/blog-posts/list.tsx
@@ -117,7 +117,7 @@ export const BlogPostList = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/tutorial-headless/src/pages/blog-posts/list.tsx
+++ b/examples/tutorial-headless/src/pages/blog-posts/list.tsx
@@ -124,7 +124,7 @@ export const BlogPostList = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
     getState,
     setPageIndex,

--- a/examples/tutorial-mantine/src/pages/blog-posts/list.tsx
+++ b/examples/tutorial-mantine/src/pages/blog-posts/list.tsx
@@ -102,7 +102,7 @@ export const BlogPostList = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/upload-chakra-ui-basic64/src/pages/posts/list.tsx
+++ b/examples/upload-chakra-ui-basic64/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/upload-chakra-ui-multipart/src/pages/posts/list.tsx
+++ b/examples/upload-chakra-ui-multipart/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/upload-mantine-base64/src/pages/posts/list.tsx
+++ b/examples/upload-mantine-base64/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/upload-mantine-multipart/src/pages/posts/list.tsx
+++ b/examples/upload-mantine-multipart/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/win95/src/components/table-members/index.tsx
+++ b/examples/win95/src/components/table-members/index.tsx
@@ -29,7 +29,7 @@ export const TableMembers = ({ selectedMember, setSelectedMember }: Props) => {
   const navigate = useNavigate();
 
   const {
-    tableQueryResult: membersQueryResult,
+    tableQuery: membersQueryResult,
     pageCount,
     current,
     setCurrent,

--- a/examples/win95/src/routes/video-club/members/list.tsx
+++ b/examples/win95/src/routes/video-club/members/list.tsx
@@ -25,7 +25,7 @@ export const VideoClubMemberPageList = () => {
   const navigate = useNavigate();
 
   const {
-    tableQueryResult: membersQueryResult,
+    tableQuery: membersQueryResult,
     pageCount,
     current,
     setCurrent,

--- a/examples/win95/src/routes/video-club/tapes/select-member.tsx
+++ b/examples/win95/src/routes/video-club/tapes/select-member.tsx
@@ -40,7 +40,7 @@ export const VideoClubPageTapeSelectMember = (props: Props) => {
   const { create } = useNavigation();
 
   const {
-    tableQueryResult: membersQueryResult,
+    tableQuery: membersQueryResult,
     pageCount,
     current,
     setCurrent,

--- a/examples/win95/src/routes/video-club/tapes/select-title.tsx
+++ b/examples/win95/src/routes/video-club/tapes/select-title.tsx
@@ -48,7 +48,7 @@ export const VideoClubPageTapeSelectTitle = ({
   const navigate = useNavigate();
 
   const {
-    tableQueryResult: titlesQueryResult,
+    tableQuery: titlesQueryResult,
     pageCount,
     current,
     setCurrent,

--- a/examples/win95/src/routes/video-club/titles/list.tsx
+++ b/examples/win95/src/routes/video-club/titles/list.tsx
@@ -23,7 +23,7 @@ export const VideoClubPageBrowseTitles = () => {
   const navigate = useNavigate();
 
   const {
-    tableQueryResult: titlesQueryResult,
+    tableQuery: titlesQueryResult,
     pageCount,
     current,
     setCurrent,

--- a/examples/with-persist-query/src/pages/posts/list.tsx
+++ b/examples/with-persist-query/src/pages/posts/list.tsx
@@ -61,9 +61,9 @@ export const PostList: React.FC = () => {
     previousPage,
     setPageSize,
     getColumn,
-    refineCore: { tableQueryResult },
+    refineCore: { tableQuery },
   } = useTable<IPost>({ columns });
-  console.log({ tableQueryResult });
+  console.log({ tableQuery });
   const titleColumn = getColumn("title");
 
   return (

--- a/packages/antd/src/hooks/list/useSimpleList/useSimpleList.spec.ts
+++ b/packages/antd/src/hooks/list/useSimpleList/useSimpleList.spec.ts
@@ -173,7 +173,7 @@ describe("useSimpleList Hook", () => {
     expect(result.current.listProps.pagination).toBeFalsy();
   });
 
-  it("shoukd work with query and queryResult", async () => {
+  it("should work with query and queryResult", async () => {
     const { result } = renderHook(() => useSimpleList(), {
       wrapper: TestWrapper({
         dataProvider: MockJSONServer,

--- a/packages/antd/src/hooks/list/useSimpleList/useSimpleList.spec.ts
+++ b/packages/antd/src/hooks/list/useSimpleList/useSimpleList.spec.ts
@@ -172,4 +172,20 @@ describe("useSimpleList Hook", () => {
 
     expect(result.current.listProps.pagination).toBeFalsy();
   });
+
+  it("shoukd work with query and queryResult", async () => {
+    const { result } = renderHook(() => useSimpleList(), {
+      wrapper: TestWrapper({
+        dataProvider: MockJSONServer,
+        resources: [{ name: "posts" }],
+        routerProvider,
+      }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.query.isSuccess).toBeTruthy();
+    });
+
+    expect(result.current.query).toEqual(result.current.queryResult);
+  });
 });

--- a/packages/antd/src/hooks/list/useSimpleList/useSimpleList.ts
+++ b/packages/antd/src/hooks/list/useSimpleList/useSimpleList.ts
@@ -23,9 +23,13 @@ export type useSimpleListReturnType<
   TQueryFnData extends BaseRecord = BaseRecord,
   TSearchVariables = unknown,
   TData extends BaseRecord = TQueryFnData,
-> = Omit<useTableReturnType<TData>, "tableQueryResult"> & {
+> = Omit<useTableReturnType<TData>, "tableQueryResult" | "tableQuery"> & {
   listProps: ListProps<TData>;
+  /**
+   * @deprecated Use `query` instead
+   */
   queryResult: useTableReturnType["tableQueryResult"];
+  query: useTableReturnType["tableQuery"];
   searchFormProps: FormProps<TSearchVariables>;
 };
 
@@ -91,6 +95,7 @@ export const useSimpleList = <
     setSorters,
     createLinkForSyncWithLocation,
     tableQueryResult: queryResult,
+    tableQuery: query,
     overtime,
   } = useTableCore({
     resource,
@@ -208,6 +213,7 @@ export const useSimpleList = <
       loading: liveMode === "auto" ? isLoading : !isFetched,
       pagination: antdPagination(),
     },
+    query,
     queryResult,
     filters,
     setFilters,

--- a/packages/antd/src/hooks/table/useTable/useTable.spec.tsx
+++ b/packages/antd/src/hooks/table/useTable/useTable.spec.tsx
@@ -340,7 +340,7 @@ describe("useTable Hook", () => {
     });
   });
 
-  it("shoukd work with query and queryResult", async () => {
+  it("should work with query and queryResult", async () => {
     const { result } = renderHook(() => useTable(), {
       wrapper: TestWrapper({
         dataProvider: MockJSONServer,

--- a/packages/antd/src/hooks/table/useTable/useTable.spec.tsx
+++ b/packages/antd/src/hooks/table/useTable/useTable.spec.tsx
@@ -3,7 +3,7 @@ import type { CrudFilters } from "@refinedev/core";
 import isEqual from "lodash/isEqual";
 import { renderHook, waitFor } from "@testing-library/react";
 import { Form, Input } from "antd";
-import { act, TestWrapper, render } from "@test";
+import { act, TestWrapper, render, MockJSONServer } from "@test";
 
 import { useTable } from "./useTable";
 
@@ -338,5 +338,21 @@ describe("useTable Hook", () => {
     await waitFor(() => {
       expect(getByDisplayValue("Some Name To Look For")).toBeInTheDocument();
     });
+  });
+
+  it("shoukd work with query and queryResult", async () => {
+    const { result } = renderHook(() => useTable(), {
+      wrapper: TestWrapper({
+        dataProvider: MockJSONServer,
+        resources: [{ name: "posts" }],
+        routerProvider,
+      }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.tableQuery.isSuccess).toBeTruthy();
+    });
+
+    expect(result.current.tableQuery).toEqual(result.current.tableQueryResult);
   });
 });

--- a/packages/antd/src/hooks/table/useTable/useTable.ts
+++ b/packages/antd/src/hooks/table/useTable/useTable.ts
@@ -92,6 +92,7 @@ export const useTable = <
 > = {}): useTableReturnType<TData, TError, TSearchVariables> => {
   const {
     tableQueryResult,
+    tableQuery,
     current,
     setCurrent,
     pageSize,
@@ -279,6 +280,7 @@ export const useTable = <
       scroll: { x: true },
     },
     tableQueryResult,
+    tableQuery,
     sorters,
     sorter,
     filters,

--- a/packages/core/src/hooks/useTable/index.spec.ts
+++ b/packages/core/src/hooks/useTable/index.spec.ts
@@ -472,6 +472,22 @@ describe("useTable Hook", () => {
       expect(result.current.overtime.elapsedTime).toBeUndefined();
     });
   });
+
+  it("shoukd work with tableQuery and tableQueryResult", async () => {
+    const { result } = renderHook(() => useTable(), {
+      wrapper: TestWrapper({
+        dataProvider: MockJSONServer,
+        resources: [{ name: "posts" }],
+        routerProvider,
+      }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.tableQuery.isSuccess).toBeTruthy();
+    });
+
+    expect(result.current.tableQuery).toEqual(result.current.tableQueryResult);
+  });
 });
 
 describe("useTable Filters", () => {

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -201,6 +201,10 @@ export type useTableReturnType<
   TData extends BaseRecord = BaseRecord,
   TError extends HttpError = HttpError,
 > = {
+  tableQuery: QueryObserverResult<GetListResponse<TData>, TError>;
+  /**
+   * @deprecated `tableQueryResult` is deprecated. Use `tableQuery` instead.
+   */
   tableQueryResult: QueryObserverResult<GetListResponse<TData>, TError>;
   /**
    * @deprecated `sorter` is deprecated. Use `sorters` instead.
@@ -559,6 +563,7 @@ export function useTable<
 
   return {
     tableQueryResult: queryResult,
+    tableQuery: queryResult,
     sorters,
     setSorters: setSortWithUnion,
     sorter: sorters,

--- a/packages/mui/src/hooks/useDataGrid/index.spec.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.spec.ts
@@ -238,13 +238,19 @@ describe("useDataGrid Hook", () => {
     expect(newPost).toEqual(postToUpdate);
   });
 
-  it("shoukd work with query and queryResult", async () => {
-    const { result } = renderHook(() => useDataGrid(), {
-      wrapper: TestWrapper({
-        dataProvider: MockJSONServer,
-        resources: [{ name: "posts" }],
-      }),
-    });
+  it("should work with query and queryResult", async () => {
+    const { result } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: MockJSONServer,
+          resources: [{ name: "posts" }],
+        }),
+      },
+    );
 
     await waitFor(() => {
       expect(result.current.tableQuery.isSuccess).toBeTruthy();

--- a/packages/mui/src/hooks/useDataGrid/index.spec.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.spec.ts
@@ -237,4 +237,19 @@ describe("useDataGrid Hook", () => {
 
     expect(newPost).toEqual(postToUpdate);
   });
+
+  it("shoukd work with query and queryResult", async () => {
+    const { result } = renderHook(() => useDataGrid(), {
+      wrapper: TestWrapper({
+        dataProvider: MockJSONServer,
+        resources: [{ name: "posts" }],
+      }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.tableQuery.isSuccess).toBeTruthy();
+    });
+
+    expect(result.current.tableQuery).toEqual(result.current.tableQueryResult);
+  });
 });

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -171,6 +171,7 @@ export function useDataGrid<
 
   const {
     tableQueryResult,
+    tableQuery,
     current,
     setCurrent,
     pageSize,
@@ -321,6 +322,7 @@ export function useDataGrid<
 
   return {
     tableQueryResult,
+    tableQuery,
     dataGridProps: {
       disableRowSelectionOnClick: true,
       rows: data?.data || [],

--- a/packages/react-table/src/useTable/index.ts
+++ b/packages/react-table/src/useTable/index.ts
@@ -75,7 +75,7 @@ export function useTable<
     (refineCoreProps.pagination?.mode ?? hasPaginationString) !== "off";
 
   const {
-    tableQueryResult: { data },
+    tableQuery: { data },
     current,
     setCurrent,
     pageSize: pageSizeCore,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

useTable usage like this:

```tsx
const { tableQueryResult } = useTable();
```

## What is the new behavior?

refactored to this for better readability

```tsx
const { tableQuery } = useTable();
```

fixes #6169


