### PR TITLE
fix(kbar): update kbar dependency version to exact match

### DIFF
--- a/.changeset/young-mails-tie.md
+++ b/.changeset/young-mails-tie.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/kbar": patch
+---
+
+fix: failed to resolve entry for package "kbar" #6902
+
+Fixed Vite build error in new refine projects by updating kbar dependency version.
+
+[Resolves #6902](https://github.com/refinedev/refine/issues/6902)

--- a/packages/kbar/package.json
+++ b/packages/kbar/package.json
@@ -40,7 +40,7 @@
     "types": "node ../shared/generate-declarations.js"
   },
   "dependencies": {
-    "kbar": "^0.1.0-beta.40"
+    "kbar": "0.1.0-beta.40"
   },
   "devDependencies": {
     "@esbuild-plugins/node-resolve": "^0.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12308,8 +12308,8 @@ importers:
   packages/kbar:
     dependencies:
       kbar:
-        specifier: ^0.1.0-beta.40
-        version: 0.1.0-beta.45(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
+        specifier: 0.1.0-beta.40
+        version: 0.1.0-beta.40(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
       react:
         specifier: ^17.0.0 || ^18.0.0
         version: 18.3.0
@@ -20471,6 +20471,9 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  command-score@0.1.2:
+    resolution: {integrity: sha512-VtDvQpIJBvBatnONUsPzXYFVKQQAhuf3XTNOAsdBxCNO/QCtUUd8LSgjn0GVarBkCad6aJCZfXgrjYbl/KRr7w==}
+
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
@@ -22361,10 +22364,6 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  fuse.js@6.6.2:
-    resolution: {integrity: sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==}
-    engines: {node: '>=10'}
-
   gauge@4.0.4:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -24101,8 +24100,8 @@ packages:
     resolution: {integrity: sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==}
     engines: {node: '>=12.0.0'}
 
-  kbar@0.1.0-beta.45:
-    resolution: {integrity: sha512-kXvjthqPLoWZXlxLJPrFKioskNdQv1O3Ukg5mqq2ExK3Ix1qvYT3W/ACDRIv/e/CHxPWZoTriB4oFbQ6UCSX5g==}
+  kbar@0.1.0-beta.40:
+    resolution: {integrity: sha512-vEV02WuEBvKaSivO2DnNtyd3gUAbruYrZCax5fXcLcVTFV6q0/w6Ew3z6Qy+AqXxbZdWguwQ3POIwgdHevp+6A==}
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
@@ -28283,6 +28282,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
@@ -40207,6 +40207,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  command-score@0.1.2: {}
+
   commander@10.0.1: {}
 
   commander@12.0.0: {}
@@ -42555,8 +42557,6 @@ snapshots:
       functions-have-names: 1.2.3
 
   functions-have-names@1.2.3: {}
-
-  fuse.js@6.6.2: {}
 
   gauge@4.0.4:
     dependencies:
@@ -45261,11 +45261,11 @@ snapshots:
 
   kareem@2.5.1: {}
 
-  kbar@0.1.0-beta.45(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0):
+  kbar@0.1.0-beta.40(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0):
     dependencies:
       '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
+      command-score: 0.1.2
       fast-equals: 2.0.4
-      fuse.js: 6.6.2
       react: 18.3.0
       react-dom: 18.3.0(react@18.3.0)
       react-virtual: 2.10.4(react@18.3.0)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

New refine projects created with CLI fail to start with Vite build error "Failed to resolve entry for package 'kbar'". The error occurs because kbar package has incorrect main/module/exports configuration in newer beta versions (0.1.0-beta.47).

## What is the new behavior?

Updated kbar dependency to use exact version 0.1.0-beta.40 which has correct package entry configuration, allowing new refine projects to build and run successfully.

fixes #6902

## Notes for reviewers

This is a hotfix for the CLI-generated projects. The issue is caused by kbar package changes between beta.40 and beta.47 versions. User confirmed that manually downgrading to beta.40 resolves the