### PR TITLE
chore(chakra-ui): fix broken tsdoc links

### DIFF
--- a/.changeset/beige-cougars-add.md
+++ b/.changeset/beige-cougars-add.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/chakra-ui": patch
+---
+
+chore(tsdoc): fix broken external documentation link
+
+In TSDoc description of the `<EmailField />` component, link to the official documentation of Chakra UI was broken and couldn't be opened. This PR fixes the link by updating the URL to the correct one.

--- a/packages/chakra-ui/src/components/fields/email/index.tsx
+++ b/packages/chakra-ui/src/components/fields/email/index.tsx
@@ -5,7 +5,7 @@ import type { EmailFieldProps } from "../types";
 
 /**
  * This field is used to display email values. It uses the {@link https://chakra-ui.com/docs/components/text  `<Text>` }
- * and {@link https://chakra-ui.com/docs/components/link/usage <Link>`} components from Chakra UI.
+ * and {@link https://www.chakra-ui.com/docs/components/link <Link>`} components from Chakra UI.
  *
  * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/fields/email} for more details.
  */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

In TSDoc description of the `<EmailField />` component, link to the official documentation of Chakra UI was broken and couldn't be opened. This PR fixes the link by updating the URL to the correct one.