### PR TITLE
fix: get always latest `columns` from `table ref` when `columnFilters` or `filters` are changed.

### DIFF
--- a/.changeset/five-clouds-stare.md
+++ b/.changeset/five-clouds-stare.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/react-table": patch
+---
+
+fix: get always latest `columns` from `table ref` when `columnFilters` or `filters` are changed.

--- a/packages/react-table/src/useTable/index.ts
+++ b/packages/react-table/src/useTable/index.ts
@@ -155,8 +155,12 @@ export function useTable<
   }, [sorting]);
 
   useEffect(() => {
+    const allColumns = reactTableResult
+      .getAllColumns()
+      .map((col) => col.columnDef);
+
     const crudFilters: CrudFilter[] = columnFiltersToCrudFilters({
-      columns,
+      columns: allColumns,
       columnFilters,
     });
 


### PR DESCRIPTION
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

---

fix: get always latest `columns` from `table ref` when `columnFilters` or `filters` are changed.