### PR TITLE
chore: run codemod `use-select-query-result` for all examples

### DIFF
--- a/examples/app-crm-minimal/src/routes/companies/edit/form.tsx
+++ b/examples/app-crm-minimal/src/routes/companies/edit/form.tsx
@@ -37,17 +37,18 @@ export const CompanyForm = () => {
   });
   const { avatarUrl, name } = queryResult?.data?.data || {};
 
-  const { selectProps: selectPropsUsers, queryResult: queryResultUsers } =
-    useSelect<GetFieldsFromList<UsersSelectQuery>>({
-      resource: "users",
-      optionLabel: "name",
-      pagination: {
-        mode: "off",
-      },
-      meta: {
-        gqlQuery: USERS_SELECT_QUERY,
-      },
-    });
+  const { selectProps: selectPropsUsers, query: queryResultUsers } = useSelect<
+    GetFieldsFromList<UsersSelectQuery>
+  >({
+    resource: "users",
+    optionLabel: "name",
+    pagination: {
+      mode: "off",
+    },
+    meta: {
+      gqlQuery: USERS_SELECT_QUERY,
+    },
+  });
 
   return (
     <Edit

--- a/examples/app-crm-minimal/src/routes/companies/list/create-modal.tsx
+++ b/examples/app-crm-minimal/src/routes/companies/list/create-modal.tsx
@@ -47,7 +47,7 @@ export const CompanyCreateModal = () => {
     },
   });
 
-  const { selectProps, queryResult } = useSelect<
+  const { selectProps, query: queryResult } = useSelect<
     GetFieldsFromList<UsersSelectQuery>
   >({
     resource: "users",

--- a/examples/app-crm/src/routes/scrumboard/sales/create.tsx
+++ b/examples/app-crm/src/routes/scrumboard/sales/create.tsx
@@ -79,7 +79,7 @@ export const SalesCreatePage: FC<PropsWithChildren> = ({ children }) => {
     }
   }, [searchParams]);
 
-  const { selectProps, queryResult } = useSelect<
+  const { selectProps, query: queryResult } = useSelect<
     GetFieldsFromList<SalesCompaniesSelectQuery>
   >({
     resource: "companies",

--- a/examples/app-crm/src/routes/scrumboard/sales/edit.tsx
+++ b/examples/app-crm/src/routes/scrumboard/sales/edit.tsx
@@ -37,16 +37,14 @@ export const SalesEditPage = () => {
     },
   });
 
-  const {
-    selectProps: companySelectProps,
-    queryResult: companySelectQueryResult,
-  } = useSelect<GetFieldsFromList<SalesCompaniesSelectQuery>>({
-    resource: "companies",
-    optionLabel: "name",
-    meta: {
-      gqlQuery: SALES_COMPANIES_SELECT_QUERY,
-    },
-  });
+  const { selectProps: companySelectProps, query: companySelectQueryResult } =
+    useSelect<GetFieldsFromList<SalesCompaniesSelectQuery>>({
+      resource: "companies",
+      optionLabel: "name",
+      meta: {
+        gqlQuery: SALES_COMPANIES_SELECT_QUERY,
+      },
+    });
 
   const { selectProps: stageSelectProps } = useDealStagesSelect();
 

--- a/examples/customization-offlayout-area/src/components/sider/index.tsx
+++ b/examples/customization-offlayout-area/src/components/sider/index.tsx
@@ -126,7 +126,6 @@ export const FixedSider: React.FC = () => {
       >
         <ThemedTitle collapsed={collapsed} />
       </div>
-
       <Menu
         style={{
           marginTop: "8px",

--- a/examples/data-provider-sanity/src/pages/posts/list.tsx
+++ b/examples/data-provider-sanity/src/pages/posts/list.tsx
@@ -44,7 +44,7 @@ export const PostList = () => {
     },
   });
 
-  const { selectProps: selectPropsCategory, queryResult: queryResultCategory } =
+  const { selectProps: selectPropsCategory, query: queryResultCategory } =
     useSelect({
       resource: "category",
       optionLabel: "title",

--- a/examples/finefoods-antd/src/components/product/list-table/index.tsx
+++ b/examples/finefoods-antd/src/components/product/list-table/index.tsx
@@ -62,7 +62,7 @@ export const ProductListTable = () => {
     },
   });
 
-  const { selectProps: categorySelectProps, queryResult } =
+  const { selectProps: categorySelectProps, query: queryResult } =
     useSelect<ICategory>({
       resource: "categories",
       optionLabel: "title",

--- a/examples/finefoods-antd/src/pages/couriers/list.tsx
+++ b/examples/finefoods-antd/src/pages/couriers/list.tsx
@@ -221,8 +221,8 @@ export const CourierList = ({ children }: PropsWithChildren) => {
               <FilterDropdown {...props}>
                 <InputMask mask="(999) 999 99 99">
                   {/* 
-                                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                                    // @ts-ignore */}
+                                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                  // @ts-ignore */}
                   {(props: InputProps) => <Input {...props} />}
                 </InputMask>
               </FilterDropdown>

--- a/examples/table-material-ui-advanced/src/pages/dataGrid/index.tsx
+++ b/examples/table-material-ui-advanced/src/pages/dataGrid/index.tsx
@@ -17,7 +17,7 @@ export const BasicDataGrid: React.FC = () => {
 
   const {
     options,
-    queryResult: { isLoading },
+    query: { isLoading },
   } = useSelect<ICategory>({
     resource: "categories",
   });

--- a/examples/table-material-ui-data-grid-pro/src/pages/posts/list.tsx
+++ b/examples/table-material-ui-data-grid-pro/src/pages/posts/list.tsx
@@ -40,7 +40,7 @@ export const PostList: React.FC = () => {
 
   const {
     options,
-    queryResult: { isLoading },
+    query: { isLoading },
   } = useSelect<ICategory>({
     resource: "categories",
     hasPagination: false,

--- a/examples/table-material-ui-use-data-grid/src/pages/posts/list.tsx
+++ b/examples/table-material-ui-use-data-grid/src/pages/posts/list.tsx
@@ -33,7 +33,7 @@ export const PostList: React.FC = () => {
 
   const {
     options,
-    queryResult: { isLoading },
+    query: { isLoading },
   } = useSelect<ICategory>({
     resource: "categories",
   });

--- a/examples/table-material-ui-use-delete-many/src/pages/posts/list.tsx
+++ b/examples/table-material-ui-use-delete-many/src/pages/posts/list.tsx
@@ -39,7 +39,7 @@ export const PostList: React.FC = () => {
 
   const {
     options,
-    queryResult: { isLoading },
+    query: { isLoading },
   } = useSelect<ICategory>({
     resource: "categories",
     hasPagination: false,

--- a/examples/table-material-ui-use-update-many/src/pages/posts/list.tsx
+++ b/examples/table-material-ui-use-update-many/src/pages/posts/list.tsx
@@ -42,7 +42,7 @@ export const PostList: React.FC = () => {
 
   const {
     options,
-    queryResult: { isLoading },
+    query: { isLoading },
   } = useSelect<ICategory>({
     resource: "categories",
   });


### PR DESCRIPTION
The `use-select-query-result`(#6180) `codemod` is executed twice for all examples.