### PR TITLE
feat(docs): show http-client on simple-rest usage

### DIFF
--- a/documentation/docs/data/packages/simple-rest/index.md
+++ b/documentation/docs/data/packages/simple-rest/index.md
@@ -18,14 +18,18 @@ Simple REST package exports a function that accepts `apiUrl` and `httpClient` pa
 
 ```tsx title="app.tsx"
 import { Refine } from "@refinedev/core";
-// highlight-next-line
+// highlight-start
 import dataProvider from "@refinedev/simple-rest";
+import axios from "axios";
+// highlight-end
 
 const App = () => {
   return (
     <Refine
-      // highlight-next-line
-      dataProvider={dataProvider("<API_URL>")}
+      // highlight-start
+      // `httpClient` is optional.
+      dataProvider={(dataProvider("<API_URL>"), httpClient)}
+      // highlight-end
       /* ... */
     />
   );

--- a/documentation/docs/data/packages/simple-rest/index.md
+++ b/documentation/docs/data/packages/simple-rest/index.md
@@ -23,6 +23,9 @@ import dataProvider from "@refinedev/simple-rest";
 import axios from "axios";
 // highlight-end
 
+// highlight-start
+const httpClient = axios.create();
+
 const App = () => {
   return (
     <Refine


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
There is no example of how to give `httpClient` on simple-rest docs.

## What is the new behavior?
added an example of how to give `httpClient` to `@refinedev/simple-rest` data-provider.

