### PR TITLE
fix(supabase): parse nested values correctly when using conditional filters

### DIFF
--- a/.changeset/few-turkeys-dance.md
+++ b/.changeset/few-turkeys-dance.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/supabase": patch
+---
+
+fix: issue with parsed values when using ConditionalFilter on Supabase DataProvider #6239
+
+Fixed ConditionalFilter parsed values while using contains, containss, startswith and endswith on Supabase DataProvider Filters
+
+Fixes #6239

--- a/.changeset/few-turkeys-dance.md
+++ b/.changeset/few-turkeys-dance.md
@@ -2,8 +2,8 @@
 "@refinedev/supabase": patch
 ---
 
-fix: issue with parsed values when using ConditionalFilter on Supabase DataProvider #6239
+fix(supabase): issue with parsed values when using conditional filters
 
-Fixed ConditionalFilter parsed values while using contains, containss, startswith and endswith on Supabase DataProvider Filters
+Fixed conditional filter's parsed values while using `contains`, `containss`, `startswith` and `endswith`.
 
-Fixes #6239
+[Fixes #6239](https://github.com/refinedev/refine/issues/6239)

--- a/packages/supabase/src/utils/generateFilter.ts
+++ b/packages/supabase/src/utils/generateFilter.ts
@@ -63,11 +63,11 @@ export const generateFilter = (filter: CrudFilter, query: any) => {
               value = `%${value}%`;
             }
 
-            if(item.operator === "startswith") {
+            if (item.operator === "startswith") {
               value = `${value}%`;
             }
 
-            if(item.operator === "endswith") {
+            if (item.operator === "endswith") {
               value = `%${value}`;
             }
 

--- a/packages/supabase/src/utils/generateFilter.ts
+++ b/packages/supabase/src/utils/generateFilter.ts
@@ -59,6 +59,18 @@ export const generateFilter = (filter: CrudFilter, query: any) => {
               value = `{${item.value.map((val: any) => `"${val}"`).join(",")}}`;
             }
 
+            if (item.operator === "contains" || item.operator === "containss") {
+              value = `%${value}%`;
+            }
+
+            if(item.operator === "startswith") {
+              value = `${value}%`;
+            }
+
+            if(item.operator === "endswith") {
+              value = `%${value}`;
+            }
+
             return `${item.field}.${mapOperator(item.operator)}.${value}`;
           }
           return;

--- a/packages/supabase/test/getList/index.mock.ts
+++ b/packages/supabase/test/getList/index.mock.ts
@@ -1999,3 +1999,77 @@ nock("https://iwdfzvfqbtokqetmbmbp.supabase.co:443", {
       'h3=":443"; ma=86400',
     ],
   );
+
+nock("https://iwdfzvfqbtokqetmbmbp.supabase.co:443", {
+  encodedQueryParams: true,
+})
+  .get("/rest/v1/posts")
+  .query({
+    select: "%2A",
+    offset: "0",
+    limit: "10",
+    or: "%28title.ilike.%25Black+Psorotichia%25%2Ccontent.ilike.%25Sed+sagittis%25%29",
+  })
+  .reply(
+    200,
+    [
+      {
+        id: 1,
+        title: "Black Psorotichia Lichen",
+        slug: "61a31089-c85d-48a0-a4be-d5dce5c96b6a",
+        createdAt: "2024-04-24T13:20:10.200327+00:00",
+        content:
+          "Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.\n\nPraesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.\n\nMorbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem.",
+        categoryId: 7,
+        images: null,
+      },
+      {
+        id: 13,
+        title: "Dust Lichen",
+        slug: "ca038c02-0c6f-417b-aaf8-6f51b777d1f5",
+        createdAt: "2024-04-24T13:20:10.200327+00:00",
+        content:
+          "Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.\n\nSed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.",
+        categoryId: 7,
+        images: null,
+      },
+    ],
+    [
+      "Date",
+      "Thu, 25 Apr 2024 07:26:59 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Transfer-Encoding",
+      "chunked",
+      "Connection",
+      "close",
+      "Content-Range",
+      "0-1/2",
+      "CF-Ray",
+      "879c9ba35d5b68ae-IST",
+      "CF-Cache-Status",
+      "DYNAMIC",
+      "Access-Control-Allow-Origin",
+      "*",
+      "Content-Location",
+      "/posts?limit=10&offset=0&or=%28title.ilike.%25Black+Psorotichia%25%2Ccontent.ilike.%25Sed+sagittis%25%29&select=%2A",
+      "Strict-Transport-Security",
+      "max-age=15552000; includeSubDomains",
+      "Vary",
+      "Accept-Encoding",
+      "Via",
+      "kong/2.8.1",
+      "content-profile",
+      "public",
+      "sb-gateway-version",
+      "1",
+      "x-kong-proxy-latency",
+      "1",
+      "x-kong-upstream-latency",
+      "3",
+      "Server",
+      "cloudflare",
+      "alt-svc",
+      'h3=":443"; ma=86400',
+    ],
+  );

--- a/packages/supabase/test/getList/index.spec.ts
+++ b/packages/supabase/test/getList/index.spec.ts
@@ -399,6 +399,34 @@ describe("filtering", () => {
     expect(total).toBe(6);
   });
 
+  it("contains operator should work correctly with or", async () => {
+    const { data, total } = await dataProvider(supabaseClient).getList({
+      resource: "posts",
+      filters: [
+        {
+          operator: "or",
+          value: [
+            {
+              field: "title",
+              operator: "contains",
+              value: "Black Psorotichia",
+            },
+            {
+              field: "content",
+              operator: "contains",
+              value: "Sed sagittis",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(data).toHaveLength(2);
+    expect(data[0].title).toBe("Black Psorotichia Lichen");
+    expect(data[1].title).toBe("Dust Lichen");
+    expect(total).toBe(2);
+  });
+
   it("should change schema", async () => {
     const { data } = await dataProvider(supabaseClient).getList({
       resource: "posts",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

Consider the following filter:

```js
const filter: CrudFilter = {
  operator: 'or',
  value: [
    {
      field: 'name',
      operator: 'contains',
      value: 'foo',
    }
  ],
};
```
resolve to (name.ilike.foo) giving no results

## What is the new behavior?

The filter should resolve to (name.ilike.%foo%) 

fixes (#6239)

## Notes for reviewers

If you consider having extra tests, I can add some to cover it fully
