### PR TITLE
fix(docs): wrong description of use-select and use-autocomplete

### DIFF
--- a/documentation/docs/ui-integrations/ant-design/hooks/use-select/_basic-usage-live-preview.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-select/_basic-usage-live-preview.md
@@ -23,13 +23,21 @@ const PostCreate: React.FC = () => {
   );
 };
 // visible-block-end
-setRefineProps({
-  resources: [
-    {
-      name: "posts",
-      create: PostCreate,
-    },
-  ],
-});
-render(<RefineAntdDemo />);
+
+render(
+  <ReactRouter.BrowserRouter>
+    <RefineAntdDemo
+      resources={[
+        {
+          name: "posts",
+          create: "posts/create",
+        },
+      ]}
+    >
+      <ReactRouter.Routes>
+        <ReactRouter.Route path="posts/create" element={<PostCreate />} />
+      </ReactRouter.Routes>
+    </RefineAntdDemo>
+  </ReactRouter.BrowserRouter>,
+);
 ```

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-select/_crud-live-preview.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-select/_crud-live-preview.md
@@ -36,13 +36,21 @@ const PostCreate: React.FC = () => {
   );
 };
 // visible-block-end
-setRefineProps({
-  resources: [
-    {
-      name: "posts",
-      create: PostCreate,
-    },
-  ],
-});
-render(<RefineAntdDemo />);
+
+render(
+  <ReactRouter.BrowserRouter>
+    <RefineAntdDemo
+      resources={[
+        {
+          name: "posts",
+          create: "posts/create",
+        },
+      ]}
+    >
+      <ReactRouter.Routes>
+        <ReactRouter.Route path="posts/create" element={<PostCreate />} />
+      </ReactRouter.Routes>
+    </RefineAntdDemo>
+  </ReactRouter.BrowserRouter>,
+);
 ```

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-select/_default-value-live-preview.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-select/_default-value-live-preview.md
@@ -25,13 +25,21 @@ const PostCreate: React.FC = () => {
   );
 };
 // visible-block-end
-setRefineProps({
-  resources: [
-    {
-      name: "posts",
-      create: PostCreate,
-    },
-  ],
-});
-render(<RefineAntdDemo />);
+
+render(
+  <ReactRouter.BrowserRouter>
+    <RefineAntdDemo
+      resources={[
+        {
+          name: "posts",
+          create: "posts/create",
+        },
+      ]}
+    >
+      <ReactRouter.Routes>
+        <ReactRouter.Route path="posts/create" element={<PostCreate />} />
+      </ReactRouter.Routes>
+    </RefineAntdDemo>
+  </ReactRouter.BrowserRouter>,
+);
 ```

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-select/_on-search-live-preview.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-select/_on-search-live-preview.md
@@ -32,13 +32,21 @@ const PostCreate: React.FC = () => {
   );
 };
 // visible-block-end
-setRefineProps({
-  resources: [
-    {
-      name: "posts",
-      create: PostCreate,
-    },
-  ],
-});
-render(<RefineAntdDemo />);
+
+render(
+  <ReactRouter.BrowserRouter>
+    <RefineAntdDemo
+      resources={[
+        {
+          name: "posts",
+          create: "posts/create",
+        },
+      ]}
+    >
+      <ReactRouter.Routes>
+        <ReactRouter.Route path="posts/create" element={<PostCreate />} />
+      </ReactRouter.Routes>
+    </RefineAntdDemo>
+  </ReactRouter.BrowserRouter>,
+);
 ```

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-select/_sort-live-preview.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-select/_sort-live-preview.md
@@ -38,13 +38,21 @@ const PostCreate: React.FC = () => {
   );
 };
 // visible-block-end
