### PR TITLE
fix: landing packages animation doesn't work

### DIFF
--- a/documentation/tailwind.config.js
+++ b/documentation/tailwind.config.js
@@ -587,7 +587,7 @@ module.exports = {
         "mini-bounce": "mini-bounce 3s ease-in-out infinite",
         "dot-waves": "dot-waves 2.5s linear infinite",
         "landing-packages-left": "landing-packages-left 65s linear infinite",
-        "landing-packages-right": "landing-packages-right 25s linear infinite",
+        "landing-packages-right": "landing-packages-right 65s linear infinite",
         "code-scroll": "code-scroll 25s linear infinite",
         "beam-spin": "beam-spin 3s linear 1 forwards",
         "landing-hero-beam-line":
@@ -801,8 +801,8 @@ module.exports = {
           "100%": { transform: "translateX(-50%)" },
         },
         "landing-packages-right": {
-          "0%": { transform: "translateX(-100%)" },
-          "100%": { transform: "translateX(0%)" },
+          "0%": { transform: "translateX(0)" },
+          "100%": { transform: "translateX(50%)" },
         },
         "beam-spin": {
           "0%": {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
<img width="300" alt="Screenshot 2025-05-13 at 14 13 06" src="https://github.com/user-attachments/assets/19e43b08-5be2-4aed-bc88-4a4c3ebe5a47" />

## What is the new behavior?
<img width="300" alt="Screenshot 2025-05-13 at 14 12 42" src="https://github.com/user-attachments/assets/9d83d956-cbb7-4640-a31f-d7a9be142d2a" />


## Notes for reviewers

In this [PR](https://github.com/refinedev/refine/pull/6744/files#diff-b3200011e6db913ff360a955b68b6b13900f5565970cd5d5516a283c82e1be10), I accidentally broke the animation keyframes. This PR fixes that.