### PR TITLE
fix: remove disableRowSelectionOnClick and sx from useDataGrid

### DIFF
--- a/.changeset/flat-donkeys-march.md
+++ b/.changeset/flat-donkeys-march.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mui": minor
+---
+
+Removed the disableRowSelectionOnClick and sx properties from the return value of useDataGrid as they are not relevant to the internal data management of the MUI DataGrid.

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -48,8 +48,6 @@ type DataGridPropsType = Required<
     | "onSortModelChange"
     | "filterMode"
     | "onFilterModelChange"
-    | "sx"
-    | "disableRowSelectionOnClick"
     | "onStateChange"
     | "paginationMode"
   >
@@ -324,7 +322,6 @@ export function useDataGrid<
     tableQueryResult,
     tableQuery,
     dataGridProps: {
-      disableRowSelectionOnClick: true,
       rows: data?.data || [],
       loading: liveMode === "auto" ? isLoading : !isFetched,
       rowCount: data?.total || 0,
@@ -351,22 +348,6 @@ export function useDataGrid<
         if (isStateChanged) {
           setColumnsType(newColumnsTypes);
         }
-      },
-      sx: {
-        border: "none",
-        "& .MuiDataGrid-columnHeaders": {
-          background: darken(theme.palette.background.paper, 0.05),
-          borderBottom: `1px solid ${darken(
-            theme.palette.background.paper,
-            0.1,
-          )}`,
-        },
-        "& .MuiDataGrid-cell": {
-          borderBottom: `1px solid ${darken(
-            theme.palette.background.paper,
-            0.05,
-          )}`,
-        },
       },
       processRowUpdate: editable ? processRowUpdate : undefined,
     },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [] Tests for the changes have been added -> These props don't impact the working of the hook.
- [] Docs have been added / updated -> Not needed as these props are not mentioned in https://refine.dev/docs/ui-integrations/material-ui/hooks/use-data-grid/.
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

`useDataGrid` returns the `disableRowSelectionOnClick` and `sx` which are not relevant to the internal data management of `MUIDataGrid`.

## What is the new behavior?

fixes (issue): [[BUG] Unnecessary inclusion of disableRowSelectionOnClick in dataGridProps](https://github.com/refinedev/refine/issues/6561).

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
