### PR TITLE
fix: remove the american localization from the typos toml

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -1,5 +1,5 @@
 [default]
-locale = "en-us"
+locale = "en"
 
 extend-ignore-re = [
     "\\.refine",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fix: remove the american localization from the typos toml

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
