### PR TITLE
fix(core): wrap `setFiltersFn` with `useCallback`

### DIFF
--- a/.changeset/spotty-jokes-swim.md
+++ b/.changeset/spotty-jokes-swim.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/core": patch
+---
+
+fix: fix setFiltersFn #6385
+
+With this we can use the setFilters as dependencies inside useEffects without infinite loop since state changes in the hook won't cause the functions to be re-assigned
+
+[Fixes #6385](https://github.com/refinedev/refine/issues/6385)

--- a/.changeset/spotty-jokes-swim.md
+++ b/.changeset/spotty-jokes-swim.md
@@ -2,7 +2,7 @@
 "@refinedev/core": patch
 ---
 
-fix: fix setFiltersFn #6385
+fix(core): wrap `setFilters` and `setSorters` methods with `useCallback` to prevent looping re-renders
 
 With this we can use the setFilters as dependencies inside useEffects without infinite loop since state changes in the hook won't cause the functions to be re-assigned
 

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -526,14 +526,14 @@ export function useTable<
         unionFilters(preferredPermanentFilters, newFilters, prevFilters),
       );
     },
-    [setFilters, unionFilters, preferredPermanentFilters],
+    [preferredPermanentFilters],
   );
 
   const setFiltersAsReplace = useCallback(
     (newFilters: CrudFilter[]) => {
       setFilters(unionFilters(preferredPermanentFilters, newFilters));
     },
-    [setFilters, unionFilters, preferredPermanentFilters],
+    [preferredPermanentFilters],
   );
 
   const setFiltersWithSetter = useCallback(
@@ -542,7 +542,7 @@ export function useTable<
         unionFilters(preferredPermanentFilters, setter(prev)),
       );
     },
-    [setFilters, unionFilters, preferredPermanentFilters],
+    [preferredPermanentFilters],
   );
 
   const setFiltersFn: useTableReturnType<TQueryFnData>["setFilters"] =
@@ -564,9 +564,12 @@ export function useTable<
       [setFiltersWithSetter, setFiltersAsReplace, setFiltersAsMerge],
     );
 
-  const setSortWithUnion = (newSorter: CrudSort[]) => {
-    setSorters(() => unionSorters(preferredPermanentSorters, newSorter));
-  };
+  const setSortWithUnion = useCallback(
+    (newSorter: CrudSort[]) => {
+      setSorters(() => unionSorters(preferredPermanentSorters, newSorter));
+    },
+    [preferredPermanentSorters],
+  );
 
   const { elapsedTime } = useLoadingOvertime({
     isLoading: queryResult.isFetching,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

Adding the `setFilters` as a dependency in the useEffect hook causes infinite loop since setFiltersFn are not wrapped in `useCallbacks`

## What is the new behavior?

No infinite loop

fixes #6385