### PR TITLE
fix(docs): fix wrong example for base64 upload

### DIFF
--- a/documentation/docs/advanced-tutorials/upload/base64-upload.md
+++ b/documentation/docs/advanced-tutorials/upload/base64-upload.md
@@ -124,4 +124,4 @@ An edit form can be made by using the `<Edit>` component instead of `<Create>` w
 
 ## Example
 
-<CodeSandboxExample path="upload-antd-multipart" />
+<CodeSandboxExample path="upload-antd-base64" />


### PR DESCRIPTION
## PR Checklist

- [X] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [X] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

Currently, it shows a multipart example instead of base64.

## What is the new behavior?

fixes #6295

## Notes for reviewers

I wasn't able to run the fix locally (*JavaScript heap out of memory* :'D), so I'm not 100% sure if I changed it in the right way.
