### PR TITLE
fix(core): `label` and `route` fields of  `useMenu.menuItems` shouldn't be deprecated

### DIFF
--- a/.changeset/fifty-moons-flash.md
+++ b/.changeset/fifty-moons-flash.md
@@ -21,3 +21,5 @@ export const Sider = () => {
   return <div>{/* ... */}</div>;
 };
 ```
+
+[Fixes #6352](https://github.com/refinedev/refine/issues/6352)

--- a/.changeset/fifty-moons-flash.md
+++ b/.changeset/fifty-moons-flash.md
@@ -1,0 +1,23 @@
+---
+"@refinedev/core": patch
+---
+
+fix: The `label` and `route` fields in `useMenu().menuItems` were marked as deprecated, but they are not actually deprecated. This issue was caused by `menuItems` extending from `IResourceItem`, however, `menuItems` populates these fields and handles deprecation of these fields internally. This change removes the deprecation warning for these fields.
+
+```tsx
+export const Sider = () => {
+  const { menuItems } = useMenu();
+  menuItems.map((item) => {
+    // these are safe to use
+    console.log(item.label);
+    console.log(item.route);
+    item.children.map((child) => {
+      // these are safe to use
+      console.log(child.label);
+      console.log(child.route);
+    });
+  });
+
+  return <div>{/* ... */}</div>;
+};
+```

--- a/packages/core/src/hooks/menu/useMenu.tsx
+++ b/packages/core/src/hooks/menu/useMenu.tsx
@@ -23,12 +23,14 @@ export type UseMenuProps = {
   hideOnMissingParameter?: boolean;
 };
 
-export type TreeMenuItem = FlatTreeItem & {
-  route?: string;
-  icon?: React.ReactNode;
-  label?: string;
-  children: TreeMenuItem[];
-};
+export type TreeMenuItem =
+  // Omitted because `label` and `route` are deprecated in `resource` but not in `menuItems`. These are populated in `prepareItem` for ease of use.
+  Omit<FlatTreeItem, "label" | "route" | "children"> & {
+    route?: string;
+    icon?: React.ReactNode;
+    label?: string;
+    children: TreeMenuItem[];
+  };
 
 const getCleanPath = (pathname: string) => {
   return pathname
@@ -86,7 +88,9 @@ export const useMenu = (
 
   const prepareItem = React.useCallback(
     (item: FlatTreeItem): TreeMenuItem | undefined => {
-      if (item?.meta?.hide ?? item?.options?.hide) return undefined;
+      if (pickNotDeprecated(item?.meta?.hide, item?.options?.hide)) {
+        return undefined;
+      }
       if (!item?.list && item.children.length === 0) return undefined;
 
       const composed = item.list


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

The `label` and `route` fields in `useMenu().menuItems` were marked as deprecated, but they are not deprecated. 


## What is the new behavior?

This change removes the deprecation warning for these fields because `useMenu` automatically handles the deprecation of these fields internally. 

<img 
width="150px"
src="https://github.com/user-attachments/assets/d400a469-f029-4902-b859-8852d0372b09" alt="reproducible example code screenshot" />

fixes #6352


