### PR TITLE
fix(docs): correct syntax error in authentication tutorial

### DIFF
--- a/.changeset/sharp-otters-burn.md
+++ b/.changeset/sharp-otters-burn.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+fix: correct syntax error in authentication tutorial example
+
+Fixes #6814

--- a/.changeset/sharp-otters-burn.md
+++ b/.changeset/sharp-otters-burn.md
@@ -1,7 +1,0 @@
----
-"@refinedev/core": patch
----
-
-fix: correct syntax error in authentication tutorial example
-
-Fixes #6814

--- a/documentation/tutorial/authentication/data-provider-integration/sandpack.tsx
+++ b/documentation/tutorial/authentication/data-provider-integration/sandpack.tsx
@@ -266,7 +266,7 @@ export const authProvider: AuthProvider = {
           logout: true,
           error: {
             message: "Unauthorized",
-            name: “Error”,
+            name: "Error",
             statusCode: error?.status ?? 403,
           },
         }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
The authentication tutorial example in the documentation contains smart quotes (`“` and `”`) instead of standard ASCII quotes (`"`), which causes a TypeScript syntax error in code editors and sandpack previews.

## What is the new behavior?
Replaced the smart quotes with standard double quotes to ensure the code compiles correctly and behaves as expected.

```diff
- name: “Error”,
+ name: "Error",
```
Fixes #6814
## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
