### PR TITLE
fix(docs): use `event.currentTarget` instead of `event.target`

### DIFF
--- a/documentation/tutorial/essentials/forms/index.md
+++ b/documentation/tutorial/essentials/forms/index.md
@@ -120,7 +120,7 @@ export const CreateProduct = () => {
   const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     // Using FormData to get the form values and convert it to an object.
-    const data = Object.fromEntries(new FormData(event.target).entries());
+    const data = Object.fromEntries(new FormData(event.currentTarget).entries());
     // Calling onFinish to submit with the data we've collected from the form.
     onFinish(data);
   };
@@ -173,7 +173,7 @@ export const CreateProduct = () => {
   const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     // Using FormData to get the form values and convert it to an object.
-    const data = Object.fromEntries(new FormData(event.target).entries());
+    const data = Object.fromEntries(new FormData(event.currentTarget).entries());
     // Calling onFinish to submit with the data we've collected from the form.
     // highlight-start
     onFinish({
@@ -330,7 +330,7 @@ export const EditProduct = () => {
   const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     // Using FormData to get the form values and convert it to an object.
-    const data = Object.fromEntries(new FormData(event.target).entries());
+    const data = Object.fromEntries(new FormData(event.currentTarget).entries());
     // Calling onFinish to submit with the data we've collected from the form.
     onFinish({
       ...data,


### PR DESCRIPTION
This addresses a documentation issue talked about here: https://github.com/refinedev/refine/issues/6479

## Bugs / Features

- [x] Related issue(s) linked

- [x] Docs have been added / updated
