### PR TITLE
fix(core): fixed type issue in useSelect's `optionLabel` and `optionValue`

### DIFF
--- a/.changeset/chilled-cherries-sin.md
+++ b/.changeset/chilled-cherries-sin.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/core": patch
+---
+
+fix(core): fixed type issue in useSelect. #6223
+
+Previously, the types would not allow functions to be passed as props. After this change, it will be possible.
+
+[Resolves #6223](https://github.com/refinedev/refine/issues/6223)

--- a/packages/core/src/hooks/useSelect/index.ts
+++ b/packages/core/src/hooks/useSelect/index.ts
@@ -45,16 +45,16 @@ export type UseSelectProps<TQueryFnData, TError, TData> = {
    * Set the option's label value
    * @default `"title"`
    */
-  optionLabel?: keyof TData extends string
-    ? keyof TData
-    : never | ((item: TData) => string);
+  optionLabel?:
+    | (keyof TData extends string ? keyof TData : never)
+    | ((item: TData) => string);
   /**
    * Set the option's value
    * @default `"id"`
    */
-  optionValue?: keyof TData extends string
-    ? keyof TData
-    : never | ((item: TData) => string);
+  optionValue?:
+    | (keyof TData extends string ? keyof TData : never)
+    | ((item: TData) => string);
   /**
    * Field name to search for.
    * @description If provided `optionLabel` is a string, uses `optionLabel`'s value.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
The type didn't allow to pass function in `optionValue` and `optionLabel`.

## What is the new behavior?
The type allows to pass function in `optionValue` and `optionLabel`.

fixes (#6223)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
