### PR TITLE
feat(core,antd,mui,mantine,chakra-ui): add new prop to auth-page to p…

### DIFF
--- a/.changeset/breezy-wolves-nail.md
+++ b/.changeset/breezy-wolves-nail.md
@@ -1,0 +1,45 @@
+---
+"@refinedev/chakra-ui": minor
+"@refinedev/mantine": minor
+"@refinedev/antd": minor
+"@refinedev/core": minor
+"@refinedev/mui": minor
+---
+
+feat: added new prop called `mutationVariables` to `<AuthPage />`. #6431
+From now on, you can pass additional parameters to the `authProvider` methods using the `mutationVariables` prop of the `<AuthPage />` component.
+
+```tsx
+import { AuthPage } from "@refinedev/antd"; // or "@refinedev/chakra-ui", "@refinedev/mantine", "@refinedev/mui"
+
+const MyLoginPage = () => {
+  return (
+    <AuthPage
+      type="login" // all other types are also supported.
+      // highlight-start
+      mutationVariables={{
+        foo: "bar",
+        xyz: "abc",
+      }}
+      // highlight-end
+    />
+  );
+};
+
+// all mutation methods are supported.
+const authProvider = {
+  login: async ({ foo, xyz, ...otherProps }) => {
+    console.log(foo); // bar
+    console.log(xyz); // abc
+    // ...
+  },
+  register: async ({ foo, xyz, ...otherProps }) => {
+    console.log(foo); // bar
+    console.log(xyz); // abc
+    // ...
+  },
+  // ...
+};
+```
+
+[Resolves #6431](https://github.com/refinedev/refine/issues/6431)

--- a/documentation/docs/authentication/components/auth-page/index.md
+++ b/documentation/docs/authentication/components/auth-page/index.md
@@ -748,6 +748,41 @@ const MyLoginPage = () => {
 };
 ```
 
+### mutationVariables
+
+`mutationVariables` is used to pass additional variables to the `authProvider` methods.
+
+```tsx
+const MyLoginPage = () => {
+  return (
+    <AuthPage
+      type="login" // all other types are also supported.
+      // highlight-start
+      mutationVariables={{
+        foo: "bar",
+        xyz: "abc",
+      }}
+      // highlight-end
+    />
+  );
+};
+
+// all mutation methods are supported.
+const authProvider = {
+  login: async ({ foo, xyz, ...otherProps }) => {
+    console.log(foo); // bar
+    console.log(xyz); // abc
+    // ...
+  },
+  register: async ({ foo, xyz, ...otherProps }) => {
+    console.log(foo); // bar
+    console.log(xyz); // abc
+    // ...
+  },
+  // ...
+};
+```
+
 ## API Reference
 
 ### Properties

--- a/documentation/docs/ui-integrations/ant-design/components/auth-page/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/auth-page/index.md
@@ -892,6 +892,41 @@ const MyLoginPage = () => {
 };
 ```
 
+### mutationVariables
+
+`mutationVariables` is used to pass additional variables to the `authProvider` methods.
+
+```tsx
+const MyLoginPage = () => {
+  return (
+    <AuthPage
+      type="login" // all other types are also supported.
+      // highlight-start
+      mutationVariables={{
+        foo: "bar",
+        xyz: "abc",
+      }}
+      // highlight-end
+    />
+  );
+};
+
+// all mutation methods are supported.
+const authProvider = {
+  login: async ({ foo, xyz, ...otherProps }) => {
+    console.log(foo); // bar
+    console.log(xyz); // abc
+    // ...
+  },
+  register: async ({ foo, xyz, ...otherProps }) => {
+    console.log(foo); // bar
+    console.log(xyz); // abc
+    // ...
+  },
+  // ...
+};
+```
+
 ## FAQ
 
 ### How can I remove the default title and logo ?

--- a/documentation/docs/ui-integrations/chakra-ui/components/auth-page/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/auth-page/index.md
@@ -878,6 +878,41 @@ const MyLoginPage = () => {
 };
 ```
 
+### mutationVariables
+
+`mutationVariables` is used to pass additional variables to the `authProvider` methods.
+
+```tsx
+const MyLoginPage = () => {
+  return (
+    <AuthPage
+      type="login" // all other types are also supported.
+      // highlight-start
+      mutationVariables={{
+        foo: "bar",
+        xyz: "abc",
+      }}
+      // highlight-end
+    />
+  );
+};
+
+// all mutation methods are supported.
+const authProvider = {
+  login: async ({ foo, xyz, ...otherProps }) => {
+    console.log(foo); // bar
+    console.log(xyz); // abc
+    // ...
+  },
+  register: async ({ foo, xyz, ...otherProps }) => {
+    console.log(foo); // bar
+    console.log(xyz); // abc
+    // ...
+  },
+  // ...
+};
+```
+
 ## API Reference
 
 ### Properties

--- a/documentation/docs/ui-integrations/mantine/components/auth-page/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/auth-page/index.md
@@ -911,6 +911,41 @@ const MyLoginPage = () => {
 };
 ```
 
+### mutationVariables
+
+`mutationVariables` is used to pass additional variables to the `authProvider` methods.
+
+```tsx
+const MyLoginPage = () => {
+  return (
+    <AuthPage
+      type="login" // all other types are also supported.
+      // highlight-start
+      mutationVariables={{
+        foo: "bar",
+        xyz: "abc",
+      }}
+      // highlight-end
+    />
+  );
+};
+
+// all mutation methods are supported.
+const authProvider = {
+  login: async ({ foo, xyz, ...otherProps }) => {
+    console.log(foo); // bar
+    console.log(xyz); // abc
+    // ...
+  },
+  register: async ({ foo, xyz, ...otherProps }) => {
+    console.log(foo); // bar
+    console.log(xyz); // abc
+    // ...
+  },
+  // ...
+};
+```
+
 ## API Reference
 
 ### Properties

--- a/documentation/docs/ui-integrations/material-ui/components/auth-page/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/auth-page/index.md
@@ -967,6 +967,43 @@ const MyLoginPage = () => {
 };
 ```
 
+### mutationVariables
+
+`mutationVariables` is used to pass additional variables to the `authProvider` methods.
+
+```tsx
+import { AuthPage } from "@refinedev/mui";
+
+const MyLoginPage = () => {
+  return (
+    <AuthPage
+      type="login" // all other types are also supported.
+      // highlight-start
+      mutationVariables={{
+        foo: "bar",
+        xyz: "abc",
+      }}
+      // highlight-end
+    />
+  );
+};
+
+// all mutation methods are supported.
+const authProvider = {
+  login: async ({ foo, xyz, ...otherProps }) => {
+    console.log(foo); // bar
+    console.log(xyz); // abc
+    // ...
+  },
+  register: async ({ foo, xyz, ...otherProps }) => {
+    console.log(foo); // bar
+    console.log(xyz); // abc
+    // ...
+  },
+  // ...
+};
+```
+
 ## API Reference
 
 ### Properties

--- a/packages/antd/src/components/pages/auth/components/forgotPassword/index.tsx
+++ b/packages/antd/src/components/pages/auth/components/forgotPassword/index.tsx
@@ -52,6 +52,7 @@ export const ForgotPasswordPage: React.FC<ResetPassworProps> = ({
   renderContent,
   formProps,
   title,
+  mutationVariables,
 }) => {
   const { token } = theme.useToken();
   const [form] = Form.useForm<ForgotPasswordFormTypes>();
@@ -104,7 +105,9 @@ export const ForgotPasswordPage: React.FC<ResetPassworProps> = ({
       <Form<ForgotPasswordFormTypes>
         layout="vertical"
         form={form}
-        onFinish={(values) => forgotPassword(values)}
+        onFinish={(values) =>
+          forgotPassword({ ...values, ...mutationVariables })
+        }
         requiredMark={false}
         {...formProps}
       >

--- a/packages/antd/src/components/pages/auth/components/login/index.tsx
+++ b/packages/antd/src/components/pages/auth/components/login/index.tsx
@@ -50,6 +50,7 @@ export const LoginPage: React.FC<LoginProps> = ({
   formProps,
   title,
   hideForm,
+  mutationVariables,
 }) => {
   const { token } = theme.useToken();
   const [form] = Form.useForm<LoginFormTypes>();
@@ -111,6 +112,7 @@ export const LoginPage: React.FC<LoginProps> = ({
                 }}
                 onClick={() =>
                   login({
+                    ...mutationVariables,
                     providerName: provider.name,
                   })
                 }
@@ -152,7 +154,7 @@ export const LoginPage: React.FC<LoginProps> = ({
         <Form<LoginFormTypes>
           layout="vertical"
           form={form}
-          onFinish={(values) => login(values)}
+          onFinish={(values) => login({ ...values, ...mutationVariables })}
           requiredMark={false}
           initialValues={{
             remember: false,

--- a/packages/antd/src/components/pages/auth/components/register/index.tsx
+++ b/packages/antd/src/components/pages/auth/components/register/index.tsx
@@ -47,6 +47,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
   formProps,
   title,
   hideForm,
+  mutationVariables,
 }) => {
   const { token } = theme.useToken();
   const [form] = Form.useForm<RegisterFormTypes>();
@@ -108,6 +109,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                 }}
                 onClick={() =>
                   register({
+                    ...mutationVariables,
                     providerName: provider.name,
                   })
                 }
@@ -152,7 +154,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
         <Form<RegisterFormTypes>
           layout="vertical"
           form={form}
-          onFinish={(values) => register(values)}
+          onFinish={(values) => register({ ...mutationVariables, ...values })}
           requiredMark={false}
           {...formProps}
         >

--- a/packages/antd/src/components/pages/auth/components/updatePassword/index.tsx
+++ b/packages/antd/src/components/pages/auth/components/updatePassword/index.tsx
@@ -46,6 +46,7 @@ export const UpdatePasswordPage: React.FC<UpdatePasswordProps> = ({
   renderContent,
   formProps,
   title,
+  mutationVariables,
 }) => {
   const { token } = theme.useToken();
   const [form] = Form.useForm<UpdatePasswordFormTypes>();
@@ -96,7 +97,9 @@ export const UpdatePasswordPage: React.FC<UpdatePasswordProps> = ({
       <Form<UpdatePasswordFormTypes>
         layout="vertical"
         form={form}
-        onFinish={(values) => updatePassword(values)}
+        onFinish={(values) =>
+          updatePassword({ ...values, ...mutationVariables })
+        }
         requiredMark={false}
         {...formProps}
       >

--- a/packages/chakra-ui/src/components/pages/auth/components/forgotPassword/index.tsx
+++ b/packages/chakra-ui/src/components/pages/auth/components/forgotPassword/index.tsx
@@ -41,6 +41,7 @@ export const ForgotPasswordPage: React.FC<ForgotPasswordProps> = ({
   renderContent,
   formProps,
   title,
+  mutationVariables,
 }) => {
   const { onSubmit, ...useFormProps } = formProps || {};
   const { mutate } = useForgotPassword<ForgotPasswordFormTypes>();
@@ -99,7 +100,7 @@ export const ForgotPasswordPage: React.FC<ForgotPasswordProps> = ({
             return onSubmit(data);
           }
 
-          return mutate(data);
+          return mutate({ ...mutationVariables, ...data });
         })}
       >
         <FormControl mb="3" isInvalid={!!errors?.email}>

--- a/packages/chakra-ui/src/components/pages/auth/components/login/index.tsx
+++ b/packages/chakra-ui/src/components/pages/auth/components/login/index.tsx
@@ -51,6 +51,7 @@ export const LoginPage: React.FC<LoginProps> = ({
   formProps,
   title,
   hideForm,
+  mutationVariables,
 }) => {
   const { onSubmit, ...useFormProps } = formProps || {};
 
@@ -86,6 +87,7 @@ export const LoginPage: React.FC<LoginProps> = ({
                 fontSize="sm"
                 onClick={() =>
                   login({
+                    ...mutationVariables,
                     providerName: provider.name,
                   })
                 }
@@ -142,7 +144,7 @@ export const LoginPage: React.FC<LoginProps> = ({
               return onSubmit(data);
             }
 
-            return login(data);
+            return login({ ...mutationVariables, ...data });
           })}
         >
           <FormControl mt="6" isInvalid={!!errors?.email}>

--- a/packages/chakra-ui/src/components/pages/auth/components/register/index.tsx
+++ b/packages/chakra-ui/src/components/pages/auth/components/register/index.tsx
@@ -46,6 +46,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
   formProps,
   title,
   hideForm,
+  mutationVariables,
 }) => {
   const { onSubmit, ...useFormProps } = formProps || {};
 
@@ -80,6 +81,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                 leftIcon={<>{provider?.icon}</>}
                 onClick={() =>
                   mutate({
+                    ...mutationVariables,
                     providerName: provider.name,
                   })
                 }
@@ -136,7 +138,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
               return onSubmit(data);
             }
 
-            return mutate(data);
+            return mutate({ ...mutationVariables, ...data });
           })}
         >
           <FormControl mt="6" isInvalid={!!errors?.email}>

--- a/packages/chakra-ui/src/components/pages/auth/components/updatePassword/index.tsx
+++ b/packages/chakra-ui/src/components/pages/auth/components/updatePassword/index.tsx
@@ -37,6 +37,7 @@ export const UpdatePasswordPage: React.FC<UpdatePasswordProps> = ({
   renderContent,
   formProps,
   title,
+  mutationVariables,
 }) => {
   const { onSubmit, ...useFormProps } = formProps || {};
   const translate = useTranslate();
@@ -92,7 +93,7 @@ export const UpdatePasswordPage: React.FC<UpdatePasswordProps> = ({
             return onSubmit(data);
           }
 
-          return mutate(data);
+          return mutate({ ...mutationVariables, ...data });
         })}
       >
         <FormControl mb="3" isInvalid={!!errors?.password}>

--- a/packages/core/src/components/pages/auth/components/forgotPassword/index.spec.tsx
+++ b/packages/core/src/components/pages/auth/components/forgotPassword/index.spec.tsx
@@ -168,4 +168,43 @@ describe("Auth Page Forgot Password", () => {
       {},
     );
   });
+
+  it("should should accept 'mutationVariables'", async () => {
+    const forgotPasswordMock = jest.fn().mockResolvedValue({ success: true });
+
+    const { getByRole, getByLabelText } = render(
+      <ForgotPasswordPage
+        mutationVariables={{
+          foo: "bar",
+          xyz: "abc",
+        }}
+      />,
+      {
+        wrapper: TestWrapper({
+          authProvider: {
+            ...mockAuthProvider,
+            forgotPassword: forgotPasswordMock,
+          },
+        }),
+      },
+    );
+
+    fireEvent.change(getByLabelText(/email/i), {
+      target: { value: "demo@refine.dev" },
+    });
+
+    fireEvent.click(
+      getByRole("button", {
+        name: /reset/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(forgotPasswordMock).toHaveBeenCalledWith({
+        foo: "bar",
+        xyz: "abc",
+        email: "demo@refine.dev",
+      });
+    });
+  });
 });

--- a/packages/core/src/components/pages/auth/components/forgotPassword/index.tsx
+++ b/packages/core/src/components/pages/auth/components/forgotPassword/index.tsx
@@ -27,6 +27,7 @@ export const ForgotPasswordPage: React.FC<ForgotPasswordProps> = ({
   renderContent,
   formProps,
   title = undefined,
+  mutationVariables,
 }) => {
   const translate = useTranslate();
   const routerType = useRouterType();
@@ -53,7 +54,7 @@ export const ForgotPasswordPage: React.FC<ForgotPasswordProps> = ({
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          forgotPassword({ email });
+          forgotPassword({ ...mutationVariables, email });
         }}
         {...formProps}
       >

--- a/packages/core/src/components/pages/auth/components/login/index.spec.tsx
+++ b/packages/core/src/components/pages/auth/components/login/index.spec.tsx
@@ -346,4 +346,49 @@ describe("Auth Page Login", () => {
       ).toHaveAttribute("href", "/forgot-password");
     }
   });
+
+  it("should should accept 'mutationVariables'", async () => {
+    const loginMock = jest.fn().mockResolvedValue({ success: true });
+
+    const { getByRole, getByLabelText } = render(
+      <LoginPage
+        mutationVariables={{
+          foo: "bar",
+          xyz: "abc",
+        }}
+      />,
+      {
+        wrapper: TestWrapper({
+          authProvider: {
+            ...mockAuthProvider,
+            login: loginMock,
+          },
+        }),
+      },
+    );
+
+    fireEvent.change(getByLabelText(/email/i), {
+      target: { value: "demo@refine.dev" },
+    });
+
+    fireEvent.change(getByLabelText(/password/i), {
+      target: { value: "demo" },
+    });
+
+    fireEvent.click(
+      getByRole("button", {
+        name: /sign in/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(loginMock).toHaveBeenCalledWith({
+        foo: "bar",
+        xyz: "abc",
+        email: "demo@refine.dev",
+        password: "demo",
+        remember: false,
+      });
+    });
+  });
 });

--- a/packages/core/src/components/pages/auth/components/login/index.tsx
+++ b/packages/core/src/components/pages/auth/components/login/index.tsx
@@ -25,6 +25,7 @@ export const LoginPage: React.FC<LoginProps> = ({
   formProps,
   title = undefined,
   hideForm,
+  mutationVariables,
 }) => {
   const routerType = useRouterType();
   const Link = useLink();
@@ -62,6 +63,7 @@ export const LoginPage: React.FC<LoginProps> = ({
           <button
             onClick={() =>
               login({
+                ...mutationVariables,
                 providerName: provider.name,
               })
             }
@@ -91,7 +93,7 @@ export const LoginPage: React.FC<LoginProps> = ({
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              login({ email, password, remember });
+              login({ ...mutationVariables, email, password, remember });
             }}
             {...formProps}
           >

--- a/packages/core/src/components/pages/auth/components/register/index.spec.tsx
+++ b/packages/core/src/components/pages/auth/components/register/index.spec.tsx
@@ -280,4 +280,48 @@ describe("Auth Page Register", () => {
       }),
     ).toHaveAttribute("href", "/login");
   });
+
+  it("should should accept 'mutationVariables'", async () => {
+    const registerMock = jest.fn().mockResolvedValue({ success: true });
+
+    const { getByRole, getByLabelText } = render(
+      <RegisterPage
+        mutationVariables={{
+          foo: "bar",
+          xyz: "abc",
+        }}
+      />,
+      {
+        wrapper: TestWrapper({
+          authProvider: {
+            ...mockAuthProvider,
+            register: registerMock,
+          },
+        }),
+      },
+    );
+
+    fireEvent.change(getByLabelText(/email/i), {
+      target: { value: "demo@refine.dev" },
+    });
+
+    fireEvent.change(getByLabelText(/password/i), {
+      target: { value: "demo" },
+    });
+
+    fireEvent.click(
+      getByRole("button", {
+        name: /sign up/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(registerMock).toHaveBeenCalledWith({
+        foo: "bar",
+        xyz: "abc",
+        email: "demo@refine.dev",
+        password: "demo",
+      });
+    });
+  });
 });

--- a/packages/core/src/components/pages/auth/components/register/index.tsx
+++ b/packages/core/src/components/pages/auth/components/register/index.tsx
@@ -28,6 +28,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
   formProps,
   title = undefined,
   hideForm,
+  mutationVariables,
 }) => {
   const routerType = useRouterType();
   const Link = useLink();
@@ -64,6 +65,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
           <button
             onClick={() =>
               register({
+                ...mutationVariables,
                 providerName: provider.name,
               })
             }
@@ -93,7 +95,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              register({ email, password });
+              register({ ...mutationVariables, email, password });
             }}
             {...formProps}
           >

--- a/packages/core/src/components/pages/auth/components/updatePassword/index.spec.tsx
+++ b/packages/core/src/components/pages/auth/components/updatePassword/index.spec.tsx
@@ -106,4 +106,51 @@ describe("Auth Page Update Password", () => {
       confirmPassword: "demo",
     });
   });
+
+  it("should should accept 'mutationVariables'", async () => {
+    const updatePasswordMock = jest.fn().mockResolvedValue({ success: true });
+
+    const { getByRole, getByLabelText, getAllByLabelText } = render(
+      <UpdatePasswordPage
+        mutationVariables={{
+          foo: "bar",
+          xyz: "abc",
+        }}
+      />,
+      {
+        wrapper: TestWrapper({
+          authProvider: {
+            ...mockAuthProvider,
+            updatePassword: updatePasswordMock,
+          },
+        }),
+      },
+    );
+
+    fireEvent.change(getAllByLabelText(/password/i)[0], {
+      target: { value: "demo" },
+    });
+
+    fireEvent.change(getByLabelText(/confirm new password/i), {
+      target: { value: "demo" },
+    });
+
+    fireEvent.click(
+      getByRole("button", {
+        name: /update/i,
+      }),
+    );
+
+    await waitFor(
+      () => {
+        expect(updatePasswordMock).toHaveBeenCalledWith({
+          foo: "bar",
+          xyz: "abc",
+          password: "demo",
+          confirmPassword: "demo",
+        });
+      },
+      { timeout: 500 },
+    );
+  });
 });

--- a/packages/core/src/components/pages/auth/components/updatePassword/index.tsx
+++ b/packages/core/src/components/pages/auth/components/updatePassword/index.tsx
@@ -21,6 +21,7 @@ export const UpdatePasswordPage: React.FC<UpdatePasswordProps> = ({
   renderContent,
   formProps,
   title = undefined,
+  mutationVariables,
 }) => {
   const translate = useTranslate();
 
@@ -43,6 +44,7 @@ export const UpdatePasswordPage: React.FC<UpdatePasswordProps> = ({
         onSubmit={(e) => {
           e.preventDefault();
           updatePassword({
+            ...mutationVariables,
             password: newPassword,
             confirmPassword,
           });

--- a/packages/core/src/components/pages/auth/types.tsx
+++ b/packages/core/src/components/pages/auth/types.tsx
@@ -144,6 +144,10 @@ export type AuthPageProps<
    * @optional
    *  */
   title?: React.ReactNode;
+  /**
+   * @description Can be used to pass additional variables to the mutation. This is useful when you need to pass other variables to the authProvider.
+   */
+  mutationVariables?: Record<string, any>;
 };
 
 /**
@@ -167,6 +171,7 @@ export type LoginPageProps<
   formProps?: TFormProps;
   title?: React.ReactNode;
   hideForm?: boolean;
+  mutationVariables?: Record<string, unknown>;
 }>;
 
 /**
@@ -188,6 +193,7 @@ export type RegisterPageProps<
   formProps?: TFormProps;
   title?: React.ReactNode;
   hideForm?: boolean;
+  mutationVariables?: Record<string, unknown>;
 }>;
 
 /**
@@ -207,6 +213,7 @@ export type ForgotPasswordPageProps<
   contentProps?: TContentProps;
   formProps?: TFormProps;
   title?: React.ReactNode;
+  mutationVariables?: Record<string, unknown>;
 }>;
 
 /**
@@ -225,4 +232,5 @@ export type UpdatePasswordPageProps<
   contentProps?: TContentProps;
   formProps?: TFormProps;
   title?: React.ReactNode;
+  mutationVariables?: Record<string, unknown>;
 }>;

--- a/packages/mantine/src/components/pages/auth/components/forgotPassword/index.tsx
+++ b/packages/mantine/src/components/pages/auth/components/forgotPassword/index.tsx
@@ -52,6 +52,7 @@ export const ForgotPasswordPage: React.FC<ResetPassworProps> = ({
   renderContent,
   formProps,
   title,
+  mutationVariables,
 }) => {
   const theme = useMantineTheme();
   const { useForm, FormProvider } = FormContext;
@@ -105,7 +106,7 @@ export const ForgotPasswordPage: React.FC<ResetPassworProps> = ({
             if (onSubmitProp) {
               return onSubmitProp(values);
             }
-            return forgotPassword(values);
+            return forgotPassword({ ...mutationVariables, ...values });
           })}
         >
           <TextInput

--- a/packages/mantine/src/components/pages/auth/components/login/index.tsx
+++ b/packages/mantine/src/components/pages/auth/components/login/index.tsx
@@ -52,6 +52,7 @@ export const LoginPage: React.FC<LoginProps> = ({
   formProps,
   title,
   hideForm,
+  mutationVariables,
 }) => {
   const theme = useMantineTheme();
   const { useForm, FormProvider } = FormContext;
@@ -106,6 +107,7 @@ export const LoginPage: React.FC<LoginProps> = ({
                   leftIcon={provider.icon}
                   onClick={() =>
                     login({
+                      ...mutationVariables,
                       providerName: provider.name,
                     })
                   }
@@ -146,7 +148,7 @@ export const LoginPage: React.FC<LoginProps> = ({
               if (onSubmitProp) {
                 return onSubmitProp(values);
               }
-              return login(values);
+              return login({ ...mutationVariables, ...values });
             })}
           >
             <TextInput

--- a/packages/mantine/src/components/pages/auth/components/register/index.tsx
+++ b/packages/mantine/src/components/pages/auth/components/register/index.tsx
@@ -54,6 +54,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
   providers,
   title,
   hideForm,
+  mutationVariables,
 }) => {
   const theme = useMantineTheme();
   const { useForm, FormProvider } = FormContext;
@@ -110,6 +111,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                   leftIcon={provider.icon}
                   onClick={() =>
                     register({
+                      ...mutationVariables,
                       providerName: provider.name,
                     })
                   }
@@ -153,7 +155,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
               if (onSubmitProp) {
                 return onSubmitProp(values);
               }
-              return register(values);
+              return register({ ...mutationVariables, ...values });
             })}
           >
             <TextInput

--- a/packages/mantine/src/components/pages/auth/components/updatePassword/index.tsx
+++ b/packages/mantine/src/components/pages/auth/components/updatePassword/index.tsx
@@ -43,6 +43,7 @@ export const UpdatePasswordPage: React.FC<UpdatePassworProps> = ({
   renderContent,
   formProps,
   title,
+  mutationVariables,
 }) => {
   const theme = useMantineTheme();
   const { useForm, FormProvider } = FormContext;
@@ -96,7 +97,7 @@ export const UpdatePasswordPage: React.FC<UpdatePassworProps> = ({
             if (onSubmitProp) {
               return onSubmitProp(values);
             }
-            return updatePassword(values);
+            return updatePassword({ ...mutationVariables, ...values });
           })}
         >
           <TextInput

--- a/packages/mui/src/components/pages/auth/components/forgotPassword/index.tsx
+++ b/packages/mui/src/components/pages/auth/components/forgotPassword/index.tsx
@@ -48,6 +48,7 @@ export const ForgotPasswordPage: React.FC<ForgotPasswordProps> = ({
   renderContent,
   formProps,
   title,
+  mutationVariables,
 }) => {
   const { onSubmit, ...useFormProps } = formProps || {};
   const {
@@ -107,7 +108,7 @@ export const ForgotPasswordPage: React.FC<ForgotPasswordProps> = ({
               return onSubmit(data);
             }
 
-            return mutate(data);
+            return mutate({ ...mutationVariables, ...data });
           })}
         >
           <TextField

--- a/packages/mui/src/components/pages/auth/components/login/index.tsx
+++ b/packages/mui/src/components/pages/auth/components/login/index.tsx
@@ -54,6 +54,7 @@ export const LoginPage: React.FC<LoginProps> = ({
   formProps,
   title,
   hideForm,
+  mutationVariables,
 }) => {
   const { onSubmit, ...useFormProps } = formProps || {};
   const methods = useForm<BaseRecord, HttpError, LoginFormTypes>({
@@ -113,7 +114,9 @@ export const LoginPage: React.FC<LoginProps> = ({
                     borderColor: "primary.light",
                     textTransform: "none",
                   }}
-                  onClick={() => login({ providerName: provider.name })}
+                  onClick={() =>
+                    login({ ...mutationVariables, providerName: provider.name })
+                  }
                   startIcon={provider.icon}
                 >
                   {provider.label}
@@ -159,7 +162,7 @@ export const LoginPage: React.FC<LoginProps> = ({
                 return onSubmit(data);
               }
 
-              return login(data);
+              return login({ ...mutationVariables, ...data });
             })}
           >
             <TextField

--- a/packages/mui/src/components/pages/auth/components/register/index.tsx
+++ b/packages/mui/src/components/pages/auth/components/register/index.tsx
@@ -53,6 +53,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
   formProps,
   title,
   hideForm,
+  mutationVariables,
 }) => {
   const { onSubmit, ...useFormProps } = formProps || {};
   const {
@@ -114,6 +115,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                   }}
                   onClick={() =>
                     registerMutate({
+                      ...mutationVariables,
                       providerName: provider.name,
                     })
                   }
@@ -165,7 +167,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                 return onSubmit(data);
               }
 
-              return registerMutate(data);
+              return registerMutate({ ...mutationVariables, ...data });
             })}
           >
             <TextField

--- a/packages/mui/src/components/pages/auth/components/updatePassword/index.tsx
+++ b/packages/mui/src/components/pages/auth/components/updatePassword/index.tsx
@@ -45,6 +45,7 @@ export const UpdatePasswordPage: React.FC<UpdatePasswordProps> = ({
   renderContent,
   formProps,
   title = undefined,
+  mutationVariables,
 }) => {
   const { onSubmit, ...useFormProps } = formProps || {};
   const {
@@ -105,7 +106,7 @@ export const UpdatePasswordPage: React.FC<UpdatePasswordProps> = ({
               return onSubmit(data);
             }
 
-            return update(data);
+            return update({ ...mutationVariables, ...data });
           })}
         >
           <TextField

--- a/packages/ui-tests/src/tests/pages/auth/forgotPassword.tsx
+++ b/packages/ui-tests/src/tests/pages/auth/forgotPassword.tsx
@@ -246,5 +246,44 @@ export const pageForgotPasswordTests = (
         {},
       );
     });
+
+    it("should should accept 'mutationVariables'", async () => {
+      const forgotPasswordMock = jest.fn().mockResolvedValue({ success: true });
+
+      const { getByRole, getByLabelText } = render(
+        <ForgotPasswordPage
+          mutationVariables={{
+            foo: "bar",
+            xyz: "abc",
+          }}
+        />,
+        {
+          wrapper: TestWrapper({
+            authProvider: {
+              ...mockAuthProvider,
+              forgotPassword: forgotPasswordMock,
+            },
+          }),
+        },
+      );
+
+      fireEvent.change(getByLabelText(/email/i), {
+        target: { value: "demo@refine.dev" },
+      });
+
+      fireEvent.click(
+        getByRole("button", {
+          name: /reset/i,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(forgotPasswordMock).toHaveBeenCalledWith({
+          foo: "bar",
+          xyz: "abc",
+          email: "demo@refine.dev",
+        });
+      });
+    });
   });
 };

--- a/packages/ui-tests/src/tests/pages/auth/login.tsx
+++ b/packages/ui-tests/src/tests/pages/auth/login.tsx
@@ -403,5 +403,50 @@ export const pageLoginTests = (
         ).toHaveAttribute("href", "/forgot-password");
       }
     });
+
+    it("should should accept 'mutationVariables'", async () => {
+      const loginMock = jest.fn().mockResolvedValue({ success: true });
+
+      const { getByRole, getByLabelText } = render(
+        <LoginPage
+          mutationVariables={{
+            foo: "bar",
+            xyz: "abc",
+          }}
+        />,
+        {
+          wrapper: TestWrapper({
+            authProvider: {
+              ...mockAuthProvider,
+              login: loginMock,
+            },
+          }),
+        },
+      );
+
+      fireEvent.change(getByLabelText(/email/i), {
+        target: { value: "demo@refine.dev" },
+      });
+
+      fireEvent.change(getByLabelText(/password/i), {
+        target: { value: "demo" },
+      });
+
+      fireEvent.click(
+        getByRole("button", {
+          name: /sign in/i,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(loginMock).toHaveBeenCalledWith({
+          foo: "bar",
+          xyz: "abc",
+          email: "demo@refine.dev",
+          password: "demo",
+          remember: false,
+        });
+      });
+    });
   });
 };

--- a/packages/ui-tests/src/tests/pages/auth/register.tsx
+++ b/packages/ui-tests/src/tests/pages/auth/register.tsx
@@ -336,5 +336,49 @@ export const pageRegisterTests = (
         }),
       ).toHaveAttribute("href", "/login");
     });
+
+    it("should should accept 'mutationVariables'", async () => {
+      const registerMock = jest.fn().mockResolvedValue({ success: true });
+
+      const { getByRole, getByLabelText } = render(
+        <RegisterPage
+          mutationVariables={{
+            foo: "bar",
+            xyz: "abc",
+          }}
+        />,
+        {
+          wrapper: TestWrapper({
+            authProvider: {
+              ...mockAuthProvider,
+              register: registerMock,
+            },
+          }),
+        },
+      );
+
+      fireEvent.change(getByLabelText(/email/i), {
+        target: { value: "demo@refine.dev" },
+      });
+
+      fireEvent.change(getByLabelText(/password/i), {
+        target: { value: "demo" },
+      });
+
+      fireEvent.click(
+        getByRole("button", {
+          name: /sign up/i,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(registerMock).toHaveBeenCalledWith({
+          foo: "bar",
+          xyz: "abc",
+          email: "demo@refine.dev",
+          password: "demo",
+        });
+      });
+    });
   });
 };

--- a/packages/ui-tests/src/tests/pages/auth/updatePassword.tsx
+++ b/packages/ui-tests/src/tests/pages/auth/updatePassword.tsx
@@ -219,5 +219,52 @@ export const pageUpdatePasswordTests = (
         expect(getByText(/asswords do not match/i)).toBeInTheDocument();
       });
     });
+
+    it("should should accept 'mutationVariables'", async () => {
+      const updatePasswordMock = jest.fn().mockResolvedValue({ success: true });
+
+      const { getByRole, getByLabelText, getAllByLabelText } = render(
+        <UpdatePasswordPage
+          mutationVariables={{
+            foo: "bar",
+            xyz: "abc",
+          }}
+        />,
+        {
+          wrapper: TestWrapper({
+            authProvider: {
+              ...mockAuthProvider,
+              updatePassword: updatePasswordMock,
+            },
+          }),
+        },
+      );
+
+      fireEvent.change(getAllByLabelText(/password/i)[0], {
+        target: { value: "demo" },
+      });
+
+      fireEvent.change(getByLabelText(/confirm new password/i), {
+        target: { value: "demo" },
+      });
+
+      fireEvent.click(
+        getByRole("button", {
+          name: /update/i,
+        }),
+      );
+
+      await waitFor(
+        () => {
+          expect(updatePasswordMock).toHaveBeenCalledWith({
+            foo: "bar",
+            xyz: "abc",
+            password: "demo",
+            confirmPassword: "demo",
+          });
+        },
+        { timeout: 500 },
+      );
+    });
   });
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

There is no way to pass additional parameters to `authProvider` from `<AuthPage />`.

## What is the new behavior?

With `mutationVariables` prop of the `<AuthPage />` we are able to send additional parameters to `authProvider`

fixes #6431

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
