### PR TITLE
fix(docs): correct the method name of notification provider

### DIFF
--- a/documentation/docs/notification/notification-provider/index.md
+++ b/documentation/docs/notification/notification-provider/index.md
@@ -10,7 +10,7 @@ A `notificationProvider` must include following methods:
 
 ```tsx
 const notificationProvider = {
-  show: () => {},
+  open: () => {},
   close: () => {},
 };
 ```


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
At the top of the [notification provider](https://refine.dev/docs/notification/notification-provider/) in docs. we said that a notificationProvider must include following methods:
```ts
const notificationProvider = {
  show: () => {},
  close: () => {},
};
```
but in the codebase, we have `open` instead of `show`
## What is the new behavior?
Change to correct method name from `show` -> `open`
fixes (issue)

