### PR TITLE
docs(tutorial): pin react-router-dom version to v6

### DIFF
--- a/documentation/tutorial/routing/intro/react-router/sandpack.tsx
+++ b/documentation/tutorial/routing/intro/react-router/sandpack.tsx
@@ -80,7 +80,7 @@ export const AddRouterProviderToApp = () => {
 export const dependencies = {
   ...initialDependencies,
   "@refinedev/react-router-v6": "latest",
-  "react-router-dom": "latest",
+  "react-router-dom": "^6.8.1",
 };
 
 export const finalFiles = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

Updated the sandpack configuration in tutorial to use `react-router-dom` with version 6 until we release an update with the latest v7.

Fixes #6531
