### PR TITLE
Fix typo in README: remove extra 'as' from description

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -21,7 +21,7 @@
 
 <div align="center"><strong>The sweet spot between the low/no code and “starting from scratch” for CRUD-heavy applications.</strong><br>
 
-Refine is as an open source, React meta-framework for enterprise. It provides a headless solution for everything from admin panels to
+Refine is an open source, React meta-framework for enterprise. It provides a headless solution for everything from admin panels to
 dashboards and internal tools.
 <br />
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
The README.md contains a grammatical error in the project description: "Refine is as an open source, React meta-framework for enterprise."

## What is the new behavior?

Fixed the typo by removing the extra "as": "Refine is an open source, React meta-framework for enterprise."
Fixes Issue: #6876 

## Notes for reviewers

This is a simple typo fix - no functionality changes, just correcting grammar in the documentation.
