### PR TITLE
Fix: Supabase Realtime support for single filter with warning fallback

### DIFF
--- a/packages/supabase/src/liveProvider/index.ts
+++ b/packages/supabase/src/liveProvider/index.ts
@@ -54,17 +54,22 @@ export const liveProvider = (
           return;
         }
 
-        return filters
-          .map((filter: CrudFilter): string | undefined => {
-            if ("field" in filter) {
-              return `${filter.field}=${mapOperator(filter.operator)}.${
-                filter.value
-              }`;
-            }
-            return;
-          })
-          .filter(Boolean)
-          .join(",");
+        // FIX: Warn user if multiple filters are provided, as Supabase Realtime only supports one.
+        if (filters.length > 1) {
+          console.warn(
+            "@refinedev/supabase: Realtime subscription does not support multiple filters. Only the first filter will be applied."
+          );
+        }
+
+        // FIX: Take only the first filter instead of mapping and joining them
+        const filter = filters[0];
+        if ("field" in filter) {
+          return `${filter.field}=${mapOperator(filter.operator)}.${
+            filter.value
+          }`;
+        }
+        
+        return undefined;
       };
 
       const events = types


### PR DESCRIPTION
## What is the current behavior?
Currently, the Supabase Realtime provider crashes or errors out when multiple filters are provided. The `mapFilter` function attempts to join multiple filters with a comma (e.g., `filterA,filterB`), but the Supabase Realtime API expects a single filter string. This causes the WebSocket connection to fail or be rejected.

## What is the new behavior?
The provider now detects if multiple filters are present.
1.  It logs a `console.warn` to inform the developer that Supabase Realtime only supports a single filter.
2.  It explicitly selects only the first filter (`filters[0]`) to ensure a valid connection string is generated.
3.  This prevents the crash and allows the subscription to succeed with the primary filter.

## Notes for reviewers
I verified this fix locally by simulating a `subscribe` call with multiple filters.
- **Before fix:** The payload contained an invalid comma-separated string, causing errors.
- **After fix:** The payload correctly contained only the first filter, and the warning was logged to the console.