### PR TITLE
chore(react-table-react-hook-form): add missing changesets

### DIFF
--- a/.changeset/odd-eggs-flash.md
+++ b/.changeset/odd-eggs-flash.md
@@ -1,0 +1,14 @@
+---
+"@refinedev/react-table": patch
+---
+
+chore: update `@refinedev/core` usage to reflect latest renamings.
+
+> These changes applied on internal usage of `@refinedev/core` in `@refinedev/react-table` package.
+
+```diff
+import { useTable } from '@refinedev/core';
+
+- const { tableQueryResult} = useTable();
++ const { tableQuery } = useTable();
+```

--- a/.changeset/silver-candles-wait.md
+++ b/.changeset/silver-candles-wait.md
@@ -1,0 +1,14 @@
+---
+"@refinedev/react-hook-form": patch
+---
+
+chore: update `@refinedev/core` usage to reflect latest renamings.
+
+> These changes applied on internal usage of `@refinedev/core` in `@refinedev/react-hook-form` package.
+
+```diff
+import { useForm } from '@refinedev/core';
+
+- const { queryResult, mutationResult } = useForm();
++ const { query, mutation} = useForm();
+```


### PR DESCRIPTION
Added august release missing changesets for `@refinedev/react-table` and `@refinedev/react-hook-form` packages.