### PR TITLE
chore: run codemod `use-show-query-result` for all examples

### DIFF
--- a/examples/access-control-casbin/src/pages/categories/show.tsx
+++ b/examples/access-control-casbin/src/pages/categories/show.tsx
@@ -9,7 +9,7 @@ import type { ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const CategoryShow = () => {
-  const { queryResult } = useShow<ICategory>();
+  const { query: queryResult } = useShow<ICategory>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/access-control-casbin/src/pages/posts/show.tsx
+++ b/examples/access-control-casbin/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/access-control-casbin/src/pages/users/show.tsx
+++ b/examples/access-control-casbin/src/pages/users/show.tsx
@@ -9,7 +9,7 @@ import type { IUser } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const UserShow = () => {
-  const { queryResult } = useShow<IUser>();
+  const { query: queryResult } = useShow<IUser>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/access-control-cerbos/src/pages/categories/show.tsx
+++ b/examples/access-control-cerbos/src/pages/categories/show.tsx
@@ -9,7 +9,7 @@ import type { ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const CategoryShow = () => {
-  const { queryResult } = useShow<ICategory>();
+  const { query: queryResult } = useShow<ICategory>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/access-control-cerbos/src/pages/posts/show.tsx
+++ b/examples/access-control-cerbos/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/access-control-cerbos/src/pages/users/show.tsx
+++ b/examples/access-control-cerbos/src/pages/users/show.tsx
@@ -9,7 +9,7 @@ import type { IUser } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const UserShow = () => {
-  const { queryResult } = useShow<IUser>();
+  const { query: queryResult } = useShow<IUser>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/access-control-permify/src/pages/categories/show.tsx
+++ b/examples/access-control-permify/src/pages/categories/show.tsx
@@ -9,7 +9,7 @@ import type { ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const CategoryShow = () => {
-  const { queryResult } = useShow<ICategory>();
+  const { query: queryResult } = useShow<ICategory>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/access-control-permify/src/pages/posts/show.tsx
+++ b/examples/access-control-permify/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/access-control-permify/src/pages/users/show.tsx
+++ b/examples/access-control-permify/src/pages/users/show.tsx
@@ -9,7 +9,7 @@ import type { IUser } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const UserShow = () => {
-  const { queryResult } = useShow<IUser>();
+  const { query: queryResult } = useShow<IUser>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/app-crm/src/routes/calendar/show.tsx
+++ b/examples/app-crm/src/routes/calendar/show.tsx
@@ -25,7 +25,7 @@ export const CalendarShowPage: React.FC = () => {
   const { id } = useResource();
   const { list } = useNavigation();
 
-  const { queryResult } = useShow<Event>({
+  const { query: queryResult } = useShow<Event>({
     id,
     meta: {
       gqlQuery: CALENDAR_GET_EVENT_QUERY,

--- a/examples/app-crm/src/routes/companies/components/info-form.tsx
+++ b/examples/app-crm/src/routes/companies/components/info-form.tsx
@@ -36,7 +36,7 @@ export const CompanyInfoForm = () => {
     | "website"
   >();
 
-  const { queryResult } = useShow<Company>({
+  const { query: queryResult } = useShow<Company>({
     meta: {
       gqlQuery: COMPANY_INFO_QUERY,
     },

--- a/examples/app-crm/src/routes/contacts/show/index.tsx
+++ b/examples/app-crm/src/routes/contacts/show/index.tsx
@@ -56,7 +56,7 @@ export const ContactShowPage: React.FC = () => {
   const { list } = useNavigation();
   const { mutate } = useUpdate<Contact>();
   const { mutate: deleteMutation } = useDelete<Contact>();
-  const { queryResult } = useShow<GetFields<ContactShowQuery>>({
+  const { query: queryResult } = useShow<GetFields<ContactShowQuery>>({
     meta: {
       gqlQuery: CONTACT_SHOW_QUERY,
     },

--- a/examples/app-crm/src/routes/scrumboard/kanban/edit.tsx
+++ b/examples/app-crm/src/routes/scrumboard/kanban/edit.tsx
@@ -39,7 +39,7 @@ export const KanbanEditPage = () => {
   });
 
   const {
-    queryResult: { data, isLoading },
+    query: { data, isLoading },
   } = useShow<GetFields<KanbanGetTaskQuery>>({
     meta: { gqlQuery: KANBAN_GET_TASK_QUERY },
   });

--- a/examples/auth-antd/src/pages/posts/show.tsx
+++ b/examples/auth-antd/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/auth-auth0/src/pages/posts/show.tsx
+++ b/examples/auth-auth0/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/auth-chakra-ui/src/pages/posts/show.tsx
+++ b/examples/auth-chakra-ui/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Heading, Text, Spacer } from "@chakra-ui/react";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/auth-google-login/src/pages/posts/show.tsx
+++ b/examples/auth-google-login/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/auth-keycloak/src/pages/posts/show.tsx
+++ b/examples/auth-keycloak/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/auth-mantine/src/pages/posts/show.tsx
+++ b/examples/auth-mantine/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Title, Text } from "@mantine/core";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/auth-otp/src/pages/posts/show.tsx
+++ b/examples/auth-otp/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/base-antd/src/pages/posts/show.tsx
+++ b/examples/base-antd/src/pages/posts/show.tsx
@@ -8,7 +8,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/base-chakra-ui/src/pages/posts/show.tsx
+++ b/examples/base-chakra-ui/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Heading, Text, Spacer } from "@chakra-ui/react";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/base-mantine/src/pages/posts/show.tsx
+++ b/examples/base-mantine/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Title, Text, Badge, Flex } from "@mantine/core";
 import type { ICategory, IPost, ITag } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/base-material-ui/src/pages/posts/show.tsx
+++ b/examples/base-material-ui/src/pages/posts/show.tsx
@@ -10,7 +10,7 @@ import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
 
 export const PostShow = () => {
-  const { queryResult } = useShow();
+  const { query: queryResult } = useShow();
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/blog-issue-tracker/src/pages/task/show.tsx
+++ b/examples/blog-issue-tracker/src/pages/task/show.tsx
@@ -6,7 +6,7 @@ import type { ITask, ILabel, IPriority, IStatus, IAuthUser } from "interfaces";
 const { Title, Text } = Typography;
 
 export const TaskShow: React.FC = () => {
-  const { queryResult } = useShow<ITask>();
+  const { query: queryResult } = useShow<ITask>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/blog-job-posting/src/pages/companies/show.tsx
+++ b/examples/blog-job-posting/src/pages/companies/show.tsx
@@ -8,7 +8,7 @@ import type { ICompany } from "interfaces";
 const { Title, Text, Paragraph } = Typography;
 
 export const CompanyShow = () => {
-  const { queryResult } = useShow<ICompany>();
+  const { query: queryResult } = useShow<ICompany>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/blog-job-posting/src/pages/jobs/show.tsx
+++ b/examples/blog-job-posting/src/pages/jobs/show.tsx
@@ -8,7 +8,7 @@ import type { ICompany } from "interfaces";
 const { Title, Text, Paragraph } = Typography;
 
 export const CompanyShow = () => {
-  const { queryResult } = useShow<ICompany>();
+  const { query: queryResult } = useShow<ICompany>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/blog-ra-chakra-tutorial/src/pages/posts/show.tsx
+++ b/examples/blog-ra-chakra-tutorial/src/pages/posts/show.tsx
@@ -3,7 +3,7 @@ import { Show, NumberField, TextField, DateField } from "@refinedev/chakra-ui";
 import { Heading } from "@chakra-ui/react";
 
 export const PostShow = () => {
-  const { queryResult } = useShow({
+  const { query: queryResult } = useShow({
     metaData: {
       populate: ["category"],
     },

--- a/examples/blog-react-dnd/src/pages/posts/show.tsx
+++ b/examples/blog-react-dnd/src/pages/posts/show.tsx
@@ -7,7 +7,7 @@ import type { IPost, ICategory } from "interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/blog-refine-airtable-crud/src/pages/post/show.tsx
+++ b/examples/blog-refine-airtable-crud/src/pages/post/show.tsx
@@ -3,7 +3,7 @@ import { useShow } from "@refinedev/core";
 import type { IPost } from "../../interfaces/post";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data } = queryResult;
   const record = data?.data;
 

--- a/examples/blog-refine-daisyui/src/pages/categories/show.tsx
+++ b/examples/blog-refine-daisyui/src/pages/categories/show.tsx
@@ -6,7 +6,7 @@ import type { ICategory } from "../../interfaces";
 export const CategoryShow = () => {
   const { edit, list } = useNavigation();
   const {
-    queryResult: { data },
+    query: { data },
   } = useShow<ICategory>();
 
   const record = data?.data;

--- a/examples/blog-refine-daisyui/src/pages/products/show.tsx
+++ b/examples/blog-refine-daisyui/src/pages/products/show.tsx
@@ -6,7 +6,7 @@ import type { IProduct } from "../../interfaces";
 export const ProductShow = () => {
   const { edit, list } = useNavigation();
   const {
-    queryResult: { data },
+    query: { data },
   } = useShow<IProduct>();
 
   const record = data?.data;

--- a/examples/blog-refine-digital-ocean/src/pages/companies/show.tsx
+++ b/examples/blog-refine-digital-ocean/src/pages/companies/show.tsx
@@ -6,7 +6,7 @@ import { Typography } from "antd";
 const { Title } = Typography;
 
 export const CompanyShow = () => {
-  const { queryResult } = useShow({
+  const { query: queryResult } = useShow({
     meta: {
       fields: [
         "id",

--- a/examples/blog-refine-digital-ocean/src/pages/contacts/show.tsx
+++ b/examples/blog-refine-digital-ocean/src/pages/contacts/show.tsx
@@ -6,7 +6,7 @@ import { Typography } from "antd";
 const { Title } = Typography;
 
 export const ContactShow = () => {
-  const { queryResult } = useShow({
+  const { query: queryResult } = useShow({
     meta: {
       fields: [
         "id",

--- a/examples/blog-refine-markdown/src/pages/posts/show.tsx
+++ b/examples/blog-refine-markdown/src/pages/posts/show.tsx
@@ -7,7 +7,7 @@ import { Tag, Typography } from "antd";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/blog-refine-mui/src/pages/categories/show.tsx
+++ b/examples/blog-refine-mui/src/pages/categories/show.tsx
@@ -11,7 +11,7 @@ import Stack from "@mui/material/Box";
 
 export const CategoryShow = () => {
   const translate = useTranslate();
-  const { queryResult } = useShow();
+  const { query: queryResult } = useShow();
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/blog-refine-mui/src/pages/products/show.tsx
+++ b/examples/blog-refine-mui/src/pages/products/show.tsx
@@ -13,7 +13,7 @@ import Stack from "@mui/material/Stack";
 
 export const ProductShow = () => {
   const translate = useTranslate();
-  const { queryResult } = useShow();
+  const { query: queryResult } = useShow();
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/blog-refine-nextui/src/pages/categories/show.tsx
+++ b/examples/blog-refine-nextui/src/pages/categories/show.tsx
@@ -7,7 +7,7 @@ import { ArrowLongLeftIcon } from "@heroicons/react/24/outline";
 export const CategoryShow = () => {
   const goBack = useBack();
 
-  const { queryResult } = useShow<ICategory>();
+  const { query: queryResult } = useShow<ICategory>();
 
   const category = queryResult?.data?.data;
 

--- a/examples/blog-refine-nextui/src/pages/products/show.tsx
+++ b/examples/blog-refine-nextui/src/pages/products/show.tsx
@@ -12,7 +12,7 @@ const currencyFormatter = Intl.NumberFormat("en-US", {
 export const ProductShow = () => {
   const goBack = useBack();
 
-  const { queryResult } = useShow<IProduct>();
+  const { query: queryResult } = useShow<IProduct>();
   const product = queryResult?.data?.data;
 
   const { data: categoryData } = useOne<ICategory>({

--- a/examples/blog-refine-primereact/src/pages/categories/show.tsx
+++ b/examples/blog-refine-primereact/src/pages/categories/show.tsx
@@ -8,7 +8,7 @@ import type { ICategory } from "../../interfaces";
 export const CategoryShow = () => {
   const goBack = useBack();
 
-  const { queryResult } = useShow<ICategory>();
+  const { query: queryResult } = useShow<ICategory>();
   const category = queryResult?.data?.data;
 
   return (

--- a/examples/blog-refine-primereact/src/pages/products/show.tsx
+++ b/examples/blog-refine-primereact/src/pages/products/show.tsx
@@ -8,7 +8,7 @@ import type { ICategory, IProduct } from "../../interfaces";
 export const ProductShow = () => {
   const goBack = useBack();
 
-  const { queryResult } = useShow<IProduct>();
+  const { query: queryResult } = useShow<IProduct>();
   const product = queryResult?.data?.data;
 
   const { data: categoryData } = useOne<ICategory>({

--- a/examples/blog-refine-shadcn/src/pages/blog-posts/show.tsx
+++ b/examples/blog-refine-shadcn/src/pages/blog-posts/show.tsx
@@ -13,7 +13,7 @@ import { ChevronLeft, EditIcon, ListIcon } from "lucide-react";
 export const BlogPostShow: React.FC<IResourceComponentsProps> = () => {
   const { edit, list } = useNavigation();
   const { id } = useResource();
-  const { queryResult } = useShow({
+  const { query: queryResult } = useShow({
     meta: {
       populate: ["category"],
     },

--- a/examples/blog-refine-shadcn/src/pages/categories/show.tsx
+++ b/examples/blog-refine-shadcn/src/pages/categories/show.tsx
@@ -11,7 +11,7 @@ import React from "react";
 export const CategoryShow: React.FC<IResourceComponentsProps> = () => {
   const { edit, list } = useNavigation();
   const { id } = useResource();
-  const { queryResult } = useShow({});
+  const { query: queryResult } = useShow({});
   const { data } = queryResult;
 
   const record = data?.data;

--- a/examples/command-palette-kbar/src/pages/posts/show.tsx
+++ b/examples/command-palette-kbar/src/pages/posts/show.tsx
@@ -8,7 +8,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/customization-login/src/pages/posts/show.tsx
+++ b/examples/customization-login/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/customization-offlayout-area/src/components/sider/index.tsx
+++ b/examples/customization-offlayout-area/src/components/sider/index.tsx
@@ -126,7 +126,6 @@ export const FixedSider: React.FC = () => {
       >
         <ThemedTitle collapsed={collapsed} />
       </div>
-
       <Menu
         style={{
           marginTop: "8px",

--- a/examples/customization-rtl/src/pages/posts/show.tsx
+++ b/examples/customization-rtl/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/customization-theme-antd/src/pages/posts/show.tsx
+++ b/examples/customization-theme-antd/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/customization-theme-chakra-ui/src/pages/posts/show.tsx
+++ b/examples/customization-theme-chakra-ui/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Heading, Text, Spacer } from "@chakra-ui/react";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/customization-theme-mantine/src/pages/posts/show.tsx
+++ b/examples/customization-theme-mantine/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Title, Text } from "@mantine/core";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/data-provider-airtable/src/pages/blog-posts/show.tsx
+++ b/examples/data-provider-airtable/src/pages/blog-posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const BlogPostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/data-provider-appwrite-tutorial-docs/src/pages/posts/show.tsx
+++ b/examples/data-provider-appwrite-tutorial-docs/src/pages/posts/show.tsx
@@ -7,7 +7,7 @@ import type { IPost } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/data-provider-appwrite/src/pages/posts/show.tsx
+++ b/examples/data-provider-appwrite/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory, IFile } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/data-provider-hasura/src/pages/posts/show.tsx
+++ b/examples/data-provider-hasura/src/pages/posts/show.tsx
@@ -11,7 +11,7 @@ import { POST_QUERY } from "./queries";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<GetFields<GetPostQuery>>({
+  const { query: queryResult } = useShow<GetFields<GetPostQuery>>({
     metaData: {
       gqlQuery: POST_QUERY,
     },

--- a/examples/data-provider-nestjs-query/src/pages/posts/show.tsx
+++ b/examples/data-provider-nestjs-query/src/pages/posts/show.tsx
@@ -10,7 +10,7 @@ import type { PostShowQuery } from "graphql/types";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<GetFields<PostShowQuery>>({
+  const { query: queryResult } = useShow<GetFields<PostShowQuery>>({
     metaData: {
       gqlQuery: POST_SHOW_QUERY,
     },

--- a/examples/data-provider-nestjsx-crud/src/pages/posts/show.tsx
+++ b/examples/data-provider-nestjsx-crud/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/data-provider-sanity/src/pages/posts/show.tsx
+++ b/examples/data-provider-sanity/src/pages/posts/show.tsx
@@ -7,7 +7,7 @@ import type { ICategory, IPost } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/data-provider-strapi-v4/src/pages/posts/show.tsx
+++ b/examples/data-provider-strapi-v4/src/pages/posts/show.tsx
@@ -17,7 +17,7 @@ import { API_URL } from "../../constants";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>({
+  const { query: queryResult } = useShow<IPost>({
     metaData: { populate: ["category", "cover"] },
   });
 

--- a/examples/data-provider-supabase/src/pages/posts/show.tsx
+++ b/examples/data-provider-supabase/src/pages/posts/show.tsx
@@ -19,7 +19,7 @@ const { Title, Text } = Typography;
 export const PostShow = () => {
   const [isDeprecated, setIsDeprecated] = useState(false);
 
-  const { queryResult } = useShow<IPost>({
+  const { query: queryResult } = useShow<IPost>({
     liveMode: "manual",
     onLiveEvent: () => {
       setIsDeprecated(true);

--- a/examples/field-antd-use-checkbox-group/src/pages/posts/show.tsx
+++ b/examples/field-antd-use-checkbox-group/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ITag } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/field-antd-use-radio-group/src/pages/posts/show.tsx
+++ b/examples/field-antd-use-radio-group/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ILanguage } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/field-antd-use-select-basic/src/pages/posts/show.tsx
+++ b/examples/field-antd-use-select-basic/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory, ITag } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/field-antd-use-select-infinite/src/pages/posts/show.tsx
+++ b/examples/field-antd-use-select-infinite/src/pages/posts/show.tsx
@@ -7,7 +7,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/finefoods-antd/src/components/product/drawer-show/index.tsx
+++ b/examples/finefoods-antd/src/components/product/drawer-show/index.tsx
@@ -40,7 +40,7 @@ export const ProductDrawerShow = (props: Props) => {
   const { token } = theme.useToken();
   const breakpoint = Grid.useBreakpoint();
 
-  const { queryResult } = useShow<IProduct, HttpError>({
+  const { query: queryResult } = useShow<IProduct, HttpError>({
     resource: "products",
     id: props?.id, // when undefined, id will be read from the URL.
   });

--- a/examples/finefoods-antd/src/pages/couriers/list.tsx
+++ b/examples/finefoods-antd/src/pages/couriers/list.tsx
@@ -221,8 +221,8 @@ export const CourierList = ({ children }: PropsWithChildren) => {
               <FilterDropdown {...props}>
                 <InputMask mask="(999) 999 99 99">
                   {/* 
-                                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                                    // @ts-ignore */}
+                                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                  // @ts-ignore */}
                   {(props: InputProps) => <Input {...props} />}
                 </InputMask>
               </FilterDropdown>

--- a/examples/finefoods-antd/src/pages/customers/show.tsx
+++ b/examples/finefoods-antd/src/pages/customers/show.tsx
@@ -11,7 +11,7 @@ import {
 export const CustomerShow = () => {
   const { list } = useNavigation();
   const breakpoint = Grid.useBreakpoint();
-  const { queryResult } = useShow<IUser>();
+  const { query: queryResult } = useShow<IUser>();
 
   const { data } = queryResult;
   const user = data?.data;

--- a/examples/finefoods-antd/src/pages/orders/show.tsx
+++ b/examples/finefoods-antd/src/pages/orders/show.tsx
@@ -13,7 +13,7 @@ import {
 
 export const OrderShow = () => {
   const t = useTranslate();
-  const { queryResult } = useShow<IOrder>();
+  const { query: queryResult } = useShow<IOrder>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
   const { mutate } = useUpdate();

--- a/examples/finefoods-client/src/components/orders/detail/index.tsx
+++ b/examples/finefoods-client/src/components/orders/detail/index.tsx
@@ -13,7 +13,7 @@ type OrderPageProps = {
 };
 
 export const OrderDetail: React.FC<OrderPageProps> = ({ useShowProps }) => {
-  const { queryResult } = useShow<Order>({
+  const { query: queryResult } = useShow<Order>({
     resource: "orders",
     ...useShowProps,
   });

--- a/examples/finefoods-material-ui/src/pages/customers/show.tsx
+++ b/examples/finefoods-material-ui/src/pages/customers/show.tsx
@@ -33,7 +33,7 @@ export const CustomerShow = () => {
   const go = useGo();
   const t = useTranslate();
 
-  const { queryResult } = useShow<IUser>();
+  const { query: queryResult } = useShow<IUser>();
   const user = queryResult.data?.data;
 
   const { dataGridProps } = useDataGrid<

--- a/examples/finefoods-material-ui/src/pages/orders/show.tsx
+++ b/examples/finefoods-material-ui/src/pages/orders/show.tsx
@@ -23,7 +23,7 @@ import type { IOrder } from "../../interfaces";
 export const OrderShow = () => {
   const t = useTranslate();
 
-  const { queryResult } = useShow<IOrder>();
+  const { query: queryResult } = useShow<IOrder>();
   const record = queryResult.data?.data;
   const canAcceptOrder = record?.status.text === "Pending";
   const canRejectOrder =

--- a/examples/form-antd-custom-validation/src/pages/posts/show.tsx
+++ b/examples/form-antd-custom-validation/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/form-antd-use-drawer-form/src/pages/posts/list.tsx
+++ b/examples/form-antd-use-drawer-form/src/pages/posts/list.tsx
@@ -49,7 +49,7 @@ export const PostList = () => {
 
   // Show Drawer
   const [visibleShowDrawer, setVisibleShowDrawer] = useState<boolean>(false);
-  const { queryResult, showId, setShowId } = useShow<IPost>();
+  const { query: queryResult, showId, setShowId } = useShow<IPost>();
 
   const { data: showQueryResult, isLoading: showIsLoading } = queryResult;
   const record = showQueryResult?.data;

--- a/examples/form-antd-use-modal-form/src/pages/posts/list.tsx
+++ b/examples/form-antd-use-modal-form/src/pages/posts/list.tsx
@@ -53,7 +53,7 @@ export const PostList = () => {
   // Show Modal
   const [visibleShowModal, setVisibleShowModal] = useState<boolean>(false);
 
-  const { queryResult, setShowId } = useShow<IPost>();
+  const { query: queryResult, setShowId } = useShow<IPost>();
 
   const { data: showQueryResult } = queryResult;
   const record = showQueryResult?.data;

--- a/examples/form-chakra-ui-mutation-mode/src/pages/posts/show.tsx
+++ b/examples/form-chakra-ui-mutation-mode/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Heading, Text, Spacer } from "@chakra-ui/react";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/form-chakra-ui-use-form/src/pages/posts/show.tsx
+++ b/examples/form-chakra-ui-use-form/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Heading, Text, Spacer } from "@chakra-ui/react";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/form-core-use-form/src/pages/posts/show.tsx
+++ b/examples/form-core-use-form/src/pages/posts/show.tsx
@@ -3,7 +3,7 @@ import { useShow } from "@refinedev/core";
 import type { IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data } = queryResult;
   const record = data?.data;
 

--- a/examples/form-mantine-use-form/src/pages/posts/show.tsx
+++ b/examples/form-mantine-use-form/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Title, Text } from "@mantine/core";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/form-material-ui-use-form/src/pages/posts/show.tsx
+++ b/examples/form-material-ui-use-form/src/pages/posts/show.tsx
@@ -10,7 +10,7 @@ import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
 
 export const PostShow = () => {
-  const { queryResult } = useShow();
+  const { query: queryResult } = useShow();
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/i18n-nextjs/src/app/blog-posts/show/[id]/page.tsx
+++ b/examples/i18n-nextjs/src/app/blog-posts/show/[id]/page.tsx
@@ -14,7 +14,7 @@ const { Title } = Typography;
 
 export default function BlogPostShow() {
   const { translate: t } = useTranslation();
-  const { queryResult } = useShow({});
+  const { query: queryResult } = useShow({});
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/i18n-nextjs/src/app/categories/show/[id]/page.tsx
+++ b/examples/i18n-nextjs/src/app/categories/show/[id]/page.tsx
@@ -8,7 +8,7 @@ const { Title } = Typography;
 
 export default function CategoryShow() {
   const { translate: t } = useTranslation();
-  const { queryResult } = useShow({});
+  const { query: queryResult } = useShow({});
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/i18n-react/src/pages/posts/show.tsx
+++ b/examples/i18n-react/src/pages/posts/show.tsx
@@ -8,7 +8,7 @@ const { Title, Text } = Typography;
 
 export const PostShow = () => {
   const { translate } = useTranslation();
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/import-export-antd/src/pages/posts/show.tsx
+++ b/examples/import-export-antd/src/pages/posts/show.tsx
@@ -7,7 +7,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/input-custom/src/pages/posts/show.tsx
+++ b/examples/input-custom/src/pages/posts/show.tsx
@@ -7,7 +7,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/input-date-picker/src/pages/posts/show.tsx
+++ b/examples/input-date-picker/src/pages/posts/show.tsx
@@ -7,7 +7,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/invoicer/src/pages/invoices/show.tsx
+++ b/examples/invoicer/src/pages/invoices/show.tsx
@@ -22,7 +22,7 @@ import { useStyles } from "./show.styled";
 export const InvoicesPageShow = () => {
   const { styles } = useStyles();
 
-  const { queryResult } = useShow<Invoice>({
+  const { query: queryResult } = useShow<Invoice>({
     meta: {
       populate: ["client", "account.logo"],
     },

--- a/examples/live-provider-ably/src/pages/categories/show.tsx
+++ b/examples/live-provider-ably/src/pages/categories/show.tsx
@@ -7,7 +7,7 @@ import type { ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const CategoryShow = () => {
-  const { queryResult } = useShow<ICategory>();
+  const { query: queryResult } = useShow<ICategory>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/live-provider-ably/src/pages/posts/show.tsx
+++ b/examples/live-provider-ably/src/pages/posts/show.tsx
@@ -19,7 +19,7 @@ export const PostShow = () => {
     "deleted" | "updated" | undefined
   >();
 
-  const { queryResult } = useShow<IPost>({
+  const { query: queryResult } = useShow<IPost>({
     liveMode: "manual",
     onLiveEvent: (event) => {
       if (event.type === "deleted" || event.type === "updated") {

--- a/examples/loading-overtime/src/pages/posts/show.tsx
+++ b/examples/loading-overtime/src/pages/posts/show.tsx
@@ -8,7 +8,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/mern-dashboard-client/src/pages/property-details.tsx
+++ b/examples/mern-dashboard-client/src/pages/property-details.tsx
@@ -23,7 +23,7 @@ const PropertyDetails = () => {
   const { data: user } = useGetIdentity({
     v3LegacyAuthProviderCompatible: true,
   });
-  const { queryResult } = useShow();
+  const { query: queryResult } = useShow();
   const { mutate } = useDelete();
   const { id } = useParams();
 

--- a/examples/monorepo-module-federation/apps/blog-posts/src/pages/blog-posts/show.tsx
+++ b/examples/monorepo-module-federation/apps/blog-posts/src/pages/blog-posts/show.tsx
@@ -8,7 +8,7 @@ import type { ICategory, IPost } from "../../interfaces";
 const { Title, Text } = Typography;
 
 const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/monorepo-module-federation/apps/categories/src/pages/categories/show.tsx
+++ b/examples/monorepo-module-federation/apps/categories/src/pages/categories/show.tsx
@@ -9,7 +9,7 @@ import type { ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 const CategoryShow = () => {
-  const { queryResult } = useShow<ICategory>();
+  const { query: queryResult } = useShow<ICategory>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/multi-level-menu/src/pages/posts/show.tsx
+++ b/examples/multi-level-menu/src/pages/posts/show.tsx
@@ -7,7 +7,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/multi-level-menu/src/pages/users/show.tsx
+++ b/examples/multi-level-menu/src/pages/users/show.tsx
@@ -7,7 +7,7 @@ import type { IUser } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const UserShow = () => {
-  const { queryResult } = useShow<IUser>();
+  const { query: queryResult } = useShow<IUser>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/multi-tenancy-strapi/src/pages/customer/show.tsx
+++ b/examples/multi-tenancy-strapi/src/pages/customer/show.tsx
@@ -29,7 +29,7 @@ export const CustomerShow = () => {
 
   const { styles } = useStyles();
 
-  const { queryResult } = useShow<CustomerExtended>({
+  const { query: queryResult } = useShow<CustomerExtended>({
     meta: {
       populate: ["orders.products.image"],
     },

--- a/examples/multi-tenancy-strapi/src/pages/order/show.tsx
+++ b/examples/multi-tenancy-strapi/src/pages/order/show.tsx
@@ -16,7 +16,7 @@ export const OrderShow = () => {
 
   const { styles } = useStyles();
 
-  const { queryResult } = useShow<
+  const { query: queryResult } = useShow<
     Order & {
       products: Product[];
       customer: Customer;

--- a/examples/multi-tenancy-strapi/src/pages/product/edit.tsx
+++ b/examples/multi-tenancy-strapi/src/pages/product/edit.tsx
@@ -18,7 +18,7 @@ export const ProductEdit = () => {
 
   const { styles, cx } = useStyles();
   const go = useGo();
-  const { queryResult } = useShow<ProductWithCategories>({
+  const { query: queryResult } = useShow<ProductWithCategories>({
     meta: {
       populate: ["category", "image"],
     },

--- a/examples/new-routing-example/src/pages/posts/show.tsx
+++ b/examples/new-routing-example/src/pages/posts/show.tsx
@@ -7,7 +7,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/pixels/src/pages/canvases/show.tsx
+++ b/examples/pixels/src/pages/canvases/show.tsx
@@ -33,7 +33,7 @@ export const CanvasShow: React.FC = () => {
   } = useIsAuthenticated();
 
   const {
-    queryResult: {
+    query: {
       data: { data: canvas } = {},
     },
   } = useShow<Canvas>();

--- a/examples/search/src/pages/categories/show.tsx
+++ b/examples/search/src/pages/categories/show.tsx
@@ -7,7 +7,7 @@ import type { ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const CategoryShow = () => {
-  const { queryResult } = useShow<ICategory>();
+  const { query: queryResult } = useShow<ICategory>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/search/src/pages/posts/show.tsx
+++ b/examples/search/src/pages/posts/show.tsx
@@ -7,7 +7,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/server-side-form-validation-antd/src/pages/posts/show.tsx
+++ b/examples/server-side-form-validation-antd/src/pages/posts/show.tsx
@@ -8,7 +8,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/server-side-form-validation-chakra-ui/src/pages/posts/show.tsx
+++ b/examples/server-side-form-validation-chakra-ui/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Heading, Text, Spacer } from "@chakra-ui/react";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/server-side-form-validation-mantine/src/pages/posts/show.tsx
+++ b/examples/server-side-form-validation-mantine/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Title, Text, Badge, Flex } from "@mantine/core";
 import type { ICategory, IPost, ITag } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/server-side-form-validation-material-ui/src/pages/posts/show.tsx
+++ b/examples/server-side-form-validation-material-ui/src/pages/posts/show.tsx
@@ -10,7 +10,7 @@ import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
 
 export const PostShow = () => {
-  const { queryResult } = useShow();
+  const { query: queryResult } = useShow();
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/table-antd-advanced/src/pages/posts/show.tsx
+++ b/examples/table-antd-advanced/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/table-antd-table-filter/src/pages/posts/show.tsx
+++ b/examples/table-antd-table-filter/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/table-antd-use-delete-many/src/pages/posts/show.tsx
+++ b/examples/table-antd-use-delete-many/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/table-antd-use-update-many/src/pages/posts/show.tsx
+++ b/examples/table-antd-use-update-many/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/table-chakra-ui-basic/src/pages/posts/show.tsx
+++ b/examples/table-chakra-ui-basic/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Heading, Text, Spacer } from "@chakra-ui/react";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/theme-antd-demo/src/pages/posts/show.tsx
+++ b/examples/theme-antd-demo/src/pages/posts/show.tsx
@@ -8,7 +8,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/theme-chakra-ui-demo/src/pages/posts/show.tsx
+++ b/examples/theme-chakra-ui-demo/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Heading, Text, Spacer } from "@chakra-ui/react";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/theme-mantine-demo/src/pages/posts/show.tsx
+++ b/examples/theme-mantine-demo/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Title, Text } from "@mantine/core";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/tutorial-antd/src/pages/blog-posts/show.tsx
+++ b/examples/tutorial-antd/src/pages/blog-posts/show.tsx
@@ -12,7 +12,7 @@ import { Typography } from "antd";
 const { Title } = Typography;
 
 export const BlogPostShow = () => {
-  const { queryResult } = useShow();
+  const { query: queryResult } = useShow();
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/tutorial-chakra-ui/src/pages/blog-posts/show.tsx
+++ b/examples/tutorial-chakra-ui/src/pages/blog-posts/show.tsx
@@ -10,7 +10,7 @@ import {
 import { Heading, HStack } from "@chakra-ui/react";
 
 export const BlogPostShow = () => {
-  const { queryResult } = useShow();
+  const { query: queryResult } = useShow();
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/tutorial-headless/src/pages/blog-posts/show.tsx
+++ b/examples/tutorial-headless/src/pages/blog-posts/show.tsx
@@ -4,7 +4,7 @@ import { useShow, useResource, useNavigation, useOne } from "@refinedev/core";
 export const BlogPostShow = () => {
   const { edit, list } = useNavigation();
   const { id } = useResource();
-  const { queryResult } = useShow();
+  const { query: queryResult } = useShow();
   const { data } = queryResult;
 
   const record = data?.data;

--- a/examples/tutorial-mantine/src/pages/blog-posts/show.tsx
+++ b/examples/tutorial-mantine/src/pages/blog-posts/show.tsx
@@ -9,7 +9,7 @@ import {
 import { Title } from "@mantine/core";
 
 export const BlogPostShow = () => {
-  const { queryResult } = useShow();
+  const { query: queryResult } = useShow();
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/tutorial-material-ui/src/pages/blog-posts/show.tsx
+++ b/examples/tutorial-material-ui/src/pages/blog-posts/show.tsx
@@ -10,7 +10,7 @@ import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
 
 export const BlogPostShow = () => {
-  const { queryResult } = useShow();
+  const { query: queryResult } = useShow();
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/upload-antd-base64/src/pages/users/show.tsx
+++ b/examples/upload-antd-base64/src/pages/users/show.tsx
@@ -9,7 +9,7 @@ import type { IUser } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const UserShow = () => {
-  const { queryResult } = useShow<IUser>();
+  const { query: queryResult } = useShow<IUser>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/upload-antd-multipart/src/pages/posts/show.tsx
+++ b/examples/upload-antd-multipart/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/upload-chakra-ui-basic64/src/pages/posts/show.tsx
+++ b/examples/upload-chakra-ui-basic64/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Heading, Text, Spacer } from "@chakra-ui/react";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/upload-chakra-ui-multipart/src/pages/posts/show.tsx
+++ b/examples/upload-chakra-ui-multipart/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Heading, Text, Spacer } from "@chakra-ui/react";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/upload-mantine-base64/src/pages/posts/show.tsx
+++ b/examples/upload-mantine-base64/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Title, Text } from "@mantine/core";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/upload-mantine-multipart/src/pages/posts/show.tsx
+++ b/examples/upload-mantine-multipart/src/pages/posts/show.tsx
@@ -6,7 +6,7 @@ import { Title, Text } from "@mantine/core";
 import type { ICategory, IPost } from "../../interfaces";
 
 export const PostShow: React.FC = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/win95/src/routes/rvc-website/title-detail.tsx
+++ b/examples/win95/src/routes/rvc-website/title-detail.tsx
@@ -24,7 +24,7 @@ export const RVCWebsitePageTitleDetails = ({ withBrowser = true }: Props) => {
   const { titleId } = useParams();
   const navigate = useNavigate();
 
-  const { queryResult } = useShow<VideoTitle>({
+  const { query: queryResult } = useShow<VideoTitle>({
     resource: "titles",
     id: titleId,
   });

--- a/examples/win95/src/routes/video-club/titles/show.tsx
+++ b/examples/win95/src/routes/video-club/titles/show.tsx
@@ -26,7 +26,7 @@ export const VideoClubPageShowTitle = () => {
   const navigate = useNavigate();
 
   const {
-    queryResult: { data, isLoading, refetch },
+    query: { data, isLoading, refetch },
   } = useShow<
     Omit<ExtendedVideoTitle, "rentals"> & {
       rentals: (Rental & { member: Member })[];

--- a/examples/with-custom-pages/src/pages/posts/show.tsx
+++ b/examples/with-custom-pages/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/with-javascript/src/pages/posts/show.jsx
+++ b/examples/with-javascript/src/pages/posts/show.jsx
@@ -7,7 +7,7 @@ import { Typography } from "antd";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow();
+  const { query: queryResult } = useShow();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 

--- a/examples/with-material-ui-vite/src/pages/blog-posts/show.tsx
+++ b/examples/with-material-ui-vite/src/pages/blog-posts/show.tsx
@@ -8,7 +8,7 @@ import {
 } from "@refinedev/mui";
 
 export const BlogPostShow = () => {
-  const { queryResult } = useShow({});
+  const { query: queryResult } = useShow({});
 
   const { data, isLoading } = queryResult;
 

--- a/examples/with-material-ui-vite/src/pages/categories/show.tsx
+++ b/examples/with-material-ui-vite/src/pages/categories/show.tsx
@@ -3,7 +3,7 @@ import { useShow } from "@refinedev/core";
 import { Show, TextFieldComponent as TextField } from "@refinedev/mui";
 
 export const CategoryShow = () => {
-  const { queryResult } = useShow({});
+  const { query: queryResult } = useShow({});
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/with-nextjs-next-auth/src/app/blog-posts/show/[id]/page.tsx
+++ b/examples/with-nextjs-next-auth/src/app/blog-posts/show/[id]/page.tsx
@@ -13,7 +13,7 @@ import { Typography } from "antd";
 const { Title } = Typography;
 
 export default function BlogPostShow() {
-  const { queryResult } = useShow({});
+  const { query: queryResult } = useShow({});
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/with-nextjs-next-auth/src/app/categories/show/[id]/page.tsx
+++ b/examples/with-nextjs-next-auth/src/app/categories/show/[id]/page.tsx
@@ -7,7 +7,7 @@ import { Typography } from "antd";
 const { Title } = Typography;
 
 export default function CategoryShow() {
-  const { queryResult } = useShow({});
+  const { query: queryResult } = useShow({});
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/with-nextjs/src/app/blog-posts/show/[id]/page.tsx
+++ b/examples/with-nextjs/src/app/blog-posts/show/[id]/page.tsx
@@ -13,7 +13,7 @@ import { Typography } from "antd";
 const { Title } = Typography;
 
 export default function BlogPostShow() {
-  const { queryResult } = useShow({});
+  const { query: queryResult } = useShow({});
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/with-nextjs/src/app/categories/show/[id]/page.tsx
+++ b/examples/with-nextjs/src/app/categories/show/[id]/page.tsx
@@ -7,7 +7,7 @@ import { Typography } from "antd";
 const { Title } = Typography;
 
 export default function CategoryShow() {
-  const { queryResult } = useShow({});
+  const { query: queryResult } = useShow({});
   const { data, isLoading } = queryResult;
 
   const record = data?.data;

--- a/examples/with-remix-antd/app/routes/_protected.posts.show.$id.tsx
+++ b/examples/with-remix-antd/app/routes/_protected.posts.show.$id.tsx
@@ -13,7 +13,7 @@ const { Title, Text } = Typography;
 const PostShow: React.FC = () => {
   const { initialData } = useLoaderData<typeof loader>();
 
-  const { queryResult } = useShow({
+  const { query: queryResult } = useShow({
     queryOptions: {
       initialData,
     },

--- a/examples/with-web3/src/pages/posts/show.tsx
+++ b/examples/with-web3/src/pages/posts/show.tsx
@@ -9,7 +9,7 @@ import type { IPost, ICategory } from "../../interfaces";
 const { Title, Text } = Typography;
 
 export const PostShow = () => {
-  const { queryResult } = useShow<IPost>();
+  const { query: queryResult } = useShow<IPost>();
   const { data, isLoading } = queryResult;
   const record = data?.data;
 


### PR DESCRIPTION
The `use-show-query-result`(#6174) `codemod` is executed twice for all examples.