### PR TITLE
feat(useForm): improve type parameter specification to useForm

### DIFF
--- a/packages/core/src/hooks/form/index.ts
+++ b/packages/core/src/hooks/form/index.ts
@@ -59,6 +59,12 @@ export type {
  * @typeParam TResponseError - Custom error object that extends {@link https://refine.dev/docs/core/interface-references/#httperror `HttpError`}. Defaults to `TError`
  *
  */
+
+export {
+  CreateFormVariables,
+  ExtractFormVariables,
+  ExtractSubmissionVariables,
+} from "./types";
 export const useForm = <
   TQueryFnData extends BaseRecord = BaseRecord,
   TError extends HttpError = HttpError,

--- a/packages/core/src/hooks/form/types.ts
+++ b/packages/core/src/hooks/form/types.ts
@@ -29,6 +29,9 @@ import type { LiveModeProps } from "../../contexts/live/types";
 import type { SuccessErrorNotification } from "../../contexts/notification/types";
 import type { Action } from "../../contexts/router/types";
 
+const FormVariablesSymbol = Symbol("FormVariables");
+const SubmissionVariablesSymbol = Symbol("SubmissionVariables");
+
 export type FormAction = Extract<Action, "create" | "edit" | "clone">;
 
 export type RedirectAction =
@@ -49,6 +52,22 @@ export type AutoSaveProps<TVariables> = {
     invalidateOnClose?: boolean;
   };
 };
+
+export type CreateFormVariables<TFormVariables, TSubmissionVariables> = {
+  [FormVariablesSymbol]: TFormVariables;
+  [SubmissionVariablesSymbol]: TSubmissionVariables;
+};
+
+export type ExtractFormVariables<T> = T extends {
+  [FormVariablesSymbol]: infer F;
+}
+  ? F
+  : T;
+export type ExtractSubmissionVariables<T> = T extends {
+  [SubmissionVariablesSymbol]: infer S;
+}
+  ? S
+  : T;
 
 export type AutoSaveReturnType<
   TData extends BaseRecord = BaseRecord,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

The `useForm` hook uses a single type parameter for both the form structure and the data submitted to the API. This causes type conflicts when trying to map form data  into the structure needed for the API . As a result, developers encounter type errors when attempting to submit transformed data.

## What is the new behavior?

After the changes, the `useForm` hook introduces an additional type parameter for submission data . This separates the form structure type  from the submission type . `onFinish` function correctly expects the SubmissionData type instead of the form structure type. allowing developers to easily map and submit the data without running into type issues.

fixes (issue)

## Notes for reviewers
![Screenshot 2024-12-10 220523](https://github.com/user-attachments/assets/df86a5c7-877b-4185-ac5c-d294abe9a437)

The` onValid` function is wrapped in `onValidWrapper` to address a TypeScript error where the form data (`TVariables`) does not match the expected structure for` onValid`. This results in a type conflict, so use type casting (`variables as unknown as ExtractFormVariables<TVariables>`) to ensure the correct form data type is passed to `onValid`. This resolves the error and ensures type safety during form submission.
