### PR TITLE
fix(shadcn): prevent toast id collision for undoable mutations

### DIFF
--- a/packages/refine-ui/registry/new-york/refine-ui/notification/use-notification-provider.tsx
+++ b/packages/refine-ui/registry/new-york/refine-ui/notification/use-notification-provider.tsx
@@ -30,7 +30,7 @@ export function useNotificationProvider(): NotificationProvider {
           return;
 
         case "progress": {
-          const toastId = key || Date.now();
+          const toastId = key ? `${key}-progress` : Date.now();
 
           toast(
             () => (


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added

## What is the current behavior?

When using `mutationMode: "undoable"` with the shadcn (new-york) refine UI, the undoable progress toast and the final success/error toast reuse the same toast ID. Since the progress toast is rendered with `unstyled: true`, the subsequent success notification is displayed without styles.

## What is the new behavior?

Undoable progress notifications now use a unique toast ID, preventing collisions with the final success/error notification. This ensures that success and error toasts are rendered with the correct styles.

## Fixes (issue)

Fixes #7183

## Notes for reviewers

This change implements the solution proposed in the issue discussion. The fix is intentionally minimal and scoped only to the shadcn (new-york) notification provider to avoid impacting other UI registries.
