### PR TITLE
fix(core): link component overrides to instead of go

### DIFF
--- a/.changeset/unlucky-spoons-shout.md
+++ b/.changeset/unlucky-spoons-shout.md
@@ -1,0 +1,14 @@
+---
+"@refinedev/core": patch
+---
+
+fix: Priority logic between `to` and `go` props.
+From now on, the `to` prop has priority over the `go` prop. If both are passed, the `to` prop will be used.
+
+```tsx
+// Before fix - go would override to
+<Link to="/posts" go={{ resource: "categories" }} />
+
+// After fix - to overrides go
+<Link to="/posts" go={{ resource: "categories" }} />
+```

--- a/packages/core/src/components/link/index.spec.tsx
+++ b/packages/core/src/components/link/index.spec.tsx
@@ -36,6 +36,18 @@ describe("Link", () => {
       expect(link.getAttribute("aria-label")).toBe("test-label");
       expect(link.getAttribute("foo")).toBe("bar");
     });
+
+    it("should prioritize 'to' over 'go' when both are provided", () => {
+      const { getByText } = render(
+        <Link to="/with-to" go={{ to: "/with-go" }}>
+          Test
+        </Link>,
+      );
+
+      const link = getByText("Test");
+      expect(link.tagName).toBe("A");
+      expect(link.getAttribute("href")).toBe("/with-to");
+    });
   });
 
   describe("with `go`", () => {

--- a/packages/core/src/components/link/index.tsx
+++ b/packages/core/src/components/link/index.tsx
@@ -33,9 +33,6 @@ const LinkComponent = <TProps = {}>(
   const goFunction = useGo();
 
   let resolvedTo = "";
-  if ("to" in props) {
-    resolvedTo = props.to;
-  }
   if ("go" in props) {
     if (!routerContext?.go) {
       warnOnce(
@@ -44,6 +41,9 @@ const LinkComponent = <TProps = {}>(
       );
     }
     resolvedTo = goFunction({ ...props.go, type: "path" }) as string;
+  }
+  if ("to" in props) {
+    resolvedTo = props.to;
   }
 
   if (LinkFromContext) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

`go` prop overrides `to` prop

## What is the new behavior?

`to` prop should override `go` prop.

fixes #6461

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
