### PR TITLE
build(type-generation): log errors and output properly

### DIFF
--- a/packages/shared/generate-declarations.js
+++ b/packages/shared/generate-declarations.js
@@ -4,7 +4,7 @@ const { globSync } = require("glob");
 
 const generateDeclarations = () => {
   execSync("tsc --project tsconfig.declarations.json", {
-    stdio: "inherit",
+    stdio: [process.stdin, process.stdout, process.stdout],
   });
 };
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

To avoid silent failures due to spawned processes omitting stdout when stderr has a buffer. This has caused unknown errors thrown when Release action is running for publishing the packages. Typescript (`tsc`) logs the errors and warnings to `stdout` and `stderr` only containing a summary of the error. This leads to non-debuggable output for the CI. 