### PR TITLE
fix(core):  `useInfiniteList` pagination not work

### DIFF
--- a/.changeset/rich-bugs-brake.md
+++ b/.changeset/rich-bugs-brake.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/core": patch
+---
+
+fix: `useInfiniteList` pagination not work #7034
+
+Now `useInfiniteList` correctly advances server-side pages when loading more results. This bug was caused by [this commit](https://github.com/refinedev/refine/commit/1a02f020fdc2030e7c7a702e3bd9bfddae2fe1c8).
+
+Resolves #7034

--- a/packages/core/src/hooks/data/useInfiniteList.ts
+++ b/packages/core/src/hooks/data/useInfiniteList.ts
@@ -250,7 +250,8 @@ export const useInfiniteList = <
     queryFn: (context) => {
       const paginationProperties = {
         ...prefferedPagination,
-        currentPage: context.pageParam,
+        currentPage:
+          (context.pageParam as number) ?? prefferedPagination.currentPage,
       };
 
       const meta = {
@@ -260,7 +261,7 @@ export const useInfiniteList = <
 
       return getList<TQueryFnData>({
         resource: resource?.name || "",
-        pagination: prefferedPagination,
+        pagination: paginationProperties,
         filters: prefferedFilters,
         sorters: prefferedSorters,
         meta,
@@ -344,8 +345,6 @@ export const useInfiniteList = <
     ...overtimeOptions,
     isLoading: queryResponse.isFetching,
   });
-
-  queryResponse.data?.pages;
 
   return {
     query: queryResponse,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

`useInfiniteList` always sends the initial `currentPage` to the data provider, so loading more requests re-fetch page 1.

## What is the new behavior?

Fixed by using `context.pageParam` from Tanstack Query

fixes #7034

## Notes for reviewers

This bug was caused by [this commit](https://github.com/refinedev/refine/commit/1a02f020fdc2030e7c7a702e3bd9bfddae2fe1c8)
