### PR TITLE
fix: `mui/x-data-grid` throws an error on sandpack

### DIFF
--- a/documentation/docs/guides-concepts/authentication/auth-pages/mui.tsx
+++ b/documentation/docs/guides-concepts/authentication/auth-pages/mui.tsx
@@ -18,7 +18,7 @@ export function MaterialUIAuth() {
         "@mui/lab": "^6.0.0-beta.14",
         "@mui/material": "^6.1.7",
         "@mui/system": "latest",
-        "@mui/x-data-grid": "^7.23.5",
+        "@mui/x-data-grid": "7.23.5",
       }}
       startRoute="/login"
       files={{

--- a/documentation/docs/guides-concepts/forms/server-side-validation-mui.tsx
+++ b/documentation/docs/guides-concepts/forms/server-side-validation-mui.tsx
@@ -17,7 +17,7 @@ export default function ServerSideValidationMui() {
         "@mui/lab": "^6.0.0-beta.14",
         "@mui/material": "^6.1.7",
         "@mui/system": "latest",
-        "@mui/x-data-grid": "^7.23.5",
+        "@mui/x-data-grid": "7.23.5",
         "react-router": "^7.0.2",
         "react-hook-form": "^7.43.5",
       }}

--- a/documentation/docs/guides-concepts/general-concepts/auth-pages/mui.tsx
+++ b/documentation/docs/guides-concepts/general-concepts/auth-pages/mui.tsx
@@ -18,7 +18,7 @@ export function MaterialUIAuth() {
         "@mui/lab": "^6.0.0-beta.14",
         "@mui/material": "^6.1.7",
         "@mui/system": "latest",
-        "@mui/x-data-grid": "^7.23.5",
+        "@mui/x-data-grid": "7.23.5",
       }}
       startRoute="/login"
       files={{

--- a/documentation/docs/guides-concepts/general-concepts/layout/mui.tsx
+++ b/documentation/docs/guides-concepts/general-concepts/layout/mui.tsx
@@ -19,7 +19,7 @@ export function MaterialUILayout() {
         "@mui/lab": "^6.0.0-beta.14",
         "@mui/material": "^6.1.7",
         "@mui/system": "latest",
-        "@mui/x-data-grid": "^7.23.5",
+        "@mui/x-data-grid": "7.23.5",
       }}
       startRoute="/my-products"
       files={{

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/auth-page.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/auth-page.tsx
@@ -18,7 +18,7 @@ export default function AuthPage() {
         "@mui/lab": "^6.0.0-beta.14",
         "@mui/material": "^6.1.7",
         "@mui/system": "latest",
-        "@mui/x-data-grid": "^7.23.5",
+        "@mui/x-data-grid": "7.23.5",
         "react-router": "^7.0.2",
         "react-hook-form": "^7.43.5",
       }}

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/basic-views.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/basic-views.tsx
@@ -17,7 +17,7 @@ export default function BasicViews() {
         "@mui/lab": "^6.0.0-beta.14",
         "@mui/material": "^6.1.7",
         "@mui/system": "latest",
-        "@mui/x-data-grid": "^7.23.5",
+        "@mui/x-data-grid": "7.23.5",
         "react-router": "^7.0.2",
         "react-hook-form": "^7.43.5",
       }}

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/example.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/example.tsx
@@ -17,7 +17,7 @@ export default function Example() {
         "@mui/lab": "^6.0.0-beta.14",
         "@mui/material": "^6.1.7",
         "@mui/system": "latest",
-        "@mui/x-data-grid": "^7.23.5",
+        "@mui/x-data-grid": "7.23.5",
         "react-router": "^7.0.2",
         "react-hook-form": "^7.43.5",
       }}

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/layout-next-js.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/layout-next-js.tsx
@@ -17,7 +17,7 @@ export default function LayoutNextjs() {
         "@mui/lab": "^6.0.0-beta.14",
         "@mui/material": "^6.1.7",
         "@mui/system": "latest",
-        "@mui/x-data-grid": "^7.23.5",
+        "@mui/x-data-grid": "7.23.5",
         "@refinedev/nextjs-router": "latest",
       }}
       // template="nextjs"

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/layout-react-router-dom.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/layout-react-router-dom.tsx
@@ -19,7 +19,7 @@ export default function LayoutReactRouterDom() {
         "@mui/lab": "^6.0.0-beta.14",
         "@mui/material": "^6.1.7",
         "@mui/system": "latest",
-        "@mui/x-data-grid": "^7.23.5",
+        "@mui/x-data-grid": "7.23.5",
         "react-router": "^7.0.2",
         "react-hook-form": "^7.43.5",
       }}

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/layout-remix.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/layout-remix.tsx
@@ -17,7 +17,7 @@ export default function LayoutRemix() {
         "@mui/lab": "^6.0.0-beta.14",
         "@mui/material": "^6.1.7",
         "@mui/system": "latest",
-        "@mui/x-data-grid": "^7.23.5",
+        "@mui/x-data-grid": "7.23.5",
         "@refinedev/remix-router": "latest",
       }}
       startRoute="/products"

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/theming.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/theming.tsx
@@ -19,7 +19,7 @@ export default function Usage() {
         "@mui/lab": "^6.0.0-beta.14",
         "@mui/material": "^6.1.7",
         "@mui/system": "latest",
-        "@mui/x-data-grid": "^7.23.5",
+        "@mui/x-data-grid": "7.23.5",
         "react-router": "^7.0.2",
         "react-hook-form": "^7.43.5",
       }}

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/usage-next-js.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/usage-next-js.tsx
@@ -17,7 +17,7 @@ export default function UsageNextjs() {
         "@mui/lab": "^6.0.0-beta.14",
         "@mui/material": "^6.1.7",
         "@mui/system": "latest",
-        "@mui/x-data-grid": "^7.23.5",
+        "@mui/x-data-grid": "7.23.5",
         "react-hook-form": "^7.43.5",
         "@refinedev/nextjs-router": "latest",
       }}

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/usage-react-router-dom.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/usage-react-router-dom.tsx
@@ -17,7 +17,7 @@ export default function UsageReactRouterDom() {
         "@mui/lab": "^6.0.0-beta.14",
         "@mui/material": "^6.1.7",
         "@mui/system": "latest",
-        "@mui/x-data-grid": "^7.23.5",
+        "@mui/x-data-grid": "7.23.5",
         "react-hook-form": "^7.43.5",
         "react-router": "^7.0.2",
         "@refinedev/react-router": "latest",

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/usage-remix.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/usage-remix.tsx
@@ -17,7 +17,7 @@ export default function UsageRemix() {
         "@mui/lab": "^6.0.0-beta.14",
         "@mui/material": "^6.1.7",
         "@mui/system": "latest",
-        "@mui/x-data-grid": "^7.23.5",
+        "@mui/x-data-grid": "7.23.5",
         "react-hook-form": "^7.43.5",
         "@refinedev/remix-router": "latest",
       }}

--- a/documentation/tutorial/ui-libraries/intro/material-ui/react-router/sandpack.tsx
+++ b/documentation/tutorial/ui-libraries/intro/material-ui/react-router/sandpack.tsx
@@ -238,7 +238,7 @@ export const dependencies = {
   "@emotion/styled": "11.11.5",
   "@mui/lab": "^6.0.0-beta.14",
   "@mui/material": "^6.1.7",
-  "@mui/x-data-grid": "^7.23.5",
+  "@mui/x-data-grid": "7.23.5",
   "@refinedev/mui": "latest",
   "@mui/system": "latest",
   "@refinedev/react-hook-form": "latest",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

----
`mui/x-data-grid` throws an error on Sandpack:
![image](https://github.com/user-attachments/assets/35fe108c-6f04-4147-a783-eab20fb48a79)

because of this [tutorial](https://refine.dev/tutorial/ui-libraries/refactoring/material-ui/react-router/#) is not working.

This error is caused by [`mui/x-data-grid`](https://github.com/mui/mui-x/pull/15627), and until they release a fix, I have locked the version.

