### PR TITLE
docs(tutorial): removed refineCoreProps from the ANTD example

### DIFF
--- a/documentation/docs/guides-concepts/forms/server-side-validation-antd.tsx
+++ b/documentation/docs/guides-concepts/forms/server-side-validation-antd.tsx
@@ -122,12 +122,12 @@ const { Title } = Typography;
 const { TextArea } = Input;
 
 export const ProductCreate = () => {
-  const { formProps, saveButtonProps } = useForm({ refineCoreProps: { redirect: "show" }});
+  const { formProps, saveButtonProps } = useForm({ redirect: "show" });
 
   return (
     <Create saveButtonProps={saveButtonProps}>
       <Form {...formProps} layout="vertical">
-        <Form.Item
+        <Form.Item  
             label="Name"
             name="name"
         >

--- a/documentation/tutorial/ui-libraries/refactoring/ant-design/react-router/index.md
+++ b/documentation/tutorial/ui-libraries/refactoring/ant-design/react-router/index.md
@@ -326,9 +326,7 @@ import { Form, Input, Select, InputNumber } from "antd";
 export const EditProduct = () => {
   // highlight-start
   const { formProps, saveButtonProps, query } = useForm({
-    refineCoreProps: {
-      redirect: "show",
-    },
+    redirect: "show",
   });
   // highlight-end
 
@@ -381,9 +379,7 @@ import { Form, Input, Select, InputNumber } from "antd";
 export const CreateProduct = () => {
   // highlight-start
   const { formProps, saveButtonProps } = useForm({
-    refineCoreProps: {
-      redirect: "edit",
-    },
+    redirect: "edit",
   });
   // highlight-end
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [X] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

Removed the refineCoreProps from the ANTD examples in the tutorial. It was not intended to be placed there.

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
