### PR TITLE
fix(antd): export `useDrawer` from package

### DIFF
--- a/.changeset/fresh-ads-add.md
+++ b/.changeset/fresh-ads-add.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/antd": patch
+---
+
+- Export `useDrawer`out of antd package.
+
+[Resolves #6944](https://github.com/refinedev/refine/issues/6944)

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -548,6 +548,7 @@ module.exports = {
                 "ui-integrations/ant-design/hooks/use-radio-group/index",
                 "ui-integrations/ant-design/hooks/use-import/index",
                 "ui-integrations/ant-design/hooks/use-modal/index",
+                "ui-integrations/ant-design/hooks/use-drawer/index",
               ],
             },
             {

--- a/packages/antd/src/hooks/drawer/useDrawer/index.tsx
+++ b/packages/antd/src/hooks/drawer/useDrawer/index.tsx
@@ -6,9 +6,17 @@ export type useDrawerReturnType = {
 } & Omit<useModalReturnType, "visible">;
 
 export type useDrawerProps = {
+  /**
+   * Default props for Ant Design {@link https://ant.design/components/drawer/ `<Drawer>`} component.
+   */
   drawerProps?: DrawerProps;
 };
 
+/**
+ * By using `useDrawer` you get props for your records from API in accordance with Ant Design {@link https://ant.design/components/drawer/ `<Drawer>`} component.
+ *
+ * @see {@link https://refine.dev/docs/ui-integrations/ant-design/hooks/use-drawer} for more details.
+ */
 export const useDrawer = ({
   drawerProps = {},
 }: useDrawerProps = {}): useDrawerReturnType => {

--- a/packages/antd/src/hooks/index.ts
+++ b/packages/antd/src/hooks/index.ts
@@ -7,3 +7,4 @@ export * from "./useFileUploadState";
 export * from "./modal";
 export * from "./useSiderVisible";
 export * from "./useThemedLayoutContext";
+export * from "./drawer";


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
`useDrawer` is not exported from the antd package.

## What is the new behavior?
`useDrawer` is exported from the antd package.

resolves #6944

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