-setRefineProps({
-  resources: [
-    {
-      name: "posts",
-      create: PostCreate,
-    },
-  ],
-});
-render(<RefineAntdDemo />);
+
+render(
+  <ReactRouter.BrowserRouter>
+    <RefineAntdDemo
+      resources={[
+        {
+          name: "posts",
+          create: "posts/create",
+        },
+      ]}
+    >
+      <ReactRouter.Routes>
+        <ReactRouter.Route path="posts/create" element={<PostCreate />} />
+      </ReactRouter.Routes>
+    </RefineAntdDemo>
+  </ReactRouter.BrowserRouter>,
+);
 ```

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-select/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-select/index.md
@@ -143,19 +143,36 @@ useSelect({
 
 ### defaultValue
 
-The `defaultValue` is a property that can be used to not only set default options for a `<select>` component but also add extra options.
+Is used to fetch extra options from the API.
 
-However, issues may arise when the `<select>` component has many entries and pagination is required. In such cases, the `defaultValue` might not be visible among the currently displayed options, which could cause the `<select>` component to malfunction.
-
-To prevent this, a separate `useMany` query is sent to the backend carrying the `defaultValue` and added to the options of the `<select>` component, ensuring that the default values are always present in the current array of options.
-
-Since the `useMany` query is used to query the necessary data, the `defaultValue` can be a single value or an array of values like the following:
+If there are many `<select>` options and pagination is needed, the `defaultValue` might not be in the visible list. This can break the `<select>` component. To prevent this, a separate `useMany` query fetches the `defaultValue` from the backend and adds it to the options, ensuring it exists in the list. Since it uses `useMany`, `defaultValue` can be a single value or an array:
 
 ```tsx
 useSelect({
   defaultValue: 1, // or [1, 2]
 });
 ```
+
+:::info
+
+`defaultValue` **does not** set a default selection. It only ensures the default value exists in the options.
+
+To set a default selection, pass `defaultValue` to the `value` prop of `<Select>` or `useForm`:
+
+```tsx
+const form = useForm({
+  defaultValues: {
+    category: { id: 1 }, // Default selected value
+  },
+});
+
+const { selectProps } = useSelect({
+  resource: "categories",
+  defaultValue: [1], // Ensures the default value is included in options
+});
+```
+
+:::
 
 ### selectedOptionsOrder
 

--- a/documentation/docs/ui-integrations/material-ui/hooks/use-auto-complete/_basic-usage-live-preview.md
+++ b/documentation/docs/ui-integrations/material-ui/hooks/use-auto-complete/_basic-usage-live-preview.md
@@ -1,5 +1,6 @@
 ```tsx live url=http://localhost:3000 previewHeight=300px
 setInitialRoutes(["/posts/create"]);
+
 // visible-block-start
 import { useAutocomplete } from "@refinedev/mui";
 import { Autocomplete, TextField } from "@mui/material";
@@ -36,13 +37,20 @@ const PostCreate: React.FC = () => {
   );
 };
 // visible-block-end
-setRefineProps({
-  resources: [
-    {
-      name: "posts",
-      create: PostCreate,
-    },
-  ],
-});
-render(<RefineMuiDemo />);
+render(
+  <ReactRouter.BrowserRouter>
+    <RefineMuiDemo
+      resources={[
+        {
+          name: "posts",
+          create: "posts/create",
+        },
+      ]}
+    >
+      <ReactRouter.Routes>
+        <ReactRouter.Route path="posts/create" element={<PostCreate />} />
+      </ReactRouter.Routes>
+    </RefineMuiDemo>
+  </ReactRouter.BrowserRouter>,
+);
 ```

--- a/documentation/docs/ui-integrations/material-ui/hooks/use-auto-complete/_crud-live-preview.md
+++ b/documentation/docs/ui-integrations/material-ui/hooks/use-auto-complete/_crud-live-preview.md
@@ -64,13 +64,20 @@ const PostCreate: React.FC = () => {
   );
 };
 // visible-block-end
-setRefineProps({
-  resources: [
-    {
-      name: "posts",
-      create: PostCreate,
-    },
-  ],
-});
-render(<RefineMuiDemo />);
+render(
+  <ReactRouter.BrowserRouter>
+    <RefineMuiDemo
+      resources={[
+        {
+          name: "posts",
+          create: "posts/create",
+        },
+      ]}
+    >
+      <ReactRouter.Routes>
+        <ReactRouter.Route path="posts/create" element={<PostCreate />} />
+      </ReactRouter.Routes>
+    </RefineMuiDemo>
+  </ReactRouter.BrowserRouter>,
+);
 ```

--- a/documentation/docs/ui-integrations/material-ui/hooks/use-auto-complete/_default-value-live-preview.md
+++ b/documentation/docs/ui-integrations/material-ui/hooks/use-auto-complete/_default-value-live-preview.md
@@ -38,13 +38,20 @@ const PostCreate: React.FC = () => {
   );
 };
 // visible-block-end
