### PR TITLE
fix(core): `invalidates` prop of `useUpdateMany` doesn't work

### DIFF
--- a/.changeset/sour-ravens-begin.md
+++ b/.changeset/sour-ravens-begin.md
@@ -1,0 +1,16 @@
+---
+"@refinedev/core": patch
+---
+
+fix: `invalidates` prop of `useUpdateMany` doesn't work. #6209
+
+From now on, the `invalidates` prop of the `useUpdateMany` hook will work as expected.
+
+```tsx
+const { mutate } = useUpdateMany({
+  resource: "posts",
+  invalidates: ["all"], // invalidates all queries of the "posts" resource
+});
+
+mutate({ ids: [1, 2, 3], values: { title: "new title" } });
+```

--- a/packages/core/src/hooks/data/useUpdateMany.spec.tsx
+++ b/packages/core/src/hooks/data/useUpdateMany.spec.tsx
@@ -1244,6 +1244,37 @@ describe("useUpdateMany Hook [with params]", () => {
       );
     });
   });
+
+  it("should override default invalidate", async () => {
+    const invalidateStore = jest.fn();
+    jest.spyOn(UseInvalidate, "useInvalidate").mockReturnValue(invalidateStore);
+
+    const { result } = renderHook(() => useUpdateMany(), {
+      wrapper: TestWrapper({
+        dataProvider: MockJSONServer,
+        resources: [{ name: "posts" }],
+      }),
+    });
+
+    act(() => {
+      result.current.mutate({
+        invalidates: ["resourceAll"],
+        resource: "posts",
+        ids: ["1", "2"],
+        values: {},
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy();
+    });
+
+    expect(invalidateStore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invalidates: ["resourceAll"],
+      }),
+    );
+  });
 });
 
 describe("useUpdateMany Hook [with props]", () => {
@@ -2595,6 +2626,42 @@ describe("useUpdateMany Hook [with props]", () => {
         ),
       );
     });
+  });
+
+  it("should override default invalidate", async () => {
+    const invalidateStore = jest.fn();
+    jest.spyOn(UseInvalidate, "useInvalidate").mockReturnValue(invalidateStore);
+
+    const { result } = renderHook(
+      () =>
+        useUpdateMany({
+          resource: "posts",
+          invalidates: ["resourceAll"],
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: MockJSONServer,
+          resources: [{ name: "posts" }],
+        }),
+      },
+    );
+
+    act(() => {
+      result.current.mutate({
+        ids: ["1", "2"],
+        values: {},
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy();
+    });
+
+    expect(invalidateStore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invalidates: ["resourceAll"],
+      }),
+    );
   });
 });
 

--- a/packages/core/src/hooks/data/useUpdateMany.ts
+++ b/packages/core/src/hooks/data/useUpdateMany.ts
@@ -486,6 +486,7 @@ export const useUpdateMany = <
         ids = idsFromProps,
         resource: resourceName = resourceFromProps,
         dataProviderName = dataProviderNameFromProps,
+        invalidates = invalidatesFromProps,
       } = variables;
       if (!ids) throw missingIdError;
       if (!resourceName) throw missingResourceError;
@@ -495,7 +496,7 @@ export const useUpdateMany = <
       // invalidate the cache for the list and many queries:
       invalidateStore({
         resource: identifier,
-        invalidates: ["list", "many"],
+        invalidates: invalidates ?? ["list", "many"],
         dataProviderName: pickDataProvider(
           identifier,
           dataProviderName,
@@ -506,7 +507,7 @@ export const useUpdateMany = <
       ids.forEach((id) =>
         invalidateStore({
           resource: identifier,
-          invalidates: ["detail"],
+          invalidates: invalidates ?? ["detail"],
           dataProviderName: pickDataProvider(
             identifier,
             dataProviderName,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
this is not working

```tsx
const { mutate } = useUpdateMany();
mutate({ invalidates: ["all"], resource: "posts", values: {}, ids: [1, 2, 3] });
```
## What is the new behavior?

now working

fixes #6209

