### PR TITLE
fix(rest): getMany mapResponse return value

### DIFF
--- a/.changeset/late-drinks-boil.md
+++ b/.changeset/late-drinks-boil.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/rest": patch
+---
+
+fix: `getMany` `mapResponse` return value is wrong.
+
+Now `getMany` properly handles both array and object response formats by checking if the response is an array and returning the appropriate data structure.

--- a/packages/rest/src/data-providers/nestjsx-crud/nestjsx-crud.options.ts
+++ b/packages/rest/src/data-providers/nestjsx-crud/nestjsx-crud.options.ts
@@ -55,7 +55,15 @@ export const nestjsxCrudDataProviderOptions: CreateDataProviderOptions = {
 
       return query.queryObject;
     },
-    mapResponse: async (response, _params) => await response.json(),
+    mapResponse: async (response, params) => {
+      const body = await response.json<BaseRecord[] | { data: BaseRecord[] }>();
+
+      if (Array.isArray(body)) {
+        return body;
+      }
+
+      return body.data;
+    },
   },
   create: {
     getEndpoint: (params) => params.resource,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

The `getMany` method in rest data provider was incorrectly handling response mapping. It was simply returning `await response.json()` without considering different response formats. This caused issues when the API returns data in `{ data: BaseRecord[] }` format instead of a direct array.

## What is the new behavior?

Now `getMany` properly handles both response formats:
- If response is an array: returns the array directly
- If response is an object with `data` property: returns `body.data`

This makes it consistent with `getList` method behavior and supports different API response structures.

fixes (no related issue)

## Notes for reviewers

This fix aligns the `getMany` method's `mapResponse` function with the same logic used in `getList`. The change ensures compatibility with APIs that wrap their response data in an object structure.