### PR TITLE
docs: fix example locations for GitHub Banner removal

### DIFF
--- a/documentation/docs/guides-concepts/faq/index.md
+++ b/documentation/docs/guides-concepts/faq/index.md
@@ -330,9 +330,9 @@ To remove the GitHub Banner, you need to find and remove the `<GitHubBanner />` 
 
 Here are the locations where you can find and remove the `<GitHubBanner />` component based on different React platforms:
 
-- Vite: `src/App.tsx` - [See an example](https://github.com/refinedev/refine/blob/main/examples/auth-antd/src/App.tsx#L161)
-- Next.js: `src/app/layout.tsx` - [See an example](https://github.com/refinedev/refine/blob/main/examples/with-nextjs/src/app/layout.tsx#L37)
-- Remix: `app/root.tsx` - [See an example](https://github.com/refinedev/refine/blob/main/examples/with-remix-antd/app/root.tsx#L37)
+- Vite: `src/App.tsx` - [See an example](https://github.com/refinedev/refine/blob/main/examples/auth-antd/src/App.tsx#L166)
+- Next.js: `src/app/layout.tsx` - [See an example](https://github.com/refinedev/refine/blob/main/examples/with-nextjs/src/app/layout.tsx#L38)
+- Remix: `app/root.tsx` - [See an example](https://github.com/refinedev/refine/blob/main/examples/with-remix-antd/app/root.tsx#L39)
 
 ## How to solve "Module 'X' has no exported member 'Y'" error?
 


### PR DESCRIPTION
Updated example locations for removing the GitHub Banner component in various React platforms.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
