### PR TITLE
refactor: pagination `current` -> currentPage

### DIFF
--- a/cypress/e2e/inferencer-antd/all.cy.ts
+++ b/cypress/e2e/inferencer-antd/all.cy.ts
@@ -318,7 +318,7 @@ describe("inferencer-antd", () => {
 
     cy.get(".ant-pagination-prev").first().click();
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
 
     cy.wait("@getFirstPagePosts");
   });

--- a/cypress/e2e/inferencer-antd/all.cy.ts
+++ b/cypress/e2e/inferencer-antd/all.cy.ts
@@ -158,7 +158,7 @@ describe("inferencer-antd", () => {
       cy.get("#status").should("have.value", body?.status);
       cy.fixture("categories").then((categories) => {
         const category = categories.find(
-          (category) => category.id === body?.category?.id,
+          (category: any) => category.id === body?.category?.id,
         );
         cy.get(`.ant-select-selection-item[title="${category?.title}"]`).should(
           "exist",
@@ -299,7 +299,7 @@ describe("inferencer-antd", () => {
 
     cy.getAntdPaginationItem(2).click();
 
-    cy.url().should("include", "current=2");
+    cy.url().should("include", "currentPage=2");
 
     cy.wait("@getSecondPagePosts");
 

--- a/cypress/e2e/inferencer-chakra-ui/all.cy.ts
+++ b/cypress/e2e/inferencer-chakra-ui/all.cy.ts
@@ -301,7 +301,7 @@ describe("inferencer-chakra-ui", () => {
 
     cy.get("button").contains(2).click();
 
-    cy.url().should("include", "current=2");
+    cy.url().should("include", "currentPage=2");
 
     cy.wait("@getSecondPagePosts").then((interception) => {
       const { request } = interception;

--- a/cypress/e2e/inferencer-chakra-ui/all.cy.ts
+++ b/cypress/e2e/inferencer-chakra-ui/all.cy.ts
@@ -313,7 +313,7 @@ describe("inferencer-chakra-ui", () => {
 
     cy.get("button").contains(1).click();
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
 
     cy.wait("@getBlogPosts").then((interception) => {
       const { request } = interception;

--- a/cypress/e2e/inferencer-graphql-hasura/all.cy.ts
+++ b/cypress/e2e/inferencer-graphql-hasura/all.cy.ts
@@ -84,7 +84,7 @@ describe("inferencer-antd", () => {
       cy.get("#content").should("have.value", data?.content);
       cy.fixture("hasura-categories").then((categories) => {
         const category = categories.data.categories.find(
-          (category) => category.id === data?.category_id,
+          (category: any) => category.id === data?.category_id,
         );
         cy.get(`.ant-select-selection-item[title="${category?.title}"]`).should(
           "exist",
@@ -174,7 +174,7 @@ describe("inferencer-antd", () => {
 
     cy.getAntdPaginationItem(2).click();
     cy.wait("@getSecondPagePosts");
-    cy.url().should("include", "current=2");
+    cy.url().should("include", "currentPage=2");
 
     cy.get(".ant-pagination-prev").first().click();
     cy.wait("@getFirstPagePosts");

--- a/cypress/e2e/inferencer-graphql-hasura/all.cy.ts
+++ b/cypress/e2e/inferencer-graphql-hasura/all.cy.ts
@@ -178,6 +178,6 @@ describe("inferencer-antd", () => {
 
     cy.get(".ant-pagination-prev").first().click();
     cy.wait("@getFirstPagePosts");
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
   });
 });

--- a/cypress/e2e/inferencer-headless/all.cy.ts
+++ b/cypress/e2e/inferencer-headless/all.cy.ts
@@ -189,7 +189,7 @@ describe("inferencer-headless", () => {
 
     cy.get("button").contains("<").click();
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
 
     cy.wait("@getFirstPagePosts");
   });

--- a/cypress/e2e/inferencer-headless/all.cy.ts
+++ b/cypress/e2e/inferencer-headless/all.cy.ts
@@ -170,7 +170,7 @@ describe("inferencer-headless", () => {
 
     cy.get("button").contains(">").click();
 
-    cy.url().should("include", "current=2");
+    cy.url().should("include", "currentPage=2");
 
     cy.wait("@getSecondPagePosts");
 

--- a/cypress/e2e/inferencer-mantine/all.cy.ts
+++ b/cypress/e2e/inferencer-mantine/all.cy.ts
@@ -273,7 +273,7 @@ describe("inferencer-mantine", () => {
     cy.getMantineLoadingOverlay().should("not.exist");
 
     cy.get(".mantine-Pagination-item").contains("2").click();
-    cy.url().should("include", "current=2");
+    cy.url().should("include", "currentPage=2");
     cy.getMantineLoadingOverlay().should("not.exist");
     cy.wait("@getBlogPosts").then((interception) => {
       const { request } = interception;

--- a/cypress/e2e/inferencer-mantine/all.cy.ts
+++ b/cypress/e2e/inferencer-mantine/all.cy.ts
@@ -285,7 +285,7 @@ describe("inferencer-mantine", () => {
 
     cy.get(".mantine-Pagination-item").contains("1").click();
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
 
     cy.wait("@getBlogPosts").then((interception) => {
       const { request } = interception;

--- a/cypress/e2e/inferencer-material-ui/all.cy.ts
+++ b/cypress/e2e/inferencer-material-ui/all.cy.ts
@@ -317,7 +317,7 @@ describe("inferencer-material-ui", () => {
 
     cy.get("[title='Go to previous page']").click();
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
 
     cy.wait("@getFirstPagePosts");
   });

--- a/cypress/e2e/inferencer-material-ui/all.cy.ts
+++ b/cypress/e2e/inferencer-material-ui/all.cy.ts
@@ -312,7 +312,7 @@ describe("inferencer-material-ui", () => {
     ).as("getSecondPagePosts");
 
     cy.get("[title='Go to next page']").click();
-    cy.url().should("include", "current=2");
+    cy.url().should("include", "currentPage=2");
     cy.wait("@getSecondPagePosts");
 
     cy.get("[title='Go to previous page']").click();

--- a/cypress/e2e/table-antd-use-table/all.cy.ts
+++ b/cypress/e2e/table-antd-use-table/all.cy.ts
@@ -98,7 +98,7 @@ describe("table-antd-use-table", () => {
 
     cy.getAntdPaginationItem(2).click();
 
-    cy.url().should("include", "current=2");
+    cy.url().should("include", "currentPage=2");
 
     cy.wait("@getSecondPagePosts");
 

--- a/cypress/e2e/table-antd-use-table/all.cy.ts
+++ b/cypress/e2e/table-antd-use-table/all.cy.ts
@@ -117,7 +117,7 @@ describe("table-antd-use-table", () => {
 
     cy.get(".ant-pagination-prev").first().click();
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
 
     cy.wait("@getFirstPagePosts");
   });
@@ -135,6 +135,6 @@ describe("table-antd-use-table", () => {
 
     cy.get(".ant-btn-primary").click();
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
   });
 });

--- a/cypress/e2e/table-chakra-ui-basic/all.cy.ts
+++ b/cypress/e2e/table-chakra-ui-basic/all.cy.ts
@@ -118,7 +118,7 @@ describe("table-chakra-ui-basic", () => {
 
     cy.get("#prev-page").click();
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
 
     cy.wait("@getPosts").then((interception) => {
       const { request } = interception;
@@ -138,6 +138,6 @@ describe("table-chakra-ui-basic", () => {
     cy.get("#title").type("lorem");
     cy.get(".tabler-icon-check").click();
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
   });
 });

--- a/cypress/e2e/table-chakra-ui-basic/all.cy.ts
+++ b/cypress/e2e/table-chakra-ui-basic/all.cy.ts
@@ -106,7 +106,7 @@ describe("table-chakra-ui-basic", () => {
 
     cy.get("#next-page").click();
 
-    cy.url().should("include", "current=2");
+    cy.url().should("include", "currentPage=2");
 
     cy.wait("@getSecondPagePosts").then((interception) => {
       const { request } = interception;

--- a/cypress/e2e/table-mantine-basic/all.cy.ts
+++ b/cypress/e2e/table-mantine-basic/all.cy.ts
@@ -103,7 +103,7 @@ describe("table-mantine-basic", () => {
 
     cy.get(".mantine-Pagination-item").contains("1").click();
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
 
     cy.wait("@getPosts").then((interception) => {
       const { request } = interception;
@@ -123,6 +123,6 @@ describe("table-mantine-basic", () => {
     cy.get("#title").type("lorem");
     cy.get(".tabler-icon-check").click();
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
   });
 });

--- a/cypress/e2e/table-mantine-basic/all.cy.ts
+++ b/cypress/e2e/table-mantine-basic/all.cy.ts
@@ -91,7 +91,7 @@ describe("table-mantine-basic", () => {
   it("should work with pagination", () => {
     cy.get(".mantine-Pagination-item").contains("2").click();
 
-    cy.url().should("include", "current=2");
+    cy.url().should("include", "currentPage=2");
 
     cy.wait("@getPosts").then((interception) => {
       const { request } = interception;

--- a/cypress/e2e/table-material-ui-cursor-pagination/all.cy.ts
+++ b/cypress/e2e/table-material-ui-cursor-pagination/all.cy.ts
@@ -21,7 +21,7 @@ describe("table-material-ui-cursor-pagination", () => {
     cy.get("[title='Go to next page']").should("not.be.disabled");
     cy.get("[title='Go to next page']").click();
 
-    cy.url().should("include", "current=2");
+    cy.url().should("include", "currentPage=2");
 
     cy.wait("@getSecondPageCommits");
 

--- a/cypress/e2e/table-material-ui-cursor-pagination/all.cy.ts
+++ b/cypress/e2e/table-material-ui-cursor-pagination/all.cy.ts
@@ -36,7 +36,7 @@ describe("table-material-ui-cursor-pagination", () => {
     cy.get("[title='Go to previous page']").should("not.be.disabled");
     cy.get("[title='Go to previous page']").click();
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
 
     cy.wait("@getFirstPageCommits");
   });

--- a/cypress/e2e/table-material-ui-use-data-grid/all.cy.ts
+++ b/cypress/e2e/table-material-ui-use-data-grid/all.cy.ts
@@ -120,7 +120,7 @@ describe("table-material-ui-use-data-grid", () => {
 
     cy.get("[title='Go to previous page']").click();
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
 
     cy.wait("@getFirstPagePosts");
   });
@@ -156,7 +156,7 @@ describe("table-material-ui-use-data-grid", () => {
 
     cy.get("[placeholder='Filter value']").type("lorem");
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
   });
 
   it("should update a cell", () => {

--- a/cypress/e2e/table-material-ui-use-data-grid/all.cy.ts
+++ b/cypress/e2e/table-material-ui-use-data-grid/all.cy.ts
@@ -101,7 +101,7 @@ describe("table-material-ui-use-data-grid", () => {
 
     cy.get("[title='Go to next page']").click();
 
-    cy.url().should("include", "current=2");
+    cy.url().should("include", "currentPage=2");
 
     cy.wait("@getSecondPagePosts");
 

--- a/cypress/e2e/table-react-table-basic/all.cy.ts
+++ b/cypress/e2e/table-react-table-basic/all.cy.ts
@@ -125,7 +125,7 @@ describe("table-react-table-basic", () => {
 
     cy.get("#previous-button").click();
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
 
     cy.wait("@getFirstPagePosts");
   });
@@ -137,6 +137,6 @@ describe("table-react-table-basic", () => {
 
     cy.get("#title").type("lorem");
 
-    cy.url().should("include", "current=1");
+    cy.url().should("include", "currentPage=1");
   });
 });

--- a/cypress/e2e/table-react-table-basic/all.cy.ts
+++ b/cypress/e2e/table-react-table-basic/all.cy.ts
@@ -106,7 +106,7 @@ describe("table-react-table-basic", () => {
 
     cy.get("#next-button").click();
 
-    cy.url().should("include", "current=2");
+    cy.url().should("include", "currentPage=2");
 
     cy.wait("@getSecondPagePosts");
 

--- a/documentation/blog/2023-03-03-ra-chakra-tutorial.md
+++ b/documentation/blog/2023-03-03-ra-chakra-tutorial.md
@@ -641,7 +641,7 @@ export const PostList = () => {
     getRowModel,
     setOptions,
     // highlight-next-line
-    refineCore: { current, pageCount, setCurrent },
+    refineCore: { currentPage: current, pageCount, setCurrentPage: setCurrent },
   } = useTable({
     columns,
     refineCoreProps: {

--- a/documentation/docs/core/interface-references/index.md
+++ b/documentation/docs/core/interface-references/index.md
@@ -391,7 +391,7 @@ type ResourceAuditLogPermissions = "create" | "update" | "delete" | string;
 
 ```tsx
 type SyncWithLocationParams = {
-  pagination: { current?: number; pageSize?: number };
+  pagination: { currentPage?: number; pageSize?: number };
   sorters: CrudSorting;
   filters: CrudFilters;
 };

--- a/documentation/docs/data/hooks/use-infinite-list/index.md
+++ b/documentation/docs/data/hooks/use-infinite-list/index.md
@@ -25,7 +25,7 @@ Here is a basic example of how to use the `useInfiniteList` hook.
 
 The `useInfiniteList` hook supports pagination properties just like [`useList`](/docs/data/hooks/use-list). To handle pagination, the `useInfiniteList` hook passes the `pagination` property to the `getList` method from the `dataProvider`.
 
-Dynamically changing the `pagination` properties will trigger a new request. The `fetchNextPage` method will increase the `pagination.current` property by one and trigger a new request as well.
+Dynamically changing the `pagination` properties will trigger a new request. The `fetchNextPage` method will increase the `pagination.currentPage` property by one and trigger a new request as well.
 
 ### Retrieving the Total Row Count
 
@@ -44,7 +44,7 @@ import { useInfiniteList } from "@refinedev/core";
 
 const postListQueryResult = useInfiniteList({
   resource: "posts",
-  pagination: { current: 3, pageSize: 8 },
+  pagination: { currentPage: 3, pageSize: 8 },
 });
 ```
 

--- a/documentation/docs/data/hooks/use-table/index.md
+++ b/documentation/docs/data/hooks/use-table/index.md
@@ -34,7 +34,7 @@ In basic usage, `useTable` returns the data as it comes from the endpoint. By de
 
 It also syncs the pagination state with the URL if you enable the [`syncWithLocation`](#syncwithlocation).
 
-By default, the `current` is 1 and the `pageSize` is 10. You can change default values by passing the `pagination.current` and `pagination.pageSize` props to the `useTable` hook.
+By default, the `current` is 1 and the `pageSize` is 10. You can change default values by passing the `pagination.currentPage` and `pagination.pageSize` props to the `useTable` hook.
 
 You can also change the `current` and `pageSize` values by using the `setCurrent` and `setPageSize` functions that are returned by the `useTable` hook. Every change will trigger a new fetch.
 
@@ -147,7 +147,7 @@ useTable({
 });
 ```
 
-### pagination.current
+### pagination.currentPage
 
 Sets the initial value of the page index. Defaults to `1`.
 

--- a/documentation/docs/guides-concepts/tables/example/core.tsx
+++ b/documentation/docs/guides-concepts/tables/example/core.tsx
@@ -44,11 +44,11 @@ export default function App() {
 
 export const ProductTableTsxCode = `
 import React from "react";
-import { useTable, pageCount, pageSize, current, setCurrent } from "@refinedev/core";
+import { useTable, pageCount, pageSize, currentPage, setCurrentPage } from "@refinedev/core";
 
 
 export const ProductTable: React.FC = () => {
-    const { tableQuery, pageCount, pageSize, current, setCurrent } = useTable<IProduct>({
+    const { tableQuery, pageCount, pageSize, currentPage, setCurrentPage } = useTable<IProduct>({
         resource: "products",
         pagination: {
             current: 1, 
@@ -83,21 +83,21 @@ export const ProductTable: React.FC = () => {
                 </tbody>
             </table>
             <hr />
-            <p>Current Page: {current}</p>
+            <p>Current Page: {currentPage}</p>
             <p>Page Size: {pageSize}</p>
             <button
               onClick={() => {
-                setCurrent(current - 1);
+                setCurrentPage(currentPage - 1);
               }}
-              disabled={current < 2}
+              disabled={currentPage < 2}
             >
               Previous Page
             </button>
             <button
               onClick={() => {
-                setCurrent(current + 1);
+                setCurrentPage(currentPage + 1);
               }}
-              disabled={current === pageCount}
+              disabled={currentPage === pageCount}
             >
               Next Page
             </button>

--- a/documentation/docs/guides-concepts/tables/example/pagination.tsx
+++ b/documentation/docs/guides-concepts/tables/example/pagination.tsx
@@ -47,7 +47,7 @@ import React from "react";
 import { useTable } from "@refinedev/core";
 
 export const ProductTable: React.FC = () => {
-  const { tableQuery, pageCount, pageSize, current, setCurrent } = useTable<IProduct>({
+  const { tableQuery, pageCount, pageSize, currentPage, setCurrentPage } = useTable<IProduct>({
     resource: "products",
     pagination: {
         current: 1, 
@@ -83,21 +83,21 @@ export const ProductTable: React.FC = () => {
         </tbody>
       </table>
       <hr />
-      <p>Current Page: {current}</p>
+      <p>Current Page: {currentPage}</p>
       <p>Page Size: {pageSize}</p>
       <button
         onClick={() => {
-          setCurrent(current - 1);
+          setCurrentPage(currentPage - 1);
         }}
-        disabled={current < 2}
+        disabled={currentPage < 2}
       >
         Previous Page
       </button>
       <button
         onClick={() => {
-          setCurrent(current + 1);
+          setCurrentPage(currentPage + 1);
         }}
-        disabled={current === pageCount}
+        disabled={currentPage === pageCount}
       >
         Next Page
       </button>

--- a/documentation/docs/migration-guide/4x-to-5x.md
+++ b/documentation/docs/migration-guide/4x-to-5x.md
@@ -365,10 +365,35 @@ useList({
 useTable({
 -    initialCurrent: 1,
 -    initialPageSize: 20,
-+    pagination: { current: 1, pageSize: 20 },
 -    hasPagination: false,
-+    pagination: { mode: "off" },
++    pagination: { mode: "off", currentPage: 1, pageSize: 20 },
 })
+```
+
+#### pagination.current -> pagination.currentPage
+
+🚨 Affects: useTable, useDataGrid, useSimpleList, useSubscription, useList, useCheckboxGroup, useSelect
+
+```diff
+useTable({
+-   pagination: { current: 1 },
++   pagination: { currentPage: 1 },
+})
+```
+
+#### setCurrent -> setCurrentPage
+
+🚨 Affects: useTable, useDataGrid, useSimpleList
+
+The `setCurrent` function has been renamed to `setCurrentPage`:
+
+```diff
+const {
+-    setCurrent,
+-    current,
++    currentPage,
++    setCurrentPage,
+} = useTable();
 ```
 
 #### Resource options → meta
@@ -414,14 +439,14 @@ The config parameter has been flattened in data hooks:
 ```diff
 useList({
 -    config: {
--        pagination: { current: 1, pageSize: 10 },
+-        pagination: { currentPage: 1, pageSize: 10 },
 -        sorters: [{ field: "title", order: "asc" }],
 -        filters: [{ field: "status", operator: "eq", value: "published" }],
 -        hasPagination: false,
 -        sort: [{ field: "title", order: "asc" }],
 -        metaData: { foo: "bar" },
 -    },
-+    pagination: { current: 1, pageSize: 10, mode: "off" },
++    pagination: { currentPage: 1, pageSize: 10, mode: "off" },
 +    sorters: [{ field: "title", order: "asc" }],
 +    filters: [{ field: "status", operator: "eq", value: "published" }],
 +    meta: { foo: "bar" },
@@ -438,7 +463,10 @@ The `useTable` hook and its UI variants (`useDataGrid` from @refinedev/mui, `use
 useTable({
 -    initialCurrent: 1,
 -    initialPageSize: 10,
-+    pagination: { current: 1, pageSize: 10 },
+-    hasPagination: false,
++    pagination: { currentPage: 1, pageSize: 10 , mode: "off" },
+-    setCurrent,
++    setCurrentPage,
 
 -    initialSorter: [{ field: "title", order: "asc" }],
 -    permanentSorter: [{ field: "status", order: "asc" }],
@@ -456,8 +484,6 @@ useTable({
 +        defaultBehavior: "replace"
 +    },
 
--    hasPagination: false,
-+    pagination: { mode: "off" },
 })
 
 // Return values also changed
@@ -465,6 +491,8 @@ const {
 -    sorter,
 -    setSorter,
 -    tableQueryResult,
+-    current,
++    currentPage,
 +    sorters,
 +    setSorters,
 +    tableQuery,

--- a/documentation/docs/packages/tanstack-table/use-table/index.md
+++ b/documentation/docs/packages/tanstack-table/use-table/index.md
@@ -146,7 +146,7 @@ useTable({
 });
 ```
 
-### pagination.current
+### pagination.currentPage
 
 Sets the initial value of the page index. Default value is `1`.
 
@@ -154,7 +154,7 @@ Sets the initial value of the page index. Default value is `1`.
 useTable({
   refineCoreProps: {
     pagination: {
-      current: 2,
+      currentPage: 2,
     },
   },
 });

--- a/documentation/docs/routing/integrations/next-js/index.md
+++ b/documentation/docs/routing/integrations/next-js/index.md
@@ -1040,7 +1040,7 @@ export default async function ProductList() {
 async function getData() {
   const response = await dataProvider(API_URL).getList({
     resource: "posts",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
   });
 
   return {
@@ -1147,7 +1147,7 @@ type GetDataParams = {
 
 async function getData(
   params: GetDataParams = {
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     filters: [],
   },
 ) {

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-checkbox-group/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-checkbox-group/index.md
@@ -247,7 +247,7 @@ For example, lets say that we have 1000 post records:
 const { selectProps } = useCheckboxGroup({
   resource: "categories",
   // highlight-next-line
-  pagination: { current: 3, pageSize: 8 },
+  pagination: { currentPage: 3, pageSize: 8 },
 });
 ```
 

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-radio-group/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-radio-group/index.md
@@ -246,7 +246,7 @@ For example, lets say that we have 1000 post records:
 const { radioGroupProps } = useRadioGroup({
   resource: "categories",
   // highlight-next-line
-  pagination: { current: 3, pageSize: 8 },
+  pagination: { currentPage: 3, pageSize: 8 },
 });
 ```
 

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-simple-list/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-simple-list/index.md
@@ -137,7 +137,7 @@ If you have multiple resources with the same name, you can pass the `identifier`
 
 > For more information, refer to the [`identifier` of the `<Refine/>` component documentation &#8594](/docs/core/refine-component#identifier)
 
-### pagination.current
+### pagination.currentPage
 
 Sets the initial value of the page index. It is `1` by default.
 

--- a/documentation/docs/ui-integrations/ant-design/hooks/use-table/index.md
+++ b/documentation/docs/ui-integrations/ant-design/hooks/use-table/index.md
@@ -248,7 +248,7 @@ useTable({
 });
 ```
 
-### pagination.current
+### pagination.currentPage
 
 Sets the initial value of the page index. It is set to `1` by default.
 

--- a/documentation/docs/ui-integrations/material-ui/hooks/use-data-grid/index.md
+++ b/documentation/docs/ui-integrations/material-ui/hooks/use-data-grid/index.md
@@ -370,7 +370,7 @@ useDataGrid({
 });
 ```
 
-### pagination.current
+### pagination.currentPage
 
 Sets the initial value of the page index. Default value is `1`.
 

--- a/documentation/src/refine-theme/landing-hero-showcase-section.tsx
+++ b/documentation/src/refine-theme/landing-hero-showcase-section.tsx
@@ -487,7 +487,7 @@ const ShowcaseHR = ({ className }: { className?: string }) => {
                         const { data } = useList({
                           resource: "polls",
                           filters: [{ field: "status", operator: "eq", value: "active" }],
-                          pagination: { current: 1, pageSize: 1 },
+                          pagination: { currentPage: 1, pageSize: 1 },
                           liveMode: "auto",
                         });
                                 `,

--- a/documentation/tutorial/authentication/data-provider-integration/index.md
+++ b/documentation/tutorial/authentication/data-provider-integration/index.md
@@ -159,7 +159,7 @@ export const ListProducts = () => {
   } = useTable({
     // highlight-next-line
     resource: "protected-products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: { initial: [{ field: "id", order: "asc" }] },
   });
 

--- a/documentation/tutorial/authentication/data-provider-integration/sandpack.tsx
+++ b/documentation/tutorial/authentication/data-provider-integration/sandpack.tsx
@@ -39,8 +39,8 @@ export const dataProvider: DataProvider = {
     const params = new URLSearchParams();
 
     if (pagination) {
-      params.append("_start", (pagination.current - 1) * pagination.pageSize);
-      params.append("_end", pagination.current * pagination.pageSize);
+      params.append("_start", (pagination.currentPage - 1) * pagination.pageSize);
+      params.append("_end", pagination.currentPage * pagination.pageSize);
     }
 
     if (sorters && sorters.length > 0) {
@@ -146,7 +146,7 @@ export const ListProducts = () => {
     setSorters,
   } = useTable({
     resource: "protected-products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: { initial: [{ field: "id", order: "asc" }] },
   });
 

--- a/documentation/tutorial/essentials/data-fetching/listing-data/index.md
+++ b/documentation/tutorial/essentials/data-fetching/listing-data/index.md
@@ -15,7 +15,7 @@ To list records using Refine's hooks, first we need to implement the [`getList`]
 The `getList` method accepts `resource`, `pagination`, `sorters`, `filters` and `meta` properties.
 
 - `resource` refers to the entity we're fetching.
-- `pagination` is an object containing the `current` and `pageSize` properties.
+- `pagination` is an object containing the `currentPage` and `pageSize` properties.
 - `sorters` is an array containing the sorters we're using.
 - `filters` is an array containing the filters we're using.
 - `meta` is an object containing any additional data passed to the hook.
@@ -148,8 +148,11 @@ export const dataProvider: DataProvider = {
     const params = new URLSearchParams();
 
     if (pagination) {
-      params.append("_start", (pagination.current - 1) * pagination.pageSize);
-      params.append("_end", pagination.current * pagination.pageSize);
+      params.append(
+        "_start",
+        (pagination.currentPage - 1) * pagination.pageSize,
+      );
+      params.append("_end", pagination.currentPage * pagination.pageSize);
     }
 
     const response = await fetch(`${API_URL}/${resource}?${params.toString()}`);
@@ -181,7 +184,7 @@ export const ListProducts = () => {
   const { data, isLoading } = useList({
     resource: "products",
     // highlight-next-line
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
   });
 
   if (isLoading) {
@@ -222,8 +225,11 @@ export const dataProvider: DataProvider = {
     const params = new URLSearchParams();
 
     if (pagination) {
-      params.append("_start", (pagination.current - 1) * pagination.pageSize);
-      params.append("_end", pagination.current * pagination.pageSize);
+      params.append(
+        "_start",
+        (pagination.currentPage - 1) * pagination.pageSize,
+      );
+      params.append("_end", pagination.currentPage * pagination.pageSize);
     }
 
     // highlight-start
@@ -260,7 +266,7 @@ import { useList } from "@refinedev/core";
 export const ListProducts = () => {
   const { data, isLoading } = useList({
     resource: "products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     // highlight-next-line
     sorters: [{ field: "name", order: "asc" }],
   });
@@ -307,8 +313,11 @@ export const dataProvider: DataProvider = {
     const params = new URLSearchParams();
 
     if (pagination) {
-      params.append("_start", (pagination.current - 1) * pagination.pageSize);
-      params.append("_end", pagination.current * pagination.pageSize);
+      params.append(
+        "_start",
+        (pagination.currentPage - 1) * pagination.pageSize,
+      );
+      params.append("_end", pagination.currentPage * pagination.pageSize);
     }
 
     if (sorters && sorters.length > 0) {
@@ -354,7 +363,7 @@ import { useList } from "@refinedev/core";
 export const ListProducts = () => {
   const { data, isLoading } = useList({
     resource: "products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: [{ field: "name", order: "asc" }],
     // highlight-next-line
     filters: [{ field: "material", operator: "eq", value: "Aluminum" }],

--- a/documentation/tutorial/essentials/data-fetching/listing-data/sandpack.tsx
+++ b/documentation/tutorial/essentials/data-fetching/listing-data/sandpack.tsx
@@ -80,8 +80,8 @@ export const dataProvider: DataProvider = {
     const params = new URLSearchParams();
 
     if (pagination) {
-        params.append("_start", (pagination.current - 1) * pagination.pageSize);
-        params.append("_end", pagination.current * pagination.pageSize);
+        params.append("_start", (pagination.currentPage - 1) * pagination.pageSize);
+        params.append("_end", pagination.currentPage * pagination.pageSize);
     }
 
     const response = await fetch(\`\${API_URL}/\${resource}?\${params.toString()}\`);
@@ -135,8 +135,8 @@ export const dataProvider: DataProvider = {
     const params = new URLSearchParams();
 
     if (pagination) {
-      params.append("_start", (pagination.current - 1) * pagination.pageSize);
-      params.append("_end", pagination.current * pagination.pageSize);
+      params.append("_start", (pagination.currentPage - 1) * pagination.pageSize);
+      params.append("_end", pagination.currentPage * pagination.pageSize);
     }
 
     if (sorters && sorters.length > 0) {
@@ -195,8 +195,8 @@ export const dataProvider: DataProvider = {
     const params = new URLSearchParams();
 
     if (pagination) {
-      params.append("_start", (pagination.current - 1) * pagination.pageSize);
-      params.append("_end", pagination.current * pagination.pageSize);
+      params.append("_start", (pagination.currentPage - 1) * pagination.pageSize);
+      params.append("_end", pagination.currentPage * pagination.pageSize);
     }
 
     if (sorters && sorters.length > 0) {
@@ -301,7 +301,7 @@ import { useList } from "@refinedev/core";
 export const ListProducts = () => {
   const { data, isLoading } = useList({
     resource: "products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
   });
 
   if (isLoading) {
@@ -335,7 +335,7 @@ import { useList } from "@refinedev/core";
 export const ListProducts = () => {
   const { data, isLoading } = useList({
     resource: "products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: [{ field: "name", order: "asc" }],
   });
 
@@ -370,7 +370,7 @@ import { useList } from "@refinedev/core";
 export const ListProducts = () => {
   const { data, isLoading } = useList({
     resource: "products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: [{ field: "name", order: "asc" }],
     filters: [{ field: "material", operator: "eq", value: "Aluminum" }],
   });

--- a/documentation/tutorial/essentials/forms/sandpack.tsx
+++ b/documentation/tutorial/essentials/forms/sandpack.tsx
@@ -89,8 +89,8 @@ export const dataProvider: DataProvider = {
     const params = new URLSearchParams();
 
     if (pagination) {
-      params.append("_start", (pagination.current - 1) * pagination.pageSize);
-      params.append("_end", pagination.current * pagination.pageSize);
+      params.append("_start", (pagination.currentPage - 1) * pagination.pageSize);
+      params.append("_end", pagination.currentPage * pagination.pageSize);
     }
 
     if (sorters && sorters.length > 0) {

--- a/documentation/tutorial/essentials/tables/index.md
+++ b/documentation/tutorial/essentials/tables/index.md
@@ -61,7 +61,7 @@ export const ListProducts = () => {
     tableQuery: { data, isLoading },
   } = useTable({
     resource: "products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: { initial: [{ field: "id", order: "asc" }] },
   });
   // highlight-end
@@ -119,7 +119,7 @@ export const ListProducts = () => {
     tableQuery: { data, isLoading },
   } = useTable({
     resource: "products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: { initial: [{ field: "id", order: "asc" }] },
   });
 
@@ -254,8 +254,11 @@ export const dataProvider: DataProvider = {
     const params = new URLSearchParams();
 
     if (pagination) {
-      params.append("_start", (pagination.current - 1) * pagination.pageSize);
-      params.append("_end", pagination.current * pagination.pageSize);
+      params.append(
+        "_start",
+        (pagination.currentPage - 1) * pagination.pageSize,
+      );
+      params.append("_end", pagination.currentPage * pagination.pageSize);
     }
 
     if (sorters && sorters.length > 0) {
@@ -326,7 +329,7 @@ export const ListProducts = () => {
     // highlight-end
   } = useTable({
     resource: "products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: { initial: [{ field: "id", order: "asc" }] },
   });
 
@@ -441,7 +444,7 @@ export const ListProducts = () => {
     // highlight-end
   } = useTable({
     resource: "products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: { initial: [{ field: "id", order: "asc" }] },
   });
 

--- a/documentation/tutorial/essentials/tables/sandpack.tsx
+++ b/documentation/tutorial/essentials/tables/sandpack.tsx
@@ -118,7 +118,7 @@ import { useTable } from "@refinedev/core";
 export const ListProducts = () => {
   const { tableQuery: { data, isLoading } } = useTable({
     resource: "products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: { initial: [{ field: "id", order: "asc" }] },
   });
 
@@ -164,7 +164,7 @@ export const ListProducts = () => {
     tableQuery: { data, isLoading },
   } = useTable({
     resource: "products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: { initial: [{ field: "id", order: "asc" }] },
   });
 
@@ -279,8 +279,8 @@ export const dataProvider: DataProvider = {
     const params = new URLSearchParams();
 
     if (pagination) {
-      params.append("_start", (pagination.current - 1) * pagination.pageSize);
-      params.append("_end", pagination.current * pagination.pageSize);
+      params.append("_start", (pagination.currentPage - 1) * pagination.pageSize);
+      params.append("_end", pagination.currentPage * pagination.pageSize);
     }
 
     if (sorters && sorters.length > 0) {
@@ -324,8 +324,8 @@ export const dataProvider: DataProvider = {
     const params = new URLSearchParams();
 
     if (pagination) {
-      params.append("_start", (pagination.current - 1) * pagination.pageSize);
-      params.append("_end", pagination.current * pagination.pageSize);
+      params.append("_start", (pagination.currentPage - 1) * pagination.pageSize);
+      params.append("_end", pagination.currentPage * pagination.pageSize);
     }
 
     if (sorters && sorters.length > 0) {
@@ -428,7 +428,7 @@ export const ListProducts = () => {
     pageCount,
   } = useTable({
     resource: "products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: { initial: [{ field: "id", order: "asc" }] },
   });
 
@@ -519,7 +519,7 @@ export const ListProducts = () => {
     setSorters,
   } = useTable({
     resource: "products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: { initial: [{ field: "id", order: "asc" }] },
   });
 

--- a/documentation/tutorial/routing/inferring-parameters/react-router/index.md
+++ b/documentation/tutorial/routing/inferring-parameters/react-router/index.md
@@ -36,7 +36,7 @@ export const ListProducts = () => {
   } = useTable({
     // removed-line
     resource: "products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: { initial: [{ field: "id", order: "asc" }] },
   });
 

--- a/documentation/tutorial/routing/navigation/react-router/index.md
+++ b/documentation/tutorial/routing/navigation/react-router/index.md
@@ -80,7 +80,7 @@ export const ListProducts = () => {
     setSorters,
   } = useTable({
     resource: "protected-products",
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: { initial: [{ field: "id", order: "asc" }] },
   });
 

--- a/documentation/tutorial/routing/syncing-state/react-router/index.md
+++ b/documentation/tutorial/routing/syncing-state/react-router/index.md
@@ -28,7 +28,7 @@ export const ListProducts = () => {
     sorters,
     setSorters,
   } = useTable({
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
     sorters: { initial: [{ field: "id", order: "asc" }] },
     // highlight-next-line
     syncWithLocation: true,

--- a/examples/auth-chakra-ui/src/pages/posts/list.tsx
+++ b/examples/auth-chakra-ui/src/pages/posts/list.tsx
@@ -127,9 +127,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/auth-mantine/src/pages/posts/list.tsx
+++ b/examples/auth-mantine/src/pages/posts/list.tsx
@@ -108,9 +108,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/base-chakra-ui/src/pages/posts/list.tsx
+++ b/examples/base-chakra-ui/src/pages/posts/list.tsx
@@ -127,9 +127,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/base-mantine/src/pages/posts/list.tsx
+++ b/examples/base-mantine/src/pages/posts/list.tsx
@@ -108,9 +108,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/blog-ecommerce/pages/index.tsx
+++ b/examples/blog-ecommerce/pages/index.tsx
@@ -16,8 +16,8 @@ export const ProductList: React.FC<ItemProps> = ({ products, stores }) => {
   const {
     tableQuery: tableQueryResult,
     setFilters,
-    current,
-    setCurrent,
+    currentPage,
+    setCurrentPage,
     pageSize,
   } = useTable<IProduct>({
     resource: "products",
@@ -97,14 +97,14 @@ export const ProductList: React.FC<ItemProps> = ({ products, stores }) => {
 
       <Flex justify={"flex-end"} mt={4} mb={4} gap={2}>
         {Array.from(Array(totalPageCount), (e, i) => {
-          if (current > totalPageCount) {
-            setCurrent(i);
+          if (currentPage > totalPageCount) {
+            setCurrentPage(i);
           }
           return (
             <Button
               key={i}
               colorScheme={"teal"}
-              onClick={() => setCurrent(i + 1)}
+              onClick={() => setCurrentPage(i + 1)}
             >
               {i + 1}
             </Button>
@@ -121,7 +121,7 @@ export const getServerSideProps: GetServerSideProps = async () => {
   const data = await DataProvider(`${API_URL}/api`).getList<IProduct>({
     resource: "products",
     meta: { populate: ["image"] },
-    pagination: { current: 1, pageSize: 9 },
+    pagination: { currentPage: 1, pageSize: 9 },
   });
 
   const { data: storesData } =

--- a/examples/blog-ra-chakra-tutorial/src/pages/posts/list.tsx
+++ b/examples/blog-ra-chakra-tutorial/src/pages/posts/list.tsx
@@ -85,7 +85,7 @@ export const PostList = () => {
     getHeaderGroups,
     getRowModel,
     setOptions,
-    refineCore: { current, pageCount, setCurrent },
+    refineCore: { currentPage: current, pageCount, setCurrentPage: setCurrent },
   } = useTable({
     columns,
 

--- a/examples/blog-react-dnd/src/components/constants/useData.ts
+++ b/examples/blog-react-dnd/src/components/constants/useData.ts
@@ -11,7 +11,7 @@ function useData() {
     resource: "products",
 
     pagination: {
-      current: 2,
+      currentPage: 2,
     },
   });
 

--- a/examples/blog-refine-daisyui/src/components/dashboard/RecentSales.tsx
+++ b/examples/blog-refine-daisyui/src/components/dashboard/RecentSales.tsx
@@ -93,7 +93,7 @@ export const RecentSales = () => {
   );
 
   const {
-    refineCore: { filters, setCurrent, setFilters },
+    refineCore: { filters, setCurrentPage: setCurrent, setFilters },
     getHeaderGroups,
     getRowModel,
   } = useTable({

--- a/examples/blog-refine-daisyui/src/pages/categories/list.tsx
+++ b/examples/blog-refine-daisyui/src/pages/categories/list.tsx
@@ -84,7 +84,7 @@ export const CategoryList = () => {
   const {
     getHeaderGroups,
     getRowModel,
-    refineCore: { setCurrent, filters, setFilters },
+    refineCore: { setCurrentPage: setCurrent, filters, setFilters },
     getState,
     setPageIndex,
     getCanPreviousPage,

--- a/examples/blog-refine-daisyui/src/pages/products/list.tsx
+++ b/examples/blog-refine-daisyui/src/pages/products/list.tsx
@@ -94,7 +94,7 @@ export const ProductList = () => {
   const {
     getHeaderGroups,
     getRowModel,
-    refineCore: { filters, setCurrent, setFilters },
+    refineCore: { filters, setCurrentPage: setCurrent, setFilters },
     getState,
     setPageIndex,
     getCanPreviousPage,

--- a/examples/blog-refine-mantine-strapi/src/pages/posts/list.tsx
+++ b/examples/blog-refine-mantine-strapi/src/pages/posts/list.tsx
@@ -65,7 +65,7 @@ export const PostList: React.FC = () => {
   const {
     getHeaderGroups,
     getRowModel,
-    refineCore: { setCurrent, pageCount, current },
+    refineCore: { setCurrentPage: setCurrent, pageCount, currentPage: current },
   } = useTable({
     columns,
 

--- a/examples/blog-refine-mui/src/components/recent-sales/index.tsx
+++ b/examples/blog-refine-mui/src/components/recent-sales/index.tsx
@@ -14,14 +14,18 @@ import { getDefaultFilter } from "@refinedev/core";
 import type { IOrder, IOrderStatus } from "../../interfaces";
 
 export function RecentSales() {
-  const { dataGridProps, setCurrent, setFilters, filters } =
-    useDataGrid<IOrder>({
-      resource: "orders",
+  const {
+    dataGridProps,
+    setCurrentPage: setCurrent,
+    setFilters,
+    filters,
+  } = useDataGrid<IOrder>({
+    resource: "orders",
 
-      pagination: {
-        pageSize: 5,
-      },
-    });
+    pagination: {
+      pageSize: 5,
+    },
+  });
 
   const currencyFormatter = new Intl.NumberFormat("en-US", {
     style: "currency",

--- a/examples/blog-refine-nextui/src/components/table/RecentSalesTable.tsx
+++ b/examples/blog-refine-nextui/src/components/table/RecentSalesTable.tsx
@@ -66,11 +66,11 @@ export const RecentSalesTable = () => {
   const {
     tableQuery: tableQueryResult,
     pageCount,
-    current,
+    currentPage: current,
     pageSize,
     sorters,
     filters,
-    setCurrent,
+    setCurrentPage: setCurrent,
     setPageSize,
     setSorters,
     setFilters,

--- a/examples/blog-refine-nextui/src/pages/categories/list.tsx
+++ b/examples/blog-refine-nextui/src/pages/categories/list.tsx
@@ -46,10 +46,10 @@ export const CategoryList = () => {
   const {
     tableQuery: tableQueryResult,
     pageCount,
-    current,
+    currentPage: current,
     pageSize,
     filters,
-    setCurrent,
+    setCurrentPage: setCurrent,
     setPageSize,
     setSorters,
     setFilters,

--- a/examples/blog-refine-nextui/src/pages/products/list.tsx
+++ b/examples/blog-refine-nextui/src/pages/products/list.tsx
@@ -51,10 +51,10 @@ export const ProductList = () => {
   const {
     tableQuery: tableQueryResult,
     pageCount,
-    current,
+    currentPage: current,
     pageSize,
     filters,
-    setCurrent,
+    setCurrentPage: setCurrent,
     setPageSize,
     setSorters,
     setFilters,

--- a/examples/blog-refine-primereact/src/components/dashboard/recentSales/index.tsx
+++ b/examples/blog-refine-primereact/src/components/dashboard/recentSales/index.tsx
@@ -13,11 +13,11 @@ export const RecentSales = () => {
   const {
     tableQuery: tableQueryResult,
     pageCount,
-    current,
+    currentPage: current,
     pageSize,
     sorters,
     filters,
-    setCurrent,
+    setCurrentPage: setCurrent,
     setPageSize,
     setSorters,
     setFilters,

--- a/examples/blog-refine-primereact/src/pages/categories/list.tsx
+++ b/examples/blog-refine-primereact/src/pages/categories/list.tsx
@@ -18,11 +18,11 @@ export const CategoryList = () => {
   const {
     tableQuery: tableQueryResult,
     pageCount,
-    current,
+    currentPage: current,
     pageSize,
     sorters,
     filters,
-    setCurrent,
+    setCurrentPage: setCurrent,
     setPageSize,
     setSorters,
     setFilters,

--- a/examples/blog-refine-primereact/src/pages/products/list.tsx
+++ b/examples/blog-refine-primereact/src/pages/products/list.tsx
@@ -26,11 +26,11 @@ export const ProductList = () => {
   const {
     tableQuery: tableQueryResult,
     pageCount,
-    current,
+    currentPage: current,
     pageSize,
     sorters,
     filters,
-    setCurrent,
+    setCurrentPage: setCurrent,
     setPageSize,
     setSorters,
     setFilters,

--- a/examples/customization-theme-chakra-ui/src/pages/posts/list.tsx
+++ b/examples/customization-theme-chakra-ui/src/pages/posts/list.tsx
@@ -127,9 +127,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/customization-theme-mantine/src/pages/posts/list.tsx
+++ b/examples/customization-theme-mantine/src/pages/posts/list.tsx
@@ -108,9 +108,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/field-antd-use-select-infinite/src/pages/posts/list.tsx
+++ b/examples/field-antd-use-select-infinite/src/pages/posts/list.tsx
@@ -37,7 +37,7 @@ export const PostList = () => {
     useSelect<ICategory>({
       resource: "categories",
       pagination: {
-        current: page,
+        currentPage: page,
         pageSize: 20,
         mode: "server",
       },

--- a/examples/finefoods-antd/src/components/dashboard/orderTimeline/index.tsx
+++ b/examples/finefoods-antd/src/components/dashboard/orderTimeline/index.tsx
@@ -42,7 +42,7 @@ export const OrderTimeline = ({ height = "432px" }: Props) => {
         },
       ],
       pagination: {
-        current: 1,
+        currentPage: 1,
         pageSize: 8,
       },
     });

--- a/examples/finefoods-antd/src/components/dashboard/trendingMenu/index.tsx
+++ b/examples/finefoods-antd/src/components/dashboard/trendingMenu/index.tsx
@@ -14,7 +14,7 @@ export const TrendingMenu: React.FC = () => {
   const //`useSimpleList` does not accept all of Ant Design's `List` component props anymore. You can directly use `List` component instead.,
     { listProps } = useSimpleList<ITrendingProducts>({
       resource: "trendingProducts",
-      pagination: { pageSize: 5, current: 1 },
+      pagination: { pageSize: 5, currentPage: 1 },
       syncWithLocation: false,
     });
 

--- a/examples/finefoods-antd/src/components/product/list-card/index.tsx
+++ b/examples/finefoods-antd/src/components/product/list-card/index.tsx
@@ -39,7 +39,7 @@ export const ProductListCard = () => {
       setFilters,
     } = useSimpleList<IProduct, HttpError>({
       pagination: {
-        current: 1,
+        currentPage: 1,
         pageSize: 12,
       },
       filters: {

--- a/examples/finefoods-client/src/app/categories/[id]/page.tsx
+++ b/examples/finefoods-client/src/app/categories/[id]/page.tsx
@@ -16,8 +16,8 @@ export default async function CategoryShowPage({
   const { products } = await getData({
     categoryId: params.id,
     productPaginationOptions: {
-      current: searchParams.current
-        ? Number(searchParams.current as string)
+      currentPage: searchParams.currentPage
+        ? Number(searchParams.currentPage as string)
         : 1,
     },
   });

--- a/examples/finefoods-material-ui/src/components/dashboard/orderTimeline/index.tsx
+++ b/examples/finefoods-material-ui/src/components/dashboard/orderTimeline/index.tsx
@@ -17,8 +17,8 @@ export const OrderTimeline: React.FC = () => {
 
   const {
     tableQuery: tableQueryResult,
-    current,
-    setCurrent,
+    currentPage: current,
+    setCurrentPage: setCurrent,
     pageCount,
   } = useTable<IOrder>({
     resource: "orders",

--- a/examples/finefoods-material-ui/src/components/product/list-card/index.tsx
+++ b/examples/finefoods-material-ui/src/components/product/list-card/index.tsx
@@ -67,7 +67,7 @@ export const ProductListCard = (props: Props) => {
         value: newFilters,
       },
     ]);
-    props.setCurrent(1);
+    props.setCurrentPage(1);
   };
 
   return (
@@ -88,7 +88,7 @@ export const ProductListCard = (props: Props) => {
                 value: [],
               },
             ]);
-            props.setCurrent(1);
+            props.setCurrentPage(1);
           }}
         />
         {props.categories.map((category) => {
@@ -257,7 +257,7 @@ export const ProductListCard = (props: Props) => {
           props.setPageSize(+e.target.value);
         }}
         onPageChange={(_e, page) => {
-          props.setCurrent(page + 1);
+          props.setCurrentPage(page + 1);
         }}
       />
     </>

--- a/examples/form-chakra-ui-mutation-mode/src/pages/posts/list.tsx
+++ b/examples/form-chakra-ui-mutation-mode/src/pages/posts/list.tsx
@@ -127,9 +127,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/form-chakra-ui-use-drawer-form/src/pages/posts/list.tsx
+++ b/examples/form-chakra-ui-use-drawer-form/src/pages/posts/list.tsx
@@ -133,9 +133,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/form-chakra-ui-use-form/src/pages/posts/list.tsx
+++ b/examples/form-chakra-ui-use-form/src/pages/posts/list.tsx
@@ -130,6 +130,7 @@ export const PostList: React.FC = () => {
       setCurrentPage,
       pageCount,
       currentPage,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/form-chakra-ui-use-form/src/pages/posts/list.tsx
+++ b/examples/form-chakra-ui-use-form/src/pages/posts/list.tsx
@@ -127,9 +127,9 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage,
       pageCount,
-      current,
+      currentPage,
       tableQuery: { data: tableData },
     },
   } = useTable({
@@ -206,9 +206,9 @@ export const PostList: React.FC = () => {
         </Table>
       </TableContainer>
       <Pagination
-        current={current}
+        current={currentPage}
         pageCount={pageCount}
-        setCurrent={setCurrent}
+        setCurrent={setCurrentPage}
       />
     </List>
   );

--- a/examples/form-chakra-use-modal-form/src/pages/posts/list.tsx
+++ b/examples/form-chakra-use-modal-form/src/pages/posts/list.tsx
@@ -132,9 +132,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/form-core-use-form/src/pages/posts/list.tsx
+++ b/examples/form-core-use-form/src/pages/posts/list.tsx
@@ -13,7 +13,7 @@ export const PostList: React.FC = () => {
     resource: "posts",
 
     pagination: {
-      current: page,
+      currentPage: page,
       pageSize: PAGE_SIZE,
     },
   });

--- a/examples/form-mantine-mutation-mode/src/pages/posts/list.tsx
+++ b/examples/form-mantine-mutation-mode/src/pages/posts/list.tsx
@@ -101,9 +101,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/form-mantine-use-drawer-form/src/pages/posts/list.tsx
+++ b/examples/form-mantine-use-drawer-form/src/pages/posts/list.tsx
@@ -154,9 +154,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/form-mantine-use-form/src/pages/posts/list.tsx
+++ b/examples/form-mantine-use-form/src/pages/posts/list.tsx
@@ -108,9 +108,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/form-mantine-use-modal-form/src/pages/posts/list.tsx
+++ b/examples/form-mantine-use-modal-form/src/pages/posts/list.tsx
@@ -154,9 +154,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/form-mantine-use-steps-form/src/pages/posts/list.tsx
+++ b/examples/form-mantine-use-steps-form/src/pages/posts/list.tsx
@@ -101,9 +101,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/form-material-ui-use-steps-form/src/pages/posts/edit.tsx
+++ b/examples/form-material-ui-use-steps-form/src/pages/posts/edit.tsx
@@ -26,7 +26,7 @@ const stepTitles = [
 export const PostEdit: React.FC = () => {
   const {
     saveButtonProps,
-    refineCore: { formLoading, queryResult, onFinish },
+    refineCore: { formLoading, query, onFinish },
     register,
     handleSubmit,
     control,
@@ -39,7 +39,7 @@ export const PostEdit: React.FC = () => {
 
   const { autocompleteProps } = useAutocomplete<ICategory>({
     resource: "categories",
-    defaultValue: queryResult?.data?.data.category.id,
+    defaultValue: query?.data?.data.category.id,
   });
 
   const renderFormByStep = (step: number) => {

--- a/examples/import-export-mantine/src/pages/posts/list.tsx
+++ b/examples/import-export-mantine/src/pages/posts/list.tsx
@@ -112,9 +112,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/invoicer/src/components/header/search/index.tsx
+++ b/examples/invoicer/src/components/header/search/index.tsx
@@ -26,7 +26,7 @@ export const Search = () => {
   const { data: dataAccount } = useList<Account>({
     resource: "accounts",
     pagination: {
-      current: 1,
+      currentPage: 1,
       pageSize: 999,
     },
     filters: [
@@ -49,7 +49,7 @@ export const Search = () => {
   const { data: dataClient } = useList<Client>({
     resource: "clients",
     pagination: {
-      current: 1,
+      currentPage: 1,
       pageSize: 999,
     },
     filters: [

--- a/examples/mern-dashboard-client/src/pages/all-properties.tsx
+++ b/examples/mern-dashboard-client/src/pages/all-properties.tsx
@@ -16,8 +16,8 @@ const AllProperties = () => {
 
   const {
     tableQuery: { data, isLoading, isError },
-    current,
-    setCurrent,
+    currentPage: current,
+    setCurrentPage: setCurrent,
     setPageSize,
     pageCount,
     sorters: sorter,

--- a/examples/server-side-form-validation-chakra-ui/src/pages/posts/list.tsx
+++ b/examples/server-side-form-validation-chakra-ui/src/pages/posts/list.tsx
@@ -127,9 +127,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/server-side-form-validation-mantine/src/pages/posts/list.tsx
+++ b/examples/server-side-form-validation-mantine/src/pages/posts/list.tsx
@@ -108,9 +108,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/table-chakra-ui-advanced/src/pages/posts/list.tsx
+++ b/examples/table-chakra-ui-advanced/src/pages/posts/list.tsx
@@ -226,9 +226,10 @@ export const PostList: React.FC = () => {
     setOptions,
     resetRowSelection,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/table-chakra-ui-basic/src/pages/posts/list.tsx
+++ b/examples/table-chakra-ui-basic/src/pages/posts/list.tsx
@@ -127,9 +127,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/table-mantine-advanced/src/pages/posts/list.tsx
+++ b/examples/table-mantine-advanced/src/pages/posts/list.tsx
@@ -199,9 +199,10 @@ export const PostList: React.FC = () => {
     resetRowSelection,
     refineCore: {
       tableQuery: { data: tableData },
-      setCurrent,
+
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
     },
   } = useTable<IPost>({
     columns,

--- a/examples/table-mantine-basic/src/pages/posts/list.tsx
+++ b/examples/table-mantine-basic/src/pages/posts/list.tsx
@@ -100,9 +100,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/table-mantine-basic/src/pages/posts/list.tsx
+++ b/examples/table-mantine-basic/src/pages/posts/list.tsx
@@ -112,7 +112,7 @@ export const PostList: React.FC = () => {
       syncWithLocation: true,
 
       pagination: {
-        current: 2,
+        currentPage: 2,
         pageSize: 10,
       },
 

--- a/examples/table-material-ui-advanced/src/pages/table/index.tsx
+++ b/examples/table-material-ui-advanced/src/pages/table/index.tsx
@@ -170,6 +170,7 @@ export const PostList: React.FC = () => {
   const {
     options: {
       state: { pagination, rowSelection },
+
       pageCount,
     },
     setOptions,

--- a/examples/table-material-ui-use-data-grid/src/pages/posts/list.tsx
+++ b/examples/table-material-ui-use-data-grid/src/pages/posts/list.tsx
@@ -12,7 +12,7 @@ export const PostList: React.FC = () => {
     syncWithLocation: true,
 
     pagination: {
-      current: 1,
+      currentPage: 1,
       pageSize: 10,
     },
 

--- a/examples/theme-chakra-ui-demo/src/pages/posts/list.tsx
+++ b/examples/theme-chakra-ui-demo/src/pages/posts/list.tsx
@@ -127,9 +127,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/theme-mantine-demo/src/pages/posts/list.tsx
+++ b/examples/theme-mantine-demo/src/pages/posts/list.tsx
@@ -108,9 +108,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/tutorial-chakra-ui/src/pages/blog-posts/list.tsx
+++ b/examples/tutorial-chakra-ui/src/pages/blog-posts/list.tsx
@@ -114,9 +114,10 @@ export const BlogPostList = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/tutorial-mantine/src/pages/blog-posts/list.tsx
+++ b/examples/tutorial-mantine/src/pages/blog-posts/list.tsx
@@ -99,9 +99,10 @@ export const BlogPostList = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/upload-chakra-ui-basic64/src/pages/posts/list.tsx
+++ b/examples/upload-chakra-ui-basic64/src/pages/posts/list.tsx
@@ -127,9 +127,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/upload-chakra-ui-multipart/src/pages/posts/list.tsx
+++ b/examples/upload-chakra-ui-multipart/src/pages/posts/list.tsx
@@ -127,9 +127,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/upload-mantine-base64/src/pages/posts/list.tsx
+++ b/examples/upload-mantine-base64/src/pages/posts/list.tsx
@@ -108,9 +108,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/upload-mantine-multipart/src/pages/posts/list.tsx
+++ b/examples/upload-mantine-multipart/src/pages/posts/list.tsx
@@ -108,9 +108,10 @@ export const PostList: React.FC = () => {
     getRowModel,
     setOptions,
     refineCore: {
-      setCurrent,
+      setCurrentPage: setCurrent,
       pageCount,
-      current,
+      currentPage: current,
+
       tableQuery: { data: tableData },
     },
   } = useTable({

--- a/examples/use-infinite-list/src/github-data-provider/index.ts
+++ b/examples/use-infinite-list/src/github-data-provider/index.ts
@@ -15,7 +15,7 @@ export const githubDataProvider = (
   getList: async ({ resource, pagination }) => {
     const { data } = await httpClient.get(
       `https://api.github.com/${resource}?until=${
-        pagination?.current || new Date().toISOString()
+        pagination?.currentPage || new Date().toISOString()
       }`,
     );
 

--- a/examples/win95/src/components/table-members/index.tsx
+++ b/examples/win95/src/components/table-members/index.tsx
@@ -31,8 +31,8 @@ export const TableMembers = ({ selectedMember, setSelectedMember }: Props) => {
   const {
     tableQuery: membersQueryResult,
     pageCount,
-    current,
-    setCurrent,
+    currentPage: current,
+    setCurrentPage: setCurrent,
     filters,
     setFilters,
   } = useTable<ExtendedMember>({

--- a/examples/win95/src/routes/rvc-website/home.tsx
+++ b/examples/win95/src/routes/rvc-website/home.tsx
@@ -94,7 +94,7 @@ const NewTitles = (props: {
   const { data } = useList<VideoTitle>({
     resource: "titles",
     sorters: [{ field: "created_at", order: "desc" }],
-    pagination: { current: 1, pageSize: 10 },
+    pagination: { currentPage: 1, pageSize: 10 },
   });
   const titles = data?.data;
 

--- a/examples/win95/src/routes/video-club/members/list.tsx
+++ b/examples/win95/src/routes/video-club/members/list.tsx
@@ -32,8 +32,8 @@ export const VideoClubMemberPageList = () => {
   const {
     tableQuery: membersQueryResult,
     pageCount,
-    current,
-    setCurrent,
+    currentPage: current,
+    setCurrentPage: setCurrent,
     filters,
     setFilters,
   } = useTable<ExtendedMember>({

--- a/examples/win95/src/routes/video-club/tapes/select-member.tsx
+++ b/examples/win95/src/routes/video-club/tapes/select-member.tsx
@@ -42,8 +42,8 @@ export const VideoClubPageTapeSelectMember = (props: Props) => {
   const {
     tableQuery: membersQueryResult,
     pageCount,
-    current,
-    setCurrent,
+    currentPage: current,
+    setCurrentPage: setCurrent,
     filters,
     setFilters,
   } = useTable<ExtendedMember>({

--- a/examples/win95/src/routes/video-club/tapes/select-title.tsx
+++ b/examples/win95/src/routes/video-club/tapes/select-title.tsx
@@ -50,8 +50,8 @@ export const VideoClubPageTapeSelectTitle = ({
   const {
     tableQuery: titlesQueryResult,
     pageCount,
-    current,
-    setCurrent,
+    currentPage: current,
+    setCurrentPage: setCurrent,
     filters,
     setFilters,
   } = useTable<ExtendedVideoTitle>({

--- a/examples/win95/src/routes/video-club/titles/list.tsx
+++ b/examples/win95/src/routes/video-club/titles/list.tsx
@@ -29,8 +29,8 @@ export const VideoClubPageBrowseTitles = () => {
   const {
     tableQuery: titlesQueryResult,
     pageCount,
-    current,
-    setCurrent,
+    currentPage: current,
+    setCurrentPage: setCurrent,
     filters,
     setFilters,
   } = useTable<ExtendedVideoTitle>({

--- a/examples/with-meta-properties/src/rest-data-provider/index.ts
+++ b/examples/with-meta-properties/src/rest-data-provider/index.ts
@@ -12,7 +12,11 @@ const restDataProvider: DataProvider = {
 
     const url = `${API_URL}/${resource}`;
 
-    const { current = 1, pageSize = 10, mode = "server" } = pagination ?? {};
+    const {
+      currentPage = 1,
+      pageSize = 10,
+      mode = "server",
+    } = pagination ?? {};
 
     const queryFilters = generateFilter(filters);
 
@@ -24,8 +28,8 @@ const restDataProvider: DataProvider = {
     } = {};
 
     if (mode === "server") {
-      query._start = (current - 1) * pageSize;
-      query._end = current * pageSize;
+      query._start = (currentPage - 1) * pageSize;
+      query._end = currentPage * pageSize;
     }
 
     const generatedSort = generateSort(sorters);

--- a/examples/with-nextjs-headless/src/app/blog-posts/page.tsx
+++ b/examples/with-nextjs-headless/src/app/blog-posts/page.tsx
@@ -12,10 +12,15 @@ import type { Category, BlogPost } from "@types";
 
 export default function BlogPostList() {
   const { translate: t } = useTranslation();
-  const { tableQuery, current, pageSize, setPageSize, setCurrent } =
-    useTable<BlogPost>({
-      syncWithLocation: true,
-    });
+  const {
+    tableQuery,
+    currentPage: current,
+    pageSize,
+    setPageSize,
+    setCurrentPage: setCurrent,
+  } = useTable<BlogPost>({
+    syncWithLocation: true,
+  });
 
   const { data, isLoading } = tableQuery;
   const records = data?.data ?? [];

--- a/packages/airtable/src/dataProvider.ts
+++ b/packages/airtable/src/dataProvider.ts
@@ -12,7 +12,11 @@ export const dataProvider = (
 
   return {
     getList: async ({ resource, pagination, sorters, filters }) => {
-      const { current = 1, pageSize = 10, mode = "server" } = pagination ?? {};
+      const {
+        currentPage = 1,
+        pageSize = 10,
+        mode = "server",
+      } = pagination ?? {};
 
       const generatedSort = generateSort(sorters) || [];
       const queryFilters = generateFilter(filters);
@@ -29,8 +33,10 @@ export const dataProvider = (
       return {
         data: data
           .slice(
-            isServerPaginationEnabled ? (current - 1) * pageSize : undefined,
-            isServerPaginationEnabled ? current * pageSize : undefined,
+            isServerPaginationEnabled
+              ? (currentPage - 1) * pageSize
+              : undefined,
+            isServerPaginationEnabled ? currentPage * pageSize : undefined,
           )
           .map((p) => ({
             id: p.id,

--- a/packages/antd/src/hooks/list/useSimpleList/useSimpleList.spec.ts
+++ b/packages/antd/src/hooks/list/useSimpleList/useSimpleList.spec.ts
@@ -53,7 +53,7 @@ describe("useSimpleList Hook", () => {
         useSimpleList({
           pagination: {
             pageSize: 1,
-            current: 2,
+            currentPage: 2,
           },
         }),
       {

--- a/packages/antd/src/hooks/list/useSimpleList/useSimpleList.ts
+++ b/packages/antd/src/hooks/list/useSimpleList/useSimpleList.ts
@@ -71,11 +71,11 @@ export const useSimpleList = <
   const {
     sorters,
     filters,
-    current,
+    currentPage,
     pageSize,
     pageCount,
     setFilters,
-    setCurrent,
+    setCurrentPage,
     setPageSize,
     setSorters,
     createLinkForSyncWithLocation,
@@ -109,7 +109,7 @@ export const useSimpleList = <
 
   const onChange = (page: number, pageSize?: number): void => {
     if (isPaginationEnabled) {
-      setCurrent(page);
+      setCurrentPage(page);
       setPageSize(pageSize || 10);
     }
   };
@@ -118,7 +118,7 @@ export const useSimpleList = <
     if (onSearch) {
       const searchFilters = await onSearch(values);
       if (isPaginationEnabled) {
-        setCurrent?.(1);
+        setCurrentPage?.(1);
       }
       return setFilters(searchFilters);
     }
@@ -131,7 +131,7 @@ export const useSimpleList = <
           const link = createLinkForSyncWithLocation({
             pagination: {
               pageSize,
-              current: page,
+              currentPage: page,
             },
             sorters,
             filters,
@@ -166,7 +166,7 @@ export const useSimpleList = <
           return element;
         },
         pageSize,
-        current,
+        current: currentPage,
         simple: !breakpoint.sm,
         total: data?.total,
         onChange,
@@ -191,8 +191,8 @@ export const useSimpleList = <
     setFilters,
     sorters,
     setSorters,
-    current,
-    setCurrent,
+    currentPage,
+    setCurrentPage,
     pageSize,
     setPageSize,
     pageCount,

--- a/packages/antd/src/hooks/table/useTable/useTable.spec.tsx
+++ b/packages/antd/src/hooks/table/useTable/useTable.spec.tsx
@@ -58,7 +58,7 @@ describe("useTable Hook", () => {
       () =>
         useTable({
           pagination: {
-            current: customPagination.current,
+            currentPage: customPagination.current,
             pageSize: customPagination.pageSize,
           },
         }),

--- a/packages/antd/src/hooks/table/useTable/useTable.ts
+++ b/packages/antd/src/hooks/table/useTable/useTable.ts
@@ -82,8 +82,8 @@ export const useTable = <
 > = {}): useTableReturnType<TData, TError, TSearchVariables> => {
   const {
     tableQuery,
-    current,
-    setCurrent,
+    currentPage,
+    setCurrentPage,
     pageSize,
     setPageSize,
     filters,
@@ -172,7 +172,7 @@ export const useTable = <
     }
 
     if (isPaginationEnabled) {
-      setCurrent?.(paginationState.current || 1);
+      setCurrentPage?.(paginationState.current || 1);
       setPageSize?.(paginationState.pageSize || 10);
     }
   };
@@ -183,7 +183,7 @@ export const useTable = <
       setFilters(searchFilters);
 
       if (isPaginationEnabled) {
-        setCurrent?.(1);
+        setCurrentPage?.(1);
       }
     }
   };
@@ -195,7 +195,7 @@ export const useTable = <
           const link = createLinkForSyncWithLocation({
             pagination: {
               pageSize,
-              current: page,
+              currentPage: page,
             },
             sorters,
             filters,
@@ -230,7 +230,7 @@ export const useTable = <
           return element;
         },
         pageSize,
-        current,
+        current: currentPage,
         simple: !breakpoint.sm,
         position: !breakpoint.sm ? ["bottomCenter"] : ["bottomRight"],
         total: data?.total,
@@ -257,8 +257,8 @@ export const useTable = <
     filters,
     setSorters,
     setFilters,
-    current,
-    setCurrent,
+    currentPage,
+    setCurrentPage,
     pageSize,
     setPageSize,
     pageCount,

--- a/packages/appwrite/src/dataProvider.ts
+++ b/packages/appwrite/src/dataProvider.ts
@@ -32,12 +32,16 @@ export const dataProvider = (
 
   return {
     getList: async ({ resource, pagination, filters, sorters }) => {
-      const { current = 1, pageSize = 10, mode = "server" } = pagination ?? {};
+      const {
+        currentPage = 1,
+        pageSize = 10,
+        mode = "server",
+      } = pagination ?? {};
 
       const appwriteFilters = getAppwriteFilters(filters);
 
       const appwritePagination =
-        mode === "server" ? getAppwritePagination(current, pageSize) : [];
+        mode === "server" ? getAppwritePagination(currentPage, pageSize) : [];
 
       const appwriteSorts = getAppwriteSorting(sorters);
 

--- a/packages/appwrite/src/utils/getAppwritePagination.ts
+++ b/packages/appwrite/src/utils/getAppwritePagination.ts
@@ -1,5 +1,8 @@
 import { Query } from "appwrite";
 
-export const getAppwritePagination = (current: number, pageSize: number) => {
-  return [Query.offset((current - 1) * pageSize), Query.limit(pageSize)];
+export const getAppwritePagination = (
+  currentPage: number,
+  pageSize: number,
+) => {
+  return [Query.offset((currentPage - 1) * pageSize), Query.limit(pageSize)];
 };

--- a/packages/codemod/src/transformations/refine4-to-refine5.ts
+++ b/packages/codemod/src/transformations/refine4-to-refine5.ts
@@ -5,6 +5,8 @@ import { renameUseFormQueryResultAndMutationResult } from "./rename-query-and-mu
 import { renameUseTableQueryResult } from "./rename-query-and-mutation-result/use-table-query-result";
 import { removeUseNewQueryKeysFromRefineOptions } from "./v5/remove-useNewQueryKeys-from-refine-options";
 import { renameITreeMenuToTreeMenuItem } from "./v5/rename-itreemenu-to-treemenuitem";
+import { renameCurrentToCurrentPage } from "./v5/rename-current-to-currentPage";
+import { renamePaginationCurrentToCurrentPage } from "./v5/rename-pagination-current-to-currentPage";
 
 export default function transformer(file: FileInfo, api: API): string {
   const j = api.jscodeshift;
@@ -15,6 +17,8 @@ export default function transformer(file: FileInfo, api: API): string {
   renameUseTableQueryResult(j, source);
   renameUseFormQueryResultAndMutationResult(j, source);
   renameITreeMenuToTreeMenuItem(j, source);
+  renameCurrentToCurrentPage(j, source);
+  renamePaginationCurrentToCurrentPage(j, source);
 
   return source.toSource();
 }

--- a/packages/codemod/src/transformations/v5/rename-current-to-currentPage.test.ts
+++ b/packages/codemod/src/transformations/v5/rename-current-to-currentPage.test.ts
@@ -1,0 +1,148 @@
+import renameCurrentToCurrentPage from "./rename-current-to-currentPage";
+import jscodeshift, { type JSCodeshift } from "jscodeshift";
+
+const transform = (source: string) => {
+  const j: JSCodeshift = jscodeshift.withParser("tsx");
+  const root = j(source);
+
+  renameCurrentToCurrentPage(j, root);
+
+  return root.toSource({
+    quote: "double",
+    trailingComma: true,
+  });
+};
+
+describe("rename-current-to-currentPage", () => {
+  it("should alias current and setCurrent from useTable when imported from @refinedev/react-table", () => {
+    const source = `
+      import { useTable } from "@refinedev/core";
+      const { current, setCurrent } = useTable();
+    `;
+    const expected = `
+      import { useTable } from "@refinedev/core";
+      const { currentPage: current, setCurrentPage: setCurrent } = useTable();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should not alias if useTable is imported from another package", () => {
+    const source = `
+      import { useTable } from "some-other-lib";
+      const { current, setCurrent } = useTable();
+    `;
+    const expected = `
+      import { useTable } from "some-other-lib";
+      const { current, setCurrent } = useTable();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should alias only current if setCurrent is not present and imported from @refinedev/react-table", () => {
+    const source = `
+      import { useTable } from "@refinedev/react-table";
+      const { current } = useTable();
+    `;
+    const expected = `
+      import { useTable } from "@refinedev/react-table";
+      const { currentPage: current } = useTable();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should alias only setCurrent if current is not present and imported from @refinedev/react-table", () => {
+    const source = `
+      import { useTable } from "@refinedev/react-table";
+      const { setCurrent } = useTable();
+    `;
+    const expected = `
+      import { useTable } from "@refinedev/react-table";
+      const { setCurrentPage: setCurrent } = useTable();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should not change unrelated destructuring", () => {
+    const source = `
+      import { useTable } from "@refinedev/react-table";
+      const { pageSize, pagination } = useTable();
+    `;
+    const expected = `
+      import { useTable } from "@refinedev/react-table";
+      const { pageSize, pagination } = useTable();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should work with useDataGrid", () => {
+    const source = `
+      import { useDataGrid } from "@refinedev/mui";
+      const { current, setCurrent } = useDataGrid();
+    `;
+    const expected = `
+      import { useDataGrid } from "@refinedev/mui";
+      const { currentPage: current, setCurrentPage: setCurrent } = useDataGrid();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should not alias useDataGrid if imported from another package", () => {
+    const source = `
+      import { useDataGrid } from "other-lib";
+      const { current, setCurrent } = useDataGrid();
+    `;
+    const expected = `
+      import { useDataGrid } from "other-lib";
+      const { current, setCurrent } = useDataGrid();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should not alias useTable if imported from another package", () => {
+    const source = `
+      import { useTable } from "other-lib";
+      const { current, setCurrent } = useTable();
+    `;
+    const expected = `
+      import { useTable } from "other-lib";
+      const { current, setCurrent } = useTable();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should work with useSimpleList from @refinedev/antd", () => {
+    const source = `
+      import { useSimpleList } from "@refinedev/simple-list";
+      const { current, setCurrent } = useSimpleList();
+    `;
+    const expected = `
+      import { useSimpleList } from "@refinedev/simple-list";
+      const { currentPage: current, setCurrentPage: setCurrent } = useSimpleList();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should not alias useSimpleList if imported from another package", () => {
+    const source = `
+      import { useSimpleList } from "other-lib";
+      const { current, setCurrent } = useSimpleList();
+    `;
+    const expected = `
+      import { useSimpleList } from "other-lib";
+      const { current, setCurrent } = useSimpleList();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should refactor refineCore.current to refineCore.currentPage", () => {
+    const source = `
+      import { useTable } from "@refinedev/react-table";
+      const { setCurrent } = useTable();
+    `;
+    const expected = `
+      import { useTable } from "@refinedev/react-table";
+      const { setCurrentPage: setCurrent } = useTable();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+});

--- a/packages/codemod/src/transformations/v5/rename-current-to-currentPage.test.ts
+++ b/packages/codemod/src/transformations/v5/rename-current-to-currentPage.test.ts
@@ -145,4 +145,102 @@ describe("rename-current-to-currentPage", () => {
     `;
     expect(transform(source).trim()).toBe(expected.trim());
   });
+
+  it("should handle nested destructuring with refineCore", () => {
+    const source = `
+      import { useTable } from "@refinedev/react-table";
+      const {
+        refineCore: { setCurrent, current, pageCount }
+      } = useTable();
+    `;
+    const expected = `
+      import { useTable } from "@refinedev/react-table";
+      const {
+        refineCore: {
+          setCurrentPage: setCurrent,
+          currentPage: current,
+          pageCount,
+        }
+      } = useTable();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should handle nested destructuring with only current", () => {
+    const source = `
+      import { useTable } from "@refinedev/core";
+      const {
+        refineCore: { current, pageCount }
+      } = useTable();
+    `;
+    const expected = `
+      import { useTable } from "@refinedev/core";
+      const {
+        refineCore: {
+          currentPage: current,
+          pageCount,
+        }
+      } = useTable();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should handle nested destructuring with only setCurrent", () => {
+    const source = `
+      import { useTable } from "@refinedev/react-table";
+      const {
+        refineCore: { setCurrent, pageCount }
+      } = useTable();
+    `;
+    const expected = `
+      import { useTable } from "@refinedev/react-table";
+      const {
+        refineCore: {
+          setCurrentPage: setCurrent,
+          pageCount,
+        }
+      } = useTable();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should handle mixed nested and flat destructuring", () => {
+    const source = `
+      import { useTable } from "@refinedev/react-table";
+      const {
+        getHeaderGroups,
+        getRowModel,
+        refineCore: { setCurrent, current, pageCount }
+      } = useTable();
+    `;
+    const expected = `
+      import { useTable } from "@refinedev/react-table";
+      const {
+        getHeaderGroups,
+        getRowModel,
+        refineCore: {
+          setCurrentPage: setCurrent,
+          currentPage: current,
+          pageCount,
+        }
+      } = useTable();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should not transform nested destructuring from unsupported packages", () => {
+    const source = `
+      import { useTable } from "other-lib";
+      const {
+        refineCore: { setCurrent, current }
+      } = useTable();
+    `;
+    const expected = `
+      import { useTable } from "other-lib";
+      const {
+        refineCore: { setCurrent, current }
+      } = useTable();
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
 });

--- a/packages/codemod/src/transformations/v5/rename-current-to-currentPage.ts
+++ b/packages/codemod/src/transformations/v5/rename-current-to-currentPage.ts
@@ -1,0 +1,108 @@
+import type { API, FileInfo, Collection, JSCodeshift } from "jscodeshift";
+
+const HOOK_PACKAGE_MAPPINGS = {
+  useTable: ["@refinedev/core", "@refinedev/react-table"],
+  useDataGrid: ["@refinedev/mui"],
+  useSimpleList: ["@refinedev/simple-list"],
+};
+
+export const renameCurrentToCurrentPage = (
+  j: JSCodeshift,
+  root: Collection<any>,
+) => {
+  // Track which hooks are imported from which packages
+  const hookSources = new Map<string, string[]>();
+
+  // First pass: collect hook imports and their sources
+  Object.keys(HOOK_PACKAGE_MAPPINGS).forEach((hookName) => {
+    const supportedPackages = HOOK_PACKAGE_MAPPINGS[hookName];
+
+    supportedPackages.forEach((packageName) => {
+      root
+        .find(j.ImportDeclaration, {
+          source: { value: packageName },
+        })
+        .forEach((path) => {
+          const importDecl = path.value;
+          if (!importDecl.specifiers) return;
+
+          const hasHook = importDecl.specifiers.some(
+            (spec) =>
+              spec.type === "ImportSpecifier" &&
+              spec.imported.name === hookName,
+          );
+
+          if (hasHook) {
+            if (!hookSources.has(hookName)) {
+              hookSources.set(hookName, []);
+            }
+            hookSources.get(hookName)!.push(packageName);
+          }
+        });
+    });
+  });
+
+  // Second pass: find and transform destructuring assignments
+  root
+    .find(j.VariableDeclarator)
+    .filter((path) => {
+      const { node } = path;
+      return (
+        node.id?.type === "ObjectPattern" &&
+        node.init?.type === "CallExpression" &&
+        node.init.callee?.type === "Identifier" &&
+        hookSources.has(node.init.callee.name)
+      );
+    })
+    .forEach((path) => {
+      const { node } = path;
+      const hookName = (node.init as any).callee.name;
+      const objectPattern = node.id as any;
+
+      // Only proceed if this hook is from a supported package
+      if (!hookSources.has(hookName)) return;
+
+      let hasChanges = false;
+
+      // Transform the properties in the destructuring
+      objectPattern.properties = objectPattern.properties.map((prop: any) => {
+        if (
+          prop.type === "ObjectProperty" &&
+          prop.key?.type === "Identifier" &&
+          prop.value?.type === "Identifier"
+        ) {
+          const keyName = prop.key.name;
+          const valueName = prop.value.name;
+
+          if (keyName === "current") {
+            hasChanges = true;
+            return j.objectProperty(
+              j.identifier("currentPage"),
+              j.identifier(valueName),
+            );
+          }
+
+          if (keyName === "setCurrent") {
+            hasChanges = true;
+            return j.objectProperty(
+              j.identifier("setCurrentPage"),
+              j.identifier(valueName),
+            );
+          }
+        }
+
+        return prop;
+      });
+    });
+
+  return root;
+};
+
+export default function transformer(
+  j: JSCodeshift,
+  root: Collection<any>,
+): string {
+  renameCurrentToCurrentPage(j, root);
+
+  return root.toSource();
+}

--- a/packages/codemod/src/transformations/v5/rename-pagination-current-to-currentPage.test.ts
+++ b/packages/codemod/src/transformations/v5/rename-pagination-current-to-currentPage.test.ts
@@ -1,0 +1,214 @@
+import renamePaginationCurrentToCurrentPage from "./rename-pagination-current-to-currentPage";
+import jscodeshift, { type JSCodeshift } from "jscodeshift";
+
+const transform = (source: string) => {
+  const j: JSCodeshift = jscodeshift.withParser("tsx");
+  const root = j(source);
+
+  renamePaginationCurrentToCurrentPage(j, root);
+
+  return root.toSource({
+    quote: "double",
+    trailingComma: true,
+  });
+};
+
+describe("rename-pagination-current-to-currentPage", () => {
+  it("should rename pagination.current to pagination.currentPage in useTable", () => {
+    const source = `
+      import { useTable } from "@refinedev/core";
+      const { data } = useTable({
+        resource: "posts",
+        pagination: { current: 1, pageSize: 10 }
+      });
+    `;
+    const expected = `
+      import { useTable } from "@refinedev/core";
+      const { data } = useTable({
+        resource: "posts",
+        pagination: { currentPage: 1, pageSize: 10 }
+      });
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should rename pagination.current to pagination.currentPage in useList", () => {
+    const source = `
+      import { useList } from "@refinedev/core";
+      const { data } = useList({
+        resource: "posts",
+        pagination: { current: 2, pageSize: 5 }
+      });
+    `;
+    const expected = `
+      import { useList } from "@refinedev/core";
+      const { data } = useList({
+        resource: "posts",
+        pagination: { currentPage: 2, pageSize: 5 }
+      });
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should rename pagination.current to pagination.currentPage in useDataGrid", () => {
+    const source = `
+      import { useDataGrid } from "@refinedev/mui";
+      const { dataGridProps } = useDataGrid({
+        resource: "posts",
+        pagination: { current: 1, pageSize: 10 }
+      });
+    `;
+    const expected = `
+      import { useDataGrid } from "@refinedev/mui";
+      const { dataGridProps } = useDataGrid({
+        resource: "posts",
+        pagination: { currentPage: 1, pageSize: 10 }
+      });
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should rename pagination.current to pagination.currentPage in useSimpleList", () => {
+    const source = `
+      import { useSimpleList } from "@refinedev/antd";
+      const { listProps } = useSimpleList({
+        resource: "posts",
+        pagination: { current: 3, pageSize: 20 }
+      });
+    `;
+    const expected = `
+      import { useSimpleList } from "@refinedev/antd";
+      const { listProps } = useSimpleList({
+        resource: "posts",
+        pagination: { currentPage: 3, pageSize: 20 }
+      });
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should rename pagination.current to pagination.currentPage in useSelect", () => {
+    const source = `
+      import { useSelect } from "@refinedev/core";
+      const { options } = useSelect({
+        resource: "categories",
+        pagination: { current: 1, pageSize: 100 }
+      });
+    `;
+    const expected = `
+      import { useSelect } from "@refinedev/core";
+      const { options } = useSelect({
+        resource: "categories",
+        pagination: { currentPage: 1, pageSize: 100 }
+      });
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should not transform if hook is from non-refine package", () => {
+    const source = `
+      import { useTable } from "other-library";
+      const { data } = useTable({
+        resource: "posts",
+        pagination: { current: 1, pageSize: 10 }
+      });
+    `;
+    const expected = `
+      import { useTable } from "other-library";
+      const { data } = useTable({
+        resource: "posts",
+        pagination: { current: 1, pageSize: 10 }
+      });
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should not transform if there is no pagination property", () => {
+    const source = `
+      import { useList } from "@refinedev/core";
+      const { data } = useList({
+        resource: "posts"
+      });
+    `;
+    const expected = `
+      import { useList } from "@refinedev/core";
+      const { data } = useList({
+        resource: "posts"
+      });
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should not transform if pagination has no current property", () => {
+    const source = `
+      import { useTable } from "@refinedev/core";
+      const { data } = useTable({
+        resource: "posts",
+        pagination: { pageSize: 10 }
+      });
+    `;
+    const expected = `
+      import { useTable } from "@refinedev/core";
+      const { data } = useTable({
+        resource: "posts",
+        pagination: { pageSize: 10 }
+      });
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should preserve other pagination properties", () => {
+    const source = `
+      import { useList } from "@refinedev/core";
+      const { data } = useList({
+        resource: "posts",
+        pagination: { current: 1, pageSize: 10, showTotal: true, showQuickJumper: false }
+      });
+    `;
+    const expected = `
+      import { useList } from "@refinedev/core";
+      const { data } = useList({
+        resource: "posts",
+        pagination: { currentPage: 1, pageSize: 10, showTotal: true, showQuickJumper: false }
+      });
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should handle nested objects and not transform other current properties", () => {
+    const source = `
+      import { useTable } from "@refinedev/core";
+      const { data } = useTable({
+        resource: "posts",
+        pagination: { current: 1, pageSize: 10 },
+        sorters: { current: "title" }
+      });
+    `;
+    const expected = `
+      import { useTable } from "@refinedev/core";
+      const { data } = useTable({
+        resource: "posts",
+        pagination: { currentPage: 1, pageSize: 10 },
+        sorters: { current: "title" }
+      });
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+
+  it("should work with react-table package", () => {
+    const source = `
+      import { useTable } from "@refinedev/react-table";
+      const { getHeaderGroups } = useTable({
+        resource: "posts",
+        pagination: { current: 2, pageSize: 15 }
+      });
+    `;
+    const expected = `
+      import { useTable } from "@refinedev/react-table";
+      const { getHeaderGroups } = useTable({
+        resource: "posts",
+        pagination: { currentPage: 2, pageSize: 15 }
+      });
+    `;
+    expect(transform(source).trim()).toBe(expected.trim());
+  });
+});

--- a/packages/codemod/src/transformations/v5/rename-pagination-current-to-currentPage.ts
+++ b/packages/codemod/src/transformations/v5/rename-pagination-current-to-currentPage.ts
@@ -1,0 +1,113 @@
+import type { API, FileInfo, Collection, JSCodeshift } from "jscodeshift";
+
+const HOOK_PACKAGE_MAPPINGS = {
+  useTable: ["@refinedev/core", "@refinedev/react-table", "@refinedev/antd"],
+  useDataGrid: ["@refinedev/mui"],
+  useList: ["@refinedev/core"],
+  useSimpleList: ["@refinedev/antd"],
+  useSelect: [
+    "@refinedev/core",
+    "@refinedev/antd",
+    "@refinedev/mui",
+    "@refinedev/mantine",
+    "@refinedev/chakra-ui",
+  ],
+  useInfiniteList: ["@refinedev/core"],
+};
+
+export const renamePaginationCurrentToCurrentPage = (
+  j: JSCodeshift,
+  root: Collection<any>,
+) => {
+  // Track which hooks are imported from which packages
+  const hookSources = new Map<string, string[]>();
+
+  // First pass: collect hook imports and their sources
+  Object.keys(HOOK_PACKAGE_MAPPINGS).forEach((hookName) => {
+    const supportedPackages = HOOK_PACKAGE_MAPPINGS[hookName];
+
+    supportedPackages.forEach((packageName) => {
+      root
+        .find(j.ImportDeclaration, {
+          source: { value: packageName },
+        })
+        .forEach((path) => {
+          const importDecl = path.value;
+          if (!importDecl.specifiers) return;
+
+          const hasHook = importDecl.specifiers.some(
+            (spec) =>
+              spec.type === "ImportSpecifier" &&
+              spec.imported.name === hookName,
+          );
+
+          if (hasHook) {
+            if (!hookSources.has(hookName)) {
+              hookSources.set(hookName, []);
+            }
+            hookSources.get(hookName)!.push(packageName);
+          }
+        });
+    });
+  });
+
+  // Second pass: find and transform hook calls (pagination parameters)
+  root
+    .find(j.CallExpression)
+    .filter((path) => {
+      const { node } = path;
+      return (
+        node.callee?.type === "Identifier" &&
+        hookSources.has(node.callee.name) &&
+        node.arguments.length > 0 &&
+        node.arguments[0].type === "ObjectExpression"
+      );
+    })
+    .forEach((path) => {
+      const { node } = path;
+      const hookName = (node.callee as any).name;
+      const optionsObject = node.arguments[0] as any;
+
+      // Only proceed if this hook is from a supported package
+      if (!hookSources.has(hookName)) return;
+
+      // Find pagination property in the options object
+      optionsObject.properties.forEach((prop: any) => {
+        if (
+          (prop.type === "ObjectProperty" || prop.type === "Property") &&
+          prop.key?.type === "Identifier" &&
+          prop.key.name === "pagination" &&
+          prop.value?.type === "ObjectExpression"
+        ) {
+          // Transform current property inside pagination object
+          prop.value.properties = prop.value.properties.map(
+            (paginationProp: any) => {
+              if (
+                (paginationProp.type === "ObjectProperty" ||
+                  paginationProp.type === "Property") &&
+                paginationProp.key?.type === "Identifier" &&
+                paginationProp.key.name === "current"
+              ) {
+                return j.objectProperty(
+                  j.identifier("currentPage"),
+                  paginationProp.value,
+                );
+              }
+              return paginationProp;
+            },
+          );
+        }
+      });
+    });
+
+  return root;
+};
+
+export default function transformer(
+  j: JSCodeshift,
+  root: Collection<any>,
+): string {
+  renamePaginationCurrentToCurrentPage(j, root);
+
+  return root.toSource();
+}

--- a/packages/core/src/components/authenticated/index.spec.tsx
+++ b/packages/core/src/components/authenticated/index.spec.tsx
@@ -246,11 +246,11 @@ describe("Authenticated", () => {
     );
   });
 
-  it("should redirect to `/my-path?to=/dashboard?current=1&pageSize=2` if not authenticated (`redirectOnFail` with append query)", async () => {
+  it("should redirect to `/my-path?to=/dashboard?currentPage=1&pageSize=2` if not authenticated (`redirectOnFail` with append query)", async () => {
     const mockGo = jest.fn();
 
     const currentQuery = {
-      current: 1,
+      currentPage: 1,
       pageSize: 2,
     };
 
@@ -307,7 +307,7 @@ describe("Authenticated", () => {
         expect.objectContaining({
           to: "/my-path",
           query: {
-            to: "/dashboard?current=1&pageSize=2",
+            to: "/dashboard?currentPage=1&pageSize=2",
           },
           type: "replace",
         }),
@@ -315,11 +315,11 @@ describe("Authenticated", () => {
     );
   });
 
-  it("should redirect to `/my-path?to=/dashboard?current=1&pageSize=2` if not authenticated (authProvider's check with append query)", async () => {
+  it("should redirect to `/my-path?to=/dashboard?currentPage=1&pageSize=2` if not authenticated (authProvider's check with append query)", async () => {
     const mockGo = jest.fn();
 
     const currentQuery = {
-      current: 1,
+      currentPage: 1,
       pageSize: 2,
     };
 
@@ -375,7 +375,7 @@ describe("Authenticated", () => {
         expect.objectContaining({
           to: "/my-path",
           query: {
-            to: "/dashboard?current=1&pageSize=2",
+            to: "/dashboard?currentPage=1&pageSize=2",
           },
           type: "replace",
         }),

--- a/packages/core/src/contexts/data/types.ts
+++ b/packages/core/src/contexts/data/types.ts
@@ -174,7 +174,7 @@ export interface Pagination {
    * Initial page index
    * @default 1
    */
-  current?: number;
+  currentPage?: number;
   /**
    * Initial number of items per page
    * @default 10

--- a/packages/core/src/definitions/helpers/handlePaginationParams/index.spec.ts
+++ b/packages/core/src/definitions/helpers/handlePaginationParams/index.spec.ts
@@ -3,7 +3,7 @@ import { handlePaginationParams } from ".";
 describe("handlePaginationParams", () => {
   it("should return default pagination", () => {
     expect(handlePaginationParams()).toEqual({
-      current: 1,
+      currentPage: 1,
       pageSize: 10,
       mode: "server",
     });
@@ -12,10 +12,10 @@ describe("handlePaginationParams", () => {
   it("should return pagination from `pagination` prop", () => {
     expect(
       handlePaginationParams({
-        pagination: { current: 2, pageSize: 20, mode: "client" },
+        pagination: { currentPage: 2, pageSize: 20, mode: "client" },
       }),
     ).toEqual({
-      current: 2,
+      currentPage: 2,
       pageSize: 20,
       mode: "client",
     });
@@ -24,10 +24,10 @@ describe("handlePaginationParams", () => {
   it("should return pagination from `config` prop", () => {
     expect(
       handlePaginationParams({
-        pagination: { current: 3, pageSize: 30 },
+        pagination: { currentPage: 3, pageSize: 30 },
       }),
     ).toEqual({
-      current: 3,
+      currentPage: 3,
       pageSize: 30,
       mode: "server",
     });
@@ -36,10 +36,10 @@ describe("handlePaginationParams", () => {
   it("should return pagination from `pagination` prop if config is defined", () => {
     expect(
       handlePaginationParams({
-        pagination: { current: 2, pageSize: 20, mode: "client" },
+        pagination: { currentPage: 2, pageSize: 20, mode: "client" },
       }),
     ).toEqual({
-      current: 2,
+      currentPage: 2,
       pageSize: 20,
       mode: "client",
     });
@@ -51,7 +51,7 @@ describe("handlePaginationParams", () => {
         pagination: { mode: "client" },
       }),
     ).toEqual({
-      current: 1,
+      currentPage: 1,
       pageSize: 10,
       mode: "client",
     });

--- a/packages/core/src/definitions/helpers/handlePaginationParams/index.ts
+++ b/packages/core/src/definitions/helpers/handlePaginationParams/index.ts
@@ -9,12 +9,12 @@ export const handlePaginationParams = ({
 }: HandlePaginationParamsProps = {}): Required<Pagination> => {
   const mode = pagination?.mode ?? "server";
 
-  const current = pagination?.current ?? 1;
+  const currentPage = pagination?.currentPage ?? 1;
 
   const pageSize = pagination?.pageSize ?? 10;
 
   return {
-    current,
+    currentPage,
     pageSize,
     mode,
   };

--- a/packages/core/src/definitions/helpers/useInfinitePagination/index.spec.ts
+++ b/packages/core/src/definitions/helpers/useInfinitePagination/index.spec.ts
@@ -14,7 +14,7 @@ describe("useInfiniteList pagination helper", () => {
         data: [],
         total: 10,
         pagination: {
-          current: 2,
+          currentPage: 2,
           pageSize: 3,
         },
       });
@@ -37,7 +37,7 @@ describe("useInfiniteList pagination helper", () => {
         data: [],
         total: 10,
         pagination: {
-          current: 2,
+          currentPage: 2,
           pageSize: 3,
         },
       });

--- a/packages/core/src/definitions/helpers/useInfinitePagination/index.ts
+++ b/packages/core/src/definitions/helpers/useInfinitePagination/index.ts
@@ -8,7 +8,7 @@ export const getNextPageParam = (lastPage: GetListResponse) => {
     return cursor.next;
   }
 
-  const current = pagination?.current || 1;
+  const current = pagination?.currentPage || 1;
 
   const pageSize = pagination?.pageSize || 10;
   const totalPages = Math.ceil((lastPage.total || 0) / pageSize);
@@ -24,7 +24,7 @@ export const getPreviousPageParam = (lastPage: GetListResponse) => {
     return cursor.prev;
   }
 
-  const current = pagination?.current || 1;
+  const current = pagination?.currentPage || 1;
 
   return current === 1 ? undefined : current - 1;
 };

--- a/packages/core/src/definitions/table/__snapshots__/index.spec.ts.snap
+++ b/packages/core/src/definitions/table/__snapshots__/index.spec.ts.snap
@@ -1,7 +1,7 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`definitions/table sorters should be prioritized over sorter 1`] = `"current=1&pageSize=10&sorters[0][field]=id&sorters[0][order]=desc"`;
+exports[`definitions/table sorters should be prioritized over sorter 1`] = `"currentPage=1&pageSize=10&sorters[0][field]=id&sorters[0][order]=desc"`;
 
-exports[`definitions/table stringify table params correctly 1`] = `"foo=bar&current=1&pageSize=10&sorters[0][field]=id&sorters[0][order]=desc&sorters[1][field]=title&sorters[1][order]=desc&filters[0][field]=categoryId&filters[0][operator]=in&filters[0][value][0]=1&filters[0][value][1]=2"`;
+exports[`definitions/table stringify table params correctly 1`] = `"foo=bar&currentPage=1&pageSize=10&sorters[0][field]=id&sorters[0][order]=desc&sorters[1][field]=title&sorters[1][order]=desc&filters[0][field]=categoryId&filters[0][operator]=in&filters[0][value][0]=1&filters[0][value][1]=2"`;
 
-exports[`definitions/table stringify table single sort params correctly 1`] = `"current=1&pageSize=10&sorters[0][field]=id&sorters[0][order]=desc&filters[0][field]=categoryId&filters[0][operator]=in&filters[0][value][0]=1&filters[0][value][1]=2"`;
+exports[`definitions/table stringify table single sort params correctly 1`] = `"currentPage=1&pageSize=10&sorters[0][field]=id&sorters[0][order]=desc&filters[0][field]=categoryId&filters[0][operator]=in&filters[0][value][0]=1&filters[0][value][1]=2"`;

--- a/packages/core/src/definitions/table/index.spec.ts
+++ b/packages/core/src/definitions/table/index.spec.ts
@@ -78,7 +78,7 @@ describe("definitions/table", () => {
 
   it("stringify table params correctly", async () => {
     const pagination = {
-      current: 1,
+      currentPage: 1,
       pageSize: 10,
     };
 
@@ -116,7 +116,7 @@ describe("definitions/table", () => {
 
   it("stringify table single sort params correctly", async () => {
     const pagination = {
-      current: 1,
+      currentPage: 1,
       pageSize: 10,
     };
 
@@ -135,7 +135,7 @@ describe("definitions/table", () => {
 
   it("parse table params with single sorter correctly", async () => {
     const url =
-      "?current=1&pageSize=10&sorter[0][field]=id&sorter[0][order]=desc&filters[0][operator]=in&filters[0][field]=categoryId&filters[0][value][0]=1&filters[0][value][1]=2";
+      "?currentPage=1&pageSize=10&sorter[0][field]=id&sorter[0][order]=desc&filters[0][operator]=in&filters[0][field]=categoryId&filters[0][value][0]=1&filters[0][value][1]=2";
 
     const { parsedCurrent, parsedPageSize, parsedSorter, parsedFilters } =
       parseTableParams(url);
@@ -150,7 +150,7 @@ describe("definitions/table", () => {
 
   it("sorters should be prioritized over sorter", async () => {
     const pagination = {
-      current: 1,
+      currentPage: 1,
       pageSize: 10,
     };
 
@@ -170,7 +170,7 @@ describe("definitions/table", () => {
 
   it("parse table params with advanced query object", async () => {
     const query = {
-      current: 1,
+      currentPage: 1,
       pageSize: 10,
       sorter: [
         { field: "id", order: "asc" },
@@ -619,7 +619,7 @@ describe("definitions/table", () => {
   });
 
   it("parseTableParams default sorter and filters", () => {
-    expect(parseTableParams("?current=1&pageSize=10")).toStrictEqual({
+    expect(parseTableParams("?currentPage=1&pageSize=10")).toStrictEqual({
       parsedCurrent: 1,
       parsedFilters: [],
       parsedPageSize: 10,

--- a/packages/core/src/definitions/table/index.ts
+++ b/packages/core/src/definitions/table/index.ts
@@ -11,12 +11,12 @@ import type {
 } from "../../contexts/data/types";
 
 export const parseTableParams = (url: string) => {
-  const { current, pageSize, sorters, sorter, filters } = qs.parse(
+  const { currentPage, pageSize, sorters, sorter, filters } = qs.parse(
     url.substring(1), // remove first ? character
   );
 
   return {
-    parsedCurrent: current && Number(current),
+    parsedCurrent: currentPage && Number(currentPage),
     parsedPageSize: pageSize && Number(pageSize),
     parsedSorter: (sorters as CrudSort[]) || (sorter as CrudSort[]) || [],
     parsedFilters: (filters as CrudFilter[]) ?? [],
@@ -24,10 +24,10 @@ export const parseTableParams = (url: string) => {
 };
 
 export const parseTableParamsFromQuery = (params: any) => {
-  const { current, pageSize, sorters, sorter, filters } = params;
+  const { currentPage, pageSize, sorters, sorter, filters } = params;
 
   return {
-    parsedCurrent: current && Number(current),
+    parsedCurrent: currentPage && Number(currentPage),
     parsedPageSize: pageSize && Number(pageSize),
     parsedSorter: (sorters as CrudSort[]) || (sorter as CrudSort[]) || [],
     parsedFilters: (filters as CrudFilter[]) ?? [],
@@ -38,7 +38,7 @@ export const parseTableParamsFromQuery = (params: any) => {
  * @internal This function is used to stringify table params from the useTable hook.
  */
 export const stringifyTableParams = (params: {
-  pagination?: { current?: number; pageSize?: number };
+  pagination?: { currentPage?: number; pageSize?: number };
   sorters: CrudSort[];
   sorter?: CrudSort[];
   filters: CrudFilter[];

--- a/packages/core/src/hooks/data/useInfiniteList.spec.tsx
+++ b/packages/core/src/hooks/data/useInfiniteList.spec.tsx
@@ -147,7 +147,7 @@ describe("useInfiniteList Hook", () => {
               route: undefined,
             },
             pagination: {
-              current: 1,
+              currentPage: 1,
               pageSize: 10,
               mode: "server",
             },
@@ -674,7 +674,7 @@ describe("useInfiniteList Hook", () => {
           filters: [{ field: "id", operator: "eq", value: 1 }],
           pagination: {
             mode: "client",
-            current: 10,
+            currentPage: 10,
             pageSize: 5,
           },
           sorters: [{ field: "id", order: "asc" }],
@@ -701,7 +701,7 @@ describe("useInfiniteList Hook", () => {
         filters: [{ field: "id", operator: "eq", value: 1 }],
         pagination: {
           mode: "client",
-          current: 10,
+          currentPage: 10,
           pageSize: 5,
         },
         sorters: [{ field: "id", order: "asc" }],

--- a/packages/core/src/hooks/data/useInfiniteList.ts
+++ b/packages/core/src/hooks/data/useInfiniteList.ts
@@ -239,7 +239,7 @@ export const useInfiniteList = <
     queryFn: (context) => {
       const paginationProperties = {
         ...prefferedPagination,
-        current: context.pageParam,
+        currentPage: context.pageParam,
       };
 
       const meta = {
@@ -263,7 +263,7 @@ export const useInfiniteList = <
       });
     },
     initialPageParam:
-      queryOptions?.initialPageParam ?? prefferedPagination.current,
+      queryOptions?.initialPageParam ?? prefferedPagination.currentPage,
     getNextPageParam: (lastPage) => getNextPageParam(lastPage),
     getPreviousPageParam: (lastPage) => getPreviousPageParam(lastPage),
     ...queryOptions,

--- a/packages/core/src/hooks/data/useList.spec.tsx
+++ b/packages/core/src/hooks/data/useList.spec.tsx
@@ -49,7 +49,7 @@ describe("useList Hook", () => {
           useList({
             resource: "posts",
             pagination: {
-              current: 1,
+              currentPage: 1,
               pageSize: 10,
               mode,
             },
@@ -78,7 +78,7 @@ describe("useList Hook", () => {
               {
                 filters: undefined,
                 pagination: {
-                  current: 1,
+                  currentPage: 1,
                   mode: mode || "server",
                   pageSize: 10,
                 },
@@ -101,7 +101,7 @@ describe("useList Hook", () => {
           useList({
             resource: "posts",
             pagination: {
-              current: 1,
+              currentPage: 1,
               pageSize: 10,
               mode,
             },
@@ -123,7 +123,7 @@ describe("useList Hook", () => {
         expect.objectContaining({
           resource: "posts",
           pagination: {
-            current: 1,
+            currentPage: 1,
             pageSize: 10,
             mode,
           },
@@ -152,7 +152,7 @@ describe("useList Hook", () => {
           pagination: {
             mode: "client",
             pageSize: 1,
-            current: 1,
+            currentPage: 1,
           },
         }),
       {
@@ -319,7 +319,7 @@ describe("useList Hook", () => {
                 route: undefined,
               },
               pagination: {
-                current: 1,
+                currentPage: 1,
                 mode: "server",
                 pageSize: 10,
               },
@@ -728,7 +728,7 @@ describe("useList Hook", () => {
           filters: undefined,
           sorters: undefined,
           pagination: expect.objectContaining({
-            current: 1,
+            currentPage: 1,
             pageSize: 10,
             mode: "server",
           }),
@@ -785,7 +785,7 @@ describe("useList Hook", () => {
           filters: undefined,
           sorters: undefined,
           pagination: expect.objectContaining({
-            current: 1,
+            currentPage: 1,
             pageSize: 10,
             mode: "server",
           }),
@@ -894,7 +894,7 @@ describe("useList Hook", () => {
           filters: [{ field: "id", operator: "eq", value: 1 }],
           pagination: {
             mode: "client",
-            current: 10,
+            currentPage: 10,
             pageSize: 5,
           },
           sorters: [{ field: "id", order: "asc" }],
@@ -921,7 +921,7 @@ describe("useList Hook", () => {
         filters: [{ field: "id", operator: "eq", value: 1 }],
         pagination: {
           mode: "client",
-          current: 10,
+          currentPage: 10,
           pageSize: 5,
         },
         sorters: [{ field: "id", order: "asc" }],

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -229,12 +229,15 @@ export const useList = <
     select: (rawData) => {
       let data = rawData;
 
-      const { current, mode, pageSize } = prefferedPagination;
+      const { currentPage, mode, pageSize } = prefferedPagination;
 
       if (mode === "client") {
         data = {
           ...data,
-          data: data.data.slice((current - 1) * pageSize, current * pageSize),
+          data: data.data.slice(
+            (currentPage - 1) * pageSize,
+            currentPage * pageSize,
+          ),
           total: data.total,
         };
       }

--- a/packages/core/src/hooks/export/index.ts
+++ b/packages/core/src/hooks/export/index.ts
@@ -153,7 +153,7 @@ export const useExport = <
 
     let rawData: BaseRecord[] = [];
 
-    let current = 1;
+    let currentPage = 1;
     let preparingData = true;
     while (preparingData) {
       try {
@@ -162,14 +162,14 @@ export const useExport = <
           filters,
           sorters: sorters ?? [],
           pagination: {
-            current,
+            currentPage,
             pageSize,
             mode: "server",
           },
           meta: combinedMeta,
         });
 
-        current++;
+        currentPage++;
 
         rawData.push(...data);
 

--- a/packages/core/src/hooks/router/use-parsed/index.spec.ts
+++ b/packages/core/src/hooks/router/use-parsed/index.spec.ts
@@ -13,7 +13,7 @@ describe("useParsed Hook", () => {
         routerProvider: mockRouterProvider({
           params: {
             id: "1",
-            current: 1,
+            currentPage: 1,
           },
           action: "list",
           pathname: "/posts",
@@ -22,7 +22,7 @@ describe("useParsed Hook", () => {
               return {
                 params: {
                   id: "1",
-                  current: 1,
+                  currentPage: 1,
                 },
               };
             },
@@ -34,7 +34,7 @@ describe("useParsed Hook", () => {
     expect(result.current).toEqual({
       params: {
         id: "1",
-        current: 1,
+        currentPage: 1,
       },
     });
   });

--- a/packages/core/src/hooks/useMeta/index.spec.tsx
+++ b/packages/core/src/hooks/useMeta/index.spec.tsx
@@ -200,7 +200,7 @@ describe("useMeta Hook", () => {
                 order: "asc",
               },
             ],
-            current: 1,
+            currentPage: 1,
             pageSize: 10,
           },
         }),

--- a/packages/core/src/hooks/useMeta/index.ts
+++ b/packages/core/src/hooks/useMeta/index.ts
@@ -28,7 +28,7 @@ export const useMeta = () => {
     const {
       filters: _filters,
       sorters: _sorters,
-      current: _current,
+      currentPage: _currentPage,
       pageSize: _pageSize,
       ...additionalParams
     } = params ?? {};

--- a/packages/core/src/hooks/useSelect/index.spec.ts
+++ b/packages/core/src/hooks/useSelect/index.spec.ts
@@ -580,7 +580,7 @@ describe("useSelect Hook", () => {
           resource: "posts",
           defaultValue: ["1", "2"],
           pagination: {
-            current: 1,
+            currentPage: 1,
             pageSize: 20,
           },
         }),
@@ -613,7 +613,7 @@ describe("useSelect Hook", () => {
           ]),
         }),
         pagination: {
-          current: 1,
+          currentPage: 1,
           mode: "server",
           pageSize: 20,
         },
@@ -686,7 +686,7 @@ describe("useSelect Hook", () => {
           ]),
         }),
         pagination: {
-          current: 1,
+          currentPage: 1,
           mode: "server",
           pageSize: 10,
         },
@@ -717,7 +717,7 @@ describe("useSelect Hook", () => {
           ]),
         }),
         pagination: {
-          current: 1,
+          currentPage: 1,
           mode: "server",
           pageSize: 10,
         },
@@ -821,7 +821,7 @@ describe("useSelect Hook", () => {
           resource: "posts",
           defaultValue: ["1", "2", "3"],
           pagination: {
-            current: 2,
+            currentPage: 2,
             pageSize: 1,
           },
         }),
@@ -841,7 +841,7 @@ describe("useSelect Hook", () => {
       expect.objectContaining({
         filters: [],
         pagination: {
-          current: 2,
+          currentPage: 2,
           mode: "server",
           pageSize: 1,
         },

--- a/packages/core/src/hooks/useSelect/index.ts
+++ b/packages/core/src/hooks/useSelect/index.ts
@@ -104,7 +104,7 @@ export type UseSelectProps<TQueryFnData, TError, TData> = {
   >;
   /**
    * Pagination option from [`useList()`](/docs/api-reference/core/hooks/data/useList/)
-   * @type {  current?: number; pageSize?: number;}
+   * @type {  currentPage?: number; pageSize?: number;}
    * @default `undefined`
    */
   pagination?: Prettify<
@@ -299,7 +299,7 @@ export const useSelect = <
     sorters,
     filters: filters.concat(search),
     pagination: {
-      current: pagination?.current,
+      currentPage: pagination?.currentPage,
       pageSize: pagination?.pageSize ?? 10,
       mode: pagination?.mode,
     },

--- a/packages/core/src/hooks/useTable/index.spec.ts
+++ b/packages/core/src/hooks/useTable/index.spec.ts
@@ -9,12 +9,12 @@ import { defaultRefineOptions } from "@contexts/refine";
 
 const defaultPagination = {
   pageSize: 10,
-  current: 1,
+  currentPage: 1,
 };
 
 const customPagination = {
-  current: 2,
-  defaultCurrent: 2,
+  currentPage: 2,
+  defaultCurrentPage: 2,
   defaultPageSize: 1,
   pageSize: 1,
 };
@@ -42,13 +42,13 @@ describe("useTable Hook", () => {
     const {
       tableQuery: { data },
       pageSize,
-      current,
+      currentPage,
       pageCount,
     } = result.current;
 
     expect(data?.data).toHaveLength(2);
     expect(pageSize).toEqual(defaultPagination.pageSize);
-    expect(current).toEqual(defaultPagination.current);
+    expect(currentPage).toEqual(defaultPagination.currentPage);
     expect(pageCount).toEqual(1);
   });
 
@@ -57,7 +57,7 @@ describe("useTable Hook", () => {
       () =>
         useTable({
           pagination: {
-            current: customPagination.defaultCurrent,
+            currentPage: customPagination.defaultCurrentPage,
             pageSize: customPagination.defaultPageSize,
           },
         }),
@@ -74,10 +74,10 @@ describe("useTable Hook", () => {
       expect(!result.current.tableQuery.isLoading).toBeTruthy();
     });
 
-    const { pageSize, current, pageCount } = result.current;
+    const { pageSize, currentPage, pageCount } = result.current;
 
     expect(pageSize).toEqual(customPagination.pageSize);
-    expect(current).toEqual(customPagination.current);
+    expect(currentPage).toEqual(customPagination.currentPage);
     expect(pageCount).toEqual(2);
   });
 
@@ -159,7 +159,7 @@ describe("useTable Hook", () => {
       () =>
         useTable({
           pagination: {
-            current: 1,
+            currentPage: 1,
             pageSize: 10,
           },
         }),
@@ -172,7 +172,7 @@ describe("useTable Hook", () => {
     );
 
     expect(result.current.pageSize).toBe(10);
-    expect(result.current.current).toBe(1);
+    expect(result.current.currentPage).toBe(1);
   });
 
   it("when deprecated setSorter is called, it should update sorter and sorters", async () => {
@@ -352,7 +352,7 @@ describe("useTable Hook", () => {
       () =>
         useTable({
           pagination: {
-            current: 1,
+            currentPage: 1,
             pageSize: 10,
           },
         }),
@@ -365,7 +365,7 @@ describe("useTable Hook", () => {
     );
 
     expect(result.current.pageSize).toBe(10);
-    expect(result.current.current).toBe(1);
+    expect(result.current.currentPage).toBe(1);
   });
 
   it("when deprecated setSorter is called, it should update sorter and sorters", async () => {

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -134,7 +134,7 @@ export type useTableProps<TQueryFnData, TError, TData> = {
 type ReactSetState<T> = React.Dispatch<React.SetStateAction<T>>;
 
 type SyncWithLocationParams = {
-  pagination: { current?: number; pageSize?: number };
+  pagination: { currentPage?: number; pageSize?: number };
   sorters: CrudSort[];
   filters: CrudFilter[];
 };
@@ -150,8 +150,8 @@ export type useTableReturnType<
   setFilters: ((filters: CrudFilter[], behavior?: SetFilterBehavior) => void) &
     ((setter: (prevFilters: CrudFilter[]) => CrudFilter[]) => void);
   createLinkForSyncWithLocation: (params: SyncWithLocationParams) => string;
-  current: number;
-  setCurrent: ReactSetState<useTableReturnType["current"]>;
+  currentPage: number;
+  setCurrentPage: ReactSetState<useTableReturnType["currentPage"]>;
   pageSize: number;
   setPageSize: ReactSetState<useTableReturnType["pageSize"]>;
   pageCount: number;
@@ -210,7 +210,7 @@ export function useTable<
   const isServerSideSortingEnabled =
     (sortersFromProp?.mode || "server") === "server";
   const isPaginationEnabled = pagination?.mode !== "off";
-  const prefferedCurrent = pagination?.current;
+  const prefferedCurrentPage = pagination?.currentPage;
   const prefferedPageSize = pagination?.pageSize;
   const preferredMeta = meta;
 
@@ -228,14 +228,17 @@ export function useTable<
 
   const prefferedFilterBehavior = filtersFromProp?.defaultBehavior ?? "merge";
 
-  let defaultCurrent: number;
+  let defaultCurrentPage: number;
   let defaultPageSize: number;
   let defaultSorter: CrudSort[] | undefined;
   let defaultFilter: CrudFilter[] | undefined;
 
   if (syncWithLocation) {
-    defaultCurrent =
-      parsedParams?.params?.current || parsedCurrent || prefferedCurrent || 1;
+    defaultCurrentPage =
+      parsedParams?.params?.current ||
+      parsedCurrent ||
+      prefferedCurrentPage ||
+      1;
     defaultPageSize =
       parsedParams?.params?.pageSize ||
       parsedPageSize ||
@@ -248,7 +251,7 @@ export function useTable<
       parsedParams?.params?.filters ||
       (parsedFilters.length ? parsedFilters : preferredInitialFilters);
   } else {
-    defaultCurrent = prefferedCurrent || 1;
+    defaultCurrentPage = prefferedCurrentPage || 1;
     defaultPageSize = prefferedPageSize || 10;
     defaultSorter = preferredInitialSorters;
     defaultFilter = preferredInitialFilters;
@@ -276,7 +279,7 @@ export function useTable<
   const [filters, setFilters] = useState<CrudFilter[]>(
     setInitialFilters(preferredPermanentFilters, defaultFilter ?? []),
   );
-  const [current, setCurrent] = useState<number>(defaultCurrent);
+  const [currentPage, setCurrentPage] = useState<number>(defaultCurrentPage);
   const [pageSize, setPageSize] = useState<number>(defaultPageSize);
 
   const getCurrentQueryParams = (): object => {
@@ -288,7 +291,7 @@ export function useTable<
   };
 
   const createLinkForSyncWithLocation = ({
-    pagination: { current, pageSize },
+    pagination: { currentPage, pageSize },
     sorters,
     filters,
   }: SyncWithLocationParams) => {
@@ -300,7 +303,7 @@ export function useTable<
           keepQuery: true,
         },
         query: {
-          ...(isPaginationEnabled ? { current, pageSize } : {}),
+          ...(isPaginationEnabled ? { currentPage, pageSize } : {}),
           sorters,
           filters,
           ...getCurrentQueryParams(),
@@ -311,7 +314,7 @@ export function useTable<
 
   useEffect(() => {
     if (parsedParams?.params?.search === "") {
-      setCurrent(defaultCurrent);
+      setCurrentPage(defaultCurrentPage);
       setPageSize(defaultPageSize);
       setSorters(
         setInitialSorters(preferredPermanentSorters, defaultSorter ?? []),
@@ -330,17 +333,17 @@ export function useTable<
           keepQuery: true,
         },
         query: {
-          ...(isPaginationEnabled ? { pageSize, current } : {}),
+          ...(isPaginationEnabled ? { pageSize, currentPage } : {}),
           sorters: differenceWith(sorters, preferredPermanentSorters, isEqual),
           filters: differenceWith(filters, preferredPermanentFilters, isEqual),
         },
       });
     }
-  }, [syncWithLocation, current, pageSize, sorters, filters]);
+  }, [syncWithLocation, currentPage, pageSize, sorters, filters]);
 
   const queryResult = useList<TQueryFnData, TError, TData>({
     resource: identifier,
-    pagination: { current, pageSize, mode: pagination?.mode },
+    pagination: { currentPage: currentPage, pageSize, mode: pagination?.mode },
     filters: isServerSideFilteringEnabled
       ? unionFilters(preferredPermanentFilters, filters)
       : undefined,
@@ -415,8 +418,8 @@ export function useTable<
     setSorters: setSortWithUnion,
     filters,
     setFilters: setFiltersFn,
-    current,
-    setCurrent,
+    currentPage,
+    setCurrentPage,
     pageSize,
     setPageSize,
     pageCount: pageSize

--- a/packages/graphql/src/utils/getListHelpers.ts
+++ b/packages/graphql/src/utils/getListHelpers.ts
@@ -17,11 +17,11 @@ export const buildSorters = (sorters: CrudSort[] = []) => {
 export const buildPagination = (pagination: Pagination = {}) => {
   if (pagination.mode === "off") return { limit: 2147483647 };
 
-  const { pageSize = 10, current = 1 } = pagination;
+  const { pageSize = 10, currentPage = 1 } = pagination;
 
   return {
     limit: pageSize,
-    offset: (current - 1) * pageSize,
+    offset: (currentPage - 1) * pageSize,
   };
 };
 

--- a/packages/graphql/test/getList/getList.spec.ts
+++ b/packages/graphql/test/getList/getList.spec.ts
@@ -51,7 +51,7 @@ describe("getList", () => {
           gqlQuery: gqlQuery,
         },
         pagination: {
-          current: 2,
+          currentPage: 2,
         },
       });
 

--- a/packages/graphql/test/utils/options.spec.ts
+++ b/packages/graphql/test/utils/options.spec.ts
@@ -690,7 +690,7 @@ describe("defaultOptions.getList", () => {
       const params: GetListParams = {
         resource: "blogPosts",
         pagination: {
-          current: 2,
+          currentPage: 2,
           pageSize: 10,
         },
       };
@@ -709,7 +709,7 @@ describe("defaultOptions.getList", () => {
       const params: GetListParams = {
         resource: "blogPosts",
         pagination: {
-          current: 1,
+          currentPage: 1,
           pageSize: 20,
         },
       };

--- a/packages/hasura/src/dataProvider/index.ts
+++ b/packages/hasura/src/dataProvider/index.ts
@@ -151,13 +151,13 @@ const dataProvider = (
         : camelcase(`${operation}_aggregate`);
 
       const {
-        current = 1,
+        currentPage = 1,
         pageSize: limit = 10,
         mode = "server",
       } = pagination ?? {};
 
       const hasuraPagination =
-        mode === "server" ? { limit, offset: (current - 1) * limit } : {};
+        mode === "server" ? { limit, offset: (currentPage - 1) * limit } : {};
 
       const hasuraSorting = defaultNamingConvention
         ? generateSorting(sorters)

--- a/packages/hasura/src/utils/generateUseListSubscription.ts
+++ b/packages/hasura/src/utils/generateUseListSubscription.ts
@@ -30,7 +30,7 @@ export const generateUseListSubscription = ({
   namingConvention,
 }: GenerateUseListSubscriptionParams): GenerateUseListSubscriptionReturnValues => {
   const {
-    current = 1,
+    currentPage = 1,
     pageSize: limit = 10,
     mode = "server",
   } = pagination ?? {};
@@ -60,7 +60,7 @@ export const generateUseListSubscription = ({
       ...(mode === "server"
         ? {
             limit,
-            offset: (current - 1) * limit,
+            offset: (currentPage - 1) * limit,
           }
         : {}),
       ...(hasuraSorting && {
@@ -82,7 +82,7 @@ export const generateUseListSubscription = ({
         ...(mode === "server"
           ? {
               limit,
-              offset: (current - 1) * limit,
+              offset: (currentPage - 1) * limit,
             }
           : {}),
         ...(hasuraSorting && {

--- a/packages/hasura/test/utils/generateUseListSubscription.spec.ts
+++ b/packages/hasura/test/utils/generateUseListSubscription.spec.ts
@@ -12,7 +12,7 @@ describe("generateUseListSubscription", () => {
     fields: ["id", "title", "createdAt"],
   };
   const pagination: Pagination = {
-    current: 2,
+    currentPage: 2,
     pageSize: 5,
     mode: "server",
   };

--- a/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/index.test.tsx.snap
@@ -8177,7 +8177,7 @@ exports[`ChakraUIInferencer should match the snapshot 1`] = `
               <span
                 class="token plain"
               >
-                            setCurrent
+                            setCurrentPage
               </span>
               <span
                 class="token punctuation"
@@ -8215,7 +8215,7 @@ exports[`ChakraUIInferencer should match the snapshot 1`] = `
               <span
                 class="token plain"
               >
-                            current
+                            currentPage
               </span>
               <span
                 class="token punctuation"
@@ -11458,7 +11458,7 @@ exports[`ChakraUIInferencer should match the snapshot 1`] = `
                 class="token tag script language-javascript"
                 style="color: rgb(78, 201, 176);"
               >
-                current
+                currentPage
               </span>
               <span
                 class="token tag script language-javascript punctuation"
@@ -11548,7 +11548,7 @@ exports[`ChakraUIInferencer should match the snapshot 1`] = `
                 class="token tag script language-javascript"
                 style="color: rgb(78, 201, 176);"
               >
-                setCurrent
+                setCurrentPage
               </span>
               <span
                 class="token tag script language-javascript punctuation"

--- a/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/list.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/chakra-ui/__tests__/__snapshots__/list.test.tsx.snap
@@ -7069,7 +7069,7 @@ exports[`ChakraListInferencer should match the snapshot 1`] = `
               <span
                 class="token plain"
               >
-                            setCurrent
+                            setCurrentPage
               </span>
               <span
                 class="token punctuation"
@@ -7107,7 +7107,7 @@ exports[`ChakraListInferencer should match the snapshot 1`] = `
               <span
                 class="token plain"
               >
-                            current
+                            currentPage
               </span>
               <span
                 class="token punctuation"
@@ -10247,7 +10247,7 @@ exports[`ChakraListInferencer should match the snapshot 1`] = `
                 class="token tag script language-javascript"
                 style="color: rgb(78, 201, 176);"
               >
-                current
+                currentPage
               </span>
               <span
                 class="token tag script language-javascript punctuation"
@@ -10337,7 +10337,7 @@ exports[`ChakraListInferencer should match the snapshot 1`] = `
                 class="token tag script language-javascript"
                 style="color: rgb(78, 201, 176);"
               >
-                setCurrent
+                setCurrentPage
               </span>
               <span
                 class="token tag script language-javascript punctuation"

--- a/packages/inferencer/src/inferencers/chakra-ui/list.tsx
+++ b/packages/inferencer/src/inferencers/chakra-ui/list.tsx
@@ -801,9 +801,9 @@ export const renderer = ({
             getRowModel,
             setOptions,
             refineCore: {
-                setCurrent,
+                setCurrentPage,
                 pageCount,
-                current,
+                currentPage,
                 tableQuery: { data: tableData },
             },
         } = useTable({
@@ -879,9 +879,9 @@ export const renderer = ({
                     </Table>
                 </TableContainer>
                 <Pagination
-                    current={current}
+                    current={currentPage}
                     pageCount={pageCount}
-                    setCurrent={setCurrent}
+                    setCurrent={setCurrentPage}
                 />
             </List>   
         );

--- a/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/headless/__tests__/__snapshots__/index.test.tsx.snap
@@ -12,6 +12,9 @@ exports[`ChakraUIInferencer should match the snapshot 1`] = `
         <h1>
           Posts
         </h1>
+        <button>
+          Create
+        </button>
       </div>
       <div
         style="max-width: 100%; overflow-y: scroll;"
@@ -7427,7 +7430,18 @@ exports[`ChakraUIInferencer should match the snapshot 1`] = `
               <span
                 class="token plain"
               >
-                 show 
+                 show
+              </span>
+              <span
+                class="token punctuation"
+                style="color: rgb(212, 212, 212);"
+              >
+                ,
+              </span>
+              <span
+                class="token plain"
+              >
+                 create 
               </span>
               <span
                 class="token punctuation"
@@ -9668,6 +9682,144 @@ exports[`ChakraUIInferencer should match the snapshot 1`] = `
                 style="color: rgb(78, 201, 176);"
               >
                 h1
+              </span>
+              <span
+                class="token tag punctuation"
+                style="color: rgb(212, 212, 212);"
+              >
+                &gt;
+              </span>
+              <span
+                class="token plain-text"
+              />
+            </div>
+            <div
+              class="token-line"
+              style="color: rgb(156, 220, 254);"
+            >
+              <span
+                class="token plain-text"
+              >
+                                
+              </span>
+              <span
+                class="token tag punctuation"
+                style="color: rgb(212, 212, 212);"
+              >
+                &lt;
+              </span>
+              <span
+                class="token tag"
+                style="color: rgb(78, 201, 176);"
+              >
+                button
+              </span>
+              <span
+                class="token tag"
+                style="color: rgb(78, 201, 176);"
+              >
+                 
+              </span>
+              <span
+                class="token tag attr-name"
+                style="color: rgb(156, 220, 254);"
+              >
+                onClick
+              </span>
+              <span
+                class="token tag script language-javascript script-punctuation punctuation"
+                style="color: rgb(212, 212, 212);"
+              >
+                =
+              </span>
+              <span
+                class="token tag script language-javascript punctuation"
+                style="color: rgb(212, 212, 212);"
+              >
+                {
+              </span>
+              <span
+                class="token tag script language-javascript punctuation"
+                style="color: rgb(212, 212, 212);"
+              >
+                (
+              </span>
+              <span
+                class="token tag script language-javascript punctuation"
+                style="color: rgb(212, 212, 212);"
+              >
+                )
+              </span>
+              <span
+                class="token tag script language-javascript"
+                style="color: rgb(78, 201, 176);"
+              >
+                 
+              </span>
+              <span
+                class="token tag script language-javascript arrow operator"
+                style="color: rgb(212, 212, 212);"
+              >
+                =&gt;
+              </span>
+              <span
+                class="token tag script language-javascript"
+                style="color: rgb(78, 201, 176);"
+              >
+                 
+              </span>
+              <span
+                class="token tag script language-javascript function"
+                style="color: rgb(220, 220, 170);"
+              >
+                create
+              </span>
+              <span
+                class="token tag script language-javascript punctuation"
+                style="color: rgb(212, 212, 212);"
+              >
+                (
+              </span>
+              <span
+                class="token tag script language-javascript string"
+                style="color: rgb(206, 145, 120);"
+              >
+                "posts"
+              </span>
+              <span
+                class="token tag script language-javascript punctuation"
+                style="color: rgb(212, 212, 212);"
+              >
+                )
+              </span>
+              <span
+                class="token tag script language-javascript punctuation"
+                style="color: rgb(212, 212, 212);"
+              >
+                }
+              </span>
+              <span
+                class="token tag punctuation"
+                style="color: rgb(212, 212, 212);"
+              >
+                &gt;
+              </span>
+              <span
+                class="token plain-text"
+              >
+                Create
+              </span>
+              <span
+                class="token tag punctuation"
+                style="color: rgb(212, 212, 212);"
+              >
+                &lt;/
+              </span>
+              <span
+                class="token tag"
+                style="color: rgb(78, 201, 176);"
+              >
+                button
               </span>
               <span
                 class="token tag punctuation"

--- a/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/index.test.tsx.snap
@@ -7888,7 +7888,7 @@ exports[`MantineInferencer should match the snapshot 1`] = `
               <span
                 class="token plain"
               >
-                            setCurrent
+                            setCurrentPage
               </span>
               <span
                 class="token punctuation"
@@ -7926,7 +7926,7 @@ exports[`MantineInferencer should match the snapshot 1`] = `
               <span
                 class="token plain"
               >
-                            current
+                            currentPage
               </span>
               <span
                 class="token punctuation"
@@ -11414,7 +11414,7 @@ exports[`MantineInferencer should match the snapshot 1`] = `
                 class="token tag script language-javascript"
                 style="color: rgb(78, 201, 176);"
               >
-                current
+                currentPage
               </span>
               <span
                 class="token tag script language-javascript punctuation"
@@ -11459,7 +11459,7 @@ exports[`MantineInferencer should match the snapshot 1`] = `
                 class="token tag script language-javascript"
                 style="color: rgb(78, 201, 176);"
               >
-                setCurrent
+                setCurrentPage
               </span>
               <span
                 class="token tag script language-javascript punctuation"

--- a/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/list.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/mantine/__tests__/__snapshots__/list.test.tsx.snap
@@ -6854,7 +6854,7 @@ exports[`MantineListInferencer should match the snapshot 1`] = `
               <span
                 class="token plain"
               >
-                            setCurrent
+                            setCurrentPage
               </span>
               <span
                 class="token punctuation"
@@ -6892,7 +6892,7 @@ exports[`MantineListInferencer should match the snapshot 1`] = `
               <span
                 class="token plain"
               >
-                            current
+                            currentPage
               </span>
               <span
                 class="token punctuation"
@@ -10277,7 +10277,7 @@ exports[`MantineListInferencer should match the snapshot 1`] = `
                 class="token tag script language-javascript"
                 style="color: rgb(78, 201, 176);"
               >
-                current
+                currentPage
               </span>
               <span
                 class="token tag script language-javascript punctuation"
@@ -10322,7 +10322,7 @@ exports[`MantineListInferencer should match the snapshot 1`] = `
                 class="token tag script language-javascript"
                 style="color: rgb(78, 201, 176);"
               >
-                setCurrent
+                setCurrentPage
               </span>
               <span
                 class="token tag script language-javascript punctuation"

--- a/packages/inferencer/src/inferencers/mantine/list.tsx
+++ b/packages/inferencer/src/inferencers/mantine/list.tsx
@@ -777,9 +777,9 @@ export const renderer = ({
             getRowModel,
             setOptions,
             refineCore: {
-                setCurrent,
+                setCurrentPage,
                 pageCount,
-                current,
+                currentPage,
                 tableQuery: { data: tableData },
             },
         } = useTable({
@@ -864,8 +864,8 @@ export const renderer = ({
                 <Pagination
                     position="right"
                     total={pageCount}
-                    page={current}
-                    onChange={setCurrent}
+                    page={currentPage}
+                    onChange={setCurrentPage}
                 />
             </List>
         );

--- a/packages/medusa/src/dataProvider/index.ts
+++ b/packages/medusa/src/dataProvider/index.ts
@@ -10,7 +10,11 @@ const DataProvider = (
   return {
     getList: async ({ resource, pagination, filters }) => {
       const url = `${apiUrl}/${resource}`;
-      const { current = 1, pageSize = 10, mode = "server" } = pagination ?? {};
+      const {
+        currentPage = 1,
+        pageSize = 10,
+        mode = "server",
+      } = pagination ?? {};
 
       const queryFilters = generateFilter(filters);
 
@@ -24,7 +28,7 @@ const DataProvider = (
       } = {
         ...(mode === "server"
           ? {
-              offset: (current - 1) * pageSize,
+              offset: (currentPage - 1) * pageSize,
               limit: pageSize,
             }
           : {}),

--- a/packages/mui/src/hooks/useDataGrid/index.spec.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.spec.ts
@@ -60,7 +60,7 @@ describe("useDataGrid Hook", () => {
         value: "draft",
       },
     ]);
-    expect(result.current.current).toEqual(1);
+    expect(result.current.currentPage).toEqual(1);
   });
 
   it.only.each(["client", "server"] as const)(

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -157,8 +157,8 @@ export function useDataGrid<
 
   const {
     tableQuery,
-    current,
-    setCurrent,
+    currentPage,
+    setCurrentPage,
     pageSize,
     setPageSize,
     filters,
@@ -211,7 +211,7 @@ export function useDataGrid<
 
   const handlePageChange = (page: number) => {
     if (isPaginationEnabled) {
-      setCurrent(page + 1);
+      setCurrentPage(page + 1);
     }
   };
   const handlePageSizeChange = (pageSize: number) => {
@@ -230,7 +230,7 @@ export function useDataGrid<
     setMuiCrudFilters(crudFilters);
     setFilters(crudFilters.filter((f) => f.value !== ""));
     if (isPaginationEnabled) {
-      setCurrent(1);
+      setCurrentPage(1);
     }
   };
 
@@ -240,7 +240,7 @@ export function useDataGrid<
       setMuiCrudFilters(searchFilters);
       setFilters(searchFilters.filter((f) => f.value !== ""));
       if (isPaginationEnabled) {
-        setCurrent(1);
+        setCurrentPage(1);
       }
     }
   };
@@ -254,7 +254,7 @@ export function useDataGrid<
       return {
         paginationMode: "server" as const,
         paginationModel: {
-          page: current - 1,
+          page: currentPage - 1,
           pageSize,
         },
         onPaginationModelChange: (model) => {
@@ -335,8 +335,8 @@ export function useDataGrid<
       },
       processRowUpdate: editable ? processRowUpdate : undefined,
     },
-    current,
-    setCurrent,
+    currentPage,
+    setCurrentPage,
     pageSize,
     setPageSize,
     pageCount,

--- a/packages/nestjs-query/src/utils/index.ts
+++ b/packages/nestjs-query/src/utils/index.ts
@@ -202,11 +202,11 @@ export const generatePaging = (pagination: Pagination) => {
 
   if (pagination.mode !== "server") return undefined;
 
-  if (!pagination.current || !pagination.pageSize) return undefined;
+  if (!pagination.currentPage || !pagination.pageSize) return undefined;
 
   return {
     limit: pagination.pageSize,
-    offset: (pagination.current - 1) * pagination.pageSize,
+    offset: (pagination.currentPage - 1) * pagination.pageSize,
   };
 };
 

--- a/packages/nestjs-query/test/getList/index.spec.ts
+++ b/packages/nestjs-query/test/getList/index.spec.ts
@@ -15,7 +15,7 @@ describe("getList", () => {
       }>({
         resource: "blog_posts",
         pagination: {
-          current: 2,
+          currentPage: 2,
           pageSize: 5,
           mode: "server",
         },
@@ -122,7 +122,7 @@ describe("getList", () => {
               fields: ["id"],
             },
             pagination: {
-              current: 2,
+              currentPage: 2,
               mode: "server",
               pageSize: 10,
             },

--- a/packages/nestjsx-crud/src/utils/handlePagination.ts
+++ b/packages/nestjsx-crud/src/utils/handlePagination.ts
@@ -5,13 +5,13 @@ export const handlePagination = (
   query: RequestQueryBuilder,
   pagination?: Pagination,
 ) => {
-  const { current = 1, pageSize = 10, mode = "server" } = pagination ?? {};
+  const { currentPage = 1, pageSize = 10, mode = "server" } = pagination ?? {};
 
   if (mode === "server") {
     query
       .setLimit(pageSize)
-      .setPage(current)
-      .setOffset((current - 1) * pageSize);
+      .setPage(currentPage)
+      .setOffset((currentPage - 1) * pageSize);
   }
 
   return query;

--- a/packages/nestjsx-crud/test/utils/handlePagination.spec.ts
+++ b/packages/nestjsx-crud/test/utils/handlePagination.spec.ts
@@ -6,7 +6,7 @@ describe("handlePagination", () => {
   it("should apply pagination for server mode", () => {
     let query = RequestQueryBuilder.create();
     const pagination: Pagination = {
-      current: 2,
+      currentPage: 2,
       pageSize: 20,
       mode: "server",
     };
@@ -31,7 +31,7 @@ describe("handlePagination", () => {
   it("should not apply pagination for client mode", () => {
     let query = RequestQueryBuilder.create();
     const pagination: Pagination = {
-      current: 3,
+      currentPage: 3,
       pageSize: 15,
       mode: "client",
     };
@@ -47,7 +47,7 @@ describe("handlePagination", () => {
     let query = RequestQueryBuilder.create();
 
     const pagination: Pagination = {
-      current: 3,
+      currentPage: 3,
       pageSize: 15,
     };
 

--- a/packages/react-table/src/useTable/index.spec.ts
+++ b/packages/react-table/src/useTable/index.spec.ts
@@ -66,7 +66,7 @@ describe("useTable Hook", () => {
           refineCoreProps: {
             resource: "posts",
             pagination: {
-              current: 2,
+              currentPage: 2,
               pageSize: 1,
             },
           },
@@ -84,11 +84,11 @@ describe("useTable Hook", () => {
 
     const {
       options: { state, pageCount },
-      refineCore: { pageSize: corePageSize, current },
+      refineCore: { pageSize: corePageSize, currentPage },
     } = result.current;
 
     expect(corePageSize).toBe(1);
-    expect(current).toBe(2);
+    expect(currentPage).toBe(2);
     expect(state.pagination?.pageIndex).toBe(1);
     expect(state.pagination?.pageSize).toBe(1);
     expect(pageCount).toBe(3);

--- a/packages/react-table/src/useTable/index.ts
+++ b/packages/react-table/src/useTable/index.ts
@@ -72,8 +72,8 @@ export function useTable<
 
   const {
     tableQuery: { data },
-    current,
-    setCurrent,
+    currentPage,
+    setCurrentPage,
     pageSize: pageSizeCore,
     setPageSize: setPageSizeCore,
     sorters,
@@ -94,7 +94,7 @@ export function useTable<
       : getFilteredRowModel(),
     initialState: {
       pagination: {
-        pageIndex: current - 1,
+        pageIndex: currentPage - 1,
         pageSize: pageSizeCore,
       },
       sorting: sorters.map((sorting) => ({
@@ -121,7 +121,7 @@ export function useTable<
 
   useEffect(() => {
     if (pageIndex !== undefined) {
-      setCurrent(pageIndex + 1);
+      setCurrentPage(pageIndex + 1);
     }
   }, [pageIndex]);
 
@@ -143,7 +143,7 @@ export function useTable<
       }
 
       if (sorting.length > 0 && isPaginationEnabled && !isFirstRender) {
-        setCurrent(1);
+        setCurrentPage(1);
       }
     }
   }, [sorting]);
@@ -170,7 +170,7 @@ export function useTable<
     }
 
     if (crudFilters.length > 0 && isPaginationEnabled && !isFirstRender) {
-      setCurrent(1);
+      setCurrentPage(1);
     }
   }, [columnFilters, columns]);
 

--- a/packages/simple-rest/src/provider.ts
+++ b/packages/simple-rest/src/provider.ts
@@ -16,7 +16,11 @@ export const dataProvider = (
   getList: async ({ resource, pagination, filters, sorters, meta }) => {
     const url = `${apiUrl}/${resource}`;
 
-    const { current = 1, pageSize = 10, mode = "server" } = pagination ?? {};
+    const {
+      currentPage = 1,
+      pageSize = 10,
+      mode = "server",
+    } = pagination ?? {};
 
     const { headers: headersFromMeta, method } = meta ?? {};
     const requestMethod = (method as MethodTypes) ?? "get";
@@ -31,8 +35,8 @@ export const dataProvider = (
     } = {};
 
     if (mode === "server") {
-      query._start = (current - 1) * pageSize;
-      query._end = current * pageSize;
+      query._start = (currentPage - 1) * pageSize;
+      query._end = currentPage * pageSize;
     }
 
     const generatedSort = generateSort(sorters);

--- a/packages/strapi-v4/src/dataProvider.ts
+++ b/packages/strapi-v4/src/dataProvider.ts
@@ -16,7 +16,11 @@ export const DataProvider = (
   getList: async ({ resource, pagination, filters, sorters, meta }) => {
     const url = `${apiUrl}/${resource}`;
 
-    const { current = 1, pageSize = 10, mode = "server" } = pagination ?? {};
+    const {
+      currentPage = 1,
+      pageSize = 10,
+      mode = "server",
+    } = pagination ?? {};
 
     const locale = meta?.locale;
     const fields = meta?.fields;
@@ -29,7 +33,7 @@ export const DataProvider = (
     const query = {
       ...(mode === "server"
         ? {
-            "pagination[page]": current,
+            "pagination[page]": currentPage,
             "pagination[pageSize]": pageSize,
           }
         : {}),

--- a/packages/strapi/src/dataProvider.ts
+++ b/packages/strapi/src/dataProvider.ts
@@ -86,7 +86,7 @@ export const DataProvider = (
     const url = `${apiUrl}/${resource}`;
 
     const {
-      current = 1,
+      currentPage = 1,
       pageSize: _limit = 10,
       mode = "server",
     } = pagination ?? {};
@@ -97,7 +97,7 @@ export const DataProvider = (
     const query = {
       ...(mode === "server"
         ? {
-            _start: (current - 1) * _limit,
+            _start: (currentPage - 1) * _limit,
             _limit,
           }
         : {}),

--- a/packages/supabase/src/dataProvider/index.ts
+++ b/packages/supabase/src/dataProvider/index.ts
@@ -7,7 +7,11 @@ export const dataProvider = (
 ): Required<DataProvider> => {
   return {
     getList: async ({ resource, pagination, filters, sorters, meta }) => {
-      const { current = 1, pageSize = 10, mode = "server" } = pagination ?? {};
+      const {
+        currentPage = 1,
+        pageSize = 10,
+        mode = "server",
+      } = pagination ?? {};
 
       const client = meta?.schema
         ? supabaseClient.schema(meta.schema)
@@ -18,7 +22,7 @@ export const dataProvider = (
       });
 
       if (mode === "server") {
-        query.range((current - 1) * pageSize, current * pageSize - 1);
+        query.range((currentPage - 1) * pageSize, currentPage * pageSize - 1);
       }
 
       sorters?.map((item) => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

---

refactor: rename pagination property from 'current' to 'currentPage' across the codebase

- Updated all instances of 'current' to 'currentPage' in pagination objects for consistency.
- Modified related test cases to reflect the new property name.
- Adjusted parsing and stringification functions to accommodate the change.
- Ensured backward compatibility in hooks and data providers.
