### PR TITLE
fix-types

### DIFF
--- a/packages/core/src/contexts/data/types.ts
+++ b/packages/core/src/contexts/data/types.ts
@@ -320,6 +320,7 @@ export type CrudOperators =
 export type SortOrder = "desc" | "asc" | null;
 
 export type LogicalFilter = {
+  key: undefined;
   field: string;
   operator: Exclude<CrudOperators, "or" | "and">;
   value: any;
@@ -327,6 +328,7 @@ export type LogicalFilter = {
 
 export type ConditionalFilter = {
   key?: string;
+  field: undefined;
   operator: Extract<CrudOperators, "or" | "and">;
   value: (LogicalFilter | ConditionalFilter)[];
 };

--- a/packages/core/src/contexts/data/types.ts
+++ b/packages/core/src/contexts/data/types.ts
@@ -320,7 +320,7 @@ export type CrudOperators =
 export type SortOrder = "desc" | "asc" | null;
 
 export type LogicalFilter = {
-  key: undefined;
+  key?: undefined;
   field: string;
   operator: Exclude<CrudOperators, "or" | "and">;
   value: any;
@@ -328,7 +328,7 @@ export type LogicalFilter = {
 
 export type ConditionalFilter = {
   key?: string;
-  field: undefined;
+  field?: undefined;
   operator: Extract<CrudOperators, "or" | "and">;
   value: (LogicalFilter | ConditionalFilter)[];
 };


### PR DESCRIPTION

## What is the current behavior?
I try to create custom data provider  (getList)

When i try to map filters -> ```filteres.map(f => ...)```
i cant get filter ```field``` value because of ts error: "Property field does not exist on type ConditionalFilter".

```ts
      getList: async (params) => {
        // TS error: "Property field does not exist on type ConditionalFilter"
        const filter = params.filters?.map((f) => [f.field, operators[f.operator], f.value]);
      },
```

## What is the new behavior?

No ts error
