### PR TITLE
fix(nextjs-router):  currentPage parameter not working

### DIFF
--- a/.changeset/afraid-islands-cry.md
+++ b/.changeset/afraid-islands-cry.md
@@ -1,0 +1,3 @@
+---
+"@refinedev/nextjs-router": patch
+---

--- a/packages/nextjs-router/src/app/bindings.tsx
+++ b/packages/nextjs-router/src/app/bindings.tsx
@@ -126,7 +126,7 @@ export const routerProvider: RouterProvider = {
         params: {
           ...combinedParams,
           currentPage: convertToNumberIfPossible(
-            combinedParams.current as string,
+            combinedParams.currentPage as string,
           ) as number | undefined,
           pageSize: convertToNumberIfPossible(
             combinedParams.pageSize as string,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

`currentPage` URL parameter resets to page 1 on page refresh.

## What is the new behavior?

`currentPage` parameter persists correctly across page refreshes.

fixes #7042

## Notes for reviewers

Simple one-line fix: changed `combinedParams.current` to `combinedParams.currentPage` in NextJS router provider.