### PR TITLE
chore: run codemod `use-form-query-and-mutation-result` for all examples

### DIFF
--- a/examples/access-control-casbin/src/pages/posts/edit.tsx
+++ b/examples/access-control-casbin/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/access-control-cerbos/src/pages/posts/edit.tsx
+++ b/examples/access-control-cerbos/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/access-control-permify/src/pages/posts/edit.tsx
+++ b/examples/access-control-permify/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/app-crm-minimal/src/components/layout/account-settings/index.tsx
+++ b/examples/app-crm-minimal/src/components/layout/account-settings/index.tsx
@@ -22,7 +22,11 @@ type Props = {
 };
 
 export const AccountSettings = ({ opened, setOpened, userId }: Props) => {
-  const { saveButtonProps, formProps, queryResult } = useForm<
+  const {
+    saveButtonProps,
+    formProps,
+    query: queryResult,
+  } = useForm<
     GetFields<UpdateUserMutation>,
     HttpError,
     GetVariables<UpdateUserMutationVariables>

--- a/examples/app-crm-minimal/src/routes/companies/edit/form.tsx
+++ b/examples/app-crm-minimal/src/routes/companies/edit/form.tsx
@@ -25,7 +25,12 @@ import { getNameInitials } from "@/utilities";
 import { UPDATE_COMPANY_MUTATION } from "./queries";
 
 export const CompanyForm = () => {
-  const { saveButtonProps, formProps, formLoading, queryResult } = useForm<
+  const {
+    saveButtonProps,
+    formProps,
+    formLoading,
+    query: queryResult,
+  } = useForm<
     GetFields<UpdateCompanyMutation>,
     HttpError,
     GetVariables<UpdateCompanyMutationVariables>

--- a/examples/app-crm/src/routes/calendar/edit.tsx
+++ b/examples/app-crm/src/routes/calendar/edit.tsx
@@ -18,17 +18,22 @@ export const CalendarEditPage: React.FC = () => {
   const { id } = useResource();
   const { list } = useNavigation();
 
-  const { formProps, saveButtonProps, form, onFinish, queryResult } =
-    useForm<Event>({
-      action: "edit",
-      id,
-      queryOptions: {
-        enabled: true,
-      },
-      meta: {
-        gqlMutation: CALENDAR_UPDATE_EVENT_MUTATION,
-      },
-    });
+  const {
+    formProps,
+    saveButtonProps,
+    form,
+    onFinish,
+    query: queryResult,
+  } = useForm<Event>({
+    action: "edit",
+    id,
+    queryOptions: {
+      enabled: true,
+    },
+    meta: {
+      gqlMutation: CALENDAR_UPDATE_EVENT_MUTATION,
+    },
+  });
 
   useEffect(() => {
     const startDate = queryResult?.data?.data.startDate;

--- a/examples/app-crm/src/routes/companies/components/title-form/title-form.tsx
+++ b/examples/app-crm/src/routes/companies/components/title-form/title-form.tsx
@@ -20,7 +20,11 @@ import { COMPANY_TITLE_FORM_MUTATION, COMPANY_TITLE_QUERY } from "./queries";
 import styles from "./title-form.module.css";
 
 export const CompanyTitleForm = () => {
-  const { formProps, queryResult, onFinish } = useForm<
+  const {
+    formProps,
+    query: queryResult,
+    onFinish,
+  } = useForm<
     GetFields<CompanyTitleFormMutation>,
     HttpError,
     GetVariables<CompanyTitleFormMutationVariables>

--- a/examples/app-crm/src/routes/quotes/components/products-services.tsx
+++ b/examples/app-crm/src/routes/quotes/components/products-services.tsx
@@ -116,7 +116,11 @@ const columns = [
 export const ProductsServices = () => {
   const params = useParams<{ id: string }>();
 
-  const { formProps, autoSaveProps, queryResult } = useForm<
+  const {
+    formProps,
+    autoSaveProps,
+    query: queryResult,
+  } = useForm<
     GetFields<QuotesUpdateQuoteMutation>,
     HttpError,
     GetVariables<QuotesUpdateQuoteMutationVariables>
@@ -415,7 +419,7 @@ const TaxForm = (props: {
 }) => {
   const params = useParams<{ id: string }>();
 
-  const { formProps, queryResult } = useForm<
+  const { formProps, query: queryResult } = useForm<
     Quote,
     HttpError,
     QuoteUpdateInput

--- a/examples/app-crm/src/routes/quotes/components/show-description.tsx
+++ b/examples/app-crm/src/routes/quotes/components/show-description.tsx
@@ -15,11 +15,11 @@ const MDEditor = lazy(() => import("@uiw/react-md-editor"));
 export const ShowDescription = () => {
   const params = useParams<{ id: string }>();
 
-  const { formProps, queryResult, autoSaveProps } = useForm<
-    Quote,
-    HttpError,
-    QuoteUpdateInput
-  >({
+  const {
+    formProps,
+    query: queryResult,
+    autoSaveProps,
+  } = useForm<Quote, HttpError, QuoteUpdateInput>({
     resource: "quotes",
     action: "edit",
     id: params.id,

--- a/examples/audit-log-provider/src/pages/posts/edit.tsx
+++ b/examples/audit-log-provider/src/pages/posts/edit.tsx
@@ -10,7 +10,7 @@ export const PostEdit: React.FC = () => {
   const { resourceName, id } = useResource();
 
   const {
-    refineCore: { onFinish, formLoading, queryResult },
+    refineCore: { onFinish, formLoading, query: queryResult },
     register,
     handleSubmit,
     resetField,

--- a/examples/auth-antd/src/pages/posts/edit.tsx
+++ b/examples/auth-antd/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/auth-auth0/src/pages/posts/edit.tsx
+++ b/examples/auth-auth0/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/auth-chakra-ui/src/pages/posts/edit.tsx
+++ b/examples/auth-chakra-ui/src/pages/posts/edit.tsx
@@ -14,7 +14,7 @@ import type { IPost } from "../../interfaces";
 
 export const PostEdit = () => {
   const {
-    refineCore: { formLoading, queryResult },
+    refineCore: { formLoading, query: queryResult },
     saveButtonProps,
     register,
     formState: { errors },

--- a/examples/auth-google-login/src/pages/posts/edit.tsx
+++ b/examples/auth-google-login/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/auth-headless/src/pages/posts/edit.tsx
+++ b/examples/auth-headless/src/pages/posts/edit.tsx
@@ -4,7 +4,7 @@ import { useSelect } from "@refinedev/core";
 
 export const PostEdit: React.FC = () => {
   const {
-    refineCore: { onFinish, formLoading, queryResult },
+    refineCore: { onFinish, formLoading, query: queryResult },
     register,
     handleSubmit,
     resetField,

--- a/examples/auth-keycloak/src/pages/posts/edit.tsx
+++ b/examples/auth-keycloak/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/auth-mantine/src/pages/posts/edit.tsx
+++ b/examples/auth-mantine/src/pages/posts/edit.tsx
@@ -8,7 +8,7 @@ export const PostEdit: React.FC = () => {
   const {
     saveButtonProps,
     getInputProps,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
     errors,
   } = useForm({
     initialValues: {

--- a/examples/auth-material-ui/src/pages/posts/edit.tsx
+++ b/examples/auth-material-ui/src/pages/posts/edit.tsx
@@ -12,7 +12,7 @@ import type { IPost, ICategory, IStatus, Nullable } from "../../interfaces";
 export const PostEdit: React.FC = () => {
   const {
     saveButtonProps,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
     register,
     control,
     formState: { errors },

--- a/examples/auth-otp/src/pages/posts/edit.tsx
+++ b/examples/auth-otp/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/base-antd/src/pages/posts/edit.tsx
+++ b/examples/base-antd/src/pages/posts/edit.tsx
@@ -8,13 +8,17 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult, autoSaveProps } =
-    useForm<IPost>({
-      warnWhenUnsavedChanges: true,
-      autoSave: {
-        enabled: true,
-      },
-    });
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+    autoSaveProps,
+  } = useForm<IPost>({
+    warnWhenUnsavedChanges: true,
+    autoSave: {
+      enabled: true,
+    },
+  });
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/base-chakra-ui/src/pages/posts/edit.tsx
+++ b/examples/base-chakra-ui/src/pages/posts/edit.tsx
@@ -15,7 +15,7 @@ import type { IPost } from "../../interfaces";
 
 export const PostEdit = () => {
   const {
-    refineCore: { formLoading, queryResult, autoSaveProps },
+    refineCore: { formLoading, query: queryResult, autoSaveProps },
     saveButtonProps,
     register,
     formState: { errors },

--- a/examples/base-headless/src/pages/posts/edit.tsx
+++ b/examples/base-headless/src/pages/posts/edit.tsx
@@ -4,7 +4,7 @@ import { useSelect } from "@refinedev/core";
 
 export const PostEdit: React.FC = () => {
   const {
-    refineCore: { onFinish, formLoading, queryResult },
+    refineCore: { onFinish, formLoading, query: queryResult },
     register,
     handleSubmit,
     resetField,

--- a/examples/base-mantine/src/pages/posts/edit.tsx
+++ b/examples/base-mantine/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ export const PostEdit: React.FC = () => {
     saveButtonProps,
     getInputProps,
     errors,
-    refineCore: { queryResult, autoSaveProps },
+    refineCore: { query: queryResult, autoSaveProps },
   } = useForm({
     initialValues: {
       title: "",

--- a/examples/base-material-ui/src/pages/posts/edit.tsx
+++ b/examples/base-material-ui/src/pages/posts/edit.tsx
@@ -12,7 +12,7 @@ import type { IPost, ICategory, Nullable, IStatus } from "../../interfaces";
 export const PostEdit: React.FC = () => {
   const {
     saveButtonProps,
-    refineCore: { queryResult, autoSaveProps },
+    refineCore: { query: queryResult, autoSaveProps },
     register,
     control,
     formState: { errors },

--- a/examples/blog-invoice-generator/src/pages/contacts/edit.tsx
+++ b/examples/blog-invoice-generator/src/pages/contacts/edit.tsx
@@ -5,7 +5,11 @@ import { Form, Select, Input } from "antd";
 import type { IContact } from "interfaces";
 
 export const ContactEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IContact>({
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<IContact>({
     metaData: { populate: ["client"] },
   });
 

--- a/examples/blog-invoice-generator/src/pages/invoice/edit.tsx
+++ b/examples/blog-invoice-generator/src/pages/invoice/edit.tsx
@@ -5,7 +5,11 @@ import { Form, Input, Select } from "antd";
 import type { IInvoice } from "interfaces";
 
 export const InvoiceEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IInvoice>({
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<IInvoice>({
     metaData: { populate: ["company", "contact", "missions"] },
   });
 

--- a/examples/blog-material-ui/src/pages/posts/edit.tsx
+++ b/examples/blog-material-ui/src/pages/posts/edit.tsx
@@ -11,7 +11,7 @@ import type { IPost, ICategory, Nullable } from "interfaces";
 
 export const PostEdit: React.FC = () => {
   const {
-    refineCore: { formLoading, queryResult },
+    refineCore: { formLoading, query: queryResult },
     saveButtonProps,
     register,
     control,

--- a/examples/blog-ra-chakra-tutorial/src/pages/posts/create.tsx
+++ b/examples/blog-ra-chakra-tutorial/src/pages/posts/create.tsx
@@ -13,7 +13,7 @@ import { useForm } from "@refinedev/react-hook-form";
 
 export const PostCreate = () => {
   const {
-    refineCore: { formLoading, queryResult },
+    refineCore: { formLoading, query: queryResult },
     saveButtonProps,
     register,
     resetField,

--- a/examples/blog-ra-chakra-tutorial/src/pages/posts/edit.tsx
+++ b/examples/blog-ra-chakra-tutorial/src/pages/posts/edit.tsx
@@ -12,7 +12,7 @@ import { useSelect } from "@refinedev/core";
 
 export const PostEdit = () => {
   const {
-    refineCore: { formLoading, queryResult },
+    refineCore: { formLoading, query: queryResult },
     saveButtonProps,
     register,
     setValue,

--- a/examples/blog-react-dnd/src/pages/posts/edit.tsx
+++ b/examples/blog-react-dnd/src/pages/posts/edit.tsx
@@ -6,7 +6,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost } from "interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const { selectProps: categorySelectProps } = useSelect<IPost>({
     resource: "categories",

--- a/examples/blog-refine-airtable-crud/src/pages/post/create.tsx
+++ b/examples/blog-refine-airtable-crud/src/pages/post/create.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 export const PostCreate: React.FC = () => {
   const {
-    refineCore: { onFinish, formLoading, queryResult },
+    refineCore: { onFinish, formLoading, query: queryResult },
     register,
     handleSubmit,
     formState: { errors },

--- a/examples/blog-refine-airtable-crud/src/pages/post/edit.tsx
+++ b/examples/blog-refine-airtable-crud/src/pages/post/edit.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from "react";
 
 export const PostEdit: React.FC = () => {
   const {
-    refineCore: { onFinish, formLoading, queryResult },
+    refineCore: { onFinish, formLoading, query: queryResult },
     register,
     handleSubmit,
     resetField,

--- a/examples/blog-refine-daisyui/src/pages/categories/edit.tsx
+++ b/examples/blog-refine-daisyui/src/pages/categories/edit.tsx
@@ -7,7 +7,7 @@ export const CategoryEdit = () => {
   const { list } = useNavigation();
 
   const {
-    refineCore: { onFinish, queryResult },
+    refineCore: { onFinish, query: queryResult },
     register,
     handleSubmit,
     formState: { errors },

--- a/examples/blog-refine-daisyui/src/pages/products/edit.tsx
+++ b/examples/blog-refine-daisyui/src/pages/products/edit.tsx
@@ -7,7 +7,7 @@ export const ProductEdit = () => {
   const { list } = useNavigation();
 
   const {
-    refineCore: { onFinish, queryResult },
+    refineCore: { onFinish, query: queryResult },
     register,
     handleSubmit,
     setValue,

--- a/examples/blog-refine-mantine-strapi/src/pages/posts/edit.tsx
+++ b/examples/blog-refine-mantine-strapi/src/pages/posts/edit.tsx
@@ -7,7 +7,7 @@ export const PostEdit = () => {
   const {
     getInputProps,
     saveButtonProps,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
   } = useForm({
     initialValues: {
       id: "",

--- a/examples/blog-refine-markdown/src/pages/posts/edit.tsx
+++ b/examples/blog-refine-markdown/src/pages/posts/edit.tsx
@@ -7,7 +7,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const { selectProps: categorySelectProps } = useSelect<IPost>({
     resource: "categories",

--- a/examples/blog-refine-mui/src/pages/products/edit.tsx
+++ b/examples/blog-refine-mui/src/pages/products/edit.tsx
@@ -14,7 +14,7 @@ export const ProductEdit = () => {
   const translate = useTranslate();
   const {
     saveButtonProps,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
     register,
     control,
     formState: { errors },

--- a/examples/blog-refine-primereact/src/pages/categories/edit.tsx
+++ b/examples/blog-refine-primereact/src/pages/categories/edit.tsx
@@ -13,7 +13,7 @@ export const CategoryEdit = () => {
   const goBack = useBack();
 
   const {
-    refineCore: { onFinish, formLoading, queryResult },
+    refineCore: { onFinish, formLoading, query: queryResult },
     handleSubmit,
     control,
     formState: { errors },

--- a/examples/blog-refine-primereact/src/pages/products/edit.tsx
+++ b/examples/blog-refine-primereact/src/pages/products/edit.tsx
@@ -16,7 +16,7 @@ export const ProductEdit = () => {
   const goBack = useBack();
 
   const {
-    refineCore: { onFinish, formLoading, queryResult },
+    refineCore: { onFinish, formLoading, query: queryResult },
     handleSubmit,
     control,
     formState: { errors },

--- a/examples/blog-refine-shadcn/src/pages/blog-posts/edit.tsx
+++ b/examples/blog-refine-shadcn/src/pages/blog-posts/edit.tsx
@@ -30,7 +30,7 @@ export const BlogPostEdit: React.FC<IResourceComponentsProps> = () => {
   const { list } = useNavigation();
 
   const {
-    refineCore: { onFinish, queryResult },
+    refineCore: { onFinish, query: queryResult },
     ...form
   } = useForm({
     refineCoreProps: {

--- a/examples/command-palette-kbar/src/pages/posts/edit.tsx
+++ b/examples/command-palette-kbar/src/pages/posts/edit.tsx
@@ -8,7 +8,11 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>({
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<IPost>({
     warnWhenUnsavedChanges: true,
   });
 

--- a/examples/customization-login/src/pages/posts/edit.tsx
+++ b/examples/customization-login/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/customization-offlayout-area/src/components/sider/index.tsx
+++ b/examples/customization-offlayout-area/src/components/sider/index.tsx
@@ -126,7 +126,6 @@ export const FixedSider: React.FC = () => {
       >
         <ThemedTitle collapsed={collapsed} />
       </div>
-
       <Menu
         style={{
           marginTop: "8px",

--- a/examples/customization-rtl/src/pages/posts/edit.tsx
+++ b/examples/customization-rtl/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/customization-theme-antd/src/pages/posts/edit.tsx
+++ b/examples/customization-theme-antd/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/customization-theme-chakra-ui/src/pages/posts/edit.tsx
+++ b/examples/customization-theme-chakra-ui/src/pages/posts/edit.tsx
@@ -14,7 +14,7 @@ import type { IPost } from "../../interfaces";
 
 export const PostEdit = () => {
   const {
-    refineCore: { formLoading, queryResult },
+    refineCore: { formLoading, query: queryResult },
     saveButtonProps,
     register,
     formState: { errors },

--- a/examples/customization-theme-mantine/src/pages/posts/edit.tsx
+++ b/examples/customization-theme-mantine/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ export const PostEdit: React.FC = () => {
     saveButtonProps,
     getInputProps,
     errors,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
   } = useForm({
     initialValues: {
       title: "",

--- a/examples/customization-theme-material-ui/src/pages/posts/edit.tsx
+++ b/examples/customization-theme-material-ui/src/pages/posts/edit.tsx
@@ -12,7 +12,7 @@ import type { IPost, ICategory, Nullable, IStatus } from "../../interfaces";
 export const PostEdit: React.FC = () => {
   const {
     saveButtonProps,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
     register,
     control,
     formState: { errors },

--- a/examples/data-provider-airtable/src/pages/blog-posts/edit.tsx
+++ b/examples/data-provider-airtable/src/pages/blog-posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const BlogPostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/data-provider-appwrite/src/pages/posts/edit.tsx
+++ b/examples/data-provider-appwrite/src/pages/posts/edit.tsx
@@ -12,11 +12,11 @@ import type { IPost, IPostVariables, ICategory } from "../../interfaces";
 import { normalizeFile, storage } from "../../utility";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<
-    IPost,
-    HttpError,
-    IPostVariables
-  >({
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<IPost, HttpError, IPostVariables>({
     queryOptions: {
       select: ({ data }) => {
         return {

--- a/examples/data-provider-hasura/src/pages/categories/edit.tsx
+++ b/examples/data-provider-hasura/src/pages/categories/edit.tsx
@@ -12,7 +12,11 @@ import type {
 import { CATEGORY_UPDATE_MUTATION } from "./queries";
 
 export const CategoryEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<
     GetFields<UpdateCategoryMutation>,
     HttpError,
     GetVariables<UpdateCategoryMutationVariables>

--- a/examples/data-provider-hasura/src/pages/posts/edit.tsx
+++ b/examples/data-provider-hasura/src/pages/posts/edit.tsx
@@ -26,7 +26,12 @@ import type {
 import { POST_CATEGORIES_SELECT_QUERY, POST_UPDATE_MUTATION } from "./queries";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult, formLoading } = useForm<
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+    formLoading,
+  } = useForm<
     GetFields<UpdatePostMutation>,
     HttpError,
     GetVariables<UpdatePostMutationVariables>

--- a/examples/data-provider-nestjs-query/src/pages/categories/edit.tsx
+++ b/examples/data-provider-nestjs-query/src/pages/categories/edit.tsx
@@ -7,9 +7,11 @@ import { CATEGORY_EDIT_MUTATION } from "./queries";
 import type { CategoryEditMutation } from "graphql/types";
 
 export const CategoryEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<
-    GetFields<CategoryEditMutation>
-  >({
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<GetFields<CategoryEditMutation>>({
     metaData: {
       gqlMutation: CATEGORY_EDIT_MUTATION,
     },

--- a/examples/data-provider-nestjs-query/src/pages/posts/edit.tsx
+++ b/examples/data-provider-nestjs-query/src/pages/posts/edit.tsx
@@ -15,10 +15,11 @@ import { CATEGORIES_SELECT_QUERY, POST_EDIT_MUTATION } from "./queries";
 import type { CategoriesSelectQuery, PostEditMutation } from "graphql/types";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<
-    GetFields<PostEditMutation>,
-    HttpError
-  >({
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<GetFields<PostEditMutation>, HttpError>({
     metaData: {
       gqlMutation: POST_EDIT_MUTATION,
     },

--- a/examples/data-provider-nestjsx-crud/src/pages/posts/edit.tsx
+++ b/examples/data-provider-nestjsx-crud/src/pages/posts/edit.tsx
@@ -11,7 +11,7 @@ import type { IPost, ICategory, ITags } from "../../interfaces";
 import { normalizeFile } from "../../utility/normalize";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
   const apiUrl = useApiUrl();
 
   const postData = queryResult?.data?.data;

--- a/examples/data-provider-strapi-v4/src/pages/posts/edit.tsx
+++ b/examples/data-provider-strapi-v4/src/pages/posts/edit.tsx
@@ -8,7 +8,11 @@ import { TOKEN_KEY, API_URL } from "../../constants";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostEdit: React.FC = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>({
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<IPost>({
     metaData: { populate: ["category", "cover"] },
   });
 

--- a/examples/data-provider-strapi/src/pages/posts/create.tsx
+++ b/examples/data-provider-strapi/src/pages/posts/create.tsx
@@ -18,7 +18,7 @@ import { TOKEN_KEY } from "../../constants";
 export const PostCreate = () => {
   const API_URL = useApiUrl();
 
-  const { formProps, saveButtonProps, queryResult } = useForm();
+  const { formProps, saveButtonProps, query: queryResult } = useForm();
 
   const postData = queryResult?.data?.data;
   const { selectProps } = useSelect({

--- a/examples/data-provider-supabase/src/pages/posts/edit.tsx
+++ b/examples/data-provider-supabase/src/pages/posts/edit.tsx
@@ -18,7 +18,11 @@ import { supabaseClient, normalizeFile } from "../../utility";
 
 export const PostEdit = () => {
   const [isDeprecated, setIsDeprecated] = useState(false);
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>({
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<IPost>({
     liveMode: "manual",
     onLiveEvent: () => {
       setIsDeprecated(true);

--- a/examples/field-antd-use-select-basic/src/pages/posts/edit.tsx
+++ b/examples/field-antd-use-select-basic/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory, ITag } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
   const postData = queryResult?.data?.data;
 
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/field-antd-use-select-infinite/src/pages/posts/edit.tsx
+++ b/examples/field-antd-use-select-infinite/src/pages/posts/edit.tsx
@@ -6,7 +6,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/field-material-ui-use-autocomplete/src/pages/posts/edit.tsx
+++ b/examples/field-material-ui-use-autocomplete/src/pages/posts/edit.tsx
@@ -18,7 +18,7 @@ import type {
 export const PostEdit: React.FC = () => {
   const {
     saveButtonProps,
-    refineCore: { formLoading, queryResult },
+    refineCore: { formLoading, query: queryResult },
     register,
     control,
     formState: { errors },

--- a/examples/finefoods-antd/src/pages/couriers/edit.tsx
+++ b/examples/finefoods-antd/src/pages/couriers/edit.tsx
@@ -49,7 +49,11 @@ export const CourierEdit = () => {
 
   const t = useTranslate();
   const { list } = useNavigation();
-  const { formProps, queryResult, saveButtonProps } = useForm<ICourier>();
+  const {
+    formProps,
+    query: queryResult,
+    saveButtonProps,
+  } = useForm<ICourier>();
   const courier = queryResult?.data?.data;
 
   const { selectProps: storeSelectProps } = useSelect({

--- a/examples/finefoods-antd/src/pages/couriers/list.tsx
+++ b/examples/finefoods-antd/src/pages/couriers/list.tsx
@@ -221,8 +221,8 @@ export const CourierList = ({ children }: PropsWithChildren) => {
               <FilterDropdown {...props}>
                 <InputMask mask="(999) 999 99 99">
                   {/* 
-                                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                                    // @ts-ignore */}
+                                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                  // @ts-ignore */}
                   {(props: InputProps) => <Input {...props} />}
                 </InputMask>
               </FilterDropdown>

--- a/examples/finefoods-material-ui/src/pages/couriers/edit.tsx
+++ b/examples/finefoods-material-ui/src/pages/couriers/edit.tsx
@@ -37,7 +37,7 @@ export const CourierEdit = () => {
     control,
     setValue,
     formState: { errors },
-    refineCore: { formLoading, queryResult },
+    refineCore: { formLoading, query: queryResult },
     saveButtonProps,
   } = useForm<ICourier, HttpError, Nullable<ICourier>>();
   const courier = queryResult?.data?.data;

--- a/examples/form-antd-custom-validation/src/pages/posts/edit.tsx
+++ b/examples/form-antd-custom-validation/src/pages/posts/edit.tsx
@@ -19,7 +19,7 @@ interface PostUniqueCheckRequestQuery {
 }
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/form-antd-mutation-mode/src/pages/posts/create.tsx
+++ b/examples/form-antd-mutation-mode/src/pages/posts/create.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostCreate = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
 

--- a/examples/form-antd-mutation-mode/src/pages/posts/edit.tsx
+++ b/examples/form-antd-mutation-mode/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
 

--- a/examples/form-antd-use-form/src/pages/posts/create.tsx
+++ b/examples/form-antd-use-form/src/pages/posts/create.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostCreate = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
 

--- a/examples/form-antd-use-form/src/pages/posts/edit.tsx
+++ b/examples/form-antd-use-form/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
 

--- a/examples/form-chakra-ui-mutation-mode/src/pages/posts/edit.tsx
+++ b/examples/form-chakra-ui-mutation-mode/src/pages/posts/edit.tsx
@@ -14,7 +14,7 @@ import type { IPost } from "../../interfaces";
 
 export const PostEdit = () => {
   const {
-    refineCore: { formLoading, queryResult },
+    refineCore: { formLoading, query: queryResult },
     saveButtonProps,
     register,
     formState: { errors },

--- a/examples/form-chakra-ui-use-form/src/pages/posts/edit.tsx
+++ b/examples/form-chakra-ui-use-form/src/pages/posts/edit.tsx
@@ -15,7 +15,7 @@ import type { IPost } from "../../interfaces";
 
 export const PostEdit = () => {
   const {
-    refineCore: { formLoading, queryResult },
+    refineCore: { formLoading, query: queryResult },
     saveButtonProps,
     register,
     formState: { errors },

--- a/examples/form-core-use-form/src/pages/posts/create.tsx
+++ b/examples/form-core-use-form/src/pages/posts/create.tsx
@@ -5,11 +5,11 @@ import type { IPost } from "../../interfaces";
 type FormValues = Omit<IPost, "id">;
 
 export const PostCreate: React.FC = () => {
-  const { formLoading, onFinish, queryResult } = useForm<
-    IPost,
-    HttpError,
-    FormValues
-  >();
+  const {
+    formLoading,
+    onFinish,
+    query: queryResult,
+  } = useForm<IPost, HttpError, FormValues>();
 
   // if action is "clone", we'll have defaultValues
   const defaultValues = queryResult?.data?.data;

--- a/examples/form-core-use-form/src/pages/posts/edit.tsx
+++ b/examples/form-core-use-form/src/pages/posts/edit.tsx
@@ -8,7 +8,7 @@ export const PostEdit: React.FC = () => {
   const {
     formLoading,
     onFinish,
-    queryResult,
+    query: queryResult,
     autoSaveProps,
     onFinishAutoSave,
   } = useForm<FormValues>({

--- a/examples/form-mantine-mutation-mode/src/pages/posts/edit.tsx
+++ b/examples/form-mantine-mutation-mode/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ export const PostEdit: React.FC = () => {
     saveButtonProps,
     getInputProps,
     errors,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
   } = useForm({
     initialValues: {
       title: "",

--- a/examples/form-mantine-use-form/src/pages/posts/edit.tsx
+++ b/examples/form-mantine-use-form/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ export const PostEdit: React.FC = () => {
     saveButtonProps,
     getInputProps,
     errors,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
   } = useForm({
     initialValues: {
       title: "",

--- a/examples/form-material-ui-mutation-mode/src/pages/posts/edit.tsx
+++ b/examples/form-material-ui-mutation-mode/src/pages/posts/edit.tsx
@@ -12,7 +12,7 @@ import type { ICategory, IPost, IStatus, Nullable } from "../../interfaces";
 export const PostEdit: React.FC = () => {
   const {
     saveButtonProps,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
     register,
     control,
     formState: { errors },

--- a/examples/form-material-ui-use-form/src/pages/posts/edit.tsx
+++ b/examples/form-material-ui-use-form/src/pages/posts/edit.tsx
@@ -12,7 +12,7 @@ import type { ICategory, IPost, IStatus, Nullable } from "../../interfaces";
 export const PostEdit: React.FC = () => {
   const {
     saveButtonProps,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
     register,
     control,
     formState: { errors },

--- a/examples/form-react-hook-form-use-form/src/pages/posts/edit.tsx
+++ b/examples/form-react-hook-form-use-form/src/pages/posts/edit.tsx
@@ -5,7 +5,7 @@ import { useBack, useSelect } from "@refinedev/core";
 export const PostEdit: React.FC = () => {
   const back = useBack();
   const {
-    refineCore: { onFinish, formLoading, queryResult },
+    refineCore: { onFinish, formLoading, query: queryResult },
     register,
     handleSubmit,
     formState: { errors },

--- a/examples/form-save-and-continue/src/pages/posts/edit.tsx
+++ b/examples/form-save-and-continue/src/pages/posts/edit.tsx
@@ -4,7 +4,12 @@ import { useSelect, useForm, useNavigation } from "@refinedev/core";
 import type { IPost } from "../../interfaces";
 
 export const PostEdit: React.FC = () => {
-  const { formLoading, onFinish, redirect, queryResult } = useForm<IPost>({
+  const {
+    formLoading,
+    onFinish,
+    redirect,
+    query: queryResult,
+  } = useForm<IPost>({
     redirect: false,
   });
 

--- a/examples/i18n-nextjs/src/app/blog-posts/edit/[id]/page.tsx
+++ b/examples/i18n-nextjs/src/app/blog-posts/edit/[id]/page.tsx
@@ -6,7 +6,7 @@ import { Form, Input, Select } from "antd";
 
 export default function BlogPostEdit() {
   const { translate: t } = useTranslation();
-  const { formProps, saveButtonProps, queryResult } = useForm({});
+  const { formProps, saveButtonProps, query: queryResult } = useForm({});
 
   const blogPostsData = queryResult?.data?.data;
 

--- a/examples/i18n-react/src/pages/posts/edit.tsx
+++ b/examples/i18n-react/src/pages/posts/edit.tsx
@@ -7,7 +7,7 @@ import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
   const { translate } = useTranslation();
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/import-export-antd/src/pages/posts/edit.tsx
+++ b/examples/import-export-antd/src/pages/posts/edit.tsx
@@ -6,7 +6,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/input-custom/src/pages/posts/edit.tsx
+++ b/examples/input-custom/src/pages/posts/edit.tsx
@@ -6,7 +6,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/input-date-picker/src/pages/posts/edit.tsx
+++ b/examples/input-date-picker/src/pages/posts/edit.tsx
@@ -7,7 +7,7 @@ import dayjs from "dayjs";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/invoicer/src/pages/accounts/edit.tsx
+++ b/examples/invoicer/src/pages/accounts/edit.tsx
@@ -30,7 +30,11 @@ import type { Account, AccountForm } from "@/types";
 export const AccountsPageEdit = () => {
   const { listUrl } = useNavigation();
 
-  const { formProps, queryResult } = useForm<Account, HttpError, AccountForm>({
+  const { formProps, query: queryResult } = useForm<
+    Account,
+    HttpError,
+    AccountForm
+  >({
     redirect: false,
     meta: {
       populate: ["logo", "clients", "invoices.client"],

--- a/examples/invoicer/src/pages/clients/edit.tsx
+++ b/examples/invoicer/src/pages/clients/edit.tsx
@@ -30,7 +30,7 @@ import type { Invoice } from "@/types";
 export const ClientsPageEdit = () => {
   const { list } = useNavigation();
 
-  const { formProps, queryResult } = useForm({
+  const { formProps, query: queryResult } = useForm({
     redirect: false,
     meta: {
       populate: ["account", "invoices.client", "invoices.account.logo"],

--- a/examples/live-provider-ably/src/pages/posts/edit.tsx
+++ b/examples/live-provider-ably/src/pages/posts/edit.tsx
@@ -16,7 +16,11 @@ export const PostEdit = () => {
     "deleted" | "updated" | undefined
   >();
 
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>({
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<IPost>({
     liveMode: "manual",
     onLiveEvent: (event) => {
       if (event.type === "deleted" || event.type === "updated") {

--- a/examples/loading-overtime/src/pages/posts/edit.tsx
+++ b/examples/loading-overtime/src/pages/posts/edit.tsx
@@ -8,7 +8,11 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>({
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<IPost>({
     warnWhenUnsavedChanges: true,
   });
 

--- a/examples/monorepo-module-federation/apps/blog-posts/src/pages/blog-posts/edit.tsx
+++ b/examples/monorepo-module-federation/apps/blog-posts/src/pages/blog-posts/edit.tsx
@@ -8,13 +8,17 @@ import MDEditor from "@uiw/react-md-editor";
 import type { ICategory, IPost } from "../../interfaces";
 
 const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult, autoSaveProps } =
-    useForm<IPost>({
-      warnWhenUnsavedChanges: true,
-      autoSave: {
-        enabled: true,
-      },
-    });
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+    autoSaveProps,
+  } = useForm<IPost>({
+    warnWhenUnsavedChanges: true,
+    autoSave: {
+      enabled: true,
+    },
+  });
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/multi-level-menu/src/pages/posts/edit.tsx
+++ b/examples/multi-level-menu/src/pages/posts/edit.tsx
@@ -7,7 +7,11 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>({
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<IPost>({
     warnWhenUnsavedChanges: true,
   });
 

--- a/examples/new-routing-example/src/pages/posts/edit.tsx
+++ b/examples/new-routing-example/src/pages/posts/edit.tsx
@@ -6,7 +6,11 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>({
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<IPost>({
     warnWhenUnsavedChanges: true,
   });
 

--- a/examples/refine-week-invoice-generator/src/pages/contacts/edit.tsx
+++ b/examples/refine-week-invoice-generator/src/pages/contacts/edit.tsx
@@ -4,7 +4,11 @@ import { Form, Select, Input } from "antd";
 import type { IContact } from "../../interfaces";
 
 export const EditContact = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IContact>({
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<IContact>({
     meta: { populate: ["client"] },
   });
 

--- a/examples/search/src/pages/posts/edit.tsx
+++ b/examples/search/src/pages/posts/edit.tsx
@@ -6,7 +6,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/server-side-form-validation-antd/src/pages/posts/edit.tsx
+++ b/examples/server-side-form-validation-antd/src/pages/posts/edit.tsx
@@ -9,11 +9,11 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<
-    IPost,
-    HttpError,
-    IPost
-  >();
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<IPost, HttpError, IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/server-side-form-validation-chakra-ui/src/pages/posts/edit.tsx
+++ b/examples/server-side-form-validation-chakra-ui/src/pages/posts/edit.tsx
@@ -15,7 +15,7 @@ import type { IPost } from "../../interfaces";
 
 export const PostEdit = () => {
   const {
-    refineCore: { formLoading, queryResult },
+    refineCore: { formLoading, query: queryResult },
     saveButtonProps,
     register,
     formState: { errors },

--- a/examples/server-side-form-validation-mantine/src/pages/posts/edit.tsx
+++ b/examples/server-side-form-validation-mantine/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ export const PostEdit: React.FC = () => {
     saveButtonProps,
     getInputProps,
     errors,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
   } = useForm({
     initialValues: {
       title: "",

--- a/examples/server-side-form-validation-material-ui/src/pages/posts/edit.tsx
+++ b/examples/server-side-form-validation-material-ui/src/pages/posts/edit.tsx
@@ -12,7 +12,7 @@ import type { IPost, ICategory, Nullable, IStatus } from "../../interfaces";
 export const PostEdit: React.FC = () => {
   const {
     saveButtonProps,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
     register,
     control,
     formState: { errors },

--- a/examples/store/src/components/profile/ProfileBillingAddress/ProfileBillingAddress.tsx
+++ b/examples/store/src/components/profile/ProfileBillingAddress/ProfileBillingAddress.tsx
@@ -31,7 +31,7 @@ export const ProfileBillingAddress: React.FC<MyInformationProps> = ({
     reset,
     control,
     formState: { errors, touchedFields },
-    refineCore: { onFinish, mutationResult },
+    refineCore: { onFinish, mutation: mutationResult },
   } = useForm<UpdateCustomerNameFormData>({
     refineCoreProps: {
       action: "edit",

--- a/examples/store/src/components/profile/ProfileEmail/ProfileEmail.tsx
+++ b/examples/store/src/components/profile/ProfileEmail/ProfileEmail.tsx
@@ -26,7 +26,7 @@ export const ProfileEmail: React.FC<MyInformationProps> = ({ customer }) => {
     reset,
     control,
     formState: { errors },
-    refineCore: { onFinish, mutationResult },
+    refineCore: { onFinish, mutation: mutationResult },
   } = useForm<UpdateCustomerEmailFormData>({
     defaultValues: {
       email: customer.email,

--- a/examples/store/src/components/profile/ProfileName/ProfileName.tsx
+++ b/examples/store/src/components/profile/ProfileName/ProfileName.tsx
@@ -23,7 +23,7 @@ export const ProfileName: React.FC<MyInformationProps> = ({ customer }) => {
     reset,
     control,
     formState: { errors },
-    refineCore: { onFinish, mutationResult },
+    refineCore: { onFinish, mutation: mutationResult },
   } = useForm<UpdateCustomerNameFormData>({
     refineCoreProps: {
       action: "edit",

--- a/examples/store/src/components/profile/ProfilePassword/ProfilePassword.tsx
+++ b/examples/store/src/components/profile/ProfilePassword/ProfilePassword.tsx
@@ -29,7 +29,7 @@ export const ProfilePassword: React.FC<MyInformationProps> = ({ customer }) => {
     reset,
     formState: { errors },
     setError,
-    refineCore: { onFinish, mutationResult },
+    refineCore: { onFinish, mutation: mutationResult },
   } = useForm<UpdateCustomerPasswordFormData>({
     refineCoreProps: {
       action: "edit",

--- a/examples/store/src/components/profile/ProfilePhone/ProfilePhone.tsx
+++ b/examples/store/src/components/profile/ProfilePhone/ProfilePhone.tsx
@@ -21,7 +21,7 @@ export const ProfilePhone: React.FC<MyInformationProps> = ({ customer }) => {
     reset,
     control,
     formState: { errors },
-    refineCore: { onFinish, mutationResult },
+    refineCore: { onFinish, mutation: mutationResult },
   } = useForm<UpdateCustomerPhoneFormData>({
     refineCoreProps: {
       action: "edit",

--- a/examples/table-antd-advanced/src/pages/posts/edit.tsx
+++ b/examples/table-antd-advanced/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/table-antd-table-filter/src/pages/posts/edit.tsx
+++ b/examples/table-antd-table-filter/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/table-antd-use-delete-many/src/pages/posts/edit.tsx
+++ b/examples/table-antd-use-delete-many/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/table-antd-use-update-many/src/pages/posts/edit.tsx
+++ b/examples/table-antd-use-update-many/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/table-chakra-ui-basic/src/pages/posts/edit.tsx
+++ b/examples/table-chakra-ui-basic/src/pages/posts/edit.tsx
@@ -14,7 +14,7 @@ import type { IPost } from "../../interfaces";
 
 export const PostEdit = () => {
   const {
-    refineCore: { formLoading, queryResult },
+    refineCore: { formLoading, query: queryResult },
     saveButtonProps,
     register,
     formState: { errors },

--- a/examples/theme-antd-demo/src/pages/posts/edit.tsx
+++ b/examples/theme-antd-demo/src/pages/posts/edit.tsx
@@ -8,7 +8,11 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>({
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<IPost>({
     warnWhenUnsavedChanges: true,
   });
 

--- a/examples/theme-chakra-ui-demo/src/pages/posts/edit.tsx
+++ b/examples/theme-chakra-ui-demo/src/pages/posts/edit.tsx
@@ -14,7 +14,7 @@ import type { IPost } from "../../interfaces";
 
 export const PostEdit = () => {
   const {
-    refineCore: { formLoading, queryResult },
+    refineCore: { formLoading, query: queryResult },
     saveButtonProps,
     register,
     formState: { errors },

--- a/examples/theme-mantine-demo/src/pages/posts/edit.tsx
+++ b/examples/theme-mantine-demo/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ export const PostEdit: React.FC = () => {
     saveButtonProps,
     getInputProps,
     errors,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
   } = useForm({
     initialValues: {
       title: "",

--- a/examples/theme-material-ui-demo/src/pages/posts/edit.tsx
+++ b/examples/theme-material-ui-demo/src/pages/posts/edit.tsx
@@ -12,7 +12,7 @@ import type { IPost, ICategory, Nullable, IStatus } from "../../interfaces";
 export const PostEdit: React.FC = () => {
   const {
     saveButtonProps,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
     register,
     control,
     formState: { errors },

--- a/examples/tutorial-antd/src/pages/blog-posts/edit.tsx
+++ b/examples/tutorial-antd/src/pages/blog-posts/edit.tsx
@@ -4,7 +4,7 @@ import { Form, Input, Select, DatePicker } from "antd";
 import dayjs from "dayjs";
 
 export const BlogPostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm();
+  const { formProps, saveButtonProps, query: queryResult } = useForm();
 
   const blogPostsData = queryResult?.data?.data;
 

--- a/examples/tutorial-chakra-ui/src/pages/blog-posts/edit.tsx
+++ b/examples/tutorial-chakra-ui/src/pages/blog-posts/edit.tsx
@@ -12,7 +12,7 @@ import { useSelect } from "@refinedev/core";
 
 export const BlogPostEdit = () => {
   const {
-    refineCore: { formLoading, queryResult },
+    refineCore: { formLoading, query: queryResult },
     saveButtonProps,
     register,
     resetField,

--- a/examples/tutorial-headless/src/pages/blog-posts/edit.tsx
+++ b/examples/tutorial-headless/src/pages/blog-posts/edit.tsx
@@ -6,7 +6,7 @@ export const BlogPostEdit = () => {
   const { list } = useNavigation();
 
   const {
-    refineCore: { onFinish, queryResult },
+    refineCore: { onFinish, query: queryResult },
     register,
     handleSubmit,
     resetField,

--- a/examples/tutorial-mantine/src/pages/blog-posts/edit.tsx
+++ b/examples/tutorial-mantine/src/pages/blog-posts/edit.tsx
@@ -5,7 +5,7 @@ export const BlogPostEdit = () => {
   const {
     getInputProps,
     saveButtonProps,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
   } = useForm({
     initialValues: {
       id: "",

--- a/examples/tutorial-material-ui/src/pages/blog-posts/edit.tsx
+++ b/examples/tutorial-material-ui/src/pages/blog-posts/edit.tsx
@@ -8,7 +8,7 @@ import { Controller } from "react-hook-form";
 export const BlogPostEdit = () => {
   const {
     saveButtonProps,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
     register,
     control,
     formState: { errors },

--- a/examples/upload-antd-multipart/src/pages/posts/edit.tsx
+++ b/examples/upload-antd-multipart/src/pages/posts/edit.tsx
@@ -10,7 +10,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/upload-chakra-ui-basic64/src/pages/posts/edit.tsx
+++ b/examples/upload-chakra-ui-basic64/src/pages/posts/edit.tsx
@@ -22,7 +22,7 @@ import type { IPost } from "../../interfaces";
 
 export const PostEdit = () => {
   const {
-    refineCore: { formLoading, queryResult },
+    refineCore: { formLoading, query: queryResult },
     saveButtonProps,
     register,
     watch,

--- a/examples/upload-chakra-ui-multipart/src/pages/posts/edit.tsx
+++ b/examples/upload-chakra-ui-multipart/src/pages/posts/edit.tsx
@@ -24,7 +24,7 @@ export const PostEdit = () => {
   const [uploading, setUploading] = useState(false);
   const apiUrl = useApiUrl();
   const {
-    refineCore: { formLoading, queryResult },
+    refineCore: { formLoading, query: queryResult },
     saveButtonProps,
     register,
     watch,

--- a/examples/upload-mantine-base64/src/pages/posts/edit.tsx
+++ b/examples/upload-mantine-base64/src/pages/posts/edit.tsx
@@ -31,7 +31,7 @@ export const PostEdit: React.FC = () => {
     setFieldValue,
     values,
     errors,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
   } = useForm<IPost, HttpError, FormValues>({
     initialValues: {
       title: "",

--- a/examples/upload-mantine-multipart/src/pages/posts/edit.tsx
+++ b/examples/upload-mantine-multipart/src/pages/posts/edit.tsx
@@ -36,7 +36,7 @@ export const PostEdit: React.FC = () => {
     setFieldValue,
     values,
     errors,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
   } = useForm<IPost, HttpError, FormValues>({
     initialValues: {
       title: "",

--- a/examples/upload-material-ui-base64/src/pages/posts/edit.tsx
+++ b/examples/upload-material-ui-base64/src/pages/posts/edit.tsx
@@ -19,7 +19,7 @@ export const PostEdit: React.FC = () => {
 
   const {
     saveButtonProps,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
     register,
     control,
     formState: { errors },

--- a/examples/upload-material-ui-multipart/src/pages/posts/edit.tsx
+++ b/examples/upload-material-ui-multipart/src/pages/posts/edit.tsx
@@ -21,7 +21,7 @@ export const PostEdit: React.FC = () => {
   const apiUrl = useApiUrl();
   const {
     saveButtonProps,
-    refineCore: { queryResult },
+    refineCore: { query: queryResult },
     register,
     control,
     formState: { errors },

--- a/examples/win95/src/routes/video-club/members/edit.tsx
+++ b/examples/win95/src/routes/video-club/members/edit.tsx
@@ -19,7 +19,7 @@ export const VideoClubMemberPageEdit = () => {
 
   const {
     control,
-    refineCore: { onFinish, queryResult },
+    refineCore: { onFinish, query: queryResult },
     handleSubmit,
   } = useForm<Member>();
 

--- a/examples/with-custom-pages/src/pages/posts/edit.tsx
+++ b/examples/with-custom-pages/src/pages/posts/edit.tsx
@@ -9,7 +9,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect<ICategory>({

--- a/examples/with-javascript/src/pages/posts/edit.jsx
+++ b/examples/with-javascript/src/pages/posts/edit.jsx
@@ -6,7 +6,7 @@ import { Form, Input, Select } from "antd";
 import MDEditor from "@uiw/react-md-editor";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm();
+  const { formProps, saveButtonProps, query: queryResult } = useForm();
 
   const postData = queryResult?.data?.data;
   const { selectProps: categorySelectProps } = useSelect({

--- a/examples/with-material-ui-vite/src/pages/blog-posts/edit.tsx
+++ b/examples/with-material-ui-vite/src/pages/blog-posts/edit.tsx
@@ -7,7 +7,7 @@ import { Controller } from "react-hook-form";
 export const BlogPostEdit = () => {
   const {
     saveButtonProps,
-    refineCore: { queryResult, formLoading },
+    refineCore: { query: queryResult, formLoading },
     register,
     control,
     formState: { errors },

--- a/examples/with-nextjs-next-auth/src/app/blog-posts/edit/[id]/page.tsx
+++ b/examples/with-nextjs-next-auth/src/app/blog-posts/edit/[id]/page.tsx
@@ -4,7 +4,7 @@ import { Edit, useForm, useSelect } from "@refinedev/antd";
 import { Form, Input, Select } from "antd";
 
 export default function BlogPostEdit() {
-  const { formProps, saveButtonProps, queryResult } = useForm({});
+  const { formProps, saveButtonProps, query: queryResult } = useForm({});
 
   const blogPostsData = queryResult?.data?.data;
 

--- a/examples/with-nextjs/src/app/blog-posts/edit/[id]/page.tsx
+++ b/examples/with-nextjs/src/app/blog-posts/edit/[id]/page.tsx
@@ -4,7 +4,7 @@ import { Edit, useForm, useSelect } from "@refinedev/antd";
 import { Form, Input, Select } from "antd";
 
 export default function BlogPostEdit() {
-  const { formProps, saveButtonProps, queryResult } = useForm({});
+  const { formProps, saveButtonProps, query: queryResult } = useForm({});
 
   const blogPostsData = queryResult?.data?.data;
 

--- a/examples/with-persist-query/src/pages/posts/edit.tsx
+++ b/examples/with-persist-query/src/pages/posts/edit.tsx
@@ -4,7 +4,7 @@ import { useSelect } from "@refinedev/core";
 
 export const PostEdit: React.FC = () => {
   const {
-    refineCore: { onFinish, formLoading, queryResult },
+    refineCore: { onFinish, formLoading, query: queryResult },
     register,
     handleSubmit,
     resetField,

--- a/examples/with-react-toastify/src/pages/posts/edit.tsx
+++ b/examples/with-react-toastify/src/pages/posts/edit.tsx
@@ -4,7 +4,7 @@ import { useSelect } from "@refinedev/core";
 
 export const PostEdit: React.FC = () => {
   const {
-    refineCore: { onFinish, formLoading, queryResult },
+    refineCore: { onFinish, formLoading, query: queryResult },
     register,
     handleSubmit,
     resetField,

--- a/examples/with-remix-antd/app/routes/_protected.posts.edit.$id.tsx
+++ b/examples/with-remix-antd/app/routes/_protected.posts.edit.$id.tsx
@@ -10,7 +10,11 @@ import type { IPost } from "../interfaces";
 const PostEdit: React.FC = () => {
   const { initialData } = useLoaderData<typeof loader>();
 
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>({
+  const {
+    formProps,
+    saveButtonProps,
+    query: queryResult,
+  } = useForm<IPost>({
     queryOptions: {
       initialData,
     },

--- a/examples/with-remix-headless/app/pages/posts/edit.tsx
+++ b/examples/with-remix-headless/app/pages/posts/edit.tsx
@@ -4,7 +4,7 @@ import { useSelect } from "@refinedev/core";
 
 export const PostEdit: React.FC = () => {
   const {
-    refineCore: { onFinish, formLoading, queryResult },
+    refineCore: { onFinish, formLoading, query: queryResult },
     register,
     handleSubmit,
     resetField,

--- a/examples/with-remix-headless/app/routes/_protected.posts.edit.$id.tsx
+++ b/examples/with-remix-headless/app/routes/_protected.posts.edit.$id.tsx
@@ -12,7 +12,7 @@ const PostEdit: React.FC = () => {
   const { initialData } = useLoaderData<typeof loader>();
 
   const {
-    refineCore: { onFinish, formLoading, queryResult },
+    refineCore: { onFinish, formLoading, query: queryResult },
     register,
     handleSubmit,
     resetField,

--- a/examples/with-remix-vite-headless/app/pages/posts/edit.tsx
+++ b/examples/with-remix-vite-headless/app/pages/posts/edit.tsx
@@ -4,7 +4,7 @@ import { useSelect } from "@refinedev/core";
 
 export const PostEdit: React.FC = () => {
   const {
-    refineCore: { onFinish, formLoading, queryResult },
+    refineCore: { onFinish, formLoading, query: queryResult },
     register,
     handleSubmit,
     resetField,

--- a/examples/with-remix-vite-headless/app/routes/_protected.posts.edit.$id.tsx
+++ b/examples/with-remix-vite-headless/app/routes/_protected.posts.edit.$id.tsx
@@ -12,7 +12,7 @@ const PostEdit: React.FC = () => {
   const { initialData } = useLoaderData<typeof loader>();
 
   const {
-    refineCore: { onFinish, formLoading, queryResult },
+    refineCore: { onFinish, formLoading, query: queryResult },
     register,
     handleSubmit,
     resetField,

--- a/examples/with-web3/src/pages/posts/edit.tsx
+++ b/examples/with-web3/src/pages/posts/edit.tsx
@@ -8,7 +8,7 @@ import MDEditor from "@uiw/react-md-editor";
 import type { IPost } from "../../interfaces";
 
 export const PostEdit = () => {
-  const { formProps, saveButtonProps, queryResult } = useForm<IPost>();
+  const { formProps, saveButtonProps, query: queryResult } = useForm<IPost>();
 
   const { selectProps: categorySelectProps } = useSelect<IPost>({
     resource: "categories",


### PR DESCRIPTION
The `use-form-query-and-mutation-result`(#6164) `codemod` is executed twice for all examples.