### PR TITLE
fix(hasura): meta.gqlVariables passed to deleteOne Hasura DataProvider

### DIFF
--- a/.changeset/friendly-feet-marry.md
+++ b/.changeset/friendly-feet-marry.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/hasura": patch
+---
+
+meta.gqlVariables now passed to deleteOne query for Hasura data provider

--- a/packages/hasura/src/dataProvider/index.ts
+++ b/packages/hasura/src/dataProvider/index.ts
@@ -471,7 +471,7 @@ const dataProvider = (
       if (meta?.gqlMutation) {
         const response = await client.request<BaseRecord>(meta.gqlMutation, {
           id,
-          ...meta?.variables,
+          ...meta?.gqlVariables,
         });
 
         return {

--- a/packages/hasura/test/deleteOne/index.mock.ts
+++ b/packages/hasura/test/deleteOne/index.mock.ts
@@ -448,3 +448,105 @@ nock("https://ruling-redbird-23.hasura.app:443", { encodedQueryParams: true })
       "8437587e1f6a733a-BUD",
     ],
   );
+
+nock("https://flowing-mammal-24.hasura.app:443", { encodedQueryParams: true })
+  .post("/v1/graphql", {
+    query:
+      "mutation DeletePost($id: uuid!, $includeTitle: Boolean = false) {\n  delete_posts_by_pk(id: $id) {\n    id\n    title @include(if: $includeTitle)\n  }\n}\n",
+    variables: {
+      id: "9a83b4c2-5d1e-47f6-b9c5-3a2d8e1f0c7b",
+      includeTitle: true,
+    },
+    operationName: "DeletePost",
+  })
+  .reply(
+    200,
+    {
+      data: {
+        delete_posts_by_pk: {
+          id: "9a83b4c2-5d1e-47f6-b9c5-3a2d8e1f0c7b",
+          title: "Aenean ultricies non libero sit amet pellentesque",
+        },
+      },
+    },
+    [
+      "Date",
+      "Wed, 10 Jan 2024 19:32:24 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Content-Length",
+      "137",
+      "Connection",
+      "close",
+      "x-request-id",
+      "7d98c24a10b32a6e7c1f5d9b8e4a2c1d",
+      "CF-Cache-Status",
+      "DYNAMIC",
+      "Content-Security-Policy",
+      "upgrade-insecure-requests",
+      "Referrer-Policy",
+      "strict-origin-when-cross-origin",
+      "Strict-Transport-Security",
+      "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-Frame-Options",
+      "SAMEORIGIN",
+      "X-XSS-Protection",
+      "0",
+      "Server",
+      "cloudflare",
+      "CF-RAY",
+      "84375883ac84684c-BUD",
+    ],
+  );
+
+nock("https://flowing-mammal-24.hasura.app:443", { encodedQueryParams: true })
+  .post("/v1/graphql", {
+    query:
+      "mutation DeletePost($id: uuid!, $includeTitle: Boolean = false) {\n  delete_posts_by_pk(id: $id) {\n    id\n    title @include(if: $includeTitle)\n  }\n}\n",
+    variables: {
+      id: "7b5c8a2d-6e9f-4a1b-8c3d-2e0f5a9b4c7d",
+    },
+    operationName: "DeletePost",
+  })
+  .reply(
+    200,
+    {
+      data: {
+        delete_posts_by_pk: {
+          id: "7b5c8a2d-6e9f-4a1b-8c3d-2e0f5a9b4c7d",
+        },
+      },
+    },
+    [
+      "Date",
+      "Wed, 10 Jan 2024 19:32:25 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Content-Length",
+      "77",
+      "Connection",
+      "close",
+      "x-request-id",
+      "3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d",
+      "CF-Cache-Status",
+      "DYNAMIC",
+      "Content-Security-Policy",
+      "upgrade-insecure-requests",
+      "Referrer-Policy",
+      "strict-origin-when-cross-origin",
+      "Strict-Transport-Security",
+      "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-Frame-Options",
+      "SAMEORIGIN",
+      "X-XSS-Protection",
+      "0",
+      "Server",
+      "cloudflare",
+      "CF-RAY",
+      "8437588b1d56733a-BUD",
+    ],
+  );

--- a/packages/hasura/test/deleteOne/index.spec.ts
+++ b/packages/hasura/test/deleteOne/index.spec.ts
@@ -137,4 +137,65 @@ describe("with gqlMutation", () => {
 
     expect(data.id).toEqual(id);
   });
+
+  it("correctly passes variables from meta.gqlVariables to the query", async () => {
+    const id = "9a83b4c2-5d1e-47f6-b9c5-3a2d8e1f0c7b";
+
+    const client = createClient("hasura-default");
+    const { data } = await dataProvider(client, {
+      namingConvention: "hasura-default",
+    }).deleteOne({
+      resource: "posts",
+      id,
+      meta: {
+        gqlMutation: gql`
+          mutation DeletePost(
+            $id: uuid!,
+            $includeTitle: Boolean = false
+          ) {
+            delete_posts_by_pk(id: $id) {
+              id
+              title @include(if: $includeTitle)
+            }
+          }
+        `,
+        gqlVariables: {
+          includeTitle: true,
+        },
+      },
+    });
+
+    expect(data.id).toEqual(id);
+    expect(data.title).toEqual(
+      "Aenean ultricies non libero sit amet pellentesque",
+    );
+  });
+
+  it("doesn't pass extra variables to the query without meta.gqlVariables", async () => {
+    const id = "7b5c8a2d-6e9f-4a1b-8c3d-2e0f5a9b4c7d";
+
+    const client = createClient("hasura-default");
+    const { data } = await dataProvider(client, {
+      namingConvention: "hasura-default",
+    }).deleteOne({
+      resource: "posts",
+      id,
+      meta: {
+        gqlMutation: gql`
+          mutation DeletePost(
+            $id: uuid!,
+            $includeTitle: Boolean = false
+          ) {
+            delete_posts_by_pk(id: $id) {
+              id
+              title @include(if: $includeTitle)
+            }
+          }
+        `,
+      },
+    });
+
+    expect(data.id).toEqual(id);
+    expect(data.title).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [y] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [y] Related issue(s) linked
- [y] Tests for the changes have been added
- [n/a] Docs have been added / updated
- [y] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

Hasura data provider doesn't respect meta.gqlVariables for deleteOne.

## What is the new behavior?

fixes #6775

## Notes for reviewers

