### PR TITLE
fix(docs): Material UI app not working on tutorial 

### DIFF
--- a/documentation/tutorial/ui-libraries/intro/material-ui/react-router/sandpack.tsx
+++ b/documentation/tutorial/ui-libraries/intro/material-ui/react-router/sandpack.tsx
@@ -240,6 +240,7 @@ export const dependencies = {
   "@mui/material": "^6.1.7",
   "@mui/x-data-grid": "^7.22.2",
   "@refinedev/mui": "5.0.0",
+  "@mui/system": "latest",
   "@refinedev/react-hook-form": "latest",
   "react-hook-form": "latest",
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

On tutorial, [this example](https://refine.dev/tutorial/ui-libraries/crud-components/material-ui/react-router/) gives following error: 

![image](https://github.com/user-attachments/assets/46a26e9f-5a20-4f2a-b175-44bd1087a559)


## What is the new behavior?

`"@mui/system": "latest"` dependency added to fix this problem

![image](https://github.com/user-attachments/assets/da9a94eb-b6d0-42e8-aa57-0b9b9703b1e9)

