### PR TITLE
feat(supabase): add support for between in dataProvider. maps values to gte & lte. #6119

### DIFF
--- a/.changeset/hot-cougars-dream.md
+++ b/.changeset/hot-cougars-dream.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/supabase": patch
+---
+
+feat: added support for between filter in supabase dataProvider. Maps values to gte & lte.
+
+[Feat #6119](https://github.com/refinedev/refine/issues/6119)

--- a/packages/supabase/src/dataProvider/index.ts
+++ b/packages/supabase/src/dataProvider/index.ts
@@ -39,7 +39,26 @@ export const dataProvider = (
       });
 
       filters?.map((item) => {
-        generateFilter(item, query);
+        if (item.operator === "between") {
+          generateFilter(
+            {
+              field: item.field,
+              operator: "gte",
+              value: item.value[0],
+            },
+            query,
+          );
+          generateFilter(
+            {
+              field: item.field,
+              operator: "lte",
+              value: item.value[1],
+            },
+            query,
+          );
+        } else {
+          generateFilter(item, query);
+        }
       });
 
       const { data, count, error } = await query;


### PR DESCRIPTION
- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
Current Supabase data provider does not support between date ranges.

When providing an initial filter with a between operator to useTable Hook an error occurs.

## What is the new behavior?
Supabase data provider will now map `between` date ranges from the values array to gte & lte accordingly adding support for `between` to Supabase data provider.

feat #6119 
