### PR TITLE
[BUG] Filters cannot be multiple of the same field and operator

### DIFF
--- a/packages/core/src/definitions/table/index.ts
+++ b/packages/core/src/definitions/table/index.ts
@@ -72,14 +72,16 @@ export const compareFilters = (
     return (
       ("field" in left ? left.field : undefined) ===
         ("field" in right ? right.field : undefined) &&
-      left.operator === right.operator
+      left.operator === right.operator &&
+      left.value === right.value
     );
   }
 
   return (
     ("key" in left ? left.key : undefined) ===
       ("key" in right ? right.key : undefined) &&
-    left.operator === right.operator
+    left.operator === right.operator &&
+    left.value === right.value
   );
 };
 

--- a/packages/mui/src/definitions/dataGrid/index.ts
+++ b/packages/mui/src/definitions/dataGrid/index.ts
@@ -202,7 +202,7 @@ export const transformCrudFiltersToFilterModel = (
           field: field,
           operator: transformCrudOperatorToMuiOperator(operator, columnType),
           value: value === "" ? undefined : value,
-          id: field + operator,
+          id: field + operator + gridFilterItems.length,
         });
       });
     } else {
@@ -213,7 +213,7 @@ export const transformCrudFiltersToFilterModel = (
           field: field,
           operator: transformCrudOperatorToMuiOperator(operator, columnType),
           value: value === "" ? undefined : value,
-          id: field + operator,
+          id: field + operator + gridFilterItems.length,
         });
       });
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
https://github.com/refinedev/refine/issues/6340
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
When adding multiple filters, it is not possible to create a filter with the same field and operator twice.

## What is the new behavior?
When adding multiple filters, filters with the same field and operator can co-exist as long as there is a difference in name. Filters are also identified by their field + operator + index.

fixes (core)
fixes (mui)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
