### PR TITLE
fix(docs): prevent horizontal overflow on mobile

### DIFF
--- a/documentation/src/components/blog/featured-blog-post-items/index.js
+++ b/documentation/src/components/blog/featured-blog-post-items/index.js
@@ -6,7 +6,7 @@ import clsx from "clsx";
 
 export const FeaturedBlogPostItems = ({ items }) => {
   return (
-    <div className={clsx("w-screen")}>
+    <div className={clsx("w-full")}>
       <div
         className={clsx(
           "blog-sm:max-w-[592px]",

--- a/documentation/src/refine-theme/blog-hero.tsx
+++ b/documentation/src/refine-theme/blog-hero.tsx
@@ -9,6 +9,7 @@ export const BlogHero: FC<Props> = ({ className }) => {
       className={clsx(
         "relative",
         "w-full",
+        "overflow-hidden",
         "bg-[radial-gradient(50%_100%_at_50%_0%,#431407_0%,rgba(67,20,7,0)_100%)]",
         "dark:bg-[radial-gradient(50%_100%_at_50%_0%,#431407_0%,rgba(67,20,7,0)_100%)]",
         "bg-[radial-gradient(50%_100%_at_50%_0%,#FED7AA_0%,rgba(254,215,170,0)_100%)]",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
On mobile, the `/blog` page can overflow horizontally and allows scrolling to the right.

## What is the new behavior?
The `/blog` page no longer overflows horizontally on mobile.  

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
