### PR TITLE
feat(ShowComponent): add meta prop for button visibility control

### DIFF
--- a/packages/antd/src/components/crud/show/index.tsx
+++ b/packages/antd/src/components/crud/show/index.tsx
@@ -10,6 +10,7 @@ import {
   useRouterType,
   useBack,
   useGo,
+  useShow,
 } from "@refinedev/core";
 
 import {
@@ -33,6 +34,7 @@ import type { ShowProps } from "../types";
  * @see {@link https://refine.dev/docs/ui-frameworks/antd/components/basic-views/show} for more details.
  */
 export const Show: React.FC<ShowProps> = ({
+  meta,
   title,
   canEdit,
   canDelete,
@@ -134,6 +136,8 @@ export const Show: React.FC<ShowProps> = ({
       <RefreshButton {...refreshButtonProps} />
     </>
   );
+
+  const { queryResult } = useShow({ meta, resource: identifier, id });
 
   return (
     <div {...(wrapperProps ?? {})}>

--- a/packages/antd/src/components/crud/types.ts
+++ b/packages/antd/src/components/crud/types.ts
@@ -56,4 +56,6 @@ export type ShowProps = RefineCrudShowProps<
   DeleteButtonProps,
   RefreshButtonProps,
   ListButtonProps
->;
+> & {
+  meta?: MetaQuery;
+};

--- a/packages/chakra-ui/src/components/crud/show/index.tsx
+++ b/packages/chakra-ui/src/components/crud/show/index.tsx
@@ -29,27 +29,27 @@ import {
 import type { ShowProps } from "../types";
 import { RefinePageHeaderClassNames } from "@refinedev/ui-types";
 
-export const Show: React.FC<ShowProps> = (props) => {
-  const {
-    children,
-    resource: resourceFromProps,
-    recordItemId,
-    canDelete,
-    deleteButtonProps: deleteButtonPropsFromProps,
-    canEdit,
-    dataProviderName,
-    isLoading,
-    footerButtons: footerButtonsFromProps,
-    footerButtonProps,
-    headerButtons: headerButtonsFromProps,
-    headerButtonProps,
-    wrapperProps,
-    contentProps,
-    headerProps,
-    goBack: goBackFromProps,
-    breadcrumb: breadcrumbFromProps,
-    title,
-  } = props;
+export const Show: React.FC<ShowProps> = ({
+  meta,
+  children,
+  resource: resourceFromProps,
+  recordItemId,
+  canDelete,
+  deleteButtonProps: deleteButtonPropsFromProps,
+  canEdit,
+  dataProviderName,
+  isLoading,
+  footerButtons: footerButtonsFromProps,
+  footerButtonProps,
+  headerButtons: headerButtonsFromProps,
+  headerButtonProps,
+  wrapperProps,
+  contentProps,
+  headerProps,
+  goBack: goBackFromProps,
+  breadcrumb: breadcrumbFromProps,
+  title,
+}) => {
   const translate = useTranslate();
   const {
     options: { breadcrumb: globalBreadcrumb } = {},

--- a/packages/chakra-ui/src/components/crud/types.ts
+++ b/packages/chakra-ui/src/components/crud/types.ts
@@ -13,6 +13,7 @@ import type {
   RefineCrudListProps,
   RefineCrudShowProps,
 } from "@refinedev/ui-types";
+import type { MetaQuery } from "@refinedev/core";
 
 export type CreateProps = RefineCrudCreateProps<
   SaveButtonProps,
@@ -55,4 +56,6 @@ export type ShowProps = RefineCrudShowProps<
   DeleteButtonProps,
   RefreshButtonProps,
   ListButtonProps
->;
+> & {
+  meta?: MetaQuery;
+};

--- a/packages/mantine/src/components/crud/show/index.tsx
+++ b/packages/mantine/src/components/crud/show/index.tsx
@@ -55,6 +55,7 @@ export const Show: React.FC<ShowProps> = (props) => {
     goBack: goBackFromProps,
     breadcrumb: breadcrumbFromProps,
     title,
+    meta,
   } = props;
   const translate = useTranslate();
   const {
@@ -96,10 +97,11 @@ export const Show: React.FC<ShowProps> = (props) => {
   const hasList = resource?.list && !recordItemId;
   const isDeleteButtonVisible =
     canDelete ??
-    ((resource?.meta?.canDelete ?? resource?.canDelete) ||
+    ((meta?.canDelete ?? resource?.meta?.canDelete ?? resource?.canDelete) ||
       deleteButtonPropsFromProps);
 
-  const isEditButtonVisible = canEdit ?? resource?.canEdit ?? !!resource?.edit;
+  const isEditButtonVisible =
+    canEdit ?? meta?.canEdit ?? resource?.canEdit ?? !!resource?.edit;
 
   const listButtonProps: ListButtonProps | undefined = hasList
     ? {

--- a/packages/mantine/src/components/crud/types.ts
+++ b/packages/mantine/src/components/crud/types.ts
@@ -13,6 +13,7 @@ import type {
   RefineCrudListProps,
   RefineCrudShowProps,
 } from "@refinedev/ui-types";
+import type { MetaQuery } from "@refinedev/core";
 
 export type ListProps = RefineCrudListProps<
   CreateButtonProps,
@@ -33,7 +34,9 @@ export type ShowProps = RefineCrudShowProps<
   DeleteButtonProps,
   RefreshButtonProps,
   ListButtonProps
->;
+> & {
+  meta?: MetaQuery;
+};
 
 export type CreateProps = RefineCrudCreateProps<
   SaveButtonProps,

--- a/packages/mui/src/components/crud/show/index.tsx
+++ b/packages/mui/src/components/crud/show/index.tsx
@@ -45,6 +45,7 @@ import { RefinePageHeaderClassNames } from "@refinedev/ui-types";
  * @see {@link https://refine.dev/docs/ui-frameworks/mui/components/basic-views/show} for more details.
  */
 export const Show: React.FC<ShowProps> = ({
+  meta,
   title,
   canEdit,
   canDelete,
@@ -95,14 +96,13 @@ export const Show: React.FC<ShowProps> = ({
       : breadcrumbFromProps;
 
   const hasList = resource?.list && !recordItemId;
-  const hasDelete =
+  const isDeleteButtonVisible =
     canDelete ??
-    ((resource?.meta?.canDelete ?? resource?.canDelete) ||
+    ((meta?.canDelete ?? resource?.meta?.canDelete ?? resource?.canDelete) ||
       deleteButtonPropsFromProps);
 
-  const isDeleteButtonVisible = hasDelete && typeof id !== "undefined";
-
-  const isEditButtonVisible = canEdit ?? resource?.canEdit ?? !!resource?.edit;
+  const isEditButtonVisible =
+    canEdit ?? meta?.canEdit ?? resource?.canEdit ?? !!resource?.edit;
 
   const breadcrumbComponent =
     typeof breadcrumb !== "undefined" ? (

--- a/packages/mui/src/components/crud/types.ts
+++ b/packages/mui/src/components/crud/types.ts
@@ -19,6 +19,7 @@ import type {
   RefineCrudListProps,
   RefineCrudShowProps,
 } from "@refinedev/ui-types";
+import type { MetaQuery } from "@refinedev/core";
 
 export type CreateProps = RefineCrudCreateProps<
   SaveButtonProps,
@@ -63,4 +64,6 @@ export type ShowProps = RefineCrudShowProps<
   DeleteButtonProps,
   RefreshButtonProps,
   ListButtonProps
->;
+> & {
+  meta?: MetaQuery;
+};


### PR DESCRIPTION
This PR adds support for using the `meta` prop in the `<Show>` component (both Mantine and MUI) to control the visibility of Edit and Delete buttons.

### What's Added
- `meta.canDelete` and `meta.canEdit` support
- Fallback preserved to `canDelete` and `canEdit` props

Closes #7951
