### PR TITLE
fix(auth-page): replace wrong translation keys

### DIFF
--- a/.changeset/popular-bees-smash.md
+++ b/.changeset/popular-bees-smash.md
@@ -1,0 +1,23 @@
+---
+"@refinedev/chakra-ui": patch
+"@refinedev/mantine": patch
+"@refinedev/antd": patch
+"@refinedev/mui": patch
+---
+
+fix(auth-page): fix wrong translation keys in `type="register"` and `type="forgotPassword"`
+
+In `type="forgotPassword"`:
+
+- `"pages.register.buttons.haveAccount"` is replaced with `"pages.forgotPassword.buttons.haveAccount"`
+- `"pages.login.signin"` is replaced with `"pages.forgotPassword.signin"`
+
+In `type="register"`:
+
+- `"pages.login.divider"` is replaced with `"pages.register.divider"`
+- `"pages.login.buttons.haveAccount"` is replaced with `"pages.register.buttons.haveAccount"`
+- `"pages.login.signin"` is replaced with `"pages.register.signin"`
+
+Wrong keys are kept as fallbacks in case the new keys are not found in the translation file. If you are using those keys in your project, make sure to update them accordingly. Fallback keys will be removed in future releases.
+
+[Resolves #5816](https://github.com/refinedev/refine/issues/5816)

--- a/.changeset/warm-pots-relax.md
+++ b/.changeset/warm-pots-relax.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/chakra-ui": patch
+---
+
+fix(auth-page): fix wrong translation key in `type="register"`
+
+Previously, sign in link in Register page was using wrong translation key "pages.register.buttons.noAccount". Now it is replaced with "pages.register.buttons.haveAccount".

--- a/documentation/docs/notification/notification-provider/index.md
+++ b/documentation/docs/notification/notification-provider/index.md
@@ -134,12 +134,12 @@ return (
   <TabItem value="chakra">
 
 ```tsx
-import { useNotificationProvider } from "@refinedev/chakra";
+import { useNotificationProvider } from "@refinedev/chakra-ui";
 
 return (
   <Refine
     //...
-    notificationProvider={notificationProvider()}
+    notificationProvider={useNotificationProvider}
   />
 );
 ```

--- a/packages/antd/src/components/pages/auth/components/forgotPassword/index.tsx
+++ b/packages/antd/src/components/pages/auth/components/forgotPassword/index.tsx
@@ -151,8 +151,11 @@ export const ForgotPasswordPage: React.FC<ResetPassworProps> = ({
               }}
             >
               {translate(
-                "pages.register.buttons.haveAccount",
-                "Have an account? ",
+                "pages.forgotPassword.buttons.haveAccount",
+                translate(
+                  "pages.register.buttons.haveAccount",
+                  "Have an account? ",
+                ),
               )}{" "}
               <ActiveLink
                 style={{
@@ -161,7 +164,10 @@ export const ForgotPasswordPage: React.FC<ResetPassworProps> = ({
                 }}
                 to="/login"
               >
-                {translate("pages.login.signin", "Sign in")}
+                {translate(
+                  "pages.forgotPassword.signin",
+                  translate("pages.login.signin", "Sign in"),
+                )}
               </ActiveLink>
             </Typography.Text>
           )}

--- a/packages/antd/src/components/pages/auth/components/register/index.tsx
+++ b/packages/antd/src/components/pages/auth/components/register/index.tsx
@@ -123,7 +123,10 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                   color: token.colorTextLabel,
                 }}
               >
-                {translate("pages.login.divider", "or")}
+                {translate(
+                  "pages.register.divider",
+                  translate("pages.login.divider", "or"),
+                )}
               </Typography.Text>
             </Divider>
           )}
@@ -208,8 +211,11 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                 }}
               >
                 {translate(
-                  "pages.login.buttons.haveAccount",
-                  "Have an account?",
+                  "pages.register.buttons.haveAccount",
+                  translate(
+                    "pages.login.buttons.haveAccount",
+                    "Have an account?",
+                  ),
                 )}{" "}
                 <ActiveLink
                   style={{
@@ -218,7 +224,10 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                   }}
                   to="/login"
                 >
-                  {translate("pages.login.signin", "Sign in")}
+                  {translate(
+                    "pages.register.signin",
+                    translate("pages.login.signin", "Sign in"),
+                  )}
                 </ActiveLink>
               </Typography.Text>
             )}
