### PR TITLE
fix(core): added undefined type `successNotification` and `errorNotification`

### DIFF
--- a/.changeset/blue-dingos-heal.md
+++ b/.changeset/blue-dingos-heal.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+fix: added undefined type to `successNotification` and `errorNotification` #6270
+
+Resolves #6270

--- a/.changeset/blue-dingos-heal.md
+++ b/.changeset/blue-dingos-heal.md
@@ -2,6 +2,6 @@
 "@refinedev/core": patch
 ---
 
-fix: added undefined type to `successNotification` and `errorNotification` #6270
+fix(core): added ability to return `undefined` to fallback to the default notification config when using the function form in `successNotification` and `errorNotification` props.
 
-Resolves #6270
+[Resolves #6270](https://github.com/refinedev/refine/issues/6270)

--- a/packages/core/src/contexts/notification/types.ts
+++ b/packages/core/src/contexts/notification/types.ts
@@ -15,7 +15,7 @@ export type SuccessErrorNotification<
         data?: TData,
         values?: TVariables,
         resource?: string,
-      ) => OpenNotificationParams | false);
+      ) => OpenNotificationParams | false | undefined);
   /**
    * Error notification configuration to be displayed when the mutation fails.
    * @default '"There was an error creating resource (status code: `statusCode`)" or "Error when updating resource (status code: statusCode)"'
@@ -27,7 +27,7 @@ export type SuccessErrorNotification<
         error?: TError,
         values?: TVariables,
         resource?: string,
-      ) => OpenNotificationParams | false);
+      ) => OpenNotificationParams | false | undefined);
 };
 
 export type OpenNotificationParams = {


### PR DESCRIPTION
Added undefined type to errorNotification and successNotification.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes #6270 

## Notes for reviewers
I followed the instructions provided by @aliemir in the issue discussion. Please let me know if any further changes are needed or if there are additional aspects I should address.
