### PR TITLE
docs(landing): sync right-side preview on hover in LandingSweetSpot

### DIFF
--- a/documentation/src/refine-theme/landing-sweet-spot.tsx
+++ b/documentation/src/refine-theme/landing-sweet-spot.tsx
@@ -29,9 +29,10 @@ export const LandingSweetSpot: FC<Props> = ({ className }) => {
   const activeListItem = list[activeIndex];
 
   const [shouldIncrement, setShouldIncrement] = useState(true);
+  const [isHovering, setIsHovering] = useState(false);
 
   useEffect(() => {
-    if (!shouldIncrement) {
+    if (!shouldIncrement || isHovering) {
       return;
     }
 
@@ -43,7 +44,7 @@ export const LandingSweetSpot: FC<Props> = ({ className }) => {
     }
 
     return () => clearInterval(interval);
-  }, [shouldIncrement, inView]);
+  }, [shouldIncrement, inView, isHovering]);
 
   return (
     <div ref={ref} className={clsx(className, "w-full")}>
@@ -179,6 +180,13 @@ export const LandingSweetSpot: FC<Props> = ({ className }) => {
                       onClick={() => {
                         setShouldIncrement(false);
                         setActiveIndex(index);
+                      }}
+                      onMouseEnter={() => {
+                        setIsHovering(true);
+                        setActiveIndex(index);
+                      }}
+                      onMouseLeave={() => {
+                        setIsHovering(false);
                       }}
                       className={clsx(
                         "appearance-none",


### PR DESCRIPTION
## Summary
Improves the LandingSweetSpot section on the homepage by making the right-side preview update immediately when hovering any item (Tables, List, Charts, Forms, Wizards, Authentication). This also pauses the auto-rotation while hovering for better control and user experience.

## Before
- The right-side UI/code preview did **not** change immediately when hovering.
- Hovering only affected the left-side button styles, not the actual content.

## After
- Hovering an item instantly updates the right-side preview.
- Auto-rotation pauses while hovering for better interaction control.


https://github.com/user-attachments/assets/29c2b821-73ef-420e-ae71-48ada29e2366



## Changes
- Updated `LandingSweetSpot.tsx`:
  - Add `isHovering` state to pause auto-rotation.
  - Update `activeIndex` on hover.
  - Prevent interval from running during hover.
  - Maintains smooth fade/slide animations with framer-motion.