### PR TITLE
fix(hasura): meta.gqlVariables passed to createMany Hasura data provider

### DIFF
--- a/.changeset/curvy-pumpkins-hammer.md
+++ b/.changeset/curvy-pumpkins-hammer.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/hasura": patch
+---
+
+meta.gqlVariables now passed to createMany query for Hasura data provider

--- a/packages/hasura/src/dataProvider/index.ts
+++ b/packages/hasura/src/dataProvider/index.ts
@@ -305,6 +305,7 @@ const dataProvider = (
       if (meta?.gqlMutation) {
         const response = await client.request<BaseRecord>(meta.gqlMutation, {
           objects: variablesFromParams,
+          ...meta?.gqlVariables,
         });
 
         return {

--- a/packages/hasura/test/createMany/index.mock.ts
+++ b/packages/hasura/test/createMany/index.mock.ts
@@ -443,3 +443,155 @@ nock("https://ruling-redbird-23.hasura.app:443", { encodedQueryParams: true })
       "84376bd60fb703bf-BUD",
     ],
   );
+
+// Mock for CreateManyPosts with includeCategory=true from gqlVariables
+nock("https://flowing-mammal-24.hasura.app:443", { encodedQueryParams: true })
+  .post("/v1/graphql", {
+    query:
+      "mutation CreateManyPosts($objects: [posts_insert_input!]!, $includeCategory: Boolean = false) {\n  insert_posts(objects: $objects) {\n    returning {\n      id\n      title\n      content\n      category @include(if: $includeCategory) {\n        id\n      }\n    }\n  }\n}\n",
+    variables: {
+      objects: [
+        {
+          content: "Vestibulum vulputate sapien arcu.",
+          title: "Aenean ultricies non libero sit amet pellentesque",
+          category_id: "e27156c3-9998-434f-bd5b-2b078283ff26",
+        },
+        {
+          content: "Aliquam nibh erat.",
+          title: "Etiam tincidunt ex ut auctor faucibus",
+          category_id: "e27156c3-9998-434f-bd5b-2b078283ff26",
+        },
+      ],
+      includeCategory: true,
+    },
+    operationName: "CreateManyPosts",
+  })
+  .reply(
+    200,
+    {
+      data: {
+        insert_posts: {
+          returning: [
+            {
+              id: "f1c8b6d7-3e5a-4c2b-9f8d-1e5a7b9d0c3e",
+              title: "Aenean ultricies non libero sit amet pellentesque",
+              content: "Vestibulum vulputate sapien arcu.",
+              category: {
+                id: "e27156c3-9998-434f-bd5b-2b078283ff26",
+              },
+            },
+            {
+              id: "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+              title: "Etiam tincidunt ex ut auctor faucibus",
+              content: "Aliquam nibh erat.",
+              category: {
+                id: "e27156c3-9998-434f-bd5b-2b078283ff26",
+              },
+            },
+          ],
+        },
+      },
+    },
+    [
+      "Date",
+      "Wed, 10 Jan 2024 19:45:38 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Content-Length",
+      "435",
+      "Connection",
+      "close",
+      "x-request-id",
+      "fd98c24a10b32a6e7c1f5d9b8e4a2c1d",
+      "CF-Cache-Status",
+      "DYNAMIC",
+      "Content-Security-Policy",
+      "upgrade-insecure-requests",
+      "Referrer-Policy",
+      "strict-origin-when-cross-origin",
+      "Strict-Transport-Security",
+      "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-Frame-Options",
+      "SAMEORIGIN",
+      "X-XSS-Protection",
+      "0",
+      "Server",
+      "cloudflare",
+      "CF-RAY",
+      "84376be01cba684c-BUD",
+    ],
+  );
+
+nock("https://flowing-mammal-24.hasura.app:443", { encodedQueryParams: true })
+  .post("/v1/graphql", {
+    query:
+      "mutation CreateManyPosts($objects: [posts_insert_input!]!, $includeCategory: Boolean = false) {\n  insert_posts(objects: $objects) {\n    returning {\n      id\n      title\n      content\n      category @include(if: $includeCategory) {\n        id\n      }\n    }\n  }\n}\n",
+    variables: {
+      objects: [
+        {
+          content: "Vestibulum vulputate sapien arcu.",
+          title: "Aenean ultricies non libero sit amet pellentesque",
+          category_id: "e27156c3-9998-434f-bd5b-2b078283ff26",
+        },
+        {
+          content: "Aliquam nibh erat.",
+          title: "Etiam tincidunt ex ut auctor faucibus",
+          category_id: "e27156c3-9998-434f-bd5b-2b078283ff26",
+        },
+      ],
+    },
+    operationName: "CreateManyPosts",
+  })
+  .reply(
+    200,
+    {
+      data: {
+        insert_posts: {
+          returning: [
+            {
+              id: "b5c6d7e8-f9a0-1b2c-3d4e-5f6a7b8c9d0e",
+              title: "Aenean ultricies non libero sit amet pellentesque",
+              content: "Vestibulum vulputate sapien arcu.",
+            },
+            {
+              id: "e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6b",
+              title: "Etiam tincidunt ex ut auctor faucibus",
+              content: "Aliquam nibh erat.",
+            },
+          ],
+        },
+      },
+    },
+    [
+      "Date",
+      "Wed, 10 Jan 2024 19:45:39 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Content-Length",
+      "320",
+      "Connection",
+      "close",
+      "x-request-id",
+      "3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d",
+      "CF-Cache-Status",
+      "DYNAMIC",
+      "Content-Security-Policy",
+      "upgrade-insecure-requests",
+      "Referrer-Policy",
+      "strict-origin-when-cross-origin",
+      "Strict-Transport-Security",
+      "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-Frame-Options",
+      "SAMEORIGIN",
+      "X-XSS-Protection",
+      "0",
+      "Server",
+      "cloudflare",
+      "CF-RAY",
+      "84376be52f6d733a-BUD",
+    ],
+  );

--- a/packages/hasura/test/createMany/index.spec.ts
+++ b/packages/hasura/test/createMany/index.spec.ts
@@ -172,4 +172,111 @@ describe("with gqlMutation", () => {
 
     expect(data[1]["title"]).toEqual("Etiam tincidunt ex ut auctor faucibus");
   });
+
+  it("correctly passes variables from meta.gqlVariables to the query", async () => {
+    const client = createClient("hasura-default");
+    const { data } = await dataProvider(client, {
+      namingConvention: "hasura-default",
+    }).createMany!({
+      resource: "posts",
+      variables: [
+        {
+          content: "Vestibulum vulputate sapien arcu.",
+          title: "Aenean ultricies non libero sit amet pellentesque",
+          category_id: "e27156c3-9998-434f-bd5b-2b078283ff26",
+        },
+        {
+          content: "Aliquam nibh erat.",
+          title: "Etiam tincidunt ex ut auctor faucibus",
+          category_id: "e27156c3-9998-434f-bd5b-2b078283ff26",
+        },
+      ],
+      meta: {
+        gqlMutation: gql`
+          mutation CreateManyPosts(
+            $objects: [posts_insert_input!]!,
+            $includeCategory: Boolean = false
+          ) {
+            insert_posts(objects: $objects) {
+              returning {
+                id
+                title
+                content
+                category @include(if: $includeCategory) {
+                  id
+                }
+              }
+            }
+          }
+        `,
+        gqlVariables: {
+          includeCategory: true,
+        },
+      },
+    });
+
+    expect(data[0]["title"]).toEqual(
+      "Aenean ultricies non libero sit amet pellentesque",
+    );
+    expect(data[0]["content"]).toEqual("Vestibulum vulputate sapien arcu.");
+    expect(data[0]["category"].id).toEqual(
+      "e27156c3-9998-434f-bd5b-2b078283ff26",
+    );
+
+    expect(data[1]["title"]).toEqual("Etiam tincidunt ex ut auctor faucibus");
+    expect(data[1]["content"]).toEqual("Aliquam nibh erat.");
+    expect(data[1]["category"].id).toEqual(
+      "e27156c3-9998-434f-bd5b-2b078283ff26",
+    );
+  });
+
+  it("doesn't pass extra variables to the query without meta.gqlVariables", async () => {
+    const client = createClient("hasura-default");
+    const { data } = await dataProvider(client, {
+      namingConvention: "hasura-default",
+    }).createMany!({
+      resource: "posts",
+      variables: [
+        {
+          content: "Vestibulum vulputate sapien arcu.",
+          title: "Aenean ultricies non libero sit amet pellentesque",
+          category_id: "e27156c3-9998-434f-bd5b-2b078283ff26",
+        },
+        {
+          content: "Aliquam nibh erat.",
+          title: "Etiam tincidunt ex ut auctor faucibus",
+          category_id: "e27156c3-9998-434f-bd5b-2b078283ff26",
+        },
+      ],
+      meta: {
+        gqlMutation: gql`
+          mutation CreateManyPosts(
+            $objects: [posts_insert_input!]!,
+            $includeCategory: Boolean = false
+          ) {
+            insert_posts(objects: $objects) {
+              returning {
+                id
+                title
+                content
+                category @include(if: $includeCategory) {
+                  id
+                }
+              }
+            }
+          }
+        `,
+      },
+    });
+
+    expect(data[0]["title"]).toEqual(
+      "Aenean ultricies non libero sit amet pellentesque",
+    );
+    expect(data[0]["content"]).toEqual("Vestibulum vulputate sapien arcu.");
+    expect(data[0]["category"]).toBeUndefined();
+
+    expect(data[1]["title"]).toEqual("Etiam tincidunt ex ut auctor faucibus");
+    expect(data[1]["content"]).toEqual("Aliquam nibh erat.");
+    expect(data[1]["category"]).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [y] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [y] Related issue(s) linked
- [y] Tests for the changes have been added
- [n/a] Docs have been added / updated
- [y] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

Hasura data provider doesn't respect meta.gqlVariables for createMany.

## What is the new behavior?

fixes #6775

## Notes for reviewers

