### PR TITLE
fix(useDataGrid): memorize row count

### DIFF
--- a/.changeset/sour-swans-tell.md
+++ b/.changeset/sour-swans-tell.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/mui": patch
+---
+
+fix(mui): on page change, `useDataGrid` resets to first page. #6828 #6798
+
+Fixes #6828 #6798

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -13,7 +13,7 @@ import {
   type useTableReturnType as useTableReturnTypeCore,
   useResourceParams,
 } from "@refinedev/core";
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import type {
   DataGridProps,
@@ -211,6 +211,15 @@ export function useDataGrid<
 
   const { data, isFetched, isLoading } = tableQueryResult;
 
+  const rowCountRef = useRef(data?.total || 0);
+  const rowCount = useMemo(() => {
+    if (data && data.total) {
+      rowCountRef.current = data.total;
+    }
+    return rowCountRef.current;
+  }, [data]);
+
+
   const isServerSideFilteringEnabled =
     (filtersFromProp?.mode || "server") === "server";
   const isServerSideSortingEnabled =
@@ -323,7 +332,7 @@ export function useDataGrid<
       disableRowSelectionOnClick: true,
       rows: data?.data || [],
       loading: liveMode === "auto" ? isLoading : !isFetched,
-      rowCount: data?.total || 0,
+      rowCount,
       ...dataGridPaginationValues(),
       sortingMode: isServerSideSortingEnabled ? "server" : "client",
       sortModel: transformCrudSortingToSortModel(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
on page change, the datagrid resets to first page.

## What is the new behavior?
the paging is working now

fixes (issue)
#6828 #6798 

## Notes for reviewers

@ rkmackinnon solution from #6798 

<!-- Add any notes/questions you may have for reviewers -->
