### PR TITLE
Added missing dependency dayjs

### DIFF
--- a/examples/pixels-admin/package.json
+++ b/examples/pixels-admin/package.json
@@ -30,7 +30,7 @@
     "@refinedev/supabase": "^5.9.8",
     "antd": "^5.17.0",
     "casbin": "^5.15.2",
-    "dayjs": "^1.11.13",
+    "dayjs": "^1.10.7",
     "dotenv": "^16.0.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/examples/pixels-admin/package.json
+++ b/examples/pixels-admin/package.json
@@ -30,6 +30,7 @@
     "@refinedev/supabase": "^5.9.8",
     "antd": "^5.17.0",
     "casbin": "^5.15.2",
+    "dayjs": "^1.11.13",
     "dotenv": "^16.0.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6345,7 +6345,7 @@ importers:
         specifier: ^5.15.2
         version: 5.29.0
       dayjs:
-        specifier: ^1.11.13
+        specifier: ^1.10.7
         version: 1.11.13
       dotenv:
         specifier: ^16.0.3
@@ -10769,55 +10769,9 @@ importers:
     devDependencies:
       '@esbuild-plugins/node-resolve':
         specifier: ^0.1.4
-        version: 0.1.4(esbuild@0.17.19)
-      '@refinedev/core':
-        specifier: ^4.57.1
-        version: link:../core
-      '@types/jest':
-        specifier: ^29.2.4
-        version: 29.5.12
-      jest:
-        specifier: ^29.3.1
-        version: 29.7.0(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.31)(typescript@5.4.5))
-      jest-environment-jsdom:
-        specifier: ^29.3.1
-        version: 29.7.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      nock:
-        specifier: ^13.4.0
-        version: 13.5.4
-      ts-jest:
-        specifier: ^29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(esbuild@0.17.19)(jest@29.7.0(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.31)(typescript@5.4.5)))(typescript@5.4.5)
-      tslib:
-        specifier: ^2.6.2
-        version: 2.6.2
-      tsup:
-        specifier: ^6.7.0
-        version: 6.7.0(postcss@8.5.3)(ts-node@10.9.2(@types/node@18.19.31)(typescript@5.4.5))(typescript@5.4.5)
-      typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
-
-  packages/airtable:
-    dependencies:
-      '@qualifyze/airtable-formulator':
-        specifier: ^1.0.1
-        version: 1.3.1
-      airtable:
-        specifier: ^0.11.1
-        version: 0.11.6(encoding@0.1.13)
-      asyncairtable:
-        specifier: ^2.1.0
-        version: 2.3.1(encoding@0.1.13)
-      query-string:
-        specifier: ^7.1.1
-        version: 7.1.3
-    devDependencies:
-      '@esbuild-plugins/node-resolve':
-        specifier: ^0.1.4
         version: 0.1.4(esbuild@0.21.5)
       '@refinedev/core':
-        specifier: 4.57.9
+        specifier: ^4.57.1
         version: link:../core
       '@types/jest':
         specifier: ^29.2.4
@@ -10840,6 +10794,52 @@ importers:
       tsup:
         specifier: ^6.7.0
         version: 6.7.0(postcss@8.5.3)(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5)
+      typescript:
+        specifier: ^5.4.2
+        version: 5.4.5
+
+  packages/airtable:
+    dependencies:
+      '@qualifyze/airtable-formulator':
+        specifier: ^1.0.1
+        version: 1.3.1
+      airtable:
+        specifier: ^0.11.1
+        version: 0.11.6(encoding@0.1.13)
+      asyncairtable:
+        specifier: ^2.1.0
+        version: 2.3.1(encoding@0.1.13)
+      query-string:
+        specifier: ^7.1.1
+        version: 7.1.3
+    devDependencies:
+      '@esbuild-plugins/node-resolve':
+        specifier: ^0.1.4
+        version: 0.1.4(esbuild@0.17.19)
+      '@refinedev/core':
+        specifier: 4.57.9
+        version: link:../core
+      '@types/jest':
+        specifier: ^29.2.4
+        version: 29.5.12
+      jest:
+        specifier: ^29.3.1
+        version: 29.7.0(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.31)(typescript@5.4.5))
+      jest-environment-jsdom:
+        specifier: ^29.3.1
+        version: 29.7.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      nock:
+        specifier: ^13.4.0
+        version: 13.5.4
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(esbuild@0.17.19)(jest@29.7.0(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.31)(typescript@5.4.5)))(typescript@5.4.5)
+      tslib:
+        specifier: ^2.6.2
+        version: 2.6.2
+      tsup:
+        specifier: ^6.7.0
+        version: 6.7.0(postcss@8.5.3)(ts-node@10.9.2(@types/node@18.19.31)(typescript@5.4.5))(typescript@5.4.5)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6344,6 +6344,9 @@ importers:
       casbin:
         specifier: ^5.15.2
         version: 5.29.0
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.13
       dotenv:
         specifier: ^16.0.3
         version: 16.4.5
@@ -38897,7 +38900,7 @@ snapshots:
       '@rc-component/trigger': 2.1.1(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
       classnames: 2.5.1
       copy-to-clipboard: 3.3.3
-      dayjs: 1.11.10
+      dayjs: 1.11.13
       qrcode.react: 3.1.0(react@18.3.0)
       rc-cascader: 3.24.1(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
       rc-checkbox: 3.2.0(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -38914,7 +38917,7 @@ snapshots:
       rc-motion: 2.9.0(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
       rc-notification: 5.4.0(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
       rc-pagination: 4.0.4(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
-      rc-picker: 4.4.2(date-fns@2.30.0)(dayjs@1.11.10)(luxon@3.4.4)(moment@2.30.1)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
+      rc-picker: 4.4.2(date-fns@2.30.0)(dayjs@1.11.13)(luxon@3.4.4)(moment@2.30.1)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
       rc-progress: 4.0.0(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
       rc-rate: 2.12.0(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
       rc-resize-observer: 1.4.0(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -40750,7 +40753,7 @@ snapshots:
       cli-table3: 0.6.4
       commander: 6.2.1
       common-tags: 1.8.2
-      dayjs: 1.11.10
+      dayjs: 1.11.13
       debug: 4.3.4(supports-color@8.1.1)
       enquirer: 2.4.1
       eventemitter2: 6.4.7
@@ -48623,7 +48626,7 @@ snapshots:
       react: 18.3.0
       react-dom: 18.3.0(react@18.3.0)
 
-  rc-picker@4.4.2(date-fns@2.30.0)(dayjs@1.11.10)(luxon@3.4.4)(moment@2.30.1)(react-dom@18.3.0(react@18.3.0))(react@18.3.0):
+  rc-picker@4.4.2(date-fns@2.30.0)(dayjs@1.11.13)(luxon@3.4.4)(moment@2.30.1)(react-dom@18.3.0(react@18.3.0))(react@18.3.0):
     dependencies:
       '@babel/runtime': 7.26.0
       '@rc-component/trigger': 2.2.3(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -48635,7 +48638,7 @@ snapshots:
       react-dom: 18.3.0(react@18.3.0)
     optionalDependencies:
       date-fns: 2.30.0
-      dayjs: 1.11.10
+      dayjs: 1.11.13
       luxon: 3.4.4
       moment: 2.30.1
 


### PR DESCRIPTION
without this, the app fails at startup with the message: Error: The following dependencies are imported but could not be resolved:

  dayjs/plugin/relativeTime (imported by /home/xxx/refine/pixels/pixels-admin/src/utility/time.ts)
  dayjs (imported by /home/xxx/refine/pixels/pixels-admin/src/utility/time.ts)

Are they installed?

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
fails at startup

## What is the new behavior?

fixes failed startup

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
