### PR TITLE
feat(nestjsx-crud): add between operator

### DIFF
--- a/.changeset/large-turtles-smile.md
+++ b/.changeset/large-turtles-smile.md
@@ -1,0 +1,21 @@
+---
+"@refinedev/nestjsx-crud": patch
+---
+
+Add between operator
+
+```ts
+import { useTable } from "@refinedev/core";
+
+useTable({
+  filters: {
+    initial: [
+      {
+        field: "createdAt",
+        operator: "between",
+        value: [new Date().toISOString(), new Date().toISOString()],
+      },
+    ],
+  },
+});
+```

--- a/.changeset/large-turtles-smile.md
+++ b/.changeset/large-turtles-smile.md
@@ -2,7 +2,9 @@
 "@refinedev/nestjsx-crud": patch
 ---
 
-Add between operator
+feat: add `between` filter operator
+
+Add between operator support to `CrudFilters`
 
 ```ts
 import { useTable } from "@refinedev/core";
@@ -19,3 +21,5 @@ useTable({
   },
 });
 ```
+
+[Resolves #6334](https://github.com/refinedev/refine/issues/6334)

--- a/packages/nestjsx-crud/src/utils/mapOperator.ts
+++ b/packages/nestjsx-crud/src/utils/mapOperator.ts
@@ -43,6 +43,8 @@ export const mapOperator = (operator: CrudOperators): ComparisonOperator => {
       return CondOperator.ENDS_LOW;
     case "endswiths":
       return CondOperator.ENDS;
+    case "between":
+      return CondOperator.BETWEEN;
   }
 
   return CondOperator.EQUALS;

--- a/packages/nestjsx-crud/test/utils/mapOperator.spec.ts
+++ b/packages/nestjsx-crud/test/utils/mapOperator.spec.ts
@@ -24,7 +24,7 @@ describe("mapOperator", () => {
       startswiths: CondOperator.STARTS,
       endswith: CondOperator.ENDS_LOW,
       endswiths: CondOperator.ENDS,
-      between: CondOperator.EQUALS,
+      between: CondOperator.BETWEEN,
       eq: CondOperator.EQUALS,
       nbetween: CondOperator.EQUALS,
       nendswith: CondOperator.EQUALS,


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
The `between` operator doesn’t work correctly. It uses the `eq` (equal) operator instead of `between`.
## What is the new behavior?
The `between` operator now works as expected and filters values between the specified range.
