### PR TITLE
chore: update react-hook-form to 7.57.0

### DIFF
--- a/.changeset/sweet-oranges-greet.md
+++ b/.changeset/sweet-oranges-greet.md
@@ -1,0 +1,10 @@
+---
+"@refinedev/react-hook-form": minor
+"@refinedev/devtools-ui": minor
+"@refinedev/inferencer": minor
+"@refinedev/chakra-ui": minor
+"@refinedev/mui": minor
+---
+
+chore: update `react-hook-form` to `7.57.0` to support new features like [`subscribe`](https://react-hook-form.com/docs/useform/subscribe).
+for more information, see [React Hook Form release notes](https://github.com/react-hook-form/react-hook-form/releases).

--- a/documentation/docs/guides-concepts/forms/server-side-validation-chakra-ui.tsx
+++ b/documentation/docs/guides-concepts/forms/server-side-validation-chakra-ui.tsx
@@ -18,7 +18,7 @@ export default function ServerSideValidationChakraUi() {
         "@chakra-ui/react": "^2.5.1",
         "react-dom": "^18.0.0",
         "react-router": "^7.0.2",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
       }}
       startRoute="/products/create"
       files={{

--- a/documentation/docs/guides-concepts/forms/server-side-validation-mui.tsx
+++ b/documentation/docs/guides-concepts/forms/server-side-validation-mui.tsx
@@ -20,7 +20,7 @@ export default function ServerSideValidationMui() {
         "@mui/utils": "^7.1.0",
         "@mui/x-data-grid": "7.23.5",
         "react-router": "^7.0.2",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
       }}
       startRoute="/products/create"
       files={{

--- a/documentation/docs/guides-concepts/forms/server-side-validation-react-hook-form.tsx
+++ b/documentation/docs/guides-concepts/forms/server-side-validation-react-hook-form.tsx
@@ -14,7 +14,7 @@ export default function ServerSideValidationReactHookForm() {
         "@refinedev/react-hook-form": "^4.8.12",
         "react-dom": "^18.0.0",
         "react-router": "^7.0.2",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
       }}
       startRoute="/products/create"
       files={{

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/auth-page.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/auth-page.tsx
@@ -19,7 +19,7 @@ export default function AuthPage() {
         "@chakra-ui/react": "^2.5.1",
         "react-dom": "^18.0.0",
         "react-router": "^7.0.2",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
       }}
       startRoute="/login"
       files={{

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/basic-views.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/basic-views.tsx
@@ -18,7 +18,7 @@ export default function BasicViews() {
         "@chakra-ui/react": "^2.5.1",
         "react-dom": "^18.0.0",
         "react-router": "^7.0.2",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
       }}
       startRoute="/products"
       files={{

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/example.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/example.tsx
@@ -18,7 +18,7 @@ export default function Example() {
         "@chakra-ui/react": "^2.5.1",
         "react-dom": "^18.0.0",
         "react-router": "^7.0.2",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
       }}
       startRoute="/products"
       files={{

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/layout-react-router-dom.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/layout-react-router-dom.tsx
@@ -20,7 +20,7 @@ export default function LayoutReactRouterDom() {
         "@chakra-ui/react": "^2.5.1",
         "react-dom": "^18.0.0",
         "react-router": "^7.0.2",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
       }}
       startRoute="/products"
       files={{

--- a/documentation/docs/ui-integrations/chakra-ui/introduction/previews/theming.tsx
+++ b/documentation/docs/ui-integrations/chakra-ui/introduction/previews/theming.tsx
@@ -20,7 +20,7 @@ export default function Usage() {
         "@chakra-ui/react": "^2.5.1",
         "react-dom": "^18.0.0",
         "react-router": "^7.0.2",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
       }}
       startRoute="/products"
       files={{

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/auth-page.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/auth-page.tsx
@@ -21,7 +21,7 @@ export default function AuthPage() {
         "@mui/system": "^6.4.11",
         "@mui/x-data-grid": "7.23.5",
         "react-router": "^7.0.2",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
       }}
       startRoute="/login"
       files={{

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/basic-views.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/basic-views.tsx
@@ -20,7 +20,7 @@ export default function BasicViews() {
         "@mui/system": "^6.4.11",
         "@mui/x-data-grid": "7.23.5",
         "react-router": "^7.0.2",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
       }}
       startRoute="/products"
       files={{

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/example.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/example.tsx
@@ -20,7 +20,7 @@ export default function Example() {
         "@mui/system": "^6.4.11",
         "@mui/x-data-grid": "7.23.5",
         "react-router": "^7.0.2",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
       }}
       startRoute="/products"
       files={{

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/layout-react-router-dom.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/layout-react-router-dom.tsx
@@ -22,7 +22,7 @@ export default function LayoutReactRouterDom() {
         "@mui/system": "^6.4.11",
         "@mui/x-data-grid": "^7.23.5",
         "react-router": "^7.0.2",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
       }}
       startRoute="/products"
       files={{

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/theming.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/theming.tsx
@@ -22,7 +22,7 @@ export default function Usage() {
         "@mui/system": "^6.4.11",
         "@mui/x-data-grid": "7.23.5",
         "react-router": "^7.0.2",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
       }}
       startRoute="/products"
       files={{

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/usage-next-js.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/usage-next-js.tsx
@@ -19,7 +19,7 @@ export default function UsageNextjs() {
         "@mui/material": "^6.1.7",
         "@mui/system": "^6.4.11",
         "@mui/x-data-grid": "7.23.5",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
         "@refinedev/nextjs-router": "latest",
       }}
       // template="nextjs"

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/usage-react-router-dom.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/usage-react-router-dom.tsx
@@ -19,7 +19,7 @@ export default function UsageReactRouterDom() {
         "@mui/material": "^6.1.7",
         "@mui/system": "^6.4.11",
         "@mui/x-data-grid": "7.23.5",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
         "react-router": "^7.0.2",
         "@refinedev/react-router": "latest",
       }}

--- a/documentation/docs/ui-integrations/material-ui/introduction/previews/usage-remix.tsx
+++ b/documentation/docs/ui-integrations/material-ui/introduction/previews/usage-remix.tsx
@@ -19,7 +19,7 @@ export default function UsageRemix() {
         "@mui/material": "^6.1.7",
         "@mui/system": "^6.4.11",
         "@mui/x-data-grid": "7.23.5",
-        "react-hook-form": "^7.43.5",
+        "react-hook-form": "^7.57.0",
         "@refinedev/remix-router": "latest",
       }}
       startRoute="/products"

--- a/examples/base-material-ui/package.json
+++ b/examples/base-material-ui/package.json
@@ -37,7 +37,7 @@
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/blog-material-ui-datagrid/package.json
+++ b/examples/blog-material-ui-datagrid/package.json
@@ -38,7 +38,7 @@
     "@refinedev/simple-rest": "^5.0.8",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2",
     "styled-components": "^6.1.8"
   },

--- a/examples/blog-material-ui/package.json
+++ b/examples/blog-material-ui/package.json
@@ -39,7 +39,7 @@
     "axios": "^1.6.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1"

--- a/examples/blog-ra-chakra-tutorial/package.json
+++ b/examples/blog-ra-chakra-tutorial/package.json
@@ -23,7 +23,7 @@
     "axios": "^1.6.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/blog-react-aria/package.json
+++ b/examples/blog-react-aria/package.json
@@ -35,7 +35,7 @@
     "react": "^18.0.0",
     "react-aria": "^0.1.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2",
     "react-scripts": "^5.0.0",
     "react-stately": "^3.19.0",

--- a/examples/blog-react-hook-dynamic-form/package.json
+++ b/examples/blog-react-hook-dynamic-form/package.json
@@ -38,7 +38,7 @@
     "cross-env": "^7.0.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1"

--- a/examples/blog-refine-mui/package.json
+++ b/examples/blog-refine-mui/package.json
@@ -43,7 +43,7 @@
     "i18next-xhr-backend": "^3.2.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-i18next": "^11.8.11",
     "react-router": "^7.0.2",
     "recharts": "^2.1.9"

--- a/examples/blog-refine-nextui/package.json
+++ b/examples/blog-refine-nextui/package.json
@@ -39,7 +39,7 @@
     "i18next-xhr-backend": "^3.2.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-i18next": "^11.8.11",
     "react-router": "^7.0.2",
     "recharts": "^2.1.9"

--- a/examples/blog-refine-primereact/package.json
+++ b/examples/blog-refine-primereact/package.json
@@ -35,7 +35,7 @@
     "primereact": "^9.6.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/blog-refine-react-hook-form/package.json
+++ b/examples/blog-refine-react-hook-form/package.json
@@ -37,7 +37,7 @@
     "@refinedev/simple-rest": "^5.0.8",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2",
     "web-vitals": "^1.1.1",
     "yup": "^0.32.11"

--- a/examples/blog-win95/package.json
+++ b/examples/blog-win95/package.json
@@ -33,7 +33,7 @@
     "@tanstack/react-table": "^8.2.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2",
     "react95": "^4.0.0",
     "styled-components": "^6.1.8"

--- a/examples/customization-theme-material-ui/package.json
+++ b/examples/customization-theme-material-ui/package.json
@@ -35,7 +35,7 @@
     "@refinedev/simple-rest": "^5.0.10",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/field-material-ui-use-autocomplete/package.json
+++ b/examples/field-material-ui-use-autocomplete/package.json
@@ -35,7 +35,7 @@
     "@refinedev/simple-rest": "^5.0.10",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/finefoods-material-ui/package.json
+++ b/examples/finefoods-material-ui/package.json
@@ -48,7 +48,7 @@
     "lodash": "^4.17.21",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-i18next": "^11.8.11",
     "react-input-mask": "^2.0.4",
     "react-router": "^7.0.2",

--- a/examples/form-material-ui-mutation-mode/package.json
+++ b/examples/form-material-ui-mutation-mode/package.json
@@ -35,7 +35,7 @@
     "@refinedev/simple-rest": "^5.0.10",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/form-material-ui-use-drawer-form/package.json
+++ b/examples/form-material-ui-use-drawer-form/package.json
@@ -36,7 +36,7 @@
     "@refinedev/simple-rest": "^5.0.10",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/form-material-ui-use-form/package.json
+++ b/examples/form-material-ui-use-form/package.json
@@ -35,7 +35,7 @@
     "@refinedev/simple-rest": "^5.0.10",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/form-material-ui-use-modal-form/package.json
+++ b/examples/form-material-ui-use-modal-form/package.json
@@ -35,7 +35,7 @@
     "@refinedev/simple-rest": "^5.0.10",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/form-material-ui-use-steps-form/package.json
+++ b/examples/form-material-ui-use-steps-form/package.json
@@ -35,7 +35,7 @@
     "@refinedev/simple-rest": "^5.0.10",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/form-react-hook-form-use-steps-form/package.json
+++ b/examples/form-react-hook-form-use-steps-form/package.json
@@ -30,7 +30,7 @@
     "axios": "^1.6.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/inferencer-chakra-ui/package.json
+++ b/examples/inferencer-chakra-ui/package.json
@@ -38,7 +38,7 @@
     "i18next-xhr-backend": "^3.2.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-i18next": "^11.8.11",
     "react-router": "^7.0.2"
   },

--- a/examples/inferencer-material-ui/package.json
+++ b/examples/inferencer-material-ui/package.json
@@ -41,7 +41,7 @@
     "i18next-xhr-backend": "^3.2.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-i18next": "^11.8.11",
     "react-router": "^7.0.2"
   },

--- a/examples/mern-dashboard-client/package.json
+++ b/examples/mern-dashboard-client/package.json
@@ -42,7 +42,7 @@
     "react": "^18.0.0",
     "react-apexcharts": "^1.4.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router-dom": "^6.8.1",
     "react-scripts": "^5.0.0",
     "web-vitals": "^1.1.1"

--- a/examples/refine-hr-ce/package.json
+++ b/examples/refine-hr-ce/package.json
@@ -41,7 +41,7 @@
     "dayjs": "^1.10.7",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-hot-toast": "^2.4.1",
     "react-infinite-scroll-component": "^6.1.0",
     "react-router": "^7.0.2"

--- a/examples/server-side-form-validation-material-ui/package.json
+++ b/examples/server-side-form-validation-material-ui/package.json
@@ -36,7 +36,7 @@
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/store/package.json
+++ b/examples/store/package.json
@@ -39,7 +39,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-fast-marquee": "^1.3.1",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-merge-refs": "^1.1.0",
     "react-use-measure": "^2.1.1",
     "tabbable": "^5.2.1",

--- a/examples/table-material-ui-advanced/package.json
+++ b/examples/table-material-ui-advanced/package.json
@@ -38,7 +38,7 @@
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/table-material-ui-table-filter/package.json
+++ b/examples/table-material-ui-table-filter/package.json
@@ -36,7 +36,7 @@
     "@refinedev/simple-rest": "^5.0.10",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/table-react-table-advanced/package.json
+++ b/examples/table-react-table-advanced/package.json
@@ -33,7 +33,7 @@
     "@uiw/react-md-editor": "^3.19.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/theme-material-ui-demo/package.json
+++ b/examples/theme-material-ui-demo/package.json
@@ -35,7 +35,7 @@
     "@refinedev/simple-rest": "^5.0.10",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/tutorial-material-ui/package.json
+++ b/examples/tutorial-material-ui/package.json
@@ -37,7 +37,7 @@
     "@refinedev/simple-rest": "^5.0.10",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2",
     "web-vitals": "^1.1.1"
   },

--- a/examples/upload-material-ui-base64/package.json
+++ b/examples/upload-material-ui-base64/package.json
@@ -35,7 +35,7 @@
     "@refinedev/simple-rest": "^5.0.10",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/upload-material-ui-multipart/package.json
+++ b/examples/upload-material-ui-multipart/package.json
@@ -35,7 +35,7 @@
     "@refinedev/simple-rest": "^5.0.10",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/with-material-ui-vite/package.json
+++ b/examples/with-material-ui-vite/package.json
@@ -38,7 +38,7 @@
     "@refinedev/simple-rest": "^5.0.10",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-router": "^7.0.2"
   },
   "devDependencies": {

--- a/examples/with-nextjs-headless/package.json
+++ b/examples/with-nextjs-headless/package.json
@@ -24,7 +24,7 @@
     "next-intl": "^3.25.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.43.5"
+    "react-hook-form": "^7.57.0"
   },
   "devDependencies": {
     "@types/js-cookie": "^3.0.2",

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -40,7 +40,7 @@
     "@tabler/icons-react": "^3.1.0",
     "dayjs": "^1.10.7",
     "framer-motion": "^7.5.3",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-markdown": "^6.0.1",
     "remark-gfm": "^1.0.0",
     "tslib": "^2.6.2"
@@ -75,7 +75,7 @@
     "dayjs": "^1.10.7",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-hook-form": "^7.43.5"
+    "react-hook-form": "^7.57.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/devtools-ui/package.json
+++ b/packages/devtools-ui/package.json
@@ -55,7 +55,7 @@
     "lodash-es": "^4.17.21",
     "prism-react-renderer": "^1.3.5",
     "react-gravatar": "^2.6.3",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-json-view-lite": "^1.3.0",
     "react-router": "^7.0.2",
     "semver-diff": "^3.1.1"

--- a/packages/inferencer/package.json
+++ b/packages/inferencer/package.json
@@ -181,7 +181,7 @@
     "dayjs": "^1.10.7",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-hook-form": "^7.43.5"
+    "react-hook-form": "^7.57.0"
   },
   "peerDependenciesMeta": {
     "@chakra-ui/react": {

--- a/packages/live-previews/package.json
+++ b/packages/live-previews/package.json
@@ -65,7 +65,7 @@
     "qs": "^6.10.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-i18next": "^11.8.11",
     "react-router": "^7.0.2",
     "uuid": "^9.0.1"

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -44,7 +44,7 @@
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
     "notistack": "^2.0.4",
-    "react-hook-form": "^7.43.5",
+    "react-hook-form": "^7.57.0",
     "react-markdown": "^6.0.1",
     "remark-gfm": "^1.0.0",
     "tslib": "^2.6.2",
@@ -86,7 +86,7 @@
     "dayjs": "^1.10.7",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-hook-form": "^7.43.5"
+    "react-hook-form": "^7.57.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
-    "react-hook-form": "^7.43.5"
+    "react-hook-form": "^7.57.0"
   },
   "devDependencies": {
     "@esbuild-plugins/node-resolve": "^0.1.4",
@@ -68,7 +68,7 @@
     "@types/react-dom": "^17.0.0 || ^18.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-hook-form": "^7.43.5"
+    "react-hook-form": "^7.57.0"
   },
   "engines": {
     "node": ">=10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1326,8 +1326,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -2109,8 +2109,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -3156,8 +3156,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -3450,8 +3450,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-i18next:
         specifier: ^11.8.11
         version: 11.18.6(i18next@20.6.1)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -4490,8 +4490,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -4560,8 +4560,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -4627,8 +4627,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -4694,8 +4694,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -4761,8 +4761,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -4911,8 +4911,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -5450,8 +5450,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-i18next:
         specifier: ^11.8.11
         version: 11.18.6(i18next@20.6.1)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -5814,8 +5814,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-i18next:
         specifier: ^11.8.11
         version: 11.18.6(i18next@20.6.1)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -6448,8 +6448,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-hot-toast:
         specifier: ^2.4.1
         version: 2.4.1(csstype@3.1.3)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -6832,8 +6832,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -7571,8 +7571,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -7769,8 +7769,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -7990,7 +7990,7 @@ importers:
     dependencies:
       '@hookform/error-message':
         specifier: ^2.0.0
-        version: 2.0.1(react-dom@18.3.0(react@18.3.0))(react-hook-form@7.51.3(react@18.3.0))(react@18.3.0)
+        version: 2.0.1(react-dom@18.3.0(react@18.3.0))(react-hook-form@7.57.0(react@18.3.0))(react@18.3.0)
       '@refinedev/cli':
         specifier: ^2.16.46
         version: link:../../packages/cli
@@ -8022,8 +8022,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -8689,8 +8689,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -9069,8 +9069,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -9520,8 +9520,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -9587,8 +9587,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -9996,8 +9996,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -11029,8 +11029,8 @@ importers:
         specifier: ^17.0.0 || ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-markdown:
         specifier: ^6.0.1
         version: 6.0.3(@types/react@18.3.0)(react@18.3.0)
@@ -11920,8 +11920,8 @@ importers:
         specifier: ^2.6.3
         version: 2.6.3(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-json-view-lite:
         specifier: ^1.3.0
         version: 1.4.0(react@18.3.0)
@@ -12202,8 +12202,8 @@ importers:
         specifier: ^17.0.0 || ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-markdown:
         specifier: ^6.0.1
         version: 6.0.3(@types/react@18.3.0)(react@18.3.0)
@@ -12519,8 +12519,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-i18next:
         specifier: ^11.8.11
         version: 11.18.6(i18next@20.6.1)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -12777,8 +12777,8 @@ importers:
         specifier: ^17.0.0 || ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
       react-markdown:
         specifier: ^6.0.1
         version: 6.0.3(@types/react@18.3.0)(react@18.3.0)
@@ -13051,8 +13051,8 @@ importers:
         specifier: ^17.0.0 || ^18.0.0
         version: 18.3.0(react@18.3.0)
       react-hook-form:
-        specifier: ^7.43.5
-        version: 7.51.3(react@18.3.0)
+        specifier: ^7.57.0
+        version: 7.57.0(react@18.3.0)
     devDependencies:
       '@esbuild-plugins/node-resolve':
         specifier: ^0.1.4
@@ -27115,11 +27115,11 @@ packages:
     peerDependencies:
       react: '*'
 
-  react-hook-form@7.51.3:
-    resolution: {integrity: sha512-cvJ/wbHdhYx8aviSWh28w9ImjmVsb5Y05n1+FW786vEZQJV5STNM0pW6ujS+oiBecb0ARBxJFyAnXj9+GHXACQ==}
-    engines: {node: '>=12.22.0'}
+  react-hook-form@7.57.0:
+    resolution: {integrity: sha512-RbEks3+cbvTP84l/VXGUZ+JMrKOS8ykQCRYdm5aYsxnDquL0vspsyNhGRO7pcH6hsZqWlPOjLye7rJqdtdAmlg==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17 || ^18
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-hot-toast@2.4.1:
     resolution: {integrity: sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==}
@@ -34960,11 +34960,11 @@ snapshots:
       react: 18.3.0
       react-dom: 18.3.0(react@18.3.0)
 
-  '@hookform/error-message@2.0.1(react-dom@18.3.0(react@18.3.0))(react-hook-form@7.51.3(react@18.3.0))(react@18.3.0)':
+  '@hookform/error-message@2.0.1(react-dom@18.3.0(react@18.3.0))(react-hook-form@7.57.0(react@18.3.0))(react@18.3.0)':
     dependencies:
       react: 18.3.0
       react-dom: 18.3.0(react@18.3.0)
-      react-hook-form: 7.51.3(react@18.3.0)
+      react-hook-form: 7.57.0(react@18.3.0)
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -49073,7 +49073,7 @@ snapshots:
       query-string: 4.3.4
       react: 18.3.0
 
-  react-hook-form@7.51.3(react@18.3.0):
+  react-hook-form@7.57.0(react@18.3.0):
     dependencies:
       react: 18.3.0
 


### PR DESCRIPTION
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

---

chore: update `react-hook-form` to `7.57.0` to support new features like [`subscribe`](https://react-hook-form.com/docs/useform/subscribe).
for more information, see [React Hook Form release notes](https://github.com/react-hook-form/react-hook-form/releases).
