### PR TITLE
docs(react-router-upgrade): remove extra double quote and correct version

### DIFF
--- a/documentation/docs/routing/integrations/react-router/migration-guide-v6-to-v7.md
+++ b/documentation/docs/routing/integrations/react-router/migration-guide-v6-to-v7.md
@@ -28,7 +28,7 @@ npm install @refinedev/react-router react-router
 ```diff
 
 - "@refinedev/react-router-v6": "^4.6.0"
-+ "@refinedev/react-router": "^5.0.0"
++ "@refinedev/react-router": "^1.0.1"
 
 - "react-router-dom": "^6.8.1"
 - "react-router": "^6.8.1"
@@ -64,5 +64,5 @@ npx @refinedev/codemod@latest refine-react-router-v6-to-refine-react-router
 For `react-router-dom` to `react-router`:
 
 ```bash
-npx @refinedev/codemod@latest react-router-dom-to-react-router"
+npx @refinedev/codemod@latest react-router-dom-to-react-router
 ```


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [X] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Documentation Changes

- Remove the extra trailing double quote (`"`) after the `refine-codemod` command which causes the command to fail
- Update the example `@refinedev/react-router` version changes to `^1.0.1`, as the current version (as of 12/2024) is [`1.0.1`](https://www.npmjs.com/package/@refinedev/react-router?activeTab=versions) this will help prevent confusion when verifying the upgrade
