### PR TITLE
fix(core): add checks for `ids` and `resource` to `useMany`

### DIFF
--- a/.changeset/unlucky-rules-complain.md
+++ b/.changeset/unlucky-rules-complain.md
@@ -1,0 +1,11 @@
+---
+"@refinedev/core": patch
+---
+
+fix(core): add missing checks and warnings for `ids` and `resource` props in `useMany` hook
+
+Added checks for `ids` and `resource` props to check in runtime if they are valid or not.
+
+`useMany` will warn if `ids` or `resource` props are missing unless the query is manually enabled through `queryOptions.enabled` prop.
+
+[Resolves #6617](https://github.com/refinedev/refine/issues/6617)

--- a/packages/core/src/hooks/data/useMany.ts
+++ b/packages/core/src/hooks/data/useMany.ts
@@ -37,6 +37,7 @@ import {
   type UseLoadingOvertimeReturnType,
   useLoadingOvertime,
 } from "../useLoadingOvertime";
+import warnOnce from "warn-once";
 
 export type UseManyProps<TQueryFnData, TError, TData> = {
   /**
@@ -133,17 +134,24 @@ export const useMany = <
 
   const combinedMeta = getMeta({ resource, meta: preferredMeta });
 
+  const hasIds = Array.isArray(ids);
+  const hasResource = Boolean(resource?.name);
+  const manuallyEnabled = queryOptions?.enabled === true;
+
+  warnOnce(!hasIds && !manuallyEnabled, idsWarningMessage(ids, resource?.name));
+  warnOnce(!hasResource && !manuallyEnabled, resourceWarningMessage());
+
   useResourceSubscription({
     resource: identifier,
     types: ["*"],
     params: {
-      ids: ids,
+      ids: ids ?? [],
       meta: combinedMeta,
       metaData: combinedMeta,
       subscriptionType: "useMany",
       ...liveParams,
     },
-    channel: `resources/${resource.name}`,
+    channel: `resources/${resource?.name ?? ""}`,
     enabled: isEnabled,
     liveMode,
     onLiveEvent,
@@ -163,7 +171,7 @@ export const useMany = <
       .data(pickedDataProvider)
       .resource(identifier)
       .action("many")
-      .ids(...ids)
+      .ids(...(ids ?? []))
       .params({
         ...(preferredMeta || {}),
       })
@@ -193,6 +201,7 @@ export const useMany = <
         ),
       );
     },
+    enabled: hasIds && hasResource,
     ...queryOptions,
     onSuccess: (data) => {
       queryOptions?.onSuccess?.(data);
@@ -238,3 +247,14 @@ export const useMany = <
 
   return { ...queryResponse, overtime: { elapsedTime } };
 };
+
+const idsWarningMessage = (
+  ids: BaseKey[],
+  resource: string,
+) => `[useMany]: Missing "ids" prop. Expected an array of ids, but got "${typeof ids}". Resource: "${resource}"
+
+See https://refine.dev/docs/data/hooks/use-many/#ids-`;
+
+const resourceWarningMessage = () => `[useMany]: Missing "resource" prop. Expected a string, but got undefined.
+
+See https://refine.dev/docs/data/hooks/use-many/#resource-`;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

Added checks for `ids` and `resource` props to check in runtime if they are valid or not.

`useMany` will warn if `ids` or `resource` props are missing unless the query is manually enabled through `queryOptions.enabled` prop.