### PR TITLE
fix(react-hook-form): sync late registered fields

### DIFF
--- a/.changeset/fuzzy-hats-worry.md
+++ b/.changeset/fuzzy-hats-worry.md
@@ -1,0 +1,6 @@
+---
+"@refinedev/react-hook-form": patch
+---
+
+fix: sync query values to fields that register after data loads (e.g. Controller),
+without overwriting dirty inputs.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

When query data resolves before some fields register (e.g. Controller, conditional inputs), those late fields stay empty because the initial sync already happened.

## What is the new behavior?

Query values are synced to fields that register after data loads, without overwriting dirty inputs. Late-registered fields receive the correct value once they mount.

## Notes for reviewers

Sync logic uses RHF’s mount set to detect late-registered fields; the effect runs each render but only applies values when new field names appear.