### PR TITLE
fix(antd)!: Unswap notification message and description fields

### DIFF
--- a/.changeset/thin-lamps-ring.md
+++ b/.changeset/thin-lamps-ring.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/antd": patch
+---
+
+fix(antd)!: Unswap notification message and description fields #6524
+
+Fixes swapped properties `message` and `description` for `antd`'s Notification component.
+
+Resolves #6524

--- a/packages/antd/src/providers/notificationProvider/index.tsx
+++ b/packages/antd/src/providers/notificationProvider/index.tsx
@@ -39,8 +39,8 @@ export const notificationProvider: NotificationProvider = {
     } else {
       staticNotification.open({
         key,
-        description: message,
-        message: description ?? null,
+        message,
+        description: description ?? null,
         type,
       });
     }
@@ -85,8 +85,8 @@ export const useNotificationProvider = (): NotificationProvider => {
       } else {
         notification.open({
           key,
-          description: message,
-          message: description ?? null,
+          message,
+          description: description ?? null,
           type,
         });
       }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

`message` and `description` props are swapped.

## What is the new behavior?

`message` and `description` props are un-swapped.

## Notes for reviewers

Fixes #6524 
<!-- Add any notes/questions you may have for reviewers -->
