### PR TITLE
docs: fix heading orders

### DIFF
--- a/documentation/docs/data/packages/strapi-v4/index.md
+++ b/documentation/docs/data/packages/strapi-v4/index.md
@@ -409,7 +409,7 @@ const App: React.FC = () => {
 render(<App />);
 ```
 
-##### Relations Population for `/me` request
+#### Relations Population for `/me` request
 
 If you need to the population for the `/me` request you can use it like this in your `authProvider`.
 

--- a/documentation/docs/guides-concepts/forms/index.md
+++ b/documentation/docs/guides-concepts/forms/index.md
@@ -332,7 +332,7 @@ useForm({
 });
 ```
 
-##### **Usage of `<UnsavedChangesNotifier />`**
+#### **Usage of `<UnsavedChangesNotifier />`**
 
 <Tabs wrapContent={false}>
 <TabItem value="react-router" label="React Router">

--- a/documentation/src/components/sandpack/index.tsx
+++ b/documentation/src/components/sandpack/index.tsx
@@ -388,6 +388,7 @@ const SandpackBase = ({
         <div className={clsx(showConsole ? "block" : "hidden", "h-[200px]")} />
       </div>
       <section className="hidden max-w-0 max-h-0">
+        <h6>Code Example</h6>
         <p>{`Dependencies: ${Object.keys(dependencies ?? {}).map(
           (k) => `${k}@${dependencies[k]}`,
         )}`}</p>

--- a/documentation/src/refine-theme/common-admonition.tsx
+++ b/documentation/src/refine-theme/common-admonition.tsx
@@ -115,7 +115,7 @@ export const Admonition = ({ type, title, children }: Props) => {
         )}
       >
         {(title || titles[type]) && (
-          <div
+          <h6
             className={clsx(
               "flex",
               "items-center",
@@ -128,7 +128,7 @@ export const Admonition = ({ type, title, children }: Props) => {
           >
             <Icon />
             <span className="uppercase">{title ?? titles[type] ?? ""}</span>
-          </div>
+          </h6>
         )}
         <div className={clsx("text-gray-0", "text-base", "last:mb-0")}>
           {children}

--- a/documentation/src/refine-theme/common-tab-item.tsx
+++ b/documentation/src/refine-theme/common-tab-item.tsx
@@ -1,9 +1,19 @@
 import React from "react";
 import clsx from "clsx";
 
-export default function CommonTabItem({ children, hidden, className }) {
+export default function CommonTabItem({
+  children,
+  hidden,
+  className,
+  label,
+  value,
+  ...props
+}) {
+  const tabHeading = label || value;
+
   return (
     <div role="tabpanel" className={clsx(className)} {...{ hidden }}>
+      <h5 className="hidden max-w-0 max-h-0">{tabHeading}</h5>
       {children}
     </div>
   );


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

- Updated heading hierarchy in some docs
- Added `<h6>` heading to sandpack snapshots
- Added hidden `<h5>` to tab item contents
- Replaced admonition titles with `<h5>` tags