### PR TITLE
chore: replace `react-live` dependency

### DIFF
--- a/.changeset/big-penguins-stare.md
+++ b/.changeset/big-penguins-stare.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/live-previews": patch
+---
+
+chore: replace `@aliemir/react-live` with `react-live@4`
+
+After Refine 5, outdated `react-live` package was unable to resolve components properly and caused rendering errors.
+
+This update fixes the rendering errors.

--- a/.changeset/chilly-turkeys-sit.md
+++ b/.changeset/chilly-turkeys-sit.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/inferencer": patch
+---
+
+chore: replace `@aliemir/react-live` with `react-live@4`
+
+After Refine 5, outdated `react-live` package was unable to resolve components properly and caused rendering errors.
+
+This update fixes the rendering errors.

--- a/packages/inferencer/package.json
+++ b/packages/inferencer/package.json
@@ -108,7 +108,6 @@
     "types": "node ../shared/generate-declarations.js"
   },
   "dependencies": {
-    "@aliemir/react-live": "^4.0.0",
     "@refinedev/core": "^5.0.0",
     "@tabler/icons-react": "^3.1.0",
     "dayjs": "^1.10.7",
@@ -149,6 +148,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.0.5",
+    "react-live": "^4.1.8",
     "react-router": "^7.0.2",
     "react-test-renderer": "^18.2.0",
     "ts-jest": "^29.1.2",

--- a/packages/inferencer/src/components/live/index.tsx
+++ b/packages/inferencer/src/components/live/index.tsx
@@ -2,11 +2,7 @@ import React from "react";
 import * as RefineCore from "@refinedev/core";
 import * as gql from "graphql-tag";
 
-import {
-  LivePreview,
-  LiveProvider,
-  type ContextProps,
-} from "@aliemir/react-live";
+import { LivePreview, LiveProvider, LiveContext } from "react-live";
 
 import { replaceImports, replaceExports } from "../../utilities";
 import type { AdditionalScopeType, LiveComponentProps } from "../../types";
@@ -16,10 +12,6 @@ const defaultScope: Array<AdditionalScopeType> = [
   ["@refinedev/core", "RefineCore", RefineCore],
   ["graphql-tag", "GraphqlTag", gql],
 ];
-
-const InferencerLiveContext = React.createContext<ContextProps>(
-  {} as ContextProps,
-);
 
 /**
  * Live Component will render the code with `react-live`.
@@ -70,7 +62,7 @@ export const LiveComponent: React.FC<LiveComponentProps> = ({
 
   const ErrorComponentWithError = React.useMemo(() => {
     const LiveErrorComponent = () => {
-      const { error } = React.useContext(InferencerLiveContext);
+      const { error } = React.useContext(LiveContext);
 
       if (ErrorComponent) {
         return (
@@ -99,13 +91,8 @@ export const LiveComponent: React.FC<LiveComponentProps> = ({
   }, [ErrorComponent, fetchError]);
 
   return (
-    <LiveProvider
-      Context={InferencerLiveContext}
-      code={sanitized}
-      scope={scope}
-      noInline
-    >
-      {!fetchError && <LivePreview Context={InferencerLiveContext} />}
+    <LiveProvider code={sanitized} scope={scope} noInline>
+      {!fetchError && <LivePreview />}
       <ErrorComponentWithError />
     </LiveProvider>
   );

--- a/packages/live-previews/package.json
+++ b/packages/live-previews/package.json
@@ -12,7 +12,6 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "@aliemir/react-live": "^4.0.0",
     "@ant-design/icons": "^5.5.1",
     "@auth0/auth0-react": "^1.5.0",
     "@chakra-ui/react": "^2.5.1",
@@ -67,6 +66,7 @@
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.57.0",
     "react-i18next": "^11.8.11",
+    "react-live": "^4.1.8",
     "react-router": "^7.0.2",
     "uuid": "^9.0.1"
   },

--- a/packages/live-previews/pages/preview.tsx
+++ b/packages/live-previews/pages/preview.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import type { NextPage } from "next";
-import { LivePreview, LiveProvider } from "@aliemir/react-live";
+import { LivePreview, LiveProvider } from "react-live";
 
 import Error from "@/pages/_error";
 import { Loading } from "@/src/components/loading";

--- a/packages/live-previews/src/components/live-error.tsx
+++ b/packages/live-previews/src/components/live-error.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { LiveContext } from "@aliemir/react-live";
+import { LiveContext } from "react-live";
 
 export const LiveError: React.FC = () => {
   const { error } = React.useContext(LiveContext);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11081,7 +11081,7 @@ importers:
     devDependencies:
       '@esbuild-plugins/node-resolve':
         specifier: ^0.1.4
-        version: 0.1.4(esbuild@0.17.19)
+        version: 0.1.4(esbuild@0.21.5)
       '@refinedev/core':
         specifier: ^5.0.0
         version: link:../core
@@ -11102,7 +11102,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: ^29.1.2
-        version: 29.1.2(@babel/core@7.28.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(esbuild@0.17.19)(jest@30.0.5(@types/node@20.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.1.2(@babel/core@7.28.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(esbuild@0.21.5)(jest@30.0.5(@types/node@20.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3)))(typescript@5.8.3)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -11130,7 +11130,7 @@ importers:
     devDependencies:
       '@esbuild-plugins/node-resolve':
         specifier: ^0.1.4
-        version: 0.1.4(esbuild@0.21.5)
+        version: 0.1.4(esbuild@0.17.19)
       '@refinedev/core':
         specifier: 5.0.0
         version: link:../core
@@ -11151,7 +11151,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: ^29.1.2
-        version: 29.1.2(@babel/core@7.28.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(esbuild@0.21.5)(jest@30.0.5(@types/node@20.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.1.2(@babel/core@7.28.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(esbuild@0.17.19)(jest@30.0.5(@types/node@20.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3)))(typescript@5.8.3)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -12453,9 +12453,6 @@ importers:
 
   packages/inferencer:
     dependencies:
-      '@aliemir/react-live':
-        specifier: ^4.0.0
-        version: 4.0.0(react@19.1.0)
       '@ant-design/icons':
         specifier: ^5.5.1
         version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -12616,6 +12613,9 @@ importers:
       jest-environment-jsdom:
         specifier: ^30.0.5
         version: 30.0.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      react-live:
+        specifier: ^4.1.8
+        version: 4.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -12692,9 +12692,6 @@ importers:
 
   packages/live-previews:
     dependencies:
-      '@aliemir/react-live':
-        specifier: ^4.0.0
-        version: 4.0.0(react@19.1.0)
       '@ant-design/icons':
         specifier: ^5.5.1
         version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -12857,6 +12854,9 @@ importers:
       react-i18next:
         specifier: ^11.8.11
         version: 11.18.6(i18next@20.6.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-live:
+        specifier: ^4.1.8
+        version: 4.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-router:
         specifier: ^7.0.2
         version: 7.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -13953,10 +13953,6 @@ packages:
 
   '@aliemir/dom-to-fiber-utils@0.4.1':
     resolution: {integrity: sha512-mWjCp9Uu3B1Rbtdnk23Coak831zgy+/1oS+FCTVhCAozGPUURE8IfVFQsCblZMWuT5j+QSc6JNDQ+l2JcZclzA==}
-
-  '@aliemir/react-live@4.0.0':
-    resolution: {integrity: sha512-XRdJnFhxNSqPsno46olHpexa39XKyqrKAS3reFW/7VfclFB8PMCKj5Ocq+m6yxneDoaLtde4b42EtPJEvFV4Gw==}
-    engines: {node: '>= 0.12.0', npm: '>= 2.0.0'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -27365,6 +27361,11 @@ packages:
     peerDependencies:
       react: '>=0.14.9'
 
+  prism-react-renderer@2.4.1:
+    resolution: {integrity: sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==}
+    peerDependencies:
+      react: '>=16.0.0'
+
   probe.gl@3.6.0:
     resolution: {integrity: sha512-19JydJWI7+DtR4feV+pu4Mn1I5TAc0xojuxVgZdXIyfmTLfUaFnk4OloWK1bKbPtkgGKLr2lnbnCXmpZEcEp9g==}
 
@@ -28167,6 +28168,13 @@ packages:
 
   react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
+
+  react-live@4.1.8:
+    resolution: {integrity: sha512-B2SgNqwPuS2ekqj4lcxi5TibEcjWkdVyYykBEUBshPAPDQ527x2zPEZg560n8egNtAjUpwXFQm7pcXV65aAYmg==}
+    engines: {node: '>= 0.12.0', npm: '>= 2.0.0'}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
 
   react-markdown@6.0.3:
     resolution: {integrity: sha512-kQbpWiMoBHnj9myLlmZG9T1JdoT/OEyHK7hqM6CqFT14MAkgWiWBUYijLyBmxbntaN6dCDicPcUhWhci1QYodg==}
@@ -31208,14 +31216,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-reconciler: 0.29.1(react@18.3.1)
-
-  '@aliemir/react-live@4.0.0(react@19.1.0)':
-    dependencies:
-      prism-react-renderer: 1.3.5(react@19.1.0)
-      sucrase: 3.35.0
-      use-editable: 2.3.3(react@19.1.0)
-    transitivePeerDependencies:
-      - react
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -50354,6 +50354,12 @@ snapshots:
     dependencies:
       react: 19.1.0
 
+  prism-react-renderer@2.4.1(react@19.1.0):
+    dependencies:
+      '@types/prismjs': 1.26.3
+      clsx: 2.1.1
+      react: 19.1.0
+
   probe.gl@3.6.0:
     dependencies:
       '@babel/runtime': 7.26.0
@@ -51364,6 +51370,14 @@ snapshots:
       react: 19.1.0
 
   react-lifecycles-compat@3.0.4: {}
+
+  react-live@4.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      prism-react-renderer: 2.4.1(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      sucrase: 3.35.0
+      use-editable: 2.3.3(react@19.1.0)
 
   react-markdown@6.0.3(@types/react@19.1.8)(react@19.1.0):
     dependencies:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## Changes

> Replace `@aliemir/react-live` with `react-live@4`

After Refine 5, outdated `react-live` package was unable to resolve components properly and caused rendering errors.

This update fixes the rendering errors.
