### PR TITLE
feat(core): create a `<Link />` component to navigate to a given resource.

### DIFF
--- a/.changeset/chilly-bottles-grab.md
+++ b/.changeset/chilly-bottles-grab.md
@@ -1,0 +1,43 @@
+---
+"@refinedev/core": minor
+---
+
+feat: add [`<Link />`](https://refine.dev/docs/routing/components/link/) component to navigate to a resource with a specific action. Under the hood, It uses [`useGo`](https://refine.dev/docs/routing/hooks/use-go/) to generate the URL.
+
+## Usage
+
+```tsx
+import { Link } from "@refinedev/core";
+
+const MyComponent = () => {
+  return (
+    <>
+      {/* simple usage, navigates to `/posts` */}
+      <Link to="/posts">Posts</Link>
+      {/* complex usage with more control, navigates to `/posts` with query filters */}
+      <Link
+        go={{
+          query: {
+            // `useTable` or `useDataGrid` automatically use this filters to fetch data if `syncWithLocation` is true.
+            filters: [
+              {
+                operator: "eq",
+                value: "published",
+                field: "status",
+              },
+            ],
+          },
+          to: {
+            resource: "posts",
+            action: "list",
+          },
+        }}
+      >
+        Posts
+      </Link>
+    </>
+  );
+};
+```
+
+[Fixes #6329](https://github.com/refinedev/refine/issues/6329)

--- a/.changeset/itchy-moose-reflect.md
+++ b/.changeset/itchy-moose-reflect.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/core": minor
+---
+
+chore: From now on, [`useLink`](https://refine.dev/docs/routing/hooks/use-link/) returns [`<Link />`](https://refine.dev/docs/routing/components/link/) component instead of returning [`routerProvider.Link`](https://refine.dev/docs/routing/router-provider/#link).
+
+Since the `<Link />` component uses `routerProvider.Link` under the hood with leveraging `useGo` hook to generate the URL there is no breaking change. It's recommended to use the `<Link />` component from the `@refinedev/core` package instead of `useLink` hook. This hook is used mostly for internal purposes and is only exposed for customization needs.
+
+[Fixes #6329](https://github.com/refinedev/refine/issues/6329)

--- a/documentation/docs/routing/components/link/index.md
+++ b/documentation/docs/routing/components/link/index.md
@@ -77,9 +77,11 @@ const MyComponent = () => {
     // Omit 'to' prop from LinkProps (required by react-router-dom) since we use the 'go' prop
     <Link<Omit<LinkProps, "to">>
       // Props from "react-router-dom"
+      // highlight-start
       replace={true}
       unstable_viewTransition={true}
       preventScrollReset={true}
+      // highlight-end
       // Props from "@refinedev/core"
       go={{
         to: {

--- a/documentation/docs/routing/components/link/index.md
+++ b/documentation/docs/routing/components/link/index.md
@@ -50,7 +50,7 @@ The `<Link />` component takes all the props from the [`routerProvider.Link`](/d
 
 When `go` prop is provided, this component will use [`useGo`](/docs/routing/hooks/use-go/) to create the URL to navigate to. It's accepts all the props that `useGo.go` accepts.
 
-It's usefull to use this prop when you want to navigate to a resource with a specific action.
+It's useful to use this prop when you want to navigate to a resource with a specific action.
 
 :::caution
 

--- a/documentation/docs/routing/components/link/index.md
+++ b/documentation/docs/routing/components/link/index.md
@@ -1,0 +1,94 @@
+---
+title: <Link />
+---
+
+`<Link />` is a component that is used to navigate to different pages in your application.
+
+It's uses [`routerProvider.Link`](/docs/routing/router-provider/#link) under the hood, if [`routerProvider`](/docs/routing/router-provider) is not provided, it will be use [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) HTML element.
+
+## Usage
+
+```tsx
+import { Link } from "@refinedev/core";
+
+const MyComponent = () => {
+  return (
+    <>
+      {/* simple usage, navigates to `/posts` */}
+      <Link to="/posts">Posts</Link>
+      {/* complex usage with more control, navigates to `/posts` with query filters */}
+      <Link
+        go={{
+          query: {
+            // `useTable` or `useDataGrid` automatically use this filters to fetch data if `syncWithLocation` is true.
+            filters: [
+              {
+                operator: "eq",
+                value: "published",
+                field: "status",
+              },
+            ],
+          },
+          to: {
+            resource: "posts",
+            action: "list",
+          },
+        }}
+      >
+        Posts
+      </Link>
+    </>
+  );
+};
+```
+
+## Props
+
+The `<Link />` component takes all the props from the [`routerProvider.Link`](/docs/routing/router-provider/#link) and the props that an `<a>` HTML element uses.
+
+### go
+
+When `go` prop is provided, this component will use [`useGo`](/docs/routing/hooks/use-go/) to create the URL to navigate to. It's accepts all the props that `useGo.go` accepts.
+
+It's usefull to use this prop when you want to navigate to a resource with a specific action.
+
+:::caution
+
+- `routerProvider` is required to use this prop.
+- When `to` prop is provided, `go` will be ignored.
+
+:::
+
+### to
+
+The URL to navigate to.
+
+## Type support with generics
+
+`<Link />` works with any routing library because it uses [`routerProvider.Link`](/docs/routing/router-provider/#link) internally. However, when importing it from `@refinedev/core`, it doesn't provide type support for your specific routing library. To enable full type support, you can use generics.
+
+```tsx
+import type { LinkProps } from "react-router-dom";
+import { Link } from "@refinedev/core";
+
+const MyComponent = () => {
+  return (
+    // Omit 'to' prop from LinkProps (required by react-router-dom) since we use the 'go' prop
+    <Link<Omit<LinkProps, "to">>
+      // Props from "react-router-dom"
+      replace={true}
+      unstable_viewTransition={true}
+      preventScrollReset={true}
+      // Props from "@refinedev/core"
+      go={{
+        to: {
+          resource: "posts",
+          action: "list",
+        },
+      }}
+    >
+      Posts
+    </Link>
+  );
+};
+```

--- a/documentation/docs/routing/components/link/index.md
+++ b/documentation/docs/routing/components/link/index.md
@@ -4,7 +4,7 @@ title: <Link />
 
 `<Link />` is a component that is used to navigate to different pages in your application.
 
-It's uses [`routerProvider.Link`](/docs/routing/router-provider/#link) under the hood, if [`routerProvider`](/docs/routing/router-provider) is not provided, it will be use [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) HTML element.
+It uses [`routerProvider.Link`](/docs/routing/router-provider/#link) under the hood, if [`routerProvider`](/docs/routing/router-provider) is not provided, it will be use [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) HTML element.
 
 ## Usage
 
@@ -20,7 +20,7 @@ const MyComponent = () => {
       <Link
         go={{
           query: {
-            // `useTable` or `useDataGrid` automatically use this filters to fetch data if `syncWithLocation` is true.
+            // `useTable` or `useDataGrid` automatically uses these filters to fetch data if `syncWithLocation` is true.
             filters: [
               {
                 operator: "eq",
@@ -44,7 +44,8 @@ const MyComponent = () => {
 
 ## Props
 
-The `<Link />` component takes all the props from the [`routerProvider.Link`](/docs/routing/router-provider/#link) and the props that an `<a>` HTML element uses.
+The `<Link />` component takes all the props from the [`routerProvider.Link`](/docs/routing/router-provider/#link) and the props that an `<a>` HTML element uses. In addition to these props, it also accepts the `go`
+and `to` props to navigate to a specific `resource` defined in the `<Refine />` component.
 
 ### go
 

--- a/documentation/docs/routing/hooks/use-link/index.md
+++ b/documentation/docs/routing/hooks/use-link/index.md
@@ -2,13 +2,11 @@
 title: useLink
 ---
 
-`useLink` is a hook that leverages the `Link` property of the [`routerProvider`][routerprovider] to create links compatible with the user's router library.
+`useLink` is a hook that returns [`<Link />`](/docs/routing/components/link/) component. It is used to navigate to different pages in your application.
 
 :::simple Good to know
 
-It's recommended to use the `Link` component from your router library instead of this hook. This hook is used mostly for internal purposes and is only exposed for customization needs.
-
-The `Link` components or the equivalents from the router libraries has better type support and lets you use the full power of the router library.
+- It's recommended to use the `<Link />` component from the `@refinedev/core` package instead of this hook. This hook is used mostly for internal purposes and is only exposed for customization needs.
 
 :::
 
@@ -20,14 +18,21 @@ import { useLink } from "@refinedev/core";
 const MyComponent = () => {
   const Link = useLink();
 
-  return <Link to="/posts">Posts</Link>;
+  return (
+    <>
+      <Link to="/posts">Posts</Link>
+      {/* or */}
+      <Link
+        go={{
+          to: {
+            resource: "posts",
+            action: "list",
+          },
+        }}
+      >
+        Posts
+      </Link>
+    </>
+  );
 };
 ```
-
-## Parameters
-
-### to
-
-This is the path that the link will navigate to. It should be a string.
-
-[routerprovider]: /docs/routing/router-provider

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -225,6 +225,12 @@ module.exports = {
         {
           type: "category",
           collapsed: false,
+          label: "Components",
+          items: ["routing/components/link/index"],
+        },
+        {
+          type: "category",
+          collapsed: false,
           label: "Hooks",
           items: [
             "routing/hooks/use-resource-params/index",

--- a/packages/antd/src/hooks/table/useTable/paginationLink.tsx
+++ b/packages/antd/src/hooks/table/useTable/paginationLink.tsx
@@ -11,8 +11,7 @@ export const PaginationLink = ({ to, element }: PaginationLinkProps) => {
   const routerType = useRouterType();
   const Link = useLink();
 
-  const ActiveLink =
-    routerType === "legacy" ? LegacyLink : (Link as unknown as React.FC<any>);
+  const ActiveLink = routerType === "legacy" ? LegacyLink : Link;
 
   return (
     <ActiveLink

--- a/packages/antd/src/hooks/table/useTable/paginationLink.tsx
+++ b/packages/antd/src/hooks/table/useTable/paginationLink.tsx
@@ -11,7 +11,8 @@ export const PaginationLink = ({ to, element }: PaginationLinkProps) => {
   const routerType = useRouterType();
   const Link = useLink();
 
-  const ActiveLink = routerType === "legacy" ? LegacyLink : Link;
+  const ActiveLink =
+    routerType === "legacy" ? LegacyLink : (Link as unknown as React.FC<any>);
 
   return (
     <ActiveLink

--- a/packages/cli/src/commands/add/sub-commands/resource/index.test.ts
+++ b/packages/cli/src/commands/add/sub-commands/resource/index.test.ts
@@ -7,7 +7,7 @@ const srcDirPath = `${__dirname}/../../../..`;
 
 describe("add", () => {
   beforeAll(() => {
-    // usefull for speed up the tests.
+    // useful for speed up the tests.
     jest.spyOn(console, "log").mockImplementation();
 
     jest.spyOn(testTargetModule, "installInferencer").mockImplementation();

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -8,3 +8,4 @@ export { RouteChangeHandler } from "./routeChangeHandler";
 export { CanAccess, CanAccessProps } from "./canAccess";
 export { GitHubBanner } from "./gh-banner";
 export { AutoSaveIndicator, AutoSaveIndicatorProps } from "./autoSaveIndicator";
+export { Link, LinkProps } from "./link";

--- a/packages/core/src/components/link/index.spec.tsx
+++ b/packages/core/src/components/link/index.spec.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { TestWrapper, render } from "@test/index";
+import { Link } from "./index";
+
+describe("Link", () => {
+  describe("with `to`", () => {
+    it("should render a tag without router provider", () => {
+      const { getByText } = render(<Link to="/test">Test</Link>);
+
+      const link = getByText("Test");
+      expect(link.tagName).toBe("A");
+      expect(link.getAttribute("href")).toBe("/test");
+    });
+
+    it("should render a tag with router provider", () => {
+      const { getByTestId } = render(
+        <Link<{ foo: "bar" }> foo="bar" to="/test" aria-label="test-label">
+          Test
+        </Link>,
+        {
+          wrapper: TestWrapper({
+            routerProvider: {
+              Link: ({ to, children, ...props }) => (
+                <a href={to} data-testid="test-link" {...props}>
+                  {children}
+                </a>
+              ),
+            },
+          }),
+        },
+      );
+
+      const link = getByTestId("test-link");
+      expect(link.tagName).toBe("A");
+      expect(link.getAttribute("href")).toBe("/test");
+      expect(link.getAttribute("aria-label")).toBe("test-label");
+      expect(link.getAttribute("foo")).toBe("bar");
+    });
+  });
+
+  describe("with `go`", () => {
+    it("should render a tag go.to as object", () => {
+      const { getByTestId } = render(
+        <Link
+          go={{
+            to: {
+              resource: "test",
+              action: "show",
+              id: 1,
+            },
+            options: { keepQuery: true },
+          }}
+          aria-label="test-label"
+        >
+          Test
+        </Link>,
+        {
+          wrapper: TestWrapper({
+            resources: [{ name: "test", show: "/test/:id" }],
+            routerProvider: {
+              go: () => () => {
+                return "/test/1";
+              },
+              Link: ({ to, children, ...props }) => (
+                <a href={to} data-testid="test-link" {...props}>
+                  {children}
+                </a>
+              ),
+            },
+          }),
+        },
+      );
+
+      const link = getByTestId("test-link");
+      expect(link.tagName).toBe("A");
+      expect(link.getAttribute("href")).toBe("/test/1");
+      expect(link.getAttribute("aria-label")).toBe("test-label");
+    });
+
+    it("should render a tag go.to as string", () => {
+      const { getByTestId } = render(
+        <Link
+          go={{
+            to: "/test/1",
+          }}
+          aria-label="test-label"
+        >
+          Test
+        </Link>,
+        {
+          wrapper: TestWrapper({
+            routerProvider: {
+              go: () => () => {
+                return "/test/1";
+              },
+              Link: ({ to, children, ...props }) => (
+                <a href={to} data-testid="test-link" {...props}>
+                  {children}
+                </a>
+              ),
+            },
+          }),
+        },
+      );
+
+      const link = getByTestId("test-link");
+      expect(link.tagName).toBe("A");
+      expect(link.getAttribute("href")).toBe("/test/1");
+      expect(link.getAttribute("aria-label")).toBe("test-label");
+    });
+  });
+});

--- a/packages/core/src/components/link/index.tsx
+++ b/packages/core/src/components/link/index.tsx
@@ -1,0 +1,74 @@
+import React, { type Ref, forwardRef, useContext } from "react";
+import { useGo } from "@hooks/router";
+import { RouterContext } from "@contexts/router";
+import type { GoConfigWithResource } from "../../hooks/router/use-go";
+import warnOnce from "warn-once";
+
+type LinkPropsWithGo = {
+  go: Omit<GoConfigWithResource, "type">;
+};
+
+type LinkPropsWithTo = {
+  to: string;
+};
+
+export type LinkProps<TProps = {}> = React.PropsWithChildren<
+  (LinkPropsWithGo | LinkPropsWithTo) &
+    React.AnchorHTMLAttributes<HTMLAnchorElement> &
+    TProps
+>;
+
+/**
+ * @param to The path to navigate to.
+ * @param go The useGo.go params to navigate to. If `to` provided, this will be ignored.
+ * @returns routerProvider.Link if it is provided, otherwise an anchor tag.
+ */
+const LinkComponent = <TProps = {}>(
+  props: LinkProps<TProps>,
+  ref: Ref<HTMLAnchorElement>,
+) => {
+  const routerContext = useContext(RouterContext);
+  const LinkFromContext = routerContext?.Link;
+
+  const goFunction = useGo();
+
+  let resolvedTo = "";
+  if ("to" in props) {
+    resolvedTo = props.to;
+  }
+  if ("go" in props) {
+    if (!routerContext?.go) {
+      warnOnce(
+        true,
+        "[Link]: `routerProvider` is not found. To use `go`, Please make sure that you have provided the `routerProvider` for `<Refine />` https://refine.dev/docs/routing/router-provider/ \n",
+      );
+    }
+    resolvedTo = goFunction({ ...props.go, type: "path" }) as string;
+  }
+
+  if (LinkFromContext) {
+    return (
+      <LinkFromContext
+        ref={ref}
+        {...props}
+        to={resolvedTo}
+        // This is a workaround to avoid passing `go` to the Link component.
+        go={undefined}
+      />
+    );
+  }
+  return (
+    <a
+      ref={ref}
+      href={resolvedTo}
+      {...props}
+      // This is a workaround to avoid passing `go` and `to` to the anchor tag.
+      to={undefined}
+      go={undefined}
+    />
+  );
+};
+
+export const Link = forwardRef(LinkComponent) as <T = {}>(
+  props: LinkProps<T> & { ref?: Ref<HTMLAnchorElement> },
+) => ReturnType<typeof LinkComponent>;

--- a/packages/core/src/hooks/router/use-link/index.spec.tsx
+++ b/packages/core/src/hooks/router/use-link/index.spec.tsx
@@ -1,63 +1,32 @@
 import React from "react";
 
-import { render, renderHook } from "@testing-library/react";
-
-import { MockJSONServer, TestWrapper, mockRouterProvider } from "@test";
-
+import {
+  MockJSONServer,
+  TestWrapper,
+  mockRouterProvider,
+  renderHook,
+  render,
+} from "@test";
 import { useLink } from "./";
+import "../../../components/link";
+
+jest.mock("../../../components/link", () => ({
+  Link: jest.fn().mockReturnValue(<div data-testid="mocked-link" />),
+}));
 
 describe("useLink Hook", () => {
-  it("should return routerProvider Link compotent", () => {
-    const mockLink = jest.fn();
-
+  it("should return Link component", () => {
     const { result } = renderHook(() => useLink(), {
       wrapper: TestWrapper({
         resources: [{ name: "posts" }],
         dataProvider: MockJSONServer,
-        routerProvider: mockRouterProvider({
-          fns: {
-            Link: mockLink,
-          },
-        }),
+        routerProvider: mockRouterProvider(),
       }),
     });
 
-    expect(result.current).toEqual(mockLink);
-  });
+    const Component = result.current;
 
-  it("if routerProvider go function is not defined, should return undefined", () => {
-    const { result } = renderHook(() => useLink(), {
-      wrapper: TestWrapper({
-        resources: [{ name: "posts" }],
-        dataProvider: MockJSONServer,
-        routerProvider: mockRouterProvider({
-          fns: {
-            Link: undefined,
-          },
-        }),
-      }),
-    });
-
-    const Link = result.current;
-
-    const { container } = render(<Link to="/posts" />);
-
-    expect(container.querySelector("a")?.getAttribute("href")).toEqual(
-      "/posts",
-    );
-  });
-
-  it("if it is used outside of router provider, should return undefined", () => {
-    jest.spyOn(React, "useContext").mockReturnValue(undefined);
-
-    const { result } = renderHook(() => useLink());
-
-    const Link = result.current;
-
-    const { container } = render(<Link to="/posts" />);
-
-    expect(container.querySelector("a")?.getAttribute("href")).toEqual(
-      "/posts",
-    );
+    const { getByTestId } = render(<Component to="posts" />);
+    expect(getByTestId("mocked-link")).toBeInTheDocument();
   });
 });

--- a/packages/core/src/hooks/router/use-link/index.tsx
+++ b/packages/core/src/hooks/router/use-link/index.tsx
@@ -1,17 +1,5 @@
-import { RouterContext } from "@contexts/router";
-import React, { useContext } from "react";
+import { Link } from "../../../components/link";
 
 export const useLink = () => {
-  const routerContext = useContext(RouterContext);
-
-  if (routerContext?.Link) {
-    return routerContext.Link;
-  }
-
-  const FallbackLink: Required<typeof routerContext>["Link"] = ({
-    to,
-    ...rest
-  }) => <a href={to} {...rest} />;
-
-  return FallbackLink;
+  return Link;
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
```tsx
import { useNavigation } from "@refinedev/core";
import { Link } from "react-router-dom";

export const MyComponent = () => {
  const { listUrl } = useNavigation();

  return <Link to={listUrl("posts")}>Go to posts list</Link>;
};
```
## What is the new behavior?
```tsx
import { Link } from "@refinedev/core";

export const MyComponent = () => {
  return (
    <Link
      go={{
        to: {
          resource: "posts",
          action: "list",
        },
        query: {
          filters: [
            {
              operator: "eq",
              value: "published",
              field: "status",
            },
          ],
        },
      }}
    >
      Go to the posts list
    </Link>
  );
};
```


fixes #6329

## Notes for reviewers

Examples are updated on this PR: https://github.com/refinedev/refine/pull/6331