-setRefineProps({
-  resources: [
-    {
-      name: "posts",
-      create: PostCreate,
-    },
-  ],
-});
-render(<RefineMuiDemo />);
+render(
+  <ReactRouter.BrowserRouter>
+    <RefineMuiDemo
+      resources={[
+        {
+          name: "posts",
+          create: "posts/create",
+        },
+      ]}
+    >
+      <ReactRouter.Routes>
+        <ReactRouter.Route path="posts/create" element={<PostCreate />} />
+      </ReactRouter.Routes>
+    </RefineMuiDemo>
+  </ReactRouter.BrowserRouter>,
+);
 ```

--- a/documentation/docs/ui-integrations/material-ui/hooks/use-auto-complete/_on-search-live-preview.md
+++ b/documentation/docs/ui-integrations/material-ui/hooks/use-auto-complete/_on-search-live-preview.md
@@ -45,13 +45,20 @@ const PostCreate: React.FC = () => {
   );
 };
 // visible-block-end
-setRefineProps({
-  resources: [
-    {
-      name: "posts",
-      create: PostCreate,
-    },
-  ],
-});
-render(<RefineMuiDemo />);
+render(
+  <ReactRouter.BrowserRouter>
+    <RefineMuiDemo
+      resources={[
+        {
+          name: "posts",
+          create: "posts/create",
+        },
+      ]}
+    >
+      <ReactRouter.Routes>
+        <ReactRouter.Route path="posts/create" element={<PostCreate />} />
+      </ReactRouter.Routes>
+    </RefineMuiDemo>
+  </ReactRouter.BrowserRouter>,
+);
 ```

--- a/documentation/docs/ui-integrations/material-ui/hooks/use-auto-complete/_sort-live-preview.md
+++ b/documentation/docs/ui-integrations/material-ui/hooks/use-auto-complete/_sort-live-preview.md
@@ -54,13 +54,20 @@ const PostCreate: React.FC = () => {
   );
 };
 // visible-block-end
-setRefineProps({
-  resources: [
-    {
-      name: "posts",
-      create: PostCreate,
-    },
-  ],
-});
-render(<RefineMuiDemo />);
+render(
+  <ReactRouter.BrowserRouter>
+    <RefineMuiDemo
+      resources={[
+        {
+          name: "posts",
+          create: "posts/create",
+        },
+      ]}
+    >
+      <ReactRouter.Routes>
+        <ReactRouter.Route path="posts/create" element={<PostCreate />} />
+      </ReactRouter.Routes>
+    </RefineMuiDemo>
+  </ReactRouter.BrowserRouter>,
+);
 ```

--- a/documentation/docs/ui-integrations/material-ui/hooks/use-auto-complete/index.md
+++ b/documentation/docs/ui-integrations/material-ui/hooks/use-auto-complete/index.md
@@ -80,15 +80,38 @@ useAutocomplete({
 });
 ```
 
-### defaultValue
+### `defaultValue`
 
-Allows to make options selected by default. Adds extra options to `<select>` component. In some cases like there are many entries for the `<select>` and pagination is required, `defaultValue` may not be present in the current visible options and this can break the `<select>` component. To avoid such cases, A separate `useMany` query is sent to the backend with the `defaultValue` and appended to the options of `<select>`, ensuring the default values exist in the current options array. Since it uses `useMany` to query the necessary data, the `defaultValue` can be a single value or an array of values like the following:
+Is used to fetch extra options from the API.
+
+If there are many `<select>` options and pagination is needed, the `defaultValue` might not be in the visible list. This can break the `<select>` component. To prevent this, a separate `useMany` query fetches the `defaultValue` from the backend and adds it to the options, ensuring it exists in the list. Since it uses `useMany`, `defaultValue` can be a single value or an array:
 
 ```tsx
 useAutocomplete({
   defaultValue: 1, // or [1, 2]
 });
 ```
+
+:::info
+
+`defaultValue` **does not** set a default selection. It only ensures the default value exists in the options.
+
+To set a default selection, pass `defaultValue` to the `value` prop of `<Autocomplete>` or `useForm`:
+
+```tsx
+const form = useForm({
+  defaultValues: {
+    category: { id: 1 }, // Default selected value
+  },
+});
+
+const { autocompleteProps } = useAutocomplete({
+  resource: "categories",
+  defaultValue: [1], // Ensures the default value is included in options
+});
+```
+
+:::
 
 ### selectedOptionsOrder
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

`defaultValue` prop of [`useAutoComplete`](https://refine.dev/docs/ui-integrations/material-ui/hooks/use-auto-complete/#defaultvalue) and [`useSelect`](https://refine.dev/docs/ui-integrations/ant-design/hooks/use-select/) descriptions are wrong.

## What is the new behavior?

Descriptions are updated to tell truth.

fixes #6685
