### PR TITLE
fix(with-remix-material-ui): example is broken

### DIFF
--- a/examples/with-remix-material-ui/app/entry.server.tsx
+++ b/examples/with-remix-material-ui/app/entry.server.tsx
@@ -1,6 +1,10 @@
 import type { EntryContext } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import { renderToString } from "react-dom/server";
+import CssBaseline from "@mui/material/CssBaseline";
+import GlobalStyles from "@mui/material/GlobalStyles";
+import { ColorModeContextProvider } from "~/contexts/ColorModeContext";
+import { ClientStyleCacheProvider } from "~/contexts/ClientStyleContext";
 
 export default function handleRequest(
   request: Request,
@@ -9,7 +13,13 @@ export default function handleRequest(
   remixContext: EntryContext,
 ) {
   const markup = renderToString(
-    <RemixServer context={remixContext} url={request.url} />,
+    <ClientStyleCacheProvider>
+      <ColorModeContextProvider>
+        <CssBaseline />
+        <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
+        <RemixServer context={remixContext} url={request.url} />
+      </ColorModeContextProvider>
+    </ClientStyleCacheProvider>,
   );
 
   responseHeaders.set("Content-Type", "text/html");

--- a/examples/with-remix-material-ui/app/root.tsx
+++ b/examples/with-remix-material-ui/app/root.tsx
@@ -97,34 +97,32 @@ export default function App() {
       <GitHubBanner />
       <RefineKbarProvider>
         <RefineSnackbarProvider>
-          <RefineKbarProvider>
-            <Refine
-              routerProvider={routerProvider}
-              dataProvider={dataProvider(API_URL)}
-              notificationProvider={useNotificationProvider}
-              authProvider={authProvider}
-              resources={[
-                {
-                  name: "blog_posts",
-                  list: "/blog-posts",
-                  create: "/blog-posts/create",
-                  edit: "/blog-posts/edit/:id",
-                  show: "/blog-posts/show/:id",
-                  meta: {
-                    canDelete: true,
-                  },
+          <Refine
+            routerProvider={routerProvider}
+            dataProvider={dataProvider(API_URL)}
+            notificationProvider={useNotificationProvider}
+            authProvider={authProvider}
+            resources={[
+              {
+                name: "blog_posts",
+                list: "/blog-posts",
+                create: "/blog-posts/create",
+                edit: "/blog-posts/edit/:id",
+                show: "/blog-posts/show/:id",
+                meta: {
+                  canDelete: true,
                 },
-              ]}
-              options={{
-                syncWithLocation: true,
-                warnWhenUnsavedChanges: true,
-              }}
-            >
-              <Outlet />
-              <UnsavedChangesNotifier />
-              <RefineKbar />
-            </Refine>
-          </RefineKbarProvider>
+              },
+            ]}
+            options={{
+              syncWithLocation: true,
+              warnWhenUnsavedChanges: true,
+            }}
+          >
+            <Outlet />
+            <UnsavedChangesNotifier />
+            <RefineKbar />
+          </Refine>
         </RefineSnackbarProvider>
       </RefineKbarProvider>
     </Document>

--- a/examples/with-remix-material-ui/package.json
+++ b/examples/with-remix-material-ui/package.json
@@ -31,7 +31,8 @@
     "js-cookie": "^3.0.1",
     "nookies": "^2.5.2",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-transition-group": "^4.4.5"
   },
   "devDependencies": {
     "@remix-run/dev": "^2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10610,6 +10610,9 @@ importers:
       react-dom:
         specifier: ^18.0.0
         version: 18.3.0(react@18.3.0)
+      react-transition-group:
+        specifier: ^4.4.5
+        version: 4.4.5(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.3.1


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

---

example is broken because of the following error:
```md
Error: Objects are not valid as a React child (found: object with keys {$$typeof, type, key, props, _owner, _store}). If you meant to render a collection of children, use an array instead.
    at throwOnInvalidObjectType (http://localhost:3000/build/_shared/chunk-F6FL47WC.js:9952:17)
    at reconcileChildFibers2 (http://localhost:3000/build/_shared/chunk-F6FL47WC.js:10582:15)
    at reconcileChildren (http://localhost:3000/build/_shared/chunk-F6FL47WC.js:14310:37)
    at finishClassComponent (http://localhost:3000/build/_shared/chunk-F6FL47WC.js:14738:13)
    at updateClassComponent (http://localhost:3000/build/_shared/chunk-F6FL47WC.js:14684:32)
    at beginWork (http://localhost:3000/build/_shared/chunk-F6FL47WC.js:15950:22)
    at beginWork$1 (http://localhost:3000/build/_shared/chunk-F6FL47WC.js:19781:22)
    at performUnitOfWork (http://localhost:3000/build/_shared/chunk-F6FL47WC.js:19226:20)
    at workLoopSync (http://localhost:3000/build/_shared/chunk-F6FL47WC.js:19165:13)
    at renderRootSync (http://localhost:3000/build/_shared/chunk-F6FL47WC.js:19144:15)
```

resolved by updating `react-transition-group` and configuration.
