### PR TITLE
docs(data): move API/generic signatures to top for useList/useOne (#6…

### DIFF
--- a/documentation/docs/data/hooks/use-list/index.md
+++ b/documentation/docs/data/hooks/use-list/index.md
@@ -17,6 +17,30 @@ When you need to fetch data according to sort, filter, pagination, etc. from a `
 
 - It uses a query key to cache the data. The **query key** is generated from the provided properties. You can see the query key by using the TanStack Query devtools.
 
+## API Reference
+
+### Properties
+
+<PropsTable module="@refinedev/core/useList"
+successNotification-default='`false`'
+errorNotification-default='"Error (status code: `statusCode`)"'
+/>
+
+### Type Parameters
+
+| Property     | Description                                                                                                                                                         | Type                       | Default                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
+
+### Return Values
+
+| Description                               | Type                                                                                                                            |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Result of the TanStack Query's `useQuery` | [`QueryObserverResult<{ data: TData[]; total: number; }, TError>`](https://tanstack.com/query/v4/docs/react/reference/useQuery) |
+| overtime                                  | `{ elapsedTime?: number }`                                                                                                      |
+
 ## Usage
 
 Here is a basic example of how to use the `useList` hook.
@@ -349,30 +373,6 @@ const { overtime } = useList();
 
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
-
-## API Reference
-
-### Properties
-
-<PropsTable module="@refinedev/core/useList"
-successNotification-default='`false`'
-errorNotification-default='"Error (status code: `statusCode`)"'
-/>
-
-### Type Parameters
-
-| Property     | Description                                                                                                                                                         | Type                       | Default                    |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
-| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
-
-### Return Values
-
-| Description                               | Type                                                                                                                            |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Result of the TanStack Query's `useQuery` | [`QueryObserverResult<{ data: TData[]; total: number; }, TError>`](https://tanstack.com/query/v4/docs/react/reference/useQuery) |
-| overtime                                  | `{ elapsedTime?: number }`                                                                                                      |
 
 [baserecord]: /docs/core/interface-references#baserecord
 [httperror]: /docs/core/interface-references#httperror

--- a/documentation/docs/data/hooks/use-one/index.md
+++ b/documentation/docs/data/hooks/use-one/index.md
@@ -14,6 +14,30 @@ import BasicUsageLivePreview from "./\_basic-usage-live-preview.md";
 
 It is useful when you want to fetch a single record from the API. It will return the data and some functions to control the query.
 
+## API Reference
+
+### Properties
+
+<PropsTable module="@refinedev/core/useOne"
+successNotification-default='`false`'
+errorNotification-default='"Error (status code: `statusCode`)"'
+/>
+
+### Type Parameters
+
+| Property     | Description                                                                                                                                                         | Type                       | Default                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
+| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
+| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
+| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
+
+### Return values
+
+| Description                               | Type                                                                                                                  |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Result of the TanStack Query's `useQuery` | [`QueryObserverResult<{ data: TData; error: TError; }>`](https://tanstack.com/query/v4/docs/react/reference/useQuery) |
+| overtime                                  | `{ elapsedTime?: number }`                                                                                            |
+
 ## Usage
 
 The `useOne` hook expects a `resource` and `id` property, which will be passed to the `getOne` method from the `dataProvider` as a parameter.
@@ -239,30 +263,6 @@ const { overtime } = useOne();
 
 console.log(overtime.elapsedTime); // undefined, 1000, 2000, 3000 4000, ...
 ```
-
-## API Reference
-
-### Properties
-
-<PropsTable module="@refinedev/core/useOne"
-successNotification-default='`false`'
-errorNotification-default='"Error (status code: `statusCode`)"'
-/>
-
-### Type Parameters
-
-| Property     | Description                                                                                                                                                         | Type                       | Default                    |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------- |
-| TQueryFnData | Result data returned by the query function. Extends [`BaseRecord`][baserecord]                                                                                      | [`BaseRecord`][baserecord] | [`BaseRecord`][baserecord] |
-| TError       | Custom error object that extends [`HttpError`][httperror]                                                                                                           | [`HttpError`][httperror]   | [`HttpError`][httperror]   |
-| TData        | Result data returned by the `select` function. Extends [`BaseRecord`][baserecord]. If not specified, the value of `TQueryFnData` will be used as the default value. | [`BaseRecord`][baserecord] | `TQueryFnData`             |
-
-### Return values
-
-| Description                               | Type                                                                                                                  |
-| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| Result of the TanStack Query's `useQuery` | [`QueryObserverResult<{ data: TData; error: TError; }>`](https://tanstack.com/query/v4/docs/react/reference/useQuery) |
-| overtime                                  | `{ elapsedTime?: number }`                                                                                            |
 
 [baserecord]: /docs/core/interface-references#baserecord
 [httperror]: /docs/core/interface-references#httperror


### PR DESCRIPTION
Closes #6939 
- This PR updates two docs only to validate the proposed structure. Please confirm this order is desired across all data hooks; I’ll follow up with the remaining hooks after approval.
- Reorders sections so API Reference (Props, Type Parameters, Return Values) appears before Usage.

Files changed:
- documentation/docs/data/hooks/use-list/index.md
- documentation/docs/data/hooks/use-one/index.md

PR Checklist
[x] Commit message follows guidelines
[x] Related issue linked
[x] Docs updated
[ ] Tests added (N/A — docs-only)
[ ] Changesets added (N/A — docs-only)

What is the current behavior?
- API Reference is at the bottom of these pages.

What is the new behavior?
- API Reference is the first section; TOC shows API first; anchors work. No content changes, only section order.

Notes for reviewers
- This is “batch 1” for feedback. If approved, I’ll apply the same structure to other data hooks in a follow-up.