### PR TITLE
fix(docs): repeated documentation and wrong placement

### DIFF
--- a/documentation/tutorial/ui-libraries/authentication/material-ui/react-router/index.md
+++ b/documentation/tutorial/ui-libraries/authentication/material-ui/react-router/index.md
@@ -15,7 +15,6 @@ Now our application is ready to use with layouts, views and notifications. Only 
 - Forgot password page with type `forgotPassword` which renders a forgot password form and works with the `useForgotPassword` hook.
 - Update password page with type `updatePassword` which renders a update password form and works with the `useUpdatePassword` hook.
 
-Now we've refactored our application with Material UI, we only have one thing left to do: handle notifications. Refine triggers notification in various scenarios, such as when a record is created, updated, or deleted, when there is an error from your data provider or your auth provider. It's important to provide feedback to the user when interacting with the application.
 
 ## Using `<AuthPage />` Component
 

--- a/documentation/tutorial/ui-libraries/notifications/material-ui/react-router/index.md
+++ b/documentation/tutorial/ui-libraries/notifications/material-ui/react-router/index.md
@@ -6,9 +6,9 @@ import { Sandpack, AddNotificationProviderToApp } from "./sandpack.tsx";
 
 <Sandpack>
 
-In this step, we will explore integrating Material UI's notification elements with Refine to deliver notifications to users.
+Now we've refactored our application with Material UI, we only have one thing left to do: handle notifications.
 
-Now we've refactored our application with Material UI, we only have one thing left to do: handle notifications. Refine triggers notification in various scenarios, such as when a record is created, updated, or deleted, when there is an error from your data provider or your auth provider. It's important to provide feedback to the user when interacting with the application.
+Refine triggers notification in various scenarios, such as when a record is created, updated, or deleted, when there is an error from your data provider or your auth provider. It's important to provide feedback to the user when interacting with the application.
 
 
 All these notifications are enabled just by providing a `notificationProvider` prop to the `<Refine />` component. A notification provider is responsible from displaying and dismissing notifications as well as handling undoable mutation notifications.

--- a/documentation/tutorial/ui-libraries/notifications/material-ui/react-router/index.md
+++ b/documentation/tutorial/ui-libraries/notifications/material-ui/react-router/index.md
@@ -8,7 +8,8 @@ import { Sandpack, AddNotificationProviderToApp } from "./sandpack.tsx";
 
 In this step, we will explore integrating Material UI's notification elements with Refine to deliver notifications to users.
 
-Refine triggers notification in various scenarios, such as when a record is created, updated, or deleted, when there is an error from your data provider or your auth provider. It's important to provide feedback to the user when interacting with the application.
+Now we've refactored our application with Material UI, we only have one thing left to do: handle notifications. Refine triggers notification in various scenarios, such as when a record is created, updated, or deleted, when there is an error from your data provider or your auth provider. It's important to provide feedback to the user when interacting with the application.
+
 
 All these notifications are enabled just by providing a `notificationProvider` prop to the `<Refine />` component. A notification provider is responsible from displaying and dismissing notifications as well as handling undoable mutation notifications.
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
There are [Notifications](https://refine.dev/tutorial/ui-libraries/notifications/material-ui/react-router/)-related documentation part is mentioned in [Authentication](https://refine.dev/tutorial/ui-libraries/authentication/material-ui/react-router/) section:
## What is the new behavior?
The Notification related documentation has been removed from the Authentication part and added to the right place. 
fixes (issue)
#6668

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
