### PR TITLE
chore(docs): make UI Framework Packages' highlights consistent

### DIFF
--- a/documentation/docs/packages/list-of-packages/index.md
+++ b/documentation/docs/packages/list-of-packages/index.md
@@ -12,8 +12,8 @@ To learn more about UI Libraries and integrations, check out [UI Libraries](/doc
 
 - [`@refinedev/antd`](/docs/ui-integrations/ant-design/introduction) - [Ant Design](https://ant.design/) System UI Framework support. **20+** framework-specific `hooks` and  `components`  incl. Table, Form, Select, Menu, Layout, Notification and CRUD components.
 - [`@refinedev/mui`](/docs/ui-integrations/material-ui/introduction) - [Material UI](https://mui.com/material-ui/getting-started/overview/) Framework support. **20+** framework-specific `hooks` and  `components`  incl. DataGrid (+ Pro), AutoComplete, Menu, Layout, Notification and CRUD components.
-- [`@refinedev/mantine`](/docs/ui-integrations/mantine/introduction) - [Mantine](https://mantine.dev/) UI Framework support. **20+** framework-specific **hooks** and **components** incl. Table, Form, AutoComplete, Menu, Layout, Notification and CRUD components.
-- [`@refinedev/chakra-ui`](/docs/ui-integrations/chakra-ui/introduction) - [Chakra UI](https://chakra-ui.com/) UI Framework support. **20+** framework-specific **components** incl. Menu, Layout, Notification and CRUD components.
+- [`@refinedev/mantine`](/docs/ui-integrations/mantine/introduction) - [Mantine](https://mantine.dev/) UI Framework support. **20+** framework-specific `hooks` and `components` incl. Table, Form, AutoComplete, Menu, Layout, Notification and CRUD components.
+- [`@refinedev/chakra-ui`](/docs/ui-integrations/chakra-ui/introduction) - [Chakra UI](https://chakra-ui.com/) UI Framework support. **20+** framework-specific `components` incl. Menu, Layout, Notification and CRUD components.
 
 ### Data Provider Packages:
 


### PR DESCRIPTION
In the [UI Framework Packages](https://refine.dev/docs/packages/list-of-packages/#ui-framework-packages) section of the [List of Packages](https://refine.dev/docs/packages/list-of-packages) page, words `hooks` and `components` are highlighted as `code` for the first two frameworkd and higlighted as **bold** for the two other frameworkds.

As the first package on this page (`@refinedev/core`) highlighted these words as `code`, I've highlighted those words as `code` for the last two UI frameworks too, to just be more consistent.

As the first line of this page (`@refinedev/core`) styled these words as code, I've changed those two from bold to code too.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [X] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

The words `hooks` and `components` in [UI Framework Packages](https://refine.dev/docs/packages/list-of-packages/#ui-framework-packages) section have two different variations (code and bold)

## What is the new behavior?

Those words are now all highlighted as code.

## Notes for reviewers

I know that this PR makes no sense, but as it was something that I had noticed, I thought doing a PR would be okay.