### PR TITLE
chore: run codemod `use-table-query-result` for all examples

### DIFF
--- a/examples/app-crm/src/routes/companies/list.tsx
+++ b/examples/app-crm/src/routes/companies/list.tsx
@@ -26,7 +26,7 @@ export const CompanyListPage: FC<PropsWithChildren> = ({ children }) => {
 
   const {
     tableProps,
-    tableQueryResult,
+    tableQuery: tableQueryResult,
     searchFormProps,
     filters,
     sorters,

--- a/examples/app-crm/src/routes/contacts/list.tsx
+++ b/examples/app-crm/src/routes/contacts/list.tsx
@@ -33,7 +33,7 @@ export const ContactsListPage: React.FC<Props> = ({ children }) => {
     filters,
     sorters,
     setFilters,
-    tableQueryResult,
+    tableQuery: tableQueryResult,
   } = useTable<
     GetFieldsFromList<ContactsListQuery>,
     HttpError,

--- a/examples/app-crm/src/routes/quotes/list.tsx
+++ b/examples/app-crm/src/routes/quotes/list.tsx
@@ -53,44 +53,49 @@ const statusOptions: { label: string; value: QuoteStatus }[] = [
 export const QuotesListPage: FC<PropsWithChildren> = ({ children }) => {
   const screens = Grid.useBreakpoint();
 
-  const { tableProps, searchFormProps, filters, sorters, tableQueryResult } =
-    useTable<Quote, HttpError, { title: string }>({
-      resource: "quotes",
-      onSearch: (values) => {
-        return [
-          {
-            field: "title",
-            operator: "contains",
-            value: values.title,
-          },
-        ];
-      },
-      filters: {
-        initial: [
-          {
-            field: "title",
-            value: "",
-            operator: "contains",
-          },
-          {
-            field: "status",
-            value: undefined,
-            operator: "in",
-          },
-        ],
-      },
-      sorters: {
-        initial: [
-          {
-            field: "createdAt",
-            order: "desc",
-          },
-        ],
-      },
-      meta: {
-        gqlQuery: QUOTES_TABLE_QUERY,
-      },
-    });
+  const {
+    tableProps,
+    searchFormProps,
+    filters,
+    sorters,
+    tableQuery: tableQueryResult,
+  } = useTable<Quote, HttpError, { title: string }>({
+    resource: "quotes",
+    onSearch: (values) => {
+      return [
+        {
+          field: "title",
+          operator: "contains",
+          value: values.title,
+        },
+      ];
+    },
+    filters: {
+      initial: [
+        {
+          field: "title",
+          value: "",
+          operator: "contains",
+        },
+        {
+          field: "status",
+          value: undefined,
+          operator: "in",
+        },
+      ],
+    },
+    sorters: {
+      initial: [
+        {
+          field: "createdAt",
+          order: "desc",
+        },
+      ],
+    },
+    meta: {
+      gqlQuery: QUOTES_TABLE_QUERY,
+    },
+  });
 
   const { selectProps: selectPropsCompanies } = useCompaniesSelect();
 

--- a/examples/audit-log-provider/src/pages/posts/list.tsx
+++ b/examples/audit-log-provider/src/pages/posts/list.tsx
@@ -8,7 +8,7 @@ import type { IPost } from "../../interfaces";
 export const PostList: React.FC = () => {
   const { show, close, visible } = useModal();
   const [historyId, setHistoryId] = useState<number>();
-  const { tableQueryResult } = useTable<IPost>({
+  const { tableQuery: tableQueryResult } = useTable<IPost>({
     initialSorter: [
       {
         field: "id",

--- a/examples/auth-chakra-ui/src/pages/posts/list.tsx
+++ b/examples/auth-chakra-ui/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/auth-mantine/src/pages/posts/list.tsx
+++ b/examples/auth-mantine/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/base-chakra-ui/src/pages/posts/list.tsx
+++ b/examples/base-chakra-ui/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/base-mantine/src/pages/posts/list.tsx
+++ b/examples/base-mantine/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/blog-ecommerce/pages/index.tsx
+++ b/examples/blog-ecommerce/pages/index.tsx
@@ -13,15 +13,20 @@ type ItemProps = {
 };
 
 export const ProductList: React.FC<ItemProps> = ({ products, stores }) => {
-  const { tableQueryResult, setFilters, current, setCurrent, pageSize } =
-    useTable<IProduct>({
-      resource: "products",
-      queryOptions: {
-        initialData: products,
-      },
-      initialPageSize: 9,
-      metaData: { populate: ["image"] },
-    });
+  const {
+    tableQuery: tableQueryResult,
+    setFilters,
+    current,
+    setCurrent,
+    pageSize,
+  } = useTable<IProduct>({
+    resource: "products",
+    queryOptions: {
+      initialData: products,
+    },
+    initialPageSize: 9,
+    metaData: { populate: ["image"] },
+  });
 
   const totalPageCount = Math.ceil(
     (tableQueryResult.data?.total ?? 0) / pageSize,

--- a/examples/blog-next-refine-pwa/pages/index.tsx
+++ b/examples/blog-next-refine-pwa/pages/index.tsx
@@ -17,7 +17,7 @@ type ItemProp = {
 };
 
 const ProductList: React.FC<ItemProp> = ({ products }) => {
-  const { tableQueryResult } = useTable<IProduct>({
+  const { tableQuery: tableQueryResult } = useTable<IProduct>({
     resource: "products",
     queryOptions: {
       initialData: products,

--- a/examples/blog-refine-airtable-crud/src/pages/post/list.tsx
+++ b/examples/blog-refine-airtable-crud/src/pages/post/list.tsx
@@ -94,7 +94,7 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
     getState,
     setPageIndex,

--- a/examples/blog-refine-nextui/src/components/table/RecentSalesTable.tsx
+++ b/examples/blog-refine-nextui/src/components/table/RecentSalesTable.tsx
@@ -64,7 +64,7 @@ const getChipColor = (status: number) => {
 
 export const RecentSalesTable = () => {
   const {
-    tableQueryResult,
+    tableQuery: tableQueryResult,
     pageCount,
     current,
     pageSize,

--- a/examples/blog-refine-nextui/src/pages/categories/list.tsx
+++ b/examples/blog-refine-nextui/src/pages/categories/list.tsx
@@ -44,7 +44,7 @@ const columns = [
 
 export const CategoryList = () => {
   const {
-    tableQueryResult,
+    tableQuery: tableQueryResult,
     pageCount,
     current,
     pageSize,

--- a/examples/blog-refine-nextui/src/pages/products/list.tsx
+++ b/examples/blog-refine-nextui/src/pages/products/list.tsx
@@ -49,7 +49,7 @@ const columns = [
 
 export const ProductList = () => {
   const {
-    tableQueryResult,
+    tableQuery: tableQueryResult,
     pageCount,
     current,
     pageSize,

--- a/examples/blog-refine-primereact/src/components/dashboard/recentSales/index.tsx
+++ b/examples/blog-refine-primereact/src/components/dashboard/recentSales/index.tsx
@@ -11,7 +11,7 @@ import type { IOrder, IOrderStatus } from "../../../interfaces";
 
 export const RecentSales = () => {
   const {
-    tableQueryResult,
+    tableQuery: tableQueryResult,
     pageCount,
     current,
     pageSize,

--- a/examples/blog-refine-primereact/src/pages/categories/list.tsx
+++ b/examples/blog-refine-primereact/src/pages/categories/list.tsx
@@ -16,7 +16,7 @@ import type { ICategory } from "../../interfaces";
 
 export const CategoryList = () => {
   const {
-    tableQueryResult,
+    tableQuery: tableQueryResult,
     pageCount,
     current,
     pageSize,

--- a/examples/blog-refine-primereact/src/pages/products/list.tsx
+++ b/examples/blog-refine-primereact/src/pages/products/list.tsx
@@ -24,7 +24,7 @@ const formatCurrency = (value: number) => {
 
 export const ProductList = () => {
   const {
-    tableQueryResult,
+    tableQuery: tableQueryResult,
     pageCount,
     current,
     pageSize,

--- a/examples/blog-refine-tremor/src/pages/dashboard/details/index.tsx
+++ b/examples/blog-refine-tremor/src/pages/dashboard/details/index.tsx
@@ -126,7 +126,7 @@ export const Details = () => {
     getHeaderGroups,
     getRowModel,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
     getState,
     setPageIndex,

--- a/examples/blog-win95/src/pages/categories/list.tsx
+++ b/examples/blog-win95/src/pages/categories/list.tsx
@@ -16,7 +16,7 @@ import {
 import type { ICategory } from "../../interfaces";
 
 export const CategoryList = () => {
-  const { tableQueryResult } = useTable<ICategory>({
+  const { tableQuery: tableQueryResult } = useTable<ICategory>({
     resource: "categories",
   });
 

--- a/examples/blog-win95/src/pages/posts/list.tsx
+++ b/examples/blog-win95/src/pages/posts/list.tsx
@@ -97,7 +97,7 @@ export const PostList = () => {
     setPageIndex,
     setPageSize,
     refineCore: {
-      tableQueryResult: { isLoading },
+      tableQuery: { isLoading },
     },
   } = useTable<IPost>({
     columns,

--- a/examples/customization-offlayout-area/src/components/sider/index.tsx
+++ b/examples/customization-offlayout-area/src/components/sider/index.tsx
@@ -126,7 +126,6 @@ export const FixedSider: React.FC = () => {
       >
         <ThemedTitle collapsed={collapsed} />
       </div>
-
       <Menu
         style={{
           marginTop: "8px",

--- a/examples/customization-theme-chakra-ui/src/pages/posts/list.tsx
+++ b/examples/customization-theme-chakra-ui/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/customization-theme-mantine/src/pages/posts/list.tsx
+++ b/examples/customization-theme-mantine/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/finefoods-antd/src/pages/couriers/list.tsx
+++ b/examples/finefoods-antd/src/pages/couriers/list.tsx
@@ -221,8 +221,8 @@ export const CourierList = ({ children }: PropsWithChildren) => {
               <FilterDropdown {...props}>
                 <InputMask mask="(999) 999 99 99">
                   {/* 
-                                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                                    // @ts-ignore */}
+                                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                  // @ts-ignore */}
                   {(props: InputProps) => <Input {...props} />}
                 </InputMask>
               </FilterDropdown>

--- a/examples/finefoods-material-ui/src/components/dashboard/orderTimeline/index.tsx
+++ b/examples/finefoods-material-ui/src/components/dashboard/orderTimeline/index.tsx
@@ -15,19 +15,22 @@ export const OrderTimeline: React.FC = () => {
 
   const { show } = useNavigation();
 
-  const { tableQueryResult, current, setCurrent, pageCount } = useTable<IOrder>(
-    {
-      resource: "orders",
-      initialSorter: [
-        {
-          field: "createdAt",
-          order: "desc",
-        },
-      ],
-      initialPageSize: 7,
-      syncWithLocation: false,
-    },
-  );
+  const {
+    tableQuery: tableQueryResult,
+    current,
+    setCurrent,
+    pageCount,
+  } = useTable<IOrder>({
+    resource: "orders",
+    initialSorter: [
+      {
+        field: "createdAt",
+        order: "desc",
+      },
+    ],
+    initialPageSize: 7,
+    syncWithLocation: false,
+  });
 
   const { data } = tableQueryResult;
 

--- a/examples/form-chakra-ui-mutation-mode/src/pages/posts/list.tsx
+++ b/examples/form-chakra-ui-mutation-mode/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-chakra-ui-use-drawer-form/src/pages/posts/list.tsx
+++ b/examples/form-chakra-ui-use-drawer-form/src/pages/posts/list.tsx
@@ -136,7 +136,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-chakra-ui-use-form/src/pages/posts/list.tsx
+++ b/examples/form-chakra-ui-use-form/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-chakra-use-modal-form/src/pages/posts/list.tsx
+++ b/examples/form-chakra-use-modal-form/src/pages/posts/list.tsx
@@ -135,7 +135,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-mantine-mutation-mode/src/pages/posts/list.tsx
+++ b/examples/form-mantine-mutation-mode/src/pages/posts/list.tsx
@@ -104,7 +104,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-mantine-use-drawer-form/src/pages/posts/list.tsx
+++ b/examples/form-mantine-use-drawer-form/src/pages/posts/list.tsx
@@ -157,7 +157,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-mantine-use-form/src/pages/posts/list.tsx
+++ b/examples/form-mantine-use-form/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-mantine-use-modal-form/src/pages/posts/list.tsx
+++ b/examples/form-mantine-use-modal-form/src/pages/posts/list.tsx
@@ -157,7 +157,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-mantine-use-steps-form/src/pages/posts/list.tsx
+++ b/examples/form-mantine-use-steps-form/src/pages/posts/list.tsx
@@ -104,7 +104,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/form-react-hook-form-use-form/src/pages/posts/list.tsx
+++ b/examples/form-react-hook-form-use-form/src/pages/posts/list.tsx
@@ -3,7 +3,7 @@ import { useTable, useNavigation } from "@refinedev/core";
 import type { IPost } from "../../interfaces";
 
 export const PostList: React.FC = () => {
-  const { tableQueryResult } = useTable<IPost>({
+  const { tableQuery: tableQueryResult } = useTable<IPost>({
     initialSorter: [
       {
         field: "id",

--- a/examples/form-react-hook-form-use-modal-form/src/pages/posts/list.tsx
+++ b/examples/form-react-hook-form-use-modal-form/src/pages/posts/list.tsx
@@ -5,7 +5,7 @@ import { CreatePost, EditPost } from "../../components";
 import type { IPost } from "../../interfaces";
 
 export const PostList: React.FC = () => {
-  const { tableQueryResult } = useTable<IPost>({
+  const { tableQuery: tableQueryResult } = useTable<IPost>({
     initialSorter: [
       {
         field: "id",

--- a/examples/form-react-hook-form-use-steps-form/src/pages/posts/list.tsx
+++ b/examples/form-react-hook-form-use-steps-form/src/pages/posts/list.tsx
@@ -3,7 +3,7 @@ import { useTable, useNavigation, useMany } from "@refinedev/core";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostList: React.FC = () => {
-  const { tableQueryResult } = useTable<IPost>({
+  const { tableQuery: tableQueryResult } = useTable<IPost>({
     initialSorter: [
       {
         field: "id",

--- a/examples/form-save-and-continue/src/pages/posts/list.tsx
+++ b/examples/form-save-and-continue/src/pages/posts/list.tsx
@@ -3,7 +3,7 @@ import { useTable, useNavigation } from "@refinedev/core";
 import type { IPost } from "../../interfaces";
 
 export const PostList: React.FC = () => {
-  const { tableQueryResult } = useTable<IPost>({
+  const { tableQuery: tableQueryResult } = useTable<IPost>({
     initialSorter: [
       {
         field: "id",

--- a/examples/import-export-mantine/src/pages/posts/list.tsx
+++ b/examples/import-export-mantine/src/pages/posts/list.tsx
@@ -115,7 +115,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/mern-dashboard-client/src/pages/all-properties.tsx
+++ b/examples/mern-dashboard-client/src/pages/all-properties.tsx
@@ -15,7 +15,7 @@ const AllProperties = () => {
   const navigate = useNavigate();
 
   const {
-    tableQueryResult: { data, isLoading, isError },
+    tableQuery: { data, isLoading, isError },
     current,
     setCurrent,
     setPageSize,

--- a/examples/server-side-form-validation-chakra-ui/src/pages/posts/list.tsx
+++ b/examples/server-side-form-validation-chakra-ui/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/server-side-form-validation-mantine/src/pages/posts/list.tsx
+++ b/examples/server-side-form-validation-mantine/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/store/pages/index.tsx
+++ b/examples/store/pages/index.tsx
@@ -59,7 +59,7 @@ const Home = ({
   const selectedCategoryId = selectedCategory?.id;
 
   const {
-    tableQueryResult: { data: products, isLoading, isFetching },
+    tableQuery: { data: products, isLoading, isFetching },
     filters,
     setFilters,
   } = useTable<Product>({

--- a/examples/table-chakra-ui-advanced/src/pages/posts/list.tsx
+++ b/examples/table-chakra-ui-advanced/src/pages/posts/list.tsx
@@ -229,7 +229,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/table-chakra-ui-basic/src/pages/posts/list.tsx
+++ b/examples/table-chakra-ui-basic/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/table-handson/src/pages/posts/list.tsx
+++ b/examples/table-handson/src/pages/posts/list.tsx
@@ -25,7 +25,7 @@ export const PostList = () => {
   });
 
   const {
-    tableQueryResult: {
+    tableQuery: {
       data: { data } = { data: [] },
     },
   } = useTable<IPost>({

--- a/examples/table-mantine-advanced/src/pages/posts/list.tsx
+++ b/examples/table-mantine-advanced/src/pages/posts/list.tsx
@@ -194,7 +194,7 @@ export const PostList: React.FC = () => {
     getRowModel,
     resetRowSelection,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
       setCurrent,
       pageCount,
       current,

--- a/examples/table-mantine-basic/src/pages/posts/list.tsx
+++ b/examples/table-mantine-basic/src/pages/posts/list.tsx
@@ -103,7 +103,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/table-material-ui-advanced/src/pages/table/index.tsx
+++ b/examples/table-material-ui-advanced/src/pages/table/index.tsx
@@ -182,7 +182,7 @@ export const PostList: React.FC = () => {
     getSelectedRowModel,
     resetRowSelection,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable<IPost>({
     columns,

--- a/examples/table-material-ui-cursor-pagination/src/pages/posts/list.tsx
+++ b/examples/table-material-ui-cursor-pagination/src/pages/posts/list.tsx
@@ -7,7 +7,7 @@ import type { ICommit } from "../../interfaces";
 
 export const PostList: React.FC = () => {
   const [next, setNext] = React.useState<string | undefined>(undefined);
-  const { dataGridProps, tableQueryResult } = useDataGrid<ICommit>({
+  const { dataGridProps, tableQuery: tableQueryResult } = useDataGrid<ICommit>({
     initialPageSize: 5,
     metaData: {
       cursor: {

--- a/examples/table-react-table-advanced/src/pages/posts/list.tsx
+++ b/examples/table-react-table-advanced/src/pages/posts/list.tsx
@@ -193,7 +193,7 @@ export const PostList: React.FC = () => {
     previousPage,
     resetRowSelection,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable<IPost>({
     columns,

--- a/examples/theme-chakra-ui-demo/src/pages/posts/list.tsx
+++ b/examples/theme-chakra-ui-demo/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/theme-mantine-demo/src/pages/posts/list.tsx
+++ b/examples/theme-mantine-demo/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/tutorial-chakra-ui/src/pages/blog-posts/list.tsx
+++ b/examples/tutorial-chakra-ui/src/pages/blog-posts/list.tsx
@@ -117,7 +117,7 @@ export const BlogPostList = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/tutorial-headless/src/pages/blog-posts/list.tsx
+++ b/examples/tutorial-headless/src/pages/blog-posts/list.tsx
@@ -124,7 +124,7 @@ export const BlogPostList = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
     getState,
     setPageIndex,

--- a/examples/tutorial-mantine/src/pages/blog-posts/list.tsx
+++ b/examples/tutorial-mantine/src/pages/blog-posts/list.tsx
@@ -102,7 +102,7 @@ export const BlogPostList = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/upload-chakra-ui-basic64/src/pages/posts/list.tsx
+++ b/examples/upload-chakra-ui-basic64/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/upload-chakra-ui-multipart/src/pages/posts/list.tsx
+++ b/examples/upload-chakra-ui-multipart/src/pages/posts/list.tsx
@@ -130,7 +130,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/upload-mantine-base64/src/pages/posts/list.tsx
+++ b/examples/upload-mantine-base64/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/upload-mantine-multipart/src/pages/posts/list.tsx
+++ b/examples/upload-mantine-multipart/src/pages/posts/list.tsx
@@ -111,7 +111,7 @@ export const PostList: React.FC = () => {
       setCurrent,
       pageCount,
       current,
-      tableQueryResult: { data: tableData },
+      tableQuery: { data: tableData },
     },
   } = useTable({
     columns,

--- a/examples/win95/src/components/table-members/index.tsx
+++ b/examples/win95/src/components/table-members/index.tsx
@@ -29,7 +29,7 @@ export const TableMembers = ({ selectedMember, setSelectedMember }: Props) => {
   const navigate = useNavigate();
 
   const {
-    tableQueryResult: membersQueryResult,
+    tableQuery: membersQueryResult,
     pageCount,
     current,
     setCurrent,

--- a/examples/win95/src/routes/video-club/members/list.tsx
+++ b/examples/win95/src/routes/video-club/members/list.tsx
@@ -25,7 +25,7 @@ export const VideoClubMemberPageList = () => {
   const navigate = useNavigate();
 
   const {
-    tableQueryResult: membersQueryResult,
+    tableQuery: membersQueryResult,
     pageCount,
     current,
     setCurrent,

--- a/examples/win95/src/routes/video-club/tapes/select-member.tsx
+++ b/examples/win95/src/routes/video-club/tapes/select-member.tsx
@@ -40,7 +40,7 @@ export const VideoClubPageTapeSelectMember = (props: Props) => {
   const { create } = useNavigation();
 
   const {
-    tableQueryResult: membersQueryResult,
+    tableQuery: membersQueryResult,
     pageCount,
     current,
     setCurrent,

--- a/examples/win95/src/routes/video-club/tapes/select-title.tsx
+++ b/examples/win95/src/routes/video-club/tapes/select-title.tsx
@@ -48,7 +48,7 @@ export const VideoClubPageTapeSelectTitle = ({
   const navigate = useNavigate();
 
   const {
-    tableQueryResult: titlesQueryResult,
+    tableQuery: titlesQueryResult,
     pageCount,
     current,
     setCurrent,

--- a/examples/win95/src/routes/video-club/titles/list.tsx
+++ b/examples/win95/src/routes/video-club/titles/list.tsx
@@ -23,7 +23,7 @@ export const VideoClubPageBrowseTitles = () => {
   const navigate = useNavigate();
 
   const {
-    tableQueryResult: titlesQueryResult,
+    tableQuery: titlesQueryResult,
     pageCount,
     current,
     setCurrent,

--- a/examples/with-persist-query/src/pages/posts/list.tsx
+++ b/examples/with-persist-query/src/pages/posts/list.tsx
@@ -61,7 +61,7 @@ export const PostList: React.FC = () => {
     previousPage,
     setPageSize,
     getColumn,
-    refineCore: { tableQueryResult },
+    refineCore: { tableQuery: tableQueryResult },
   } = useTable<IPost>({ columns });
   console.log({ tableQueryResult });
   const titleColumn = getColumn("title");


### PR DESCRIPTION
The `use-table-query-result`(#6190) `codemod` is executed twice for all examples.