### PR TITLE
fix(types): remove path aliases from type imports

### DIFF
--- a/.changeset/itchy-peas-pump.md
+++ b/.changeset/itchy-peas-pump.md
@@ -1,0 +1,15 @@
+---
+"@refinedev/mantine": patch
+"@refinedev/antd": patch
+"@refinedev/core": patch
+"@refinedev/kbar": patch
+"@refinedev/cli": patch
+---
+
+fix(types): remove path aliases from type imports
+
+Since typescript doesn't resolve and replace path aliases, using them for the type imports will cause `d.ts` files to reference unresolvable paths and types.
+
+While this doesn't break everything, it breaks the types in places where the path aliases are used for type imports.
+
+This change removes the path aliases from the type imports and replaces them with relative imports.

--- a/packages/antd/src/definitions/filter-mappers/index.ts
+++ b/packages/antd/src/definitions/filter-mappers/index.ts
@@ -1,7 +1,7 @@
 import type {
   FilterDropdownProps,
   MapValueEvent,
-} from "@components/table/components";
+} from "../../components/table/components";
 import dayjs from "dayjs";
 
 /**

--- a/packages/antd/src/hooks/useThemedLayoutContext/index.ts
+++ b/packages/antd/src/hooks/useThemedLayoutContext/index.ts
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 
-import { ThemedLayoutContext } from "@contexts";
-import type { IThemedLayoutContext } from "@contexts/themedLayoutContext/IThemedLayoutContext";
+import { ThemedLayoutContext } from "../../contexts";
+import type { IThemedLayoutContext } from "../../contexts/themedLayoutContext/IThemedLayoutContext";
 
 export type UseThemedLayoutContextType = IThemedLayoutContext;
 

--- a/packages/cli/src/commands/add/sub-commands/integration/packages/index.ts
+++ b/packages/cli/src/commands/add/sub-commands/integration/packages/index.ts
@@ -1,4 +1,4 @@
-import type { ProjectTypes } from "@definitions/projectTypes";
+import type { ProjectTypes } from "../../../../../definitions/projectTypes";
 import { AntDesignIntegration } from "./ant-design";
 import { ReactRouterIntegration } from "./react-router";
 

--- a/packages/cli/src/commands/check-updates/index.tsx
+++ b/packages/cli/src/commands/check-updates/index.tsx
@@ -10,7 +10,7 @@ import spinner from "@utils/spinner";
 import type {
   NpmOutdatedResponse,
   RefinePackageInstalledVersionData,
-} from "@definitions/package";
+} from "../../definitions/package";
 import semverDiff from "semver-diff";
 import { maxSatisfying } from "semver";
 

--- a/packages/cli/src/commands/update/interactive/index.ts
+++ b/packages/cli/src/commands/update/interactive/index.ts
@@ -6,7 +6,7 @@ import { parsePackageNameAndVersion } from "@utils/package";
 import type {
   PackageDependency,
   RefinePackageInstalledVersionData,
-} from "@definitions/package";
+} from "../../../definitions/package";
 
 type UIGroup = {
   patch: {

--- a/packages/cli/src/components/update-warning-table/table.ts
+++ b/packages/cli/src/components/update-warning-table/table.ts
@@ -1,8 +1,12 @@
-import type { RefinePackageInstalledVersionData } from "@definitions/package";
+import type { RefinePackageInstalledVersionData } from "../../definitions/package";
 import chalk from "chalk";
 import center from "center-align";
-import { getDependencies, getPreferedPM, getScripts } from "@utils/package";
-import { getVersionTable } from "@components/version-table";
+import {
+  getDependencies,
+  getPreferedPM,
+  getScripts,
+} from "../../utils/package";
+import { getVersionTable } from "../version-table";
 
 export interface UpdateWarningTableParams {
   data: RefinePackageInstalledVersionData[];

--- a/packages/cli/src/components/version-table/index.ts
+++ b/packages/cli/src/components/version-table/index.ts
@@ -1,4 +1,4 @@
-import type { RefinePackageInstalledVersionData } from "@definitions/package";
+import type { RefinePackageInstalledVersionData } from "../../definitions/package";
 import Table from "cli-table3";
 import chalk from "chalk";
 import { removeANSIColors } from "@utils/text";

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -1,5 +1,5 @@
-import type { NODE_ENV } from "@definitions/node";
-import type { ProjectTypes } from "@definitions/projectTypes";
+import type { NODE_ENV } from "../definitions/node";
+import type { ProjectTypes } from "../definitions/projectTypes";
 import { ENV } from "@utils/env";
 import { getOS } from "@utils/os";
 import { getInstalledRefinePackages, getRefineProjectId } from "@utils/package";

--- a/packages/cli/src/update-notifier/index.tsx
+++ b/packages/cli/src/update-notifier/index.tsx
@@ -2,7 +2,7 @@ import Conf from "conf";
 import chalk from "chalk";
 import { isRefineUptoDate } from "@commands/check-updates";
 import { printUpdateWarningTable } from "@components/update-warning-table";
-import type { RefinePackageInstalledVersionData } from "@definitions/package";
+import type { RefinePackageInstalledVersionData } from "../definitions/package";
 import { getInstalledRefinePackages } from "@utils/package";
 import { ENV } from "@utils/env";
 import { stringToBase64 } from "@utils/encode";

--- a/packages/cli/src/utils/announcement/index.tsx
+++ b/packages/cli/src/utils/announcement/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import matter from "gray-matter";
 import boxen from "boxen";
 
-import type { Announcement } from "@definitions/announcement";
+import type { Announcement } from "../../definitions/announcement";
 import { markedTerminalRenderer } from "@utils/marked-terminal-renderer";
 
 const ANNOUNCEMENT_URL =

--- a/packages/cli/src/utils/env/index.ts
+++ b/packages/cli/src/utils/env/index.ts
@@ -1,4 +1,4 @@
-import type { NODE_ENV } from "@definitions/node";
+import type { NODE_ENV } from "../../definitions/node";
 import * as dotenv from "dotenv";
 
 const refineEnv: Record<string, string> = {};

--- a/packages/cli/src/utils/package/index.ts
+++ b/packages/cli/src/utils/package/index.ts
@@ -4,7 +4,7 @@ import { existsSync, pathExists, readFileSync, readJSON } from "fs-extra";
 import globby from "globby";
 import path from "path";
 import preferredPM from "preferred-pm";
-import type { PackageJson } from "@definitions/package";
+import type { PackageJson } from "../../definitions/package";
 
 export const getPackageJson = (): PackageJson => {
   if (!existsSync("package.json")) {

--- a/packages/cli/src/utils/project/index.ts
+++ b/packages/cli/src/utils/project/index.ts
@@ -1,4 +1,4 @@
-import { ProjectTypes, UIFrameworks } from "@definitions";
+import { ProjectTypes, UIFrameworks } from "../../definitions";
 import { getDependencies, getDevDependencies } from "@utils/package";
 
 export const getProjectType = (platform?: ProjectTypes): ProjectTypes => {

--- a/packages/cli/src/utils/resource/index.ts
+++ b/packages/cli/src/utils/resource/index.ts
@@ -1,4 +1,4 @@
-import { ProjectTypes } from "@definitions/projectTypes";
+import { ProjectTypes } from "../../definitions/projectTypes";
 import camelCase from "camelcase";
 
 export const getResourcePath = (

--- a/packages/cli/src/utils/swizzle/index.ts
+++ b/packages/cli/src/utils/swizzle/index.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import type { RefineConfig } from "@definitions";
+import type { RefineConfig } from "../../definitions";
 import { provideCliHelpers } from "./provideCliHelpers";
 
 export const getRefineConfig = async (

--- a/packages/core/src/definitions/helpers/generateDocumentTitle/index.ts
+++ b/packages/core/src/definitions/helpers/generateDocumentTitle/index.ts
@@ -1,4 +1,4 @@
-import type { useTranslate } from "@hooks/i18n";
+import type { useTranslate } from "../../../hooks/i18n";
 
 import type { IResourceItem } from "../../../contexts/resource/types";
 import { safeTranslate } from "../safe-translate";

--- a/packages/core/src/definitions/helpers/safe-translate/index.ts
+++ b/packages/core/src/definitions/helpers/safe-translate/index.ts
@@ -1,4 +1,4 @@
-import type { useTranslate } from "@hooks/i18n";
+import type { useTranslate } from "../../../hooks/i18n";
 
 export const safeTranslate = (
   translate: ReturnType<typeof useTranslate>,

--- a/packages/kbar/src/components/refineKbar/index.tsx
+++ b/packages/kbar/src/components/refineKbar/index.tsx
@@ -1,8 +1,8 @@
 import React, { useContext } from "react";
 
 import { RefineKbarPropsContext } from "./../../index";
-import { useRefineKbar } from "@hooks";
-import { CommandBar } from "@components";
+import { useRefineKbar } from "../../hooks";
+import { CommandBar } from "../";
 
 export const RefineKbar: React.FC<{
   commandBarProps?: React.ComponentProps<typeof CommandBar>;

--- a/packages/mantine/src/hooks/useThemedLayoutContext/index.ts
+++ b/packages/mantine/src/hooks/useThemedLayoutContext/index.ts
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 
-import { ThemedLayoutContext } from "@contexts";
-import type { IThemedLayoutContext } from "@contexts/themedLayoutContext/IThemedLayoutContext";
+import { ThemedLayoutContext } from "../../contexts";
+import type { IThemedLayoutContext } from "../../contexts/themedLayoutContext/IThemedLayoutContext";
 
 export type UseThemedLayoutContextType = IThemedLayoutContext;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

Since typescript doesn't resolve and replace path aliases, using them for the type imports will cause `d.ts` files to reference unresolvable paths and types.

While this doesn't break everything, it breaks the types in places where the path aliases are used for type imports.

This change removes the path aliases from the type imports and replaces them with relative imports.
