### PR TITLE
docs: fix(pagination): show last page number when current + 1 equals pageCount

### DIFF
--- a/documentation/tutorial/authentication/data-provider-integration/sandpack.tsx
+++ b/documentation/tutorial/authentication/data-provider-integration/sandpack.tsx
@@ -245,7 +245,7 @@ export const ListProducts = () => {
         <div>
           {current - 1 > 0 && <span onClick={() => onPage(current - 1)}>{current - 1}</span>}
           <span className="current">{current}</span>
-          {current + 1 < pageCount && <span onClick={() => onPage(current + 1)}>{current + 1}</span>}
+          {current + 1 <= pageCount && <span onClick={() => onPage(current + 1)}>{current + 1}</span>}
         </div>
         <button type="button" onClick={onNext}>
           {">"}

--- a/documentation/tutorial/essentials/tables/index.md
+++ b/documentation/tutorial/essentials/tables/index.md
@@ -402,7 +402,7 @@ export const ListProducts = () => {
             <span onClick={() => onPage(current - 1)}>{current - 1}</span>
           )}
           <span className="current">{current}</span>
-          {current + 1 < pageCount && (
+          {current + 1 <= pageCount && (
             <span onClick={() => onPage(current + 1)}>{current + 1}</span>
           )}
         </div>

--- a/documentation/tutorial/essentials/tables/sandpack.tsx
+++ b/documentation/tutorial/essentials/tables/sandpack.tsx
@@ -495,7 +495,7 @@ export const ListProducts = () => {
         <div>
           {current - 1 > 0 && <span onClick={() => onPage(current - 1)}>{current - 1}</span>}
           <span className="current">{current}</span>
-          {current + 1 < pageCount && <span onClick={() => onPage(current + 1)}>{current + 1}</span>}
+          {current + 1 <= pageCount && <span onClick={() => onPage(current + 1)}>{current + 1}</span>}
         </div>
         <button type="button" onClick={onNext}>
           {">"}
@@ -618,7 +618,7 @@ export const ListProducts = () => {
         <div>
           {current - 1 > 0 && <span onClick={() => onPage(current - 1)}>{current - 1}</span>}
           <span className="current">{current}</span>
-          {current + 1 < pageCount && <span onClick={() => onPage(current + 1)}>{current + 1}</span>}
+          {current + 1 <= pageCount && <span onClick={() => onPage(current + 1)}>{current + 1}</span>}
         </div>
         <button type="button" onClick={onNext}>
           {">"}

--- a/documentation/tutorial/routing/inferring-parameters/react-router/sandpack.tsx
+++ b/documentation/tutorial/routing/inferring-parameters/react-router/sandpack.tsx
@@ -144,7 +144,7 @@ export const ListProducts = () => {
             <span onClick={() => onPage(current - 1)}>{current - 1}</span>
           )}
           <span className="current">{current}</span>
-          {current + 1 < pageCount && (
+          {current + 1 <= pageCount && (
             <span onClick={() => onPage(current + 1)}>{current + 1}</span>
           )}
         </div>

--- a/documentation/tutorial/routing/navigation/react-router/sandpack.tsx
+++ b/documentation/tutorial/routing/navigation/react-router/sandpack.tsx
@@ -177,7 +177,7 @@ export const ListProducts = () => {
             <span onClick={() => onPage(current - 1)}>{current - 1}</span>
           )}
           <span className="current">{current}</span>
-          {current + 1 < pageCount && (
+          {current + 1 <= pageCount && (
             <span onClick={() => onPage(current + 1)}>{current + 1}</span>
           )}
         </div>

--- a/documentation/tutorial/routing/syncing-state/react-router/sandpack.tsx
+++ b/documentation/tutorial/routing/syncing-state/react-router/sandpack.tsx
@@ -153,7 +153,7 @@ export const ListProducts = () => {
             <span onClick={() => onPage(current - 1)}>{current - 1}</span>
           )}
           <span className="current">{current}</span>
-          {current + 1 < pageCount && (
+          {current + 1 <= pageCount && (
             <span onClick={() => onPage(current + 1)}>{current + 1}</span>
           )}
         </div>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

The last page number is not shown when `current + 1 === pageCount` due to a strict `<` comparison.

## What is the new behavior?

The condition has been updated to use `<=` to ensure the last page number is displayed properly.

