### PR TITLE
fix: deprecated bordered prop in the Card component

### DIFF
--- a/packages/antd/src/components/crud/create/index.tsx
+++ b/packages/antd/src/components/crud/create/index.tsx
@@ -115,7 +115,7 @@ export const Create: React.FC<CreateProps> = ({
       >
         <Spin spinning={isLoading}>
           <Card
-            bordered={false}
+            variant="borderless"
             actions={[
               <Space
                 key="action-buttons"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

<img width="946" alt="image" src="https://github.com/user-attachments/assets/66acab0a-1f12-4889-9edf-59c4906628c9" />

Currently, Antdesign's Card component is giving a warning because `bordered` is deprecated. 

## What is the new behavior?

By using  `variant` instead of `bordered`, the warning is fixed.

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
