### PR TITLE
add `refine-sqlx` data provider

### DIFF
--- a/documentation/src/partials/data-provider/supported-data-providers.md
+++ b/documentation/src/partials/data-provider/supported-data-providers.md
@@ -24,5 +24,6 @@
 - [JSON:API](https://jsonapi.org/) by [mahirmahdi](https://github.com/MahirMahdi/refine-jsonapi)
 - [PocketBase](https://pocketbase.io/) by [kruschid](https://github.com/kruschid)
 - [PostgREST](https://github.com/ffimnsr/refine-postgrest-ts) by [ffimnsr](https://github.com/ffimnsr)
+- [Refine SQL X](https://github.com/medz/refine-sqlx) by [Seven Du (@medz)](https://github.com/medz)
 
 _If you have created a custom data provider and would like to share it with the community, feel free to create a PR. We would be happy to include it on this page for others to use._


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
refine-sqlx is a refine data provider that provides a standard SQL query interface allowing you to customize query clients for any database. It has built-in support for SQLite databases, you can directly pass bun:sqlite/node:sqlite/cloudflare d1/better-sqlite3 instances to refine-sqlx; you can also directly pass a :memory: string to use memory or pass a local file path, and it will automatically select the best SQLite driver for your runtime.