### PR TITLE
fix(docs): correct syntax error in react design patterns tutorial

### DIFF
--- a/documentation/blog/2024-09-05-react-patterns.md
+++ b/documentation/blog/2024-09-05-react-patterns.md
@@ -321,7 +321,7 @@ const higherOrderComponent = Component => {
     }
 
     render() {
-      return <Component name={this.state.name {...this.props} />
+      return <Component name={this.state.name} {...this.props} />
     }
  }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
In the return statement of the [Higher Order Components](https://refine.dev/blog/react-design-patterns/#component-enhancement-with-hocs-higher-order-components) example, the name prop's braces aren't closed.

```
return <Component name={this.state.name {...this.props} />
```

## What is the new behavior?
Change `name={this.state.name` to  `name={this.state.name}`