@@ -251,7 +260,10 @@ export const RegisterPage: React.FC<RegisterProps> = ({
               fontSize: 12,
             }}
           >
-            {translate("pages.login.buttons.haveAccount", "Have an account?")}{" "}
+            {translate(
+              "pages.register.buttons.haveAccount",
+              translate("pages.login.buttons.haveAccount", "Have an account?"),
+            )}{" "}
             <ActiveLink
               style={{
                 fontWeight: "bold",
@@ -259,7 +271,10 @@ export const RegisterPage: React.FC<RegisterProps> = ({
               }}
               to="/login"
             >
-              {translate("pages.login.signin", "Sign in")}
+              {translate(
+                "pages.register.signin",
+                translate("pages.login.signin", "Sign in"),
+              )}
             </ActiveLink>
           </Typography.Text>
         </div>

--- a/packages/chakra-ui/src/components/pages/auth/components/forgotPassword/index.tsx
+++ b/packages/chakra-ui/src/components/pages/auth/components/forgotPassword/index.tsx
@@ -117,8 +117,11 @@ export const ForgotPasswordPage: React.FC<ForgotPasswordProps> = ({
               pattern: {
                 value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
                 message: translate(
-                  "pages.login.errors.validEmail",
-                  "Invalid email address",
+                  "pages.forgotPassword.errors.validEmail",
+                  translate(
+                    "pages.login.errors.validEmail",
+                    "Invalid email address",
+                  ),
                 ),
               },
             })}
@@ -130,12 +133,18 @@ export const ForgotPasswordPage: React.FC<ForgotPasswordProps> = ({
           <Box my="6" display="flex" justifyContent="flex-end">
             <span>
               {translate(
-                "pages.register.buttons.haveAccount",
-                "Have an account?",
+                "pages.forgotPassword.buttons.haveAccount",
+                translate(
+                  "pages.register.buttons.haveAccount",
+                  "Have an account?",
+                ),
               )}
             </span>
             <ChakraLink color={importantTextColor} ml="1" as={Link} to="/login">
-              {translate("pages.login.signin", "Sign in")}
+              {translate(
+                "pages.forgotPassword.signin",
+                translate("pages.login.signin", "Sign in"),
+              )}
             </ChakraLink>
           </Box>
         )}

--- a/packages/chakra-ui/src/components/pages/auth/components/register/index.tsx
+++ b/packages/chakra-ui/src/components/pages/auth/components/register/index.tsx
@@ -217,8 +217,8 @@ export const RegisterPage: React.FC<RegisterProps> = ({
         <Box mt={6} textAlign="center">
           <span>
             {translate(
-              "pages.login.buttons.noAccount",
-              "Don’t have an account?",
+              "pages.register.buttons.haveAccount",
+              "Have an account?",
             )}
           </span>
           <ChakraLink

--- a/packages/chakra-ui/src/components/pages/auth/components/register/index.tsx
+++ b/packages/chakra-ui/src/components/pages/auth/components/register/index.tsx
@@ -195,8 +195,11 @@ export const RegisterPage: React.FC<RegisterProps> = ({
             >
               <span>
                 {translate(
-                  "pages.login.buttons.haveAccount",
-                  "Have an account?",
+                  "pages.register.buttons.haveAccount",
+                  translate(
+                    "pages.login.buttons.haveAccount",
+                    "Have an account?",
+                  ),
                 )}
               </span>
               <ChakraLink
@@ -206,7 +209,10 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                 as={Link}
                 to="/login"
               >
-                {translate("pages.login.signin", "Sign in")}
+                {translate(
+                  "pages.register.signin",
+                  translate("pages.login.signin", "Sign in"),
+                )}
               </ChakraLink>
             </Box>
           )}
@@ -228,7 +234,10 @@ export const RegisterPage: React.FC<RegisterProps> = ({
             fontWeight="bold"
             to="/login"
           >
-            {translate("pages.login.signin", "Sign in")}
+            {translate(
+              "pages.register.signin",
+              translate("pages.login.signin", "Sign in"),
+            )}
           </ChakraLink>
         </Box>
       )}

--- a/packages/mantine/src/components/pages/auth/components/forgotPassword/index.tsx
+++ b/packages/mantine/src/components/pages/auth/components/forgotPassword/index.tsx
@@ -122,8 +122,11 @@ export const ForgotPasswordPage: React.FC<ResetPassworProps> = ({
             <Group mt="md" position={loginLink ? "left" : "right"}>
               <Text size="xs">
                 {translate(
-                  "pages.login.forgotPassword.haveAccount",
-                  "Have an account?",
+                  "pages.forgotPassword.buttons.haveAccount",
+                  translate(
+                    "pages.login.forgotPassword.haveAccount",
+                    "Have an account? ",
+                  ),
                 )}{" "}
                 <Anchor component={ActiveLink as any} to="/login" weight={700}>
                   {translate("pages.forgotPassword.signin", "Sign in")}

--- a/packages/mantine/src/components/pages/auth/components/register/index.tsx
+++ b/packages/mantine/src/components/pages/auth/components/register/index.tsx
@@ -123,7 +123,10 @@ export const RegisterPage: React.FC<RegisterProps> = ({
             <Divider
               my="md"
               labelPosition="center"
-              label={translate("pages.login.divider", "or")}
+              label={translate(
+                "pages.register.divider",
+                translate("pages.login.divider", "or"),
+              )}
             />
           )}
         </>

--- a/packages/mui/src/components/pages/auth/components/forgotPassword/index.tsx
+++ b/packages/mui/src/components/pages/auth/components/forgotPassword/index.tsx
@@ -140,8 +140,11 @@ export const ForgotPasswordPage: React.FC<ForgotPasswordProps> = ({
             <Box textAlign="right" sx={{ mt: "24px" }}>
               <Typography variant="body2" component="span" fontSize="12px">
                 {translate(
-                  "pages.register.buttons.haveAccount",
-                  "Have an account?",
+                  "pages.forgotPassword.buttons.haveAccount",
+                  translate(
+                    "pages.register.buttons.haveAccount",
+                    "Have an account? ",
+                  ),
                 )}
               </Typography>{" "}
               <MuiLink
@@ -153,7 +156,10 @@ export const ForgotPasswordPage: React.FC<ForgotPasswordProps> = ({
                 fontSize="12px"
                 color="primary.light"
               >
-                {translate("pages.login.signin", "Sign in")}
+                {translate(
+                  "pages.forgotPassword.signin",
+                  translate("pages.login.signin", "Sign in"),
+                )}
               </MuiLink>
             </Box>
           )}

--- a/packages/mui/src/components/pages/auth/components/register/index.tsx
+++ b/packages/mui/src/components/pages/auth/components/register/index.tsx
@@ -131,7 +131,10 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                 marginY: "16px",
               }}
             >
-              {translate("pages.login.divider", "or")}
+              {translate(
+                "pages.register.divider",
+                translate("pages.login.divider", "or"),
+              )}
             </Divider>
           )}
         </>
@@ -238,7 +241,13 @@ export const RegisterPage: React.FC<RegisterProps> = ({
             }}
           >
             <Typography variant="body2" component="span" fontSize="12px">
-              {translate("pages.login.buttons.haveAccount", "Have an account?")}
+              {translate(
+                "pages.register.buttons.haveAccount",
+                translate(
+                  "pages.login.buttons.haveAccount",
+                  "Have an account?",
+                ),
+              )}
             </Typography>
             <MuiLink
               ml="4px"
@@ -250,7 +259,10 @@ export const RegisterPage: React.FC<RegisterProps> = ({
               fontSize="12px"
               fontWeight="bold"
             >
-              {translate("pages.login.signin", "Sign in")}
+              {translate(
+                "pages.register.signin",
+                translate("pages.login.signin", "Sign in"),
+              )}
             </MuiLink>
           </Box>
         )}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

fix(auth-page): fix wrong translation keys in `type="register"` and `type="forgotPassword"`

In `type="forgotPassword"`:

- `"pages.register.buttons.haveAccount"` is replaced with `"pages.forgotPassword.buttons.haveAccount"`
- `"pages.login.signin"` is replaced with `"pages.forgotPassword.signin"`

In `type="register"`:

- `"pages.login.divider"` is replaced with `"pages.register.divider"`
- `"pages.login.buttons.haveAccount"` is replaced with `"pages.register.buttons.haveAccount"`
- `"pages.login.signin"` is replaced with `"pages.register.signin"`

Wrong keys are kept as fallbacks in case the new keys are not found in the translation file. If you are using those keys in your project, make sure to update them accordingly. Fallback keys will be removed in future releases.

Fixes #5816 

fix(auth-page): fix wrong translation key in `type="register"`

Previously, sign in link in Register page was using wrong translation key "pages.register.buttons.noAccount". Now it is replaced with "pages.register.buttons.haveAccount".