### PR TITLE
feat(cli): add example translation file to i18n provider template

### DIFF
--- a/.changeset/quick-rats-eat.md
+++ b/.changeset/quick-rats-eat.md
@@ -1,0 +1,11 @@
+---
+"@refinedev/cli": patch
+---
+
+feat(cli): create base translation files for i18n provider in add provider command
+
+Currently `refine add provider i18n` command is only creating a demo i18n provider implementation but misses the translation files. This PR adds the base translation files for the i18n provider which is used by Refine internally in hooks, notifications and components.
+
+Now `locale/en.json` will be added with primarily used translation keys and values for the i18n provider.
+
+[Resolves #5918](https://github.com/refinedev/refine/issues/5918)

--- a/packages/cli/templates/assets/i18n/locale/en.json
+++ b/packages/cli/templates/assets/i18n/locale/en.json
@@ -25,6 +25,7 @@
     "forgotPassword": {
       "__description": "These key are used by the <AuthPage type='forgotPassword' /> components.",
       "title": "Forgot your password?",
+      "signin": "Sign in",
       "fields": {
         "email": "Email"
       },
@@ -33,12 +34,15 @@
         "requiredEmail": "Email is required"
       },
       "buttons": {
-        "submit": "Send reset instructions"
+        "submit": "Send reset instructions",
+        "haveAccount": "Have an account?"
       }
     },
     "register": {
       "__description": "These keys are used by the <AuthPage type='register' /> components.",
       "title": "Sign up for your account",
+      "signin": "Sign in",
+      "divider": "or",
       "fields": {
         "email": "Email",
         "password": "Password"

--- a/packages/cli/templates/assets/i18n/locale/en.json
+++ b/packages/cli/templates/assets/i18n/locale/en.json
@@ -1,0 +1,170 @@
+{
+  "pages": {
+    "login": {
+      "__description": "These keys are used by the <AuthPage type='login' /> components.",
+      "title": "Sign in to your account",
+      "signin": "Sign in",
+      "signup": "Sign up",
+      "divider": "or",
+      "fields": {
+        "email": "Email",
+        "password": "Password"
+      },
+      "errors": {
+        "validEmail": "Invalid email address",
+        "requiredEmail": "Email is required",
+        "requiredPassword": "Password is required"
+      },
+      "buttons": {
+        "submit": "Login",
+        "forgotPassword": "Forgot password?",
+        "noAccount": "Don’t have an account?",
+        "rememberMe": "Remember me"
+      }
+    },
+    "forgotPassword": {
+      "__description": "These key are used by the <AuthPage type='forgotPassword' /> components.",
+      "title": "Forgot your password?",
+      "fields": {
+        "email": "Email"
+      },
+      "errors": {
+        "validEmail": "Invalid email address",
+        "requiredEmail": "Email is required"
+      },
+      "buttons": {
+        "submit": "Send reset instructions"
+      }
+    },
+    "register": {
+      "__description": "These keys are used by the <AuthPage type='register' /> components.",
+      "title": "Sign up for your account",
+      "fields": {
+        "email": "Email",
+        "password": "Password"
+      },
+      "errors": {
+        "validEmail": "Invalid email address",
+        "requiredEmail": "Email is required",
+        "requiredPassword": "Password is required"
+      },
+      "buttons": {
+        "submit": "Register",
+        "haveAccount": "Have an account?"
+      }
+    },
+    "updatePassword": {
+      "__description": "These keys are used by the <AuthPage type='updatePassword' /> components.",
+      "title": "Update password",
+      "fields": {
+        "password": "New Password",
+        "confirmPassword": "Confirm new password"
+      },
+      "errors": {
+        "confirmPasswordNotMatch": "Passwords do not match",
+        "requiredPassword": "Password required",
+        "requiredConfirmPassword": "Confirm password is required"
+      },
+      "buttons": {
+        "submit": "Update"
+      }
+    },
+    "error": {
+      "__description": "These keys are used by the <ErrorPage /> components.",
+      "info": "You may have forgotten to add the {{action}} component to {{resource}} resource.",
+      "404": "Sorry, the page you visited does not exist.",
+      "resource404": "Are you sure you have created the {{resource}} resource.",
+      "backHome": "Back Home"
+    }
+  },
+  "actions": {
+    "__description": "These keys are used by the @refinedev/kbar package.",
+    "list": "List",
+    "create": "Create",
+    "edit": "Edit",
+    "show": "Show"
+  },
+  "buttons": {
+    "__description": "These keys are used by the buttons and breadcrumbs.",
+    "create": "Create",
+    "save": "Save",
+    "logout": "Logout",
+    "delete": "Delete",
+    "edit": "Edit",
+    "cancel": "Cancel",
+    "confirm": "Are you sure?",
+    "filter": "Filter",
+    "clear": "Clear",
+    "refresh": "Refresh",
+    "show": "Show",
+    "undo": "Undo",
+    "import": "Import",
+    "clone": "Clone",
+    "notAccessTitle": "You don't have permission to access"
+  },
+  "warnWhenUnsavedChanges": "Are you sure you want to leave? You have unsaved changes.",
+  "notifications": {
+    "__description": "These keys are used by the notification provider.",
+    "success": "Successful",
+    "error": "Error (status code: {{statusCode}})",
+    "undoable": "You have {{seconds}} seconds to undo",
+    "createSuccess": "Successfully created {{resource}}",
+    "createError": "There was an error creating {{resource}} (status code: {{statusCode}})",
+    "deleteSuccess": "Successfully deleted {{resource}}",
+    "deleteError": "Error when deleting {{resource}} (status code: {{statusCode}})",
+    "editSuccess": "Successfully edited {{resource}}",
+    "editError": "Error when editing {{resource}} (status code: {{statusCode}})",
+    "importProgress": "Importing: {{processed}}/{{total}}"
+  },
+  "loading": "Loading",
+  "dashboard": {
+    "__description": "This key is used by <Layout /> components to display the dashboard item in sidebar.",
+    "title": "Dashboard"
+  },
+  "posts": {
+    "__description": "These keys are used in translations for the 'posts' resource.",
+    "posts": "Posts",
+    "fields": {
+      "id": "Id",
+      "title": "Title",
+      "category": "Category",
+      "status": {
+        "title": "Status",
+        "published": "Published",
+        "draft": "Draft",
+        "rejected": "Rejected"
+      },
+      "content": "Content",
+      "createdAt": "Created At"
+    },
+    "titles": {
+      "create": "Create Post",
+      "edit": "Edit Post",
+      "list": "Posts",
+      "show": "Show Post"
+    }
+  },
+  "table": {
+    "__description": "This key is used by Inferencer components in 'list' views.",
+    "actions": "Actions"
+  },
+  "documentTitle": {
+    "__description": "These keys are used by the <DocumentTitleHandler /> components.",
+    "default": "refine",
+    "suffix": " | Refine",
+    "post": {
+      "list": "Posts | Refine",
+      "show": "#{{id}} Show Post | Refine",
+      "edit": "#{{id}} Edit Post | Refine",
+      "create": "Create new Post | Refine",
+      "clone": "#{{id}} Clone Post | Refine"
+    }
+  },
+  "autoSave": {
+    "__description": "These keys are used by the <AutoSaveIndicator /> and the auto-save feature.",
+    "success": "saved",
+    "error": "auto save failure",
+    "loading": "saving...",
+    "idle": "waiting for changes"
+  }
+}

--- a/packages/live-previews/public/locales/en/common.json
+++ b/packages/live-previews/public/locales/en/common.json
@@ -23,6 +23,7 @@
     },
     "forgotPassword": {
       "title": "Forgot your password?",
+      "signin": "Sign in",
       "fields": {
         "email": "Email"
       },
@@ -31,11 +32,14 @@
         "requiredEmail": "Email is required"
       },
       "buttons": {
-        "submit": "Send reset instructions"
+        "submit": "Send reset instructions",
+        "haveAccount": "Have an account?"
       }
     },
     "register": {
       "title": "Sign up for your account",
+      "signin": "Sign in",
+      "divider": "or",
       "fields": {
         "email": "Email",
         "password": "Password"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

Currently `refine add provider i18n` command is only creating a demo i18n provider implementation but misses the translation files. This PR adds the base translation files for the i18n provider which is used by Refine internally in hooks, notifications and components.

Now `locale/en.json` will be added with primarily used translation keys and values for the i18n provider.

Resolves #5918 