### PR TITLE
docs(tutorial): remove unnecessary paragraph

### DIFF
--- a/documentation/tutorial/ui-libraries/authentication/ant-design/react-router/index.md
+++ b/documentation/tutorial/ui-libraries/authentication/ant-design/react-router/index.md
@@ -15,8 +15,6 @@ Now our application is ready to use with layouts, views and notifications. Only 
 - Forgot password page with type `forgotPassword` which renders a forgot password form and works with the `useForgotPassword` hook.
 - Update password page with type `updatePassword` which renders a update password form and works with the `useUpdatePassword` hook.
 
-Now we've refactored our application with Ant Design, we only have one thing left to do: handle notifications. Refine triggers notification in various scenarios, such as when a record is created, updated, or deleted, when there is an error from your data provider or your auth provider. It's important to provide feedback to the user when interacting with the application.
-
 ## Using `<AuthPage />` Component
 
 Now let's update our `<Login />` component to use the `<AuthPage />` from `@refinedev/antd` package. This component will provide a consistent look and feel with the rest of the application.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [] Related issue(s) linked
- [] Tests for the changes have been added
- [X] Docs have been added / updated
- [] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

Removed a paragraph that didn't belong there. It doesn't seem to be misplaced, as a very similar paragraph exists in the notification part of the tutorial. Might be an old version that was misplaced.

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
