### PR TITLE
Fixing Issue #5954 

### DIFF
--- a/.changeset/thirty-rice-brush.md
+++ b/.changeset/thirty-rice-brush.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/antd": major
+---
+
+in queryoptions made the keepPreviousData as false so that user do not see the data of previous modal on opening the new one.

--- a/packages/antd/src/hooks/form/useForm.ts
+++ b/packages/antd/src/hooks/form/useForm.ts
@@ -252,7 +252,10 @@ export const useForm = <
     onLiveEvent,
     invalidates,
     undoableTimeout,
-    queryOptions,
+    queryOptions: {
+      ...queryOptions,
+      keepPreviousData: false,
+    },
     createMutationOptions,
     updateMutationOptions,
     id: idFromProps,

--- a/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
+++ b/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
@@ -281,7 +281,6 @@ export const useModalForm = <
           "Are you sure you want to leave? You have unsaved changes.",
         ),
       );
-
       if (warnWhenConfirm) {
         setWarnWhen(false);
       } else {
@@ -298,6 +297,7 @@ export const useModalForm = <
       if (typeof showId !== "undefined") {
         setId?.(showId);
       }
+
       const needsIdToOpen = action === "edit" || action === "clone";
       const hasId = typeof showId !== "undefined" || typeof id !== "undefined";
       if (needsIdToOpen ? hasId : true) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ *] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [* ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
The form modal was showing the data for the previously opened modal for a short time on opening the new modal.

## What is the new behavior?
The previously open data is not being shown now on opening the new modal.

fixes (issue)
The `keepPreviousData` option in the queryOptions of the `useForm.ts` file is set to false by default in the refine/package.antd package has been updated.

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
