### PR TITLE
fix(core): correct useCustom return type during loading

### DIFF
--- a/.changeset/four-ads-sin.md
+++ b/.changeset/four-ads-sin.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/core": patch
+---
+
+fix(core): correct `useCustom` return type to reflect undefined data during loading #7088
+
+Fixed a type safety issue where `useCustom` returned an empty object (`{}`) while loading but TypeScript type was `CustomResponse<TData>["data"]`. This caused runtime errors like `result.data.map is not a function` when accessing data without proper checks. Now `result.data` returns `undefined` while loading with type `CustomResponse<TData>["data"] | undefined`, requiring proper null checks like `result.data?.map()`.
+
+Resolves #7088

--- a/packages/core/src/hooks/data/useCustom.ts
+++ b/packages/core/src/hooks/data/useCustom.ts
@@ -110,11 +110,9 @@ export type UseCustomProps<TQueryFnData, TError, TQuery, TPayload, TData> = {
 export type UseCustomReturnType<TData, TError> = {
   query: QueryObserverResult<CustomResponse<TData>, TError>;
   result: {
-    data: CustomResponse<TData>["data"];
+    data: CustomResponse<TData>["data"] | undefined;
   };
 } & UseLoadingOvertimeReturnType;
-
-const EMPTY_OBJECT = Object.freeze({}) as any;
 
 export const useCustom = <
   TQueryFnData extends BaseRecord = BaseRecord,
@@ -233,7 +231,7 @@ export const useCustom = <
     return {
       query: queryResponse,
       result: {
-        data: queryResponse.data?.data || EMPTY_OBJECT,
+        data: queryResponse.data?.data,
       },
       overtime: { elapsedTime },
     };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

The `useCustom` hook returns an empty object (`{}`) for `result.data` while loading, but the TypeScript type indicates it's `CustomResponse<TData>["data"]`. This causes TypeScript to miss runtime errors when accessing properties or methods on `result.data` without proper null checks.

For example, when expecting an array, calling `result.data.map()` fails at runtime with `result.data.map is not a function`.

## What is the new behavior?

Now `result.data` returns `undefined` while loading with the correct type `CustomResponse<TData>["data"] | undefined`. This forces developers to use proper null checks like `result.data?.map()`, preventing runtime errors.

fixes #7088

## Notes for reviewers

- Updated return type definition in `useCustom.ts`
- Removed `EMPTY_OBJECT` fallback in favor of returning `undefined`
- Added test case to verify `result.data` is `undefined` during loading state
- Updated existing test to check data is defined after successful load