### PR TITLE
Change body to json format for refresh token request

### DIFF
--- a/packages/rest/src/hooks/refresh-token.after-response.hook.ts
+++ b/packages/rest/src/hooks/refresh-token.after-response.hook.ts
@@ -43,7 +43,7 @@ export const refreshTokenAfterResponseHook =
           refineOptions.REFRESH_TOKEN_URL,
           {
             method: "post",
-            body: JSON.stringify({ refreshToken: currentRefreshToken }),
+            json: { refreshToken: currentRefreshToken },
           },
         ).json();
 


### PR DESCRIPTION
fixes content-type: text/plain;charset=UTF-8 issue

* Changed the request body from `body: JSON.stringify({ refreshToken: currentRefreshToken })` to `json: { refreshToken: currentRefreshToken }` in `packages/rest/src/hooks/refresh-token.after-response.hook.ts`.
