### PR TITLE
release: June 2025

### DIFF
--- a/.changeset/famous-drinks-thank.md
+++ b/.changeset/famous-drinks-thank.md
@@ -2,7 +2,7 @@
 "@refinedev/mui": patch
 ---
 
-fix(mui): pass `meta` to `useUpdate` in `useDataGrid` hook for editable data grid.
+fix(mui): pass `meta` to `useUpdate` in `useDataGrid` hook for editable data grid. #6833
 
 ```tsx
 import { useDataGrid } from "@refinedev/mui";
@@ -15,3 +15,5 @@ const { dataGridProps } = useDataGrid({
   },
 });
 ```
+
+Resolves [#6833]

--- a/.changeset/famous-drinks-thank.md
+++ b/.changeset/famous-drinks-thank.md
@@ -1,0 +1,17 @@
+---
+"@refinedev/mui": patch
+---
+
+fix(mui): pass `meta` to `useUpdate` in `useDataGrid` hook for editable data grid.
+
+```tsx
+import { useDataGrid } from "@refinedev/mui";
+
+const { dataGridProps } = useDataGrid({
+  resource: "posts",
+  editable: true,
+  updateMutationOptions: {
+    meta: { foo: "bar" },
+  },
+});
+```

--- a/.changeset/great-birds-nail.md
+++ b/.changeset/great-birds-nail.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+fix: pass meta params to useCan hook params
+
+Now access control provider can receive additional arguments through meta params.

--- a/.changeset/great-birds-nail.md
+++ b/.changeset/great-birds-nail.md
@@ -2,6 +2,8 @@
 "@refinedev/core": patch
 ---
 
-fix: pass meta params to useCan hook params
+fix: pass meta params to useCan hook params #6833
 
 Now access control provider can receive additional arguments through meta params.
+
+Resolves [#6833]

--- a/.changeset/sour-swans-tell.md
+++ b/.changeset/sour-swans-tell.md
@@ -4,4 +4,4 @@
 
 fix(mui): on page change, `useDataGrid` resets to first page. #6828 #6798
 
-Fixes #6828 #6798
+Resolves [#6828] [#6798]

--- a/.changeset/sour-swans-tell.md
+++ b/.changeset/sour-swans-tell.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/mui": patch
+---
+
+fix(mui): on page change, `useDataGrid` resets to first page. #6828 #6798
+
+Fixes #6828 #6798

--- a/cypress/e2e/data-provider-strapi-v4/all.cy.ts
+++ b/cypress/e2e/data-provider-strapi-v4/all.cy.ts
@@ -133,8 +133,22 @@ describe("data-provider-strapi-v4", () => {
 
       cy.getAntdFilterTrigger(0).click();
       cy.get(".ant-select-selector").eq(1).click();
+
+      // Wait for dropdown options to be visible and have proper dimensions
+      cy.get(".ant-select-dropdown").should("be.visible");
+      cy.get(".ant-select-item-option-content").should(
+        "have.length.at.least",
+        1,
+      );
+
       cy.fixture("categories").then((categories) => {
         const category = categories[0];
+
+        cy.get(".ant-select-item-option-content")
+          .contains(category.title)
+          .should("be.visible")
+          .should("have.css", "width")
+          .and("not.equal", "0px");
 
         cy.get(".ant-select-item-option-content")
           .contains(category.title)

--- a/cypress/e2e/table-material-ui-cursor-pagination/all.cy.ts
+++ b/cypress/e2e/table-material-ui-cursor-pagination/all.cy.ts
@@ -8,6 +8,8 @@ describe("table-material-ui-cursor-pagination", () => {
 
   it("should work with pagination", () => {
     cy.getMaterialUILoadingCircular().should("not.exist");
+    cy.get(".MuiDataGrid-root").should("be.visible");
+    cy.get(".MuiDataGrid-row").should("have.length.at.least", 1);
 
     cy.intercept({
       url: "https://api.github.com/repos/refinedev/refine/commits*",
@@ -16,6 +18,7 @@ describe("table-material-ui-cursor-pagination", () => {
       },
     }).as("getSecondPageCommits");
 
+    cy.get("[title='Go to next page']").should("not.be.disabled");
     cy.get("[title='Go to next page']").click();
 
     cy.url().should("include", "current=2");
@@ -29,6 +32,8 @@ describe("table-material-ui-cursor-pagination", () => {
       },
     }).as("getFirstPageCommits");
 
+    // Wait for the previous page button to be enabled before clicking
+    cy.get("[title='Go to previous page']").should("not.be.disabled");
     cy.get("[title='Go to previous page']").click();
 
     cy.url().should("include", "current=1");

--- a/packages/core/src/hooks/button/button-can-access/index.meta.spec.tsx
+++ b/packages/core/src/hooks/button/button-can-access/index.meta.spec.tsx
@@ -1,0 +1,271 @@
+import { renderHook } from "@testing-library/react";
+
+import { TestWrapper, mockRouterProvider } from "@test";
+
+// Mock useCan hook for meta prop testing
+jest.mock("../../accessControl/useCan", () => ({
+  useCan: jest.fn(),
+}));
+
+import { useButtonCanAccess } from ".";
+import { useCan } from "../../accessControl/useCan";
+
+const mockUseCan = useCan as jest.MockedFunction<typeof useCan>;
+
+const actions = ["list", "show", "create", "edit", "clone", "delete"] as const;
+
+describe("useButtonCanAccess - meta prop passing to useCan", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default mock return value
+    mockUseCan.mockReturnValue({
+      data: { can: true },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as any);
+  });
+
+  it("should pass meta prop to useCan", () => {
+    const testMeta = {
+      userRole: "admin",
+      department: "finance",
+      permissions: ["read", "write", "delete"],
+    };
+
+    renderHook(
+      () =>
+        useButtonCanAccess({
+          action: "edit",
+          resource: { name: "posts" },
+          id: 456,
+          meta: testMeta,
+        }),
+      {
+        wrapper: TestWrapper({
+          resources: [{ name: "posts" }],
+          routerProvider: mockRouterProvider({
+            resource: { name: "posts" },
+          }),
+        }),
+      },
+    );
+
+    expect(mockUseCan).toHaveBeenCalledWith({
+      resource: "posts",
+      action: "edit",
+      params: {
+        meta: testMeta,
+        id: 456,
+        resource: { name: "posts" },
+      },
+      queryOptions: {
+        enabled: true,
+      },
+    });
+  });
+
+  it("should pass undefined meta when meta prop is not provided", () => {
+    renderHook(
+      () =>
+        useButtonCanAccess({
+          action: "show",
+          resource: { name: "users" },
+          id: 789,
+        }),
+      {
+        wrapper: TestWrapper({
+          resources: [{ name: "users" }],
+          routerProvider: mockRouterProvider({
+            resource: { name: "users" },
+          }),
+        }),
+      },
+    );
+
+    expect(mockUseCan).toHaveBeenCalledWith({
+      resource: "users",
+      action: "show",
+      params: {
+        meta: undefined,
+        id: 789,
+        resource: { name: "users" },
+      },
+      queryOptions: {
+        enabled: true,
+      },
+    });
+  });
+
+  it("should pass meta prop with access control disabled", () => {
+    const testMeta = {
+      customField: "test-value",
+      organizationId: 999,
+    };
+
+    renderHook(
+      () =>
+        useButtonCanAccess({
+          action: "create",
+          resource: { name: "articles" },
+          meta: testMeta,
+          accessControl: {
+            enabled: false,
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          resources: [{ name: "articles" }],
+          routerProvider: mockRouterProvider({
+            resource: { name: "articles" },
+          }),
+        }),
+      },
+    );
+
+    expect(mockUseCan).toHaveBeenCalledWith({
+      resource: "articles",
+      action: "create",
+      params: {
+        meta: testMeta,
+        id: undefined,
+        resource: { name: "articles" },
+      },
+      queryOptions: {
+        enabled: false,
+      },
+    });
+  });
+
+  it("should handle clone action correctly (converts to create)", () => {
+    const testMeta = {
+      cloneSource: "original-post",
+      templateId: 42,
+    };
+
+    renderHook(
+      () =>
+        useButtonCanAccess({
+          action: "clone",
+          resource: { name: "posts" },
+          id: 123,
+          meta: testMeta,
+        }),
+      {
+        wrapper: TestWrapper({
+          resources: [{ name: "posts" }],
+          routerProvider: mockRouterProvider({
+            resource: { name: "posts" },
+          }),
+        }),
+      },
+    );
+
+    expect(mockUseCan).toHaveBeenCalledWith({
+      resource: "posts",
+      action: "create", // clone action should be converted to create
+      params: {
+        meta: testMeta,
+        id: 123,
+        resource: { name: "posts" },
+      },
+      queryOptions: {
+        enabled: true,
+      },
+    });
+  });
+
+  it("should pass meta prop for all different actions", () => {
+    const testMeta = {
+      testCase: "all-actions",
+      timestamp: Date.now(),
+    };
+
+    actions.forEach((action) => {
+      jest.clearAllMocks();
+
+      renderHook(
+        () =>
+          useButtonCanAccess({
+            action,
+            resource: { name: "posts" },
+            id: 123,
+            meta: testMeta,
+          }),
+        {
+          wrapper: TestWrapper({
+            resources: [{ name: "posts" }],
+            routerProvider: mockRouterProvider({
+              resource: { name: "posts" },
+            }),
+          }),
+        },
+      );
+
+      expect(mockUseCan).toHaveBeenCalledWith({
+        resource: "posts",
+        action: action === "clone" ? "create" : action,
+        params: {
+          meta: testMeta,
+          id: 123,
+          resource: { name: "posts" },
+        },
+        queryOptions: {
+          enabled: true,
+        },
+      });
+    });
+  });
+
+  it("should pass complex meta object with nested properties", () => {
+    const complexMeta = {
+      filters: {
+        status: "published",
+        category: ["tech", "programming"],
+      },
+      pagination: {
+        page: 1,
+        limit: 10,
+      },
+      user: {
+        id: 42,
+        role: "editor",
+        permissions: {
+          canEdit: true,
+          canDelete: false,
+        },
+      },
+    };
+
+    renderHook(
+      () =>
+        useButtonCanAccess({
+          action: "delete",
+          resource: { name: "posts" },
+          id: 123,
+          meta: complexMeta,
+        }),
+      {
+        wrapper: TestWrapper({
+          resources: [{ name: "posts" }],
+          routerProvider: mockRouterProvider({
+            resource: { name: "posts" },
+          }),
+        }),
+      },
+    );
+
+    expect(mockUseCan).toHaveBeenCalledWith({
+      resource: "posts",
+      action: "delete",
+      params: {
+        meta: complexMeta,
+        id: 123,
+        resource: { name: "posts" },
+      },
+      queryOptions: {
+        enabled: true,
+      },
+    });
+  });
+});

--- a/packages/core/src/hooks/button/button-can-access/index.tsx
+++ b/packages/core/src/hooks/button/button-can-access/index.tsx
@@ -17,6 +17,7 @@ type ButtonCanAccessProps = {
     enabled?: boolean;
     hideIfUnauthorized?: boolean;
   };
+  meta?: Record<string, unknown>;
 };
 
 type ButtonCanAccessValues = {
@@ -43,7 +44,7 @@ export const useButtonCanAccess = (
   const { data: canAccess } = useCan({
     resource: props.resource?.name,
     action: props.action === "clone" ? "create" : props.action,
-    params: { id: props.id, resource: props.resource },
+    params: { meta: props.meta, id: props.id, resource: props.resource },
     queryOptions: {
       enabled: accessControlEnabled,
     },

--- a/packages/core/src/hooks/button/navigation-button/index.spec.tsx
+++ b/packages/core/src/hooks/button/navigation-button/index.spec.tsx
@@ -3,10 +3,31 @@ import { renderHook } from "@testing-library/react";
 import { TestWrapper, mockRouterProvider } from "@test";
 
 import { useNavigationButton } from ".";
+import { useButtonCanAccess } from "../button-can-access";
+
+// Mock the useButtonCanAccess hook
+jest.mock("../button-can-access", () => ({
+  useButtonCanAccess: jest.fn(),
+}));
+
+const mockUseButtonCanAccess = useButtonCanAccess as jest.MockedFunction<
+  typeof useButtonCanAccess
+>;
 
 const actions = ["list", "show", "create", "edit", "clone"] as const;
 
 describe("useNavigationButton", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default mock return value
+    mockUseButtonCanAccess.mockReturnValue({
+      title: "",
+      hidden: false,
+      disabled: false,
+      canAccess: { can: true },
+    });
+  });
+
   describe.each(actions)("with action %s", (action) => {
     it("should return 'to' empty string if no route is defined", () => {
       const { result } = renderHook(
@@ -122,5 +143,150 @@ describe("useNavigationButton", () => {
         expect(goMock).not.toBeCalled();
       });
     }
+  });
+
+  describe("meta prop passing", () => {
+    it("should pass meta prop to useButtonCanAccess", () => {
+      const testMeta = {
+        customField: "test-value",
+        userId: 123,
+        permissions: ["read", "write"],
+      };
+
+      renderHook(
+        () =>
+          useNavigationButton({
+            action: "show",
+            resource: "posts",
+            id: 456,
+            meta: testMeta,
+          }),
+        {
+          wrapper: TestWrapper({
+            resources: [{ name: "posts" }],
+            routerProvider: mockRouterProvider({
+              resource: { name: "posts" },
+            }),
+          }),
+        },
+      );
+
+      expect(mockUseButtonCanAccess).toHaveBeenCalledWith({
+        action: "show",
+        accessControl: undefined,
+        meta: testMeta,
+        id: 456,
+        resource: expect.objectContaining({
+          name: "posts",
+        }),
+      });
+    });
+
+    it("should pass undefined meta when meta prop is not provided", () => {
+      renderHook(
+        () =>
+          useNavigationButton({
+            action: "edit",
+            resource: "posts",
+            id: 789,
+          }),
+        {
+          wrapper: TestWrapper({
+            resources: [{ name: "posts" }],
+            routerProvider: mockRouterProvider({
+              resource: { name: "posts" },
+            }),
+          }),
+        },
+      );
+
+      expect(mockUseButtonCanAccess).toHaveBeenCalledWith({
+        action: "edit",
+        accessControl: undefined,
+        meta: undefined,
+        id: 789,
+        resource: expect.objectContaining({
+          name: "posts",
+        }),
+      });
+    });
+
+    it("should pass meta prop with accessControl options", () => {
+      const testMeta = {
+        customAccess: "admin-only",
+        department: "engineering",
+      };
+      const accessControlOptions = {
+        enabled: true,
+        hideIfUnauthorized: true,
+      };
+
+      renderHook(
+        () =>
+          useNavigationButton({
+            action: "create",
+            resource: "users",
+            meta: testMeta,
+            accessControl: accessControlOptions,
+          }),
+        {
+          wrapper: TestWrapper({
+            resources: [{ name: "users" }],
+            routerProvider: mockRouterProvider({
+              resource: { name: "users" },
+            }),
+          }),
+        },
+      );
+
+      expect(mockUseButtonCanAccess).toHaveBeenCalledWith({
+        action: "create",
+        accessControl: accessControlOptions,
+        meta: testMeta,
+        id: undefined,
+        resource: expect.objectContaining({
+          name: "users",
+        }),
+      });
+    });
+
+    it("should pass meta prop for all different actions", () => {
+      const testMeta = {
+        testCase: "all-actions",
+        timestamp: Date.now(),
+      };
+
+      actions.forEach((action) => {
+        jest.clearAllMocks();
+
+        renderHook(
+          () =>
+            useNavigationButton({
+              action,
+              resource: "posts",
+              id: action === "create" ? undefined : 123,
+              meta: testMeta,
+            }),
+          {
+            wrapper: TestWrapper({
+              resources: [{ name: "posts" }],
+              routerProvider: mockRouterProvider({
+                resource: { name: "posts" },
+              }),
+            }),
+          },
+        );
+
+        expect(mockUseButtonCanAccess).toHaveBeenCalledWith({
+          action,
+          accessControl: undefined,
+          meta: testMeta,
+          id: action === "create" ? undefined : 123,
+          resource: expect.objectContaining({
+            name: "posts",
+          }),
+        });
+      });
+    });
   });
 });

--- a/packages/core/src/hooks/button/navigation-button/index.tsx
+++ b/packages/core/src/hooks/button/navigation-button/index.tsx
@@ -61,6 +61,7 @@ export function useNavigationButton(
   const { canAccess, title, hidden, disabled } = useButtonCanAccess({
     action: props.action,
     accessControl: props.accessControl,
+    meta: props.meta,
     id,
     resource,
   });

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -13,7 +13,7 @@ import {
   type useTableReturnType as useTableReturnTypeCore,
   useResourceParams,
 } from "@refinedev/core";
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import type {
   DataGridProps,
@@ -211,6 +211,15 @@ export function useDataGrid<
 
   const { data, isFetched, isLoading } = tableQueryResult;
 
+  const rowCountRef = useRef(data?.total || 0);
+  const rowCount = useMemo(() => {
+    if (data && data.total) {
+      rowCountRef.current = data.total;
+    }
+    return rowCountRef.current;
+  }, [data]);
+
+
   const isServerSideFilteringEnabled =
     (filtersFromProp?.mode || "server") === "server";
   const isServerSideSortingEnabled =
@@ -323,7 +332,7 @@ export function useDataGrid<
       disableRowSelectionOnClick: true,
       rows: data?.data || [],
       loading: liveMode === "auto" ? isLoading : !isFetched,
-      rowCount: data?.total || 0,
+      rowCount,
       ...dataGridPaginationValues(),
       sortingMode: isServerSideSortingEnabled ? "server" : "client",
       sortModel: transformCrudSortingToSortModel(

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -311,6 +311,7 @@ export function useDataGrid<
           resource: identifier,
           id: newRow.id as string,
           values: newRow,
+          meta: updateMutationOptions?.meta,
         },
         {
           onError: (error) => {

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -213,12 +213,11 @@ export function useDataGrid<
 
   const rowCountRef = useRef(data?.total || 0);
   const rowCount = useMemo(() => {
-    if (data && data.total) {
+    if (data?.total) {
       rowCountRef.current = data.total;
     }
     return rowCountRef.current;
   }, [data]);
-
 
   const isServerSideFilteringEnabled =
     (filtersFromProp?.mode || "server") === "server";


### PR DESCRIPTION
- fix(mui): on page change, data-grid resets to first page (https://github.com/refinedev/refine/pull/6859)
- fix(mui): pass meta to use-update from use-data-grid (https://github.com/refinedev/refine/pull/6834)
- fix(mui): pass meta to use-update from use-data-grid (https://github.com/refinedev/refine/pull/6834)