### PR TITLE
Update index.tsx

### DIFF
--- a/packages/core/src/hooks/button/delete-button/index.tsx
+++ b/packages/core/src/hooks/button/delete-button/index.tsx
@@ -54,6 +54,7 @@ export function useDeleteButton(props: DeleteButtonProps): DeleteButtonValues {
     accessControl: props.accessControl,
     id,
     resource,
+    meta: props.meta,
   });
 
   const label = translate("buttons.delete", "Delete");


### PR DESCRIPTION
fix(core): pass meta params to useButtonCanAccess in useDeleteButton (#7289)

This PR addresses the issue where useDeleteButton accepts a meta property but fails to forward it to the useButtonCanAccess hook. This prevents custom Access Control Providers from receiving necessary metadata when determining delete permissions.

Related Issues
- Fixes #7285
- Closes #7289

Changes
- Updated packages/core/src/hooks/button/delete-button/index.tsx to include the meta property in the useButtonCanAccess configuration object.

How to test?

1. Create a custom accessControlProvider that logs the params of the can method.

2. Use a DeleteButton (or the useDeleteButton hook) and pass a unique meta object: <DeleteButton meta={{ foo: "bar" }} />.

3. Observe that without this fix, the meta property is undefined in the access control check; with this fix, it correctly contains { foo: "bar" }.