### PR TITLE
fix(hasura): meta.gqlVariables passed to update Hasura data provider

### DIFF
--- a/.changeset/neat-tips-provide.md
+++ b/.changeset/neat-tips-provide.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/hasura": patch
+---
+
+meta.gqlVariables now passed to update query for Hasura data provider

--- a/packages/hasura/src/dataProvider/index.ts
+++ b/packages/hasura/src/dataProvider/index.ts
@@ -351,6 +351,7 @@ const dataProvider = (
         const response = await client.request<BaseRecord>(gqlOperation, {
           id,
           object: variables || {},
+          ...meta?.gqlVariables,
         });
 
         return {

--- a/packages/hasura/test/update/index.mock.ts
+++ b/packages/hasura/test/update/index.mock.ts
@@ -459,3 +459,124 @@ nock("https://ruling-redbird-23.hasura.app:443", { encodedQueryParams: true })
       "8437d43c5966c1c6-BUD",
     ],
   );
+
+nock("https://flowing-mammal-24.hasura.app:443", { encodedQueryParams: true })
+  .post("/v1/graphql", {
+    query:
+      "mutation UpdatePost($id: uuid!, $object: posts_set_input!, $includeCategory: Boolean = false) {\n  update_posts_by_pk(pk_columns: {id: $id}, _set: $object) {\n    id\n    title\n    content\n    category_id\n    category @include(if: $includeCategory) {\n      id\n      title\n    }\n  }\n}\n",
+    variables: {
+      id: "572708c7-840d-430a-befd-1416bdee799a",
+      object: {
+        title: "Updated Title",
+        content: "Updated Content",
+        category_id: "e27156c3-9998-434f-bd5b-2b078283ff26",
+      },
+      includeCategory: true,
+    },
+    operationName: "UpdatePost",
+  })
+  .reply(
+    200,
+    {
+      data: {
+        update_posts_by_pk: {
+          id: "572708c7-840d-430a-befd-1416bdee799a",
+          title: "Updated Title",
+          content: "Updated Content",
+          category_id: "e27156c3-9998-434f-bd5b-2b078283ff26",
+          category: {
+            id: "e27156c3-9998-434f-bd5b-2b078283ff26",
+            title: "lorem1 integer tincidunt",
+          },
+        },
+      },
+    },
+    [
+      "Date",
+      "Wed, 10 Jan 2024 20:56:53 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Content-Length",
+      "274",
+      "Connection",
+      "close",
+      "x-request-id",
+      "83f68d28a0c651f19c430e2a6155ee90",
+      "CF-Cache-Status",
+      "DYNAMIC",
+      "Content-Security-Policy",
+      "upgrade-insecure-requests",
+      "Referrer-Policy",
+      "strict-origin-when-cross-origin",
+      "Strict-Transport-Security",
+      "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-Frame-Options",
+      "SAMEORIGIN",
+      "X-XSS-Protection",
+      "0",
+      "Server",
+      "cloudflare",
+      "CF-RAY",
+      "8437d441abf61cf1-BUD",
+    ],
+  );
+
+nock("https://flowing-mammal-24.hasura.app:443", { encodedQueryParams: true })
+  .post("/v1/graphql", {
+    query:
+      "mutation UpdatePost($id: uuid!, $object: posts_set_input!, $includeCategory: Boolean = false) {\n  update_posts_by_pk(pk_columns: {id: $id}, _set: $object) {\n    id\n    title\n    content\n    category_id\n    category @include(if: $includeCategory) {\n      id\n      title\n    }\n  }\n}\n",
+    variables: {
+      id: "572708c7-840d-430a-befd-1416bdee799a",
+      object: {
+        title: "Updated Title",
+        content: "Updated Content",
+        category_id: "e27156c3-9998-434f-bd5b-2b078283ff26",
+      },
+    },
+    operationName: "UpdatePost",
+  })
+  .reply(
+    200,
+    {
+      data: {
+        update_posts_by_pk: {
+          id: "572708c7-840d-430a-befd-1416bdee799a",
+          title: "Updated Title",
+          content: "Updated Content",
+          category_id: "e27156c3-9998-434f-bd5b-2b078283ff26",
+        },
+      },
+    },
+    [
+      "Date",
+      "Wed, 10 Jan 2024 20:56:53 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Content-Length",
+      "274",
+      "Connection",
+      "close",
+      "x-request-id",
+      "83f68d28a0c651f19c430e2a6155ee90",
+      "CF-Cache-Status",
+      "DYNAMIC",
+      "Content-Security-Policy",
+      "upgrade-insecure-requests",
+      "Referrer-Policy",
+      "strict-origin-when-cross-origin",
+      "Strict-Transport-Security",
+      "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-Frame-Options",
+      "SAMEORIGIN",
+      "X-XSS-Protection",
+      "0",
+      "Server",
+      "cloudflare",
+      "CF-RAY",
+      "8437d441abf61cf1-BUD",
+    ],
+  );


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [y] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [y] Related issue(s) linked
- [y] Tests for the changes have been added
- [n/a] Docs have been added / updated
- [y] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

Hasura data provider doesn't respect meta.gqlVariables for update.

## What is the new behavior?

fixes #6775

## Notes for reviewers


