### PR TITLE
fix: stale values on form close while create and edit

### DIFF
--- a/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
+++ b/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
@@ -289,6 +289,7 @@ export const useModalForm = <
       }
     }
 
+    form.resetFields();
     setId?.(undefined);
     sunflowerUseModal.close();
   }, [warnWhen, autoSaveProps.status]);
@@ -332,6 +333,7 @@ export const useModalForm = <
           form.resetFields();
         }
       },
+      hidden: formLoading,
     },
     modalProps: {
       ...newModalProps,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
- when "create" form
   - when user clicks on create form -> enters some value -> closes it
   -  when he opens it again -> previous values are still in form
- When edit
   - user clicks on editing item1 -> form opens and gets value from api -> user closes form
   - now user clicks on editing item2 -> from opens initially with stale values from past (i.e. item1 values)-> once api finishes item2 values are populated. this causes confusion for users with slow internet

## What is the new behavior?
- when "create" form
  - when user clicks on create form -> enters some value -> closes it
  - when he opens it again -> form is reset (no stale values from past)

- When edit
   - user clicks on editing item1 -> form opens but fields are hidden until api req is complete (shows loading spinner)-> populates values once api completes. no stale value is displayed from past

fixes (issue)
#5954 

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
