### PR TITLE
fix(docs): correct import path and notification provider usage

### DIFF
--- a/documentation/docs/notification/notification-provider/index.md
+++ b/documentation/docs/notification/notification-provider/index.md
@@ -134,12 +134,12 @@ return (
   <TabItem value="chakra">
 
 ```tsx
-import { useNotificationProvider } from "@refinedev/chakra";
+import { useNotificationProvider } from "@refinedev/chakra-ui";
 
 return (
   <Refine
     //...
-    notificationProvider={notificationProvider()}
+    notificationProvider={useNotificationProvider}
   />
 );
 ```


### PR DESCRIPTION
Corrected the import path from @refinedev/chakra to @refinedev/chakra-ui. Fixed the notification provider usage, ensuring useNotificationProvider is used instead of notificationProvider().

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
