### PR TITLE
fix(rest): allow override optional getMany method as undefined

### DIFF
--- a/.changeset/rare-gorillas-tan.md
+++ b/.changeset/rare-gorillas-tan.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+fix(rest): allow override optional `getMany` method as `undefined`
+
+Fixed an issue preventing optional data provider `getMany` method from being overridden with `undefined` values when creating a data provider.

--- a/packages/rest/src/create-data-provider.ts
+++ b/packages/rest/src/create-data-provider.ts
@@ -82,22 +82,24 @@ export const createDataProvider = (
 
         return { data };
       },
-      async getMany(params): Promise<GetManyResponse<any>> {
-        const endpoint = options.getMany.getEndpoint(params);
+      getMany: options.getMany
+        ? async (params): Promise<GetManyResponse<any>> => {
+            const endpoint = options.getMany.getEndpoint(params);
 
-        const headers = await options.getMany.buildHeaders(params);
+            const headers = await options.getMany.buildHeaders(params);
 
-        const query = await options.getMany.buildQueryParams(params);
+            const query = await options.getMany.buildQueryParams(params);
 
-        const response = await ky(endpoint, {
-          headers,
-          searchParams: qs.stringify(query, { encodeValuesOnly: true }),
-        });
+            const response = await ky(endpoint, {
+              headers,
+              searchParams: qs.stringify(query, { encodeValuesOnly: true }),
+            });
 
-        const data = await options.getMany.mapResponse(response, params);
+            const data = await options.getMany.mapResponse(response, params);
 
-        return { data };
-      },
+            return { data };
+          }
+        : undefined,
       create: async (params): Promise<CreateResponse<any>> => {
         const endpoint = options.create.getEndpoint(params);
 

--- a/packages/rest/test/methods/getMany.spec.ts
+++ b/packages/rest/test/methods/getMany.spec.ts
@@ -12,15 +12,15 @@ nock(API_URL)
   .reply(200, response);
 
 describe("getMany", () => {
-  const { dataProvider } = createDataProvider(
-    API_URL,
-    {},
-    {
-      headers: { "x-default-header": "getMany" },
-    },
-  );
-
   it("should return the data", async () => {
+    const { dataProvider } = createDataProvider(
+      API_URL,
+      {},
+      {
+        headers: { "x-default-header": "getMany" },
+      },
+    );
+
     const result = await dataProvider.getMany!({
       ids: [1, 2],
       resource: "getMany",
@@ -30,5 +30,13 @@ describe("getMany", () => {
     });
 
     expect(result).toEqual({ data: response });
+  });
+
+  it("should getMany undefined", async () => {
+    const { dataProvider } = createDataProvider(API_URL, {
+      getMany: undefined,
+    });
+
+    expect(dataProvider.getMany).toBeUndefined();
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

When creating a data provider with createDataProvider, optional methods like getMany cannot be overridden with undefined values, preventing users from explicitly disabling these methods.

## What is the new behavior?

The createDataProvider function now properly handles undefined values for optional methods (getMany, createMany, updateMany, deleteMany), allowing users to explicitly disable these methods when needed.
