### PR TITLE
docs(ant-design): explain the differences between `onFinish` and `formProps.onFinish`

### DIFF
--- a/documentation/docs/ui-integrations/ant-design/hooks/use-drawer-form/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-drawer-form/index.md
@@ -442,6 +442,8 @@ const { defaultFormValuesLoading } = useForm({
 
 ## Return values
 
+`useDrawerForm` returns the same values from [`useForm`](/docs/ui-integrations/ant-design/hooks/use-form#return-values) and additional values to work with [`<Drawer>`](https://ant.design/components/drawer/) components.
+
 ### show
 
 A function that opens the `<Drawer>`. It takes an optional `id` parameter. If `id` is provided, it will fetch the record data and fill the `<Form>` with it.
@@ -463,6 +465,14 @@ It contains the props needed by the `"delete"` button within the `<Drawer>` (dis
 It's required to manage `<Form>` state and actions. Under the hood the `formProps` came from [`useForm`][antd-use-form].
 
 It contains the props to manage the [Antd `<Form>`](https://ant.design/components/form#api) component such as [_`onValuesChange`, `initialValues`, `onFieldsChange`, `onFinish` etc._](/docs/ui-integrations/ant-design/hooks/use-form#return-values)
+
+:::note Difference between `onFinish` and `formProps.onFinish`
+
+`onFinish` method returned directly from `useDrawerForm` is same with the `useForm`'s `onFinish`. When working with drawers, closing the drawer after submission and resetting the fields are necessary and to handle these, `formProps.onFinish` extends the `onFinish` method and handles the closing of the drawer and clearing the fields under the hood.
+
+If you're customizing the data before submitting it to your data provider, it's recommended to use `formProps.onFinish` and let it handle the operations after the submission.
+
+:::
 
 ### drawerProps
 

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-modal-form/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-modal-form/index.md
@@ -601,11 +601,21 @@ useModalForm({
 
 ## Return Values
 
+`useModalForm` returns the same values from [`useForm`](/docs/ui-integrations/ant-design/hooks/use-form#return-values) and additional values to work with [`<Modal>`][antd-modal] components.
+
 ### formProps
 
 It's required to manage `<Form>` state and actions. Under the hood the `formProps` came from [`useForm`][antd-use-form].
 
 It contains the props to manage the [Antd `<Form>`](https://ant.design/components/form#api) components such as [`onValuesChange`, `initialValues`, `onFieldsChange`, `onFinish` etc.](/docs/ui-integrations/ant-design/hooks/use-form#return-values)
+
+:::note Difference between `onFinish` and `formProps.onFinish`
+
+`onFinish` method returned directly from `useModalForm` is same with the `useForm`'s `onFinish`. When working with modals, closing the modal after submission and resetting the fields are necessary and to handle these, `formProps.onFinish` extends the `onFinish` method and handles the closing of the modal and clearing the fields under the hood.
+
+If you're customizing the data before submitting it to your data provider, it's recommended to use `formProps.onFinish` and let it handle the operations after the submission.
+
+:::
 
 ### modalProps
 
@@ -660,8 +670,10 @@ A function that can close the `<Modal>`. It's useful when you want to close the 
 ```tsx
 const { close, modalProps, formProps, onFinish } = useModalForm();
 
-const onFinishHandler = (values) => {
-  onFinish(values);
+const onFinishHandler = async (values) => {
+  // Awaiting `onFinish` is important for features like unsaved changes notifier, invalidation, redirection etc.
+  // If you're using the `onFinish` from `formProps`, it will call the `close` internally.
+  await onFinish(values);
   close();
 };
 

--- a/documentation/src/refine-theme/common-admonition.tsx
+++ b/documentation/src/refine-theme/common-admonition.tsx
@@ -122,6 +122,7 @@ export const Admonition = ({ type, title, children }: Props) => {
               "gap-2",
               "text-xs sm:text-base 2xl:text-base 2xl:leading-7",
               "font-semibold",
+              "admonition-header",
               clsText,
             )}
           >

--- a/documentation/src/refine-theme/css/custom.css
+++ b/documentation/src/refine-theme/css/custom.css
@@ -478,6 +478,10 @@ button.sp-button.sp-icon-standalone[title="Open in CodeSandbox"]:has(svg + span)
     @apply text-gray-700 dark:text-gray-100;
 }
 
+.admonition .admonition-header code {
+    text-transform: none;
+}
+
 h4 > del:has(code:only-child) {
     @apply no-underline;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

Updated the Ant Design's `useModalForm` and `useDrawerForm` docs to clarify the differences between `onFinish()` and `formProps.onFinish()` method in return values. 

Resolves #6181 