### PR TITLE
test(cypress): add e2e for i18n-nextjs and i18n-react

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "packages/**"
       - "examples/**"
+      - "cypress/e2e/**"
     types:
       - labeled
       - synchronize

--- a/cypress/e2e/i18n-nextjs/all.cy.ts
+++ b/cypress/e2e/i18n-nextjs/all.cy.ts
@@ -1,0 +1,75 @@
+/// <reference types="cypress" />
+/// <reference types="../../cypress/support" />
+
+Cypress.on("uncaught:exception", () => {
+  return false;
+});
+
+describe("i18n-nextjs", () => {
+  beforeEach(() => {
+    cy.clearAllCookies();
+    cy.clearAllLocalStorage();
+    cy.clearAllSessionStorage();
+
+    cy.interceptGETBlogPosts();
+    cy.visit("/");
+  });
+
+  it("should change", () => {
+    cy.wait("@getBlogPosts");
+
+    // check the elements are in English which is the default language
+    cy.get(".ant-menu > .ant-menu-item")
+      .contains("Blog Posts")
+      .get(".ant-page-header-heading-left")
+      .contains("Posts")
+      .get(".refine-create-button")
+      .contains("Create")
+      .get(".ant-table-thead > tr > :nth-child(2)")
+      .contains("Title")
+      .get(".ant-table-thead > tr > :nth-child(3)")
+      .contains("Content")
+      .get(".ant-table-thead > tr > :nth-child(4)")
+      .contains("Category")
+      .get(".ant-table-thead > tr > :nth-child(5)")
+      .contains("Status")
+      .get(".ant-table-thead > tr > :nth-child(6)")
+      .contains("Created At")
+      .get(".ant-table-thead > tr > :nth-child(7)")
+      .contains("Actions");
+
+    // find the language button
+    cy.get(".ant-layout-header > .ant-btn")
+      // should contain English which is the default language
+      .contains("English")
+      // hover over the button to show the dropdown
+      .trigger("mouseover")
+      // click on the German language
+      .get(".ant-dropdown-menu-title-content")
+      .contains("German")
+      .click()
+      // should contain German
+      .get(".ant-layout-header > .ant-btn")
+      .contains("German");
+
+    // check the elements are translated
+    cy.get(".ant-menu > .ant-menu-item")
+      .contains("Einträge")
+      .get(".ant-page-header-heading-left")
+      .contains("Einträge")
+      .get(".refine-create-button")
+      .contains("Erstellen")
+      .get(".ant-table-thead > tr > :nth-child(2)")
+      .contains("Titel")
+      .get(".ant-table-thead > tr > :nth-child(3)")
+      .contains("Inhalh")
+      .get(".ant-table-thead > tr > :nth-child(4)")
+      .contains("Kategorie")
+      .get(".ant-table-thead > tr > :nth-child(5)")
+      .contains("Status")
+      .get(".ant-table-thead > tr > :nth-child(6)")
+      .contains("Erstellt am")
+      .get(".ant-table-thead > tr > :nth-child(7)")
+      .contains("Aktionen");
+  });
+});

--- a/cypress/e2e/i18n-react/all.cy.ts
+++ b/cypress/e2e/i18n-react/all.cy.ts
@@ -1,0 +1,63 @@
+/// <reference types="cypress" />
+/// <reference types="../../cypress/support" />
+
+Cypress.on("uncaught:exception", () => {
+  return false;
+});
+
+describe("i18n-react", () => {
+  beforeEach(() => {
+    cy.clearAllCookies();
+    cy.clearAllLocalStorage();
+    cy.clearAllSessionStorage();
+
+    cy.interceptGETPosts();
+    cy.visit("/");
+  });
+
+  it("should change", () => {
+    cy.wait("@getPosts");
+
+    // check the elements are in English which is the default language
+    cy.get(".ant-menu > .ant-menu-item")
+      .contains("Posts")
+      .get(".ant-page-header-heading-left")
+      .contains("Posts")
+      .get(".refine-create-button")
+      .contains("Create")
+      .get(".ant-table-thead > tr > :nth-child(2)")
+      .contains("Title")
+      .get(".ant-table-thead > tr > :nth-child(3)")
+      .contains("Category")
+      .get(".ant-table-thead > tr > :nth-child(4)")
+      .contains("Actions");
+
+    // find the language button
+    cy.get(".ant-layout-header > .ant-btn")
+      // should contain English which is the default language
+      .contains("English")
+      // hover over the button to show the dropdown
+      .trigger("mouseover")
+      // click on the German language
+      .get(".ant-dropdown-menu-title-content")
+      .contains("German")
+      .click()
+      // should contain German
+      .get(".ant-layout-header > .ant-btn")
+      .contains("German");
+
+    // check the elements are translated
+    cy.get(".ant-menu > .ant-menu-item")
+      .contains("Einträge")
+      .get(".ant-page-header-heading-left")
+      .contains("Einträge")
+      .get(".refine-create-button")
+      .contains("Erstellen")
+      .get(".ant-table-thead > tr > :nth-child(2)")
+      .contains("Titel")
+      .get(".ant-table-thead > tr > :nth-child(3)")
+      .contains("Kategorie")
+      .get(".ant-table-thead > tr > :nth-child(4)")
+      .contains("Aktionen");
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

There is no e2e test for i18n

## What is the new behavior?

i18n tests are added

