### PR TITLE
fix(i18n-nextjs): remove Suspense from layout.tsx to prevent styling …

### DIFF
--- a/examples/i18n-nextjs/src/app/layout.tsx
+++ b/examples/i18n-nextjs/src/app/layout.tsx
@@ -30,13 +30,11 @@ export default async function RootLayout({
   return (
     <html lang={locale}>
       <body>
-        <Suspense>
-          <AntdRegistry>
-            <NextIntlClientProvider locale={locale} messages={messages}>
-              <RefineContext themeMode={theme?.value}>{children}</RefineContext>
-            </NextIntlClientProvider>
-          </AntdRegistry>
-        </Suspense>
+        <AntdRegistry>
+          <NextIntlClientProvider locale={locale} messages={messages}>
+            <RefineContext themeMode={theme?.value}>{children}</RefineContext>
+          </NextIntlClientProvider>
+        </AntdRegistry>
       </body>
     </html>
   );


### PR DESCRIPTION
…flicker

The <Suspense> component wrapping the body in the i18n-nextjs example caused a flicker on initial load. Removing this component resolves the flicker.

Fixes #6813

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ X] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
The page flickers upon page loading
## What is the new behavior?
page now waits for styling before loading so no flicker

Fixes #6813

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
