### PR TITLE
feat(cli): automatically install `@refinedev/inferencer` after resources are generated

### DIFF
--- a/.changeset/eleven-bottles-rush.md
+++ b/.changeset/eleven-bottles-rush.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/cli": minor
+---
+
+feat: Automatically install `@refinedev/inferencer` if missing after generating new resources.

--- a/.changeset/eleven-bottles-rush.md
+++ b/.changeset/eleven-bottles-rush.md
@@ -2,4 +2,4 @@
 "@refinedev/cli": minor
 ---
 
-feat: Automatically install `@refinedev/inferencer` if missing after generating new resources.
+feat: Automatically install `@refinedev/inferencer` if missing after generating new resources. #6220

--- a/.changeset/eleven-bottles-rush.md
+++ b/.changeset/eleven-bottles-rush.md
@@ -2,4 +2,6 @@
 "@refinedev/cli": minor
 ---
 
-feat: Automatically install `@refinedev/inferencer` if missing after generating new resources. #6220
+feat: Automatically install `@refinedev/inferencer` if missing after generating new resources.
+
+[Resolves #6220](https://github.com/refinedev/refine/issues/6220)

--- a/packages/cli/src/commands/add/sub-commands/resource/create-resources.ts
+++ b/packages/cli/src/commands/add/sub-commands/resource/create-resources.ts
@@ -173,16 +173,16 @@ export const createResources = async (
 
   console.log();
   const isInferencerInstalled = await spinner(
-    async () => await isInstalled("@refinedev/inferencer"),
+    () => isInstalled("@refinedev/inferencer"),
     "Checking if '@refinedev/inferencer' package is installed...",
   );
   if (!isInferencerInstalled) {
     console.log("📦 Installing '@refinedev/inferencer' package...");
-    await installPackages(
-      ["@refinedev/inferencer@latest"],
-      "add",
-      "✅ '@refinedev/inferencer' package installed successfully!",
-    );
+    // await installPackages(
+    //   ["@refinedev/inferencer@latest"],
+    //   "add",
+    //   "✅ '@refinedev/inferencer' package installed successfully!",
+    // );
   }
 
   return;

--- a/packages/cli/src/commands/add/sub-commands/resource/create-resources.ts
+++ b/packages/cli/src/commands/add/sub-commands/resource/create-resources.ts
@@ -76,7 +76,7 @@ export const createResources = async (
           resourceFolderName,
         )}) already exist!`,
       );
-      process.exit(0);
+      return;
     }
 
     // uppercase first letter
@@ -173,7 +173,7 @@ export const createResources = async (
 
   console.log();
   const isInferencerInstalled = await spinner(
-    () => isInstalled("@refinedev/inferencer"),
+    async () => await isInstalled("@refinedev/inferencer"),
     "Checking if '@refinedev/inferencer' package is installed...",
   );
   if (!isInferencerInstalled) {

--- a/packages/cli/src/commands/add/sub-commands/resource/create-resources.ts
+++ b/packages/cli/src/commands/add/sub-commands/resource/create-resources.ts
@@ -58,6 +58,7 @@ export const createResources = async (
     actions = selectedActions.join(",");
   }
 
+  let isAtleastOneResourceCreated = false;
   resources.forEach((resourceName) => {
     const customActions = actions ? actions.split(",") : undefined;
     const resourceFolderName = plural(resourceName).toLowerCase();
@@ -78,6 +79,7 @@ export const createResources = async (
       );
       return;
     }
+    isAtleastOneResourceCreated = true;
 
     // uppercase first letter
     const resource = uppercaseFirstChar(resourceName);
@@ -171,18 +173,8 @@ export const createResources = async (
     );
   });
 
-  console.log();
-  const isInferencerInstalled = await spinner(
-    () => isInstalled("@refinedev/inferencer"),
-    "Checking if '@refinedev/inferencer' package is installed...",
-  );
-  if (!isInferencerInstalled) {
-    console.log("📦 Installing '@refinedev/inferencer' package...");
-    // await installPackages(
-    //   ["@refinedev/inferencer@latest"],
-    //   "add",
-    //   "✅ '@refinedev/inferencer' package installed successfully!",
-    // );
+  if (isAtleastOneResourceCreated) {
+    installInferencer();
   }
 
   return;
@@ -238,4 +230,20 @@ const generateNextJsPages = (
   // compile page files
   const compileParams = { resource, resourceFolderName };
   compileDir(resourcePageRootDirPath, compileParams);
+};
+
+export const installInferencer = async () => {
+  console.log();
+  const isInferencerInstalled = await spinner(
+    () => isInstalled("@refinedev/inferencer"),
+    "Checking if '@refinedev/inferencer' package is installed...",
+  );
+  if (!isInferencerInstalled) {
+    console.log("📦 Installing '@refinedev/inferencer' package...");
+    await installPackages(
+      ["@refinedev/inferencer@latest"],
+      "add",
+      "✅ '@refinedev/inferencer' package installed successfully!",
+    );
+  }
 };

--- a/packages/cli/src/commands/add/sub-commands/resource/create-resources.ts
+++ b/packages/cli/src/commands/add/sub-commands/resource/create-resources.ts
@@ -1,7 +1,9 @@
 import { ProjectTypes } from "@definitions/projectTypes";
 import { compileDir } from "@utils/compile";
+import { installPackages, isInstalled } from "@utils/package";
 import { getProjectType, getUIFramework } from "@utils/project";
 import { getResourcePath } from "@utils/resource";
+import spinner from "@utils/spinner";
 import { uppercaseFirstChar } from "@utils/text";
 import execa from "execa";
 import {
@@ -74,7 +76,7 @@ export const createResources = async (
           resourceFolderName,
         )}) already exist!`,
       );
