### PR TITLE
fix(graphql): fix custom mutation params issue

### DIFF
--- a/.changeset/lucky-yaks-jog.md
+++ b/.changeset/lucky-yaks-jog.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/graphql": patch
+---
+
+fix: issue with custom mutation #6665
+
+We missed passing param values for custom mutation
+
+[Fixes #6665](https://github.com/refinedev/refine/issues/6665)

--- a/packages/graphql/src/dataProvider/options.ts
+++ b/packages/graphql/src/dataProvider/options.ts
@@ -289,6 +289,7 @@ export const defaultOptions = {
     dataMapper: (response: OperationResult<any>, params: CustomParams) =>
       response.data ?? response.error?.message,
     buildVariables: (params: CustomParams) => ({
+      ...(typeof params.payload === "object" ? params.payload : {}),
       ...params?.meta?.variables,
       ...params?.meta?.gqlVariables,
     }),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
Values are not being passed

## What is the new behavior?

values from params will now be passed

fixes (#6665 )

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
