### PR TITLE
fix(strapi-v4): has missing files after swizzling

### DIFF
--- a/.changeset/gorgeous-needles-guess.md
+++ b/.changeset/gorgeous-needles-guess.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/strapi-v4": patch
+---
+
+fix: `transformHttpError.ts` and `transformErrorMessages` files are not [swizzling](https://refine.dev/docs/packages/cli/#commands).
+
+From now on, these files will be copied to the project.
+
+[Resolves #6397](https://github.com/refinedev/refine/issues/6397)

--- a/packages/strapi-v4/refine.config.js
+++ b/packages/strapi-v4/refine.config.js
@@ -5,7 +5,7 @@ module.exports = {
     items: [
       {
         group: "Providers",
-        label: "Supabase",
+        label: "Strapi V4",
         requiredPackages: ["axios@1.6.2, qs@6.10.1"],
         files: [
           {

--- a/packages/strapi-v4/refine.config.js
+++ b/packages/strapi-v4/refine.config.js
@@ -5,7 +5,7 @@ module.exports = {
     items: [
       {
         group: "Providers",
-        label: "Strapi V4",
+        label: "Strapi v4",
         requiredPackages: ["axios@1.6.2, qs@6.10.1"],
         files: [
           {

--- a/packages/strapi-v4/refine.config.js
+++ b/packages/strapi-v4/refine.config.js
@@ -41,6 +41,14 @@ module.exports = {
             dest: "./providers/strapi-v4/utils/normalizeData.ts",
           },
           {
+            src: "./src/utils/transformErrorMessages.ts",
+            dest: "./providers/strapi-v4/utils/transformErrorMessages.ts",
+          },
+          {
+            src: "./src/utils/transformHttpError.ts",
+            dest: "./providers/strapi-v4/utils/transformHttpError.ts",
+          },
+          {
             src: "./src/helpers/index.ts",
             dest: "./providers/strapi-v4/helpers/index.ts",
           },
@@ -51,14 +59,6 @@ module.exports = {
           {
             src: "./src/helpers/normalize.ts",
             dest: "./providers/strapi-v4/helpers/normalize.ts",
-          },
-          {
-            src: "./src/hooks/index.ts",
-            dest: "./providers/strapi-v4/hooks/index.ts",
-          },
-          {
-            src: "./src/hooks/upload.ts",
-            dest: "./providers/strapi-v4/hooks/upload.ts",
           },
         ],
         message: `


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?


following files are missing after swizzling.
- [transformErrorMessages.ts](https://github.com/refinedev/refine/blob/master/packages/strapi-v4/src/utils/transformErrorMessages.ts)
- [transformHttpError.ts](https://github.com/refinedev/refine/blob/master/packages/strapi-v4/src/utils/transformHttpError.ts)

following files should not be available for swizzle.
- src/providers/strapi-v4/hooks/index.ts
- src/providers/strapi-v4/hooks/upload.t


## What is the new behavior?

All missing files were added and unavailable files were removed from the swizzling process.

fixes #6397

 
