### PR TITLE
fix(react-hook-form): onChange handler `autoSave` check in `useForm`

### DIFF
--- a/.changeset/eight-drinks-compare.md
+++ b/.changeset/eight-drinks-compare.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/react-hook-form": minor
+---
+
+fix: onChange handler `autoSave` check in `useForm`
+
+Autosave can now be explicitly disabled.
+
+Resolves #6458

--- a/.changeset/eight-drinks-compare.md
+++ b/.changeset/eight-drinks-compare.md
@@ -1,5 +1,5 @@
 ---
-"@refinedev/react-hook-form": minor
+"@refinedev/react-hook-form": patch
 ---
 
 fix: onChange handler `autoSave` check in `useForm`

--- a/packages/react-hook-form/src/useForm/index.ts
+++ b/packages/react-hook-form/src/useForm/index.ts
@@ -234,7 +234,7 @@ export const useForm = <
       setWarnWhen(true);
     }
 
-    if (refineCoreProps?.autoSave) {
+    if (refineCoreProps?.autoSave?.enabled) {
       setWarnWhen(false);
 
       const onFinishProps =


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
Explicitly disabling `autoSave` doesn't work. Any value comes as true.

## What is the new behavior?
`autoSave` specification now works.

fixes #6458 

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