-      return;
+      process.exit(0);
     }
 
     // uppercase first letter
@@ -168,6 +170,20 @@ export const createResources = async (
       `🎉 Resource (${destinationResourcePath}) generated successfully!`,
     );
   });
+
+  console.log();
+  const isInferencerInstalled = await spinner(
+    () => isInstalled("@refinedev/inferencer"),
+    "Checking if '@refinedev/inferencer' package is installed...",
+  );
+  if (!isInferencerInstalled) {
+    console.log("📦 Installing '@refinedev/inferencer' package...");
+    await installPackages(
+      ["@refinedev/inferencer@latest"],
+      "add",
+      "✅ '@refinedev/inferencer' package installed successfully!",
+    );
+  }
 
   return;
 };

--- a/packages/cli/src/commands/add/sub-commands/resource/index.test.ts
+++ b/packages/cli/src/commands/add/sub-commands/resource/index.test.ts
@@ -6,14 +6,6 @@ import { existsSync, readFileSync, rmdirSync } from "fs-extra";
 const srcDirPath = `${__dirname}/../../../..`;
 
 describe("add", () => {
-  beforeEach(() => {
-    jest.spyOn(global.console, "log").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   it("should generate next js pages", () => {
     jest
       .spyOn(utilsProject, "getProjectType")

--- a/packages/cli/src/commands/add/sub-commands/resource/index.test.ts
+++ b/packages/cli/src/commands/add/sub-commands/resource/index.test.ts
@@ -6,6 +6,14 @@ import { existsSync, readFileSync, rmdirSync } from "fs-extra";
 const srcDirPath = `${__dirname}/../../../..`;
 
 describe("add", () => {
+  beforeEach(() => {
+    jest.spyOn(global.console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("should generate next js pages", () => {
     jest
       .spyOn(utilsProject, "getProjectType")

--- a/packages/cli/src/commands/add/sub-commands/resource/index.test.ts
+++ b/packages/cli/src/commands/add/sub-commands/resource/index.test.ts
@@ -6,6 +6,10 @@ import { existsSync, readFileSync, rmdirSync } from "fs-extra";
 const srcDirPath = `${__dirname}/../../../..`;
 
 describe("add", () => {
+  beforeEach(() => {
+    jest.spyOn(testTargetModule, "installInferencer").mockImplementation();
+  });
+
   it("should generate next js pages", () => {
     jest
       .spyOn(utilsProject, "getProjectType")

--- a/packages/cli/src/utils/package/index.ts
+++ b/packages/cli/src/utils/package/index.ts
@@ -166,6 +166,7 @@ export const getPreferedPM = async () => {
 export const installPackages = async (
   packages: string[],
   type: "all" | "add" = "all",
+  successMessage = "All `Refine` packages updated  🎉",
 ) => {
   const pm = await getPreferedPM();
 
@@ -187,7 +188,7 @@ export const installPackages = async (
 
     execution.on("exit", (exitCode) => {
       if (exitCode === 0) {
-        console.log("All `Refine` packages updated  🎉");
+        console.log(successMessage);
         return;
       }
 
@@ -333,4 +334,13 @@ export const getAllVersionsOfPackage = async (
   }
 
   return result;
+};
+
+export const isInstalled = async (packageName: string) => {
+  const installedPackages = await getInstalledRefinePackages();
+  if (!installedPackages) {
+    return false;
+  }
+
+  return installedPackages.some((pkg) => pkg.name === packageName);
 };

--- a/packages/cli/test/jest.setup.ts
+++ b/packages/cli/test/jest.setup.ts
@@ -1,0 +1,1 @@
+jest.spyOn(console, "log").mockImplementation(() => {});

--- a/packages/cli/test/jest.setup.ts
+++ b/packages/cli/test/jest.setup.ts
@@ -1,1 +1,0 @@
-jest.spyOn(console, "log").mockImplementation(() => {});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

CLI doesn't install `@refinedev/inferencer` package but it's required on generated resource components

## What is the new behavior?

From now on, `refinedev/cli` automatically installs `@refinedev/inferencer`.

fixes #6220


