### PR TITLE
fix(mui): debounce server filter updates in useDataGrid #7216

### DIFF
--- a/.changeset/small-baboons-sniff.md
+++ b/.changeset/small-baboons-sniff.md
@@ -1,0 +1,13 @@
+---
+"@refinedev/mui": patch
+---
+
+fix: prevent server-side filter input from dropping characters in `useDataGrid`
+
+When typing in the DataGrid filter panel with server mode, the input could lose
+recent characters because the server update resets the filter model mid-typing.
+We now debounce the `setFilters` call inside `useDataGrid` and disable the
+DataGrid's own debounce to keep the input state stable while still triggering
+server queries.
+
+Resolves #7216


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
Typing in DataGrid column filters with server-side mode drops recent characters after the fetch.

## What is the new behavior?
Filter inputs keep the full typed value while server requests run.
 

https://github.com/user-attachments/assets/877f83d2-0f2e-4c4f-8d68-4e614f23ffbf



fixes #7216

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
