### PR TITLE
feat(core): add warnWhenUnsavedChanges to useEditableTable #6811

### DIFF
--- a/.changeset/yellow-dots-beg.md
+++ b/.changeset/yellow-dots-beg.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/core": minor
+---
+
+feat: add warnWhenUnsavedChanges prop support to useEditableTable #6811
+
+Now with the warnWhenUnsavedChanges prop, developers can enable unsaved changes warnings in useEditableTable via useForm integration.
+
+Resolves #6811


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

The `useEditableTable` hook does not support the `warnWhenUnsavedChanges` prop, even though it’s supported in `useForm`.

## What is the new behavior?

You can now pass `warnWhenUnsavedChanges` to `useEditableTable`, and it will work the same way as in `useForm`, showing a confirmation when navigating away with unsaved changes.

fixes #6811 

## Notes for reviewers

