### PR TITLE
<fix>(mui): DeleteButton not properly rendering

### DIFF
--- a/packages/mui/src/components/buttons/delete/index.tsx
+++ b/packages/mui/src/components/buttons/delete/index.tsx
@@ -74,7 +74,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
   if (isHidden) return null;
 
   return (
-    <div>
+    <>
       <LoadingButton
         color="error"
         onClick={() => setOpen(true)}
@@ -119,6 +119,6 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
           </Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </>
   );
 };


### PR DESCRIPTION
Rendering a `<div>` as the parent for the DeleteButton prevent the button itself from showing and from showing the following buttons. Changing it to React's tag seems to solve the problem.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
Currently, a simple `<DeleteButton hideText recordItemId={row.id} />` inside a table is not rendering anything, even preventing following elements in the same cell to be rendered.

## What is the new behavior?
The `<DeleteButton>` and any element after it is rendered correctly.

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
