### PR TITLE
fix(core): `useUpdate` throws an error when id is an empty string. (`id=""`)

### DIFF
--- a/.changeset/weak-snails-act.md
+++ b/.changeset/weak-snails-act.md
@@ -1,0 +1,20 @@
+---
+"@refinedev/core": patch
+---
+
+fix: `useUpdate` and `useForm` hooks throws an error when `id` is an empty string. (`id=""`)
+
+This reverts a breaking change introduced in [PR #6116](https://github.com/refinedev/refine/pull/6116) and restores support for using an empty string as `id`. This enables updates without an `id` field, as allowed before `@refinedev/core@4.54.0`.
+
+Affected versions with this bug:
+
+- `@refinedev/core@4.54.0`
+- `@refinedev/core@4.54.1`
+- `@refinedev/core@4.55.0`
+- `@refinedev/core@4.56.0`
+
+The bug is fixed in:
+
+- `@refinedev/core@4.56.1`
+
+Resolves [#6505](https://github.com/refinedev/refine/issues/6505)

--- a/.changeset/weak-snails-act.md
+++ b/.changeset/weak-snails-act.md
@@ -2,7 +2,7 @@
 "@refinedev/core": patch
 ---
 
-fix: `useUpdate` and `useForm` hooks throws an error when `id` is an empty string. (`id=""`)
+fix: `useUpdate` and `useForm` hooks throws an error when `id` is an empty string. (`id=""`) #6505
 
 This reverts a breaking change introduced in [PR #6116](https://github.com/refinedev/refine/pull/6116) and restores support for using an empty string as `id`. This enables updates without an `id` field, as allowed before `@refinedev/core@4.54.0`.
 

--- a/packages/core/src/hooks/data/useUpdate.spec.tsx
+++ b/packages/core/src/hooks/data/useUpdate.spec.tsx
@@ -1162,6 +1162,37 @@ describe("useUpdate Hook [with params]", () => {
       );
     });
   });
+
+  it("should not throw error when id=''", async () => {
+    const updateMock = jest.fn();
+
+    const { result } = renderHook(() => useUpdate(), {
+      wrapper: TestWrapper({
+        dataProvider: {
+          default: {
+            ...MockJSONServer.default,
+            update: updateMock,
+          },
+        },
+        resources: [{ name: "posts" }],
+      }),
+    });
+
+    act(() => {
+      result.current.mutate({
+        id: "",
+        resource: "posts",
+        values: {},
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBeFalsy();
+      expect(updateMock).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "", resource: "posts", variables: {} }),
+      );
+    });
+  });
 });
 
 describe("useUpdate Hook [with props]", () => {
@@ -2393,6 +2424,41 @@ describe("useUpdate Hook [with props]", () => {
         new Error(
           "[useUpdate]: `id` is not defined but is required in edit and clone actions",
         ),
+      );
+    });
+  });
+
+  it("should not throw error when id=''", async () => {
+    const updateMock = jest.fn();
+
+    const { result } = renderHook(
+      () =>
+        useUpdate({
+          id: "",
+          resource: "posts",
+          values: {},
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: {
+            default: {
+              ...MockJSONServer.default,
+              update: updateMock,
+            },
+          },
+          resources: [{ name: "posts" }],
+        }),
+      },
+    );
+
+    act(() => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBeFalsy();
+      expect(updateMock).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "", resource: "posts", variables: {} }),
       );
     });
   });

--- a/packages/core/src/hooks/data/useUpdate.ts
+++ b/packages/core/src/hooks/data/useUpdate.ts
@@ -240,7 +240,7 @@ export const useUpdate = <
       metaData = metaDataFromProps,
       dataProviderName = dataProviderNameFromProps,
     }) => {
-      if (!id) throw missingIdError;
+      if (typeof id === "undefined") throw missingIdError;
       if (!values) throw missingValuesError;
       if (!resourceName) throw missingResourceError;
 
@@ -321,7 +321,7 @@ export const useUpdate = <
         detail: true,
       },
     }) => {
-      if (!id) throw missingIdError;
+      if (typeof id === "undefined") throw missingIdError;
       if (!values) throw missingValuesError;
       if (!resourceName) throw missingResourceError;
 
@@ -462,7 +462,7 @@ export const useUpdate = <
         dataProviderName = dataProviderNameFromProps,
         invalidates = invalidatesFromProps ?? ["list", "many", "detail"],
       } = variables;
-      if (!id) throw missingIdError;
+      if (typeof id === "undefined") throw missingIdError;
       if (!resourceName) throw missingResourceError;
 
       const { identifier } = select(resourceName);
@@ -495,7 +495,7 @@ export const useUpdate = <
         meta = metaFromProps,
         metaData = metaDataFromProps,
       } = variables;
-      if (!id) throw missingIdError;
+      if (typeof id === "undefined") throw missingIdError;
       if (!values) throw missingValuesError;
       if (!resourceName) throw missingResourceError;
 
@@ -586,7 +586,7 @@ export const useUpdate = <
         errorNotification = errorNotificationFromProps,
         values = valuesFromProps,
       } = variables;
-      if (!id) throw missingIdError;
+      if (typeof id === "undefined") throw missingIdError;
       if (!values) throw missingValuesError;
       if (!resourceName) throw missingResourceError;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

This throws an error:
```tsx
useUpdate({
  id: "",
});
```

## What is the new behavior?

This no longer throws an error:
```tsx
useUpdate({
  id: "",
});
```

fixes #6505

