### PR TITLE
docs(docsearch): add hierarchy.lvl0 to attributes to highlight

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -225,6 +225,9 @@ const siteConfig = {
       apiKey: "cd0188125dcd31fb4b011b5e536d963a",
       indexName: "refine",
       contextualSearch: true,
+      searchParameters: {
+        attributesToHighlight: ["hierarchy.lvl0", "hierarchy"],
+      },
     },
     metadata: [
       {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

Due to the issue in DocSearch (https://github.com/algolia/docsearch/issues/2294) we need to add `hierarchy.lvl0` to make sure we use lvl0 when displaying search results.

Resolves #6344 