### PR TITLE
chore(tutorial): update deprecated `queryResult` to `query`

### DIFF
--- a/documentation/tutorial/routing/inferring-parameters/react-router/index.md
+++ b/documentation/tutorial/routing/inferring-parameters/react-router/index.md
@@ -62,7 +62,7 @@ export const ShowProduct = () => {
   // removed-line
   const { data, isLoading } = useOne({ resource: "products", id: 123 });
   // added-line
-  const { queryResult } = useShow();
+  const { query } = useShow();
 
   /* ... */
 };

--- a/documentation/tutorial/routing/inferring-parameters/react-router/sandpack.tsx
+++ b/documentation/tutorial/routing/inferring-parameters/react-router/sandpack.tsx
@@ -162,7 +162,7 @@ import { useShow } from "@refinedev/core";
 
 export const ShowProduct = () => {
   const {
-    queryResult: { data, isLoading },
+    query: { data, isLoading },
   } = useShow();
 
   if (isLoading) {

--- a/documentation/tutorial/ui-libraries/crud-components/ant-design/react-router/index.md
+++ b/documentation/tutorial/ui-libraries/crud-components/ant-design/react-router/index.md
@@ -195,7 +195,7 @@ import { TextField, NumberField, MarkdownField, Show } from "@refinedev/antd";
 import { Typography } from "antd";
 
 export const ShowProduct = () => {
-    const { queryResult: { data, isLoading } } = useShow();
+    const { query: { data, isLoading } } = useShow();
 
     const { data: categoryData, isLoading: categoryIsLoading } =
     useOne({

--- a/documentation/tutorial/ui-libraries/crud-components/ant-design/react-router/sandpack.tsx
+++ b/documentation/tutorial/ui-libraries/crud-components/ant-design/react-router/sandpack.tsx
@@ -122,7 +122,7 @@ import { Typography } from "antd";
 
 export const ShowProduct = () => {
   const {
-    queryResult: { data, isLoading },
+    query: { data, isLoading },
   } = useShow();
 
   const { data: categoryData, isLoading: categoryIsLoading } = useOne({

--- a/documentation/tutorial/ui-libraries/crud-components/material-ui/react-router/index.md
+++ b/documentation/tutorial/ui-libraries/crud-components/material-ui/react-router/index.md
@@ -42,7 +42,7 @@ export const ListProducts = () => {
 
   const {
     options: categories,
-    queryResult: { isLoading },
+    query: { isLoading },
   } = useSelect<ICategory>({
     resource: "categories",
     pagination: false,
@@ -189,7 +189,7 @@ import Stack from "@mui/material/Stack";
 
 export const ShowProduct = () => {
   const {
-    queryResult: { data, isLoading },
+    query: { data, isLoading },
   } = useShow();
 
   const { data: categoryData, isLoading: categoryIsLoading } = useOne({

--- a/documentation/tutorial/ui-libraries/crud-components/material-ui/react-router/sandpack.tsx
+++ b/documentation/tutorial/ui-libraries/crud-components/material-ui/react-router/sandpack.tsx
@@ -42,7 +42,7 @@ export const ListProducts = () => {
 
   const {
     options: categories,
-    queryResult: { isLoading },
+    query: { isLoading },
   } = useSelect<ICategory>({
     resource: "categories",
     pagination: false,
@@ -143,7 +143,7 @@ import Stack from "@mui/material/Stack";
 
 export const ShowProduct = () => {
   const {
-    queryResult: { data, isLoading },
+    query: { data, isLoading },
   } = useShow();
 
   const { data: categoryData, isLoading: categoryIsLoading } = useOne({

--- a/documentation/tutorial/ui-libraries/refactoring/ant-design/react-router/index.md
+++ b/documentation/tutorial/ui-libraries/refactoring/ant-design/react-router/index.md
@@ -448,7 +448,7 @@ import { Typography } from "antd";
 
 export const ShowProduct = () => {
   const {
-    queryResult: { data, isLoading },
+    query: { data, isLoading },
   } = useShow();
 
   const { data: categoryData, isLoading: categoryIsLoading } = useOne({

--- a/documentation/tutorial/ui-libraries/refactoring/ant-design/react-router/sandpack.tsx
+++ b/documentation/tutorial/ui-libraries/refactoring/ant-design/react-router/sandpack.tsx
@@ -241,7 +241,7 @@ import { Typography } from "antd";
 
 export const ShowProduct = () => {
   const {
-    queryResult: { data, isLoading },
+    query: { data, isLoading },
   } = useShow();
 
   const { data: categoryData, isLoading: categoryIsLoading } = useOne({

--- a/documentation/tutorial/ui-libraries/refactoring/material-ui/react-router/index.md
+++ b/documentation/tutorial/ui-libraries/refactoring/material-ui/react-router/index.md
@@ -166,7 +166,7 @@ export const ListProducts = () => {
   // highlight-start
   const {
     options: categories,
-    queryResult: { isLoading },
+    query: { isLoading },
   } = useSelect<ICategory>({
     resource: "categories",
   });
@@ -532,7 +532,7 @@ import Stack from "@mui/material/Stack";
 
 export const ShowProduct = () => {
   const {
-    queryResult: { data, isLoading },
+    query: { data, isLoading },
   } = useShow();
 
   const { data: categoryData, isLoading: categoryIsLoading } = useOne({

--- a/documentation/tutorial/ui-libraries/refactoring/material-ui/react-router/sandpack.tsx
+++ b/documentation/tutorial/ui-libraries/refactoring/material-ui/react-router/sandpack.tsx
@@ -139,7 +139,7 @@ export const ListProducts = () => {
 
   const {
     options: categories,
-    queryResult: { isLoading },
+    query: { isLoading },
   } = useSelect<ICategory>({
     resource: "categories",
     pagination: false,
@@ -240,7 +240,7 @@ import Stack from "@mui/material/Stack";
 
 export const ShowProduct = () => {
   const {
-    queryResult: { data, isLoading },
+    query: { data, isLoading },
   } = useShow();
 
   const { data: categoryData, isLoading: categoryIsLoading } = useOne({


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

Deprecated `queryResult` was used in tutorial codes.

## What is the new behavior?

`query` is being used instead of it.

fixes #6284

## Notes for reviewers

N/A
