### PR TITLE
fix(hasura): meta.gqlVariables passed to custom Hasura data provider

### DIFF
--- a/.changeset/witty-mirrors-sparkle.md
+++ b/.changeset/witty-mirrors-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/hasura": patch
+---
+
+meta.gqlVariables now passed to custom query for Hasura data provider

--- a/packages/hasura/src/dataProvider/index.ts
+++ b/packages/hasura/src/dataProvider/index.ts
@@ -569,7 +569,7 @@ const dataProvider = (
       if (gqlOperation) {
         const response: any = await client.request(
           gqlOperation,
-          meta?.variables ?? {},
+          meta?.gqlVariables ?? {},
         );
 
         return { data: response };

--- a/packages/hasura/test/custom/index.mock.ts
+++ b/packages/hasura/test/custom/index.mock.ts
@@ -275,3 +275,104 @@ nock("https://ruling-redbird-23.hasura.app:443", { encodedQueryParams: true })
       "gzip",
     ],
   );
+
+nock("https://flowing-mammal-24.hasura.app:443", { encodedQueryParams: true })
+  .post("/v1/graphql", {
+    query:
+      "query GetPost($includeAvg: Boolean = false) {\n  posts_aggregate {\n    aggregate {\n      count\n      avg @include(if: $includeAvg) {\n        id\n      }\n    }\n  }\n}\n",
+    variables: {
+      includeAvg: true,
+    },
+    operationName: "GetPost",
+  })
+  .reply(
+    200,
+    {
+      data: {
+        posts_aggregate: {
+          aggregate: {
+            count: 318,
+            avg: {
+              id: 42,
+            },
+          },
+        },
+      },
+    },
+    [
+      "Date",
+      "Tue, 09 Jan 2024 11:15:20 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Connection",
+      "close",
+      "x-request-id",
+      "7d98c24a10b32a6e7c1f5d9b8e4a2c1d",
+      "CF-Cache-Status",
+      "DYNAMIC",
+      "Content-Security-Policy",
+      "upgrade-insecure-requests",
+      "Referrer-Policy",
+      "strict-origin-when-cross-origin",
+      "Strict-Transport-Security",
+      "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-Frame-Options",
+      "SAMEORIGIN",
+      "X-XSS-Protection",
+      "0",
+      "Server",
+      "cloudflare",
+      "CF-RAY",
+      "842c42fbb9f768bc-BUD",
+    ],
+  );
+
+nock("https://flowing-mammal-24.hasura.app:443", { encodedQueryParams: true })
+  .post("/v1/graphql", {
+    query:
+      "query GetPost($includeAvg: Boolean = false) {\n  posts_aggregate {\n    aggregate {\n      count\n      avg @include(if: $includeAvg) {\n        id\n      }\n    }\n  }\n}\n",
+    variables: {},
+    operationName: "GetPost",
+  })
+  .reply(
+    200,
+    {
+      data: {
+        posts_aggregate: {
+          aggregate: {
+            count: 318,
+          },
+        },
+      },
+    },
+    [
+      "Date",
+      "Tue, 09 Jan 2024 11:15:21 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Connection",
+      "close",
+      "x-request-id",
+      "3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d",
+      "CF-Cache-Status",
+      "DYNAMIC",
+      "Content-Security-Policy",
+      "upgrade-insecure-requests",
+      "Referrer-Policy",
+      "strict-origin-when-cross-origin",
+      "Strict-Transport-Security",
+      "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-Frame-Options",
+      "SAMEORIGIN",
+      "X-XSS-Protection",
+      "0",
+      "Server",
+      "cloudflare",
+      "CF-RAY",
+      "842c42fee9abc1c1-BUD",
+    ],
+  );

--- a/packages/hasura/test/custom/index.spec.ts
+++ b/packages/hasura/test/custom/index.spec.ts
@@ -92,4 +92,67 @@ describe("with gql", () => {
       expect(response?.data.postsAggregate.aggregate.count).toBe(318);
     },
   );
+
+  it("correctly passes variables from meta.gqlVariables to the query", async () => {
+    const apiUrl = getApiUrl("hasura-default");
+
+    const response = await dataProvider(createClient("hasura-default"), {
+      namingConvention: "hasura-default",
+    }).custom?.({
+      url: apiUrl,
+      method: "get",
+      meta: {
+        gqlQuery: gql`
+          query GetPost(
+            $includeAvg: Boolean = false
+          ) {
+            posts_aggregate {
+              aggregate {
+                count
+                avg @include(if: $includeAvg) {
+                  id
+                }
+              }
+            }
+          }
+        `,
+        gqlVariables: {
+          includeAvg: true,
+        },
+      },
+    });
+
+    expect(response?.data.posts_aggregate.aggregate.count).toBe(318);
+    expect(response?.data.posts_aggregate.aggregate.avg.id).toBe(42);
+  });
+
+  it("correctly handles the query when gqlVariables aren't provided", async () => {
+    const apiUrl = getApiUrl("hasura-default");
+
+    const response = await dataProvider(createClient("hasura-default"), {
+      namingConvention: "hasura-default",
+    }).custom?.({
+      url: apiUrl,
+      method: "get",
+      meta: {
+        gqlQuery: gql`
+          query GetPost(
+            $includeAvg: Boolean = false
+          ) {
+            posts_aggregate {
+              aggregate {
+                count
+                avg @include(if: $includeAvg) {
+                  id
+                }
+              }
+            }
+          }
+        `,
+      },
+    });
+
+    expect(response?.data.posts_aggregate.aggregate.count).toBe(318);
+    expect(response?.data.posts_aggregate.aggregate.avg).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [y] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [y] Related issue(s) linked
- [y] Tests for the changes have been added
- [n/a] Docs have been added / updated
- [y] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

Hasura data provider doesn't respect meta.gqlVariables for custom.

## What is the new behavior?

fixes #6775

## Notes for reviewers

