### PR TITLE
feat: enhance SEO and favicon 

### DIFF
--- a/documentation/src/hooks/use-route-favicon.ts
+++ b/documentation/src/hooks/use-route-favicon.ts
@@ -4,24 +4,45 @@ import { useLocation } from "@docusaurus/router";
 const DEFAULT_FAVICON_PATH = "/assets/favicon.svg";
 const BLOG_FAVICON_PATH = "/assets/favicon-blog.svg";
 const BLOG_ROUTE_PREFIX = "/blog";
+const ICON_LINK_SELECTOR = 'link[rel~="icon"]';
+const FAVICON_TYPE = "image/svg+xml";
 
 const isBlogRoute = (pathname = "") =>
   pathname === BLOG_ROUTE_PREFIX ||
   pathname.startsWith(`${BLOG_ROUTE_PREFIX}/`);
 
-const upsertFaviconLink = (rel: "icon" | "shortcut icon", href: string) => {
-  let faviconLink = document.querySelector<HTMLLinkElement>(
-    `link[rel="${rel}"]`,
+const isIconLink = (node: Node): node is HTMLLinkElement =>
+  node instanceof HTMLLinkElement &&
+  node.rel.toLowerCase().split(/\s+/).includes("icon");
+
+const ensureFaviconLinks = () => {
+  const faviconLinks = Array.from(
+    document.head.querySelectorAll<HTMLLinkElement>(ICON_LINK_SELECTOR),
   );
 
-  if (!faviconLink) {
-    faviconLink = document.createElement("link");
-    faviconLink.setAttribute("rel", rel);
-    document.head.appendChild(faviconLink);
+  if (faviconLinks.length > 0) {
+    return faviconLinks;
   }
 
-  faviconLink.setAttribute("type", "image/svg+xml");
-  faviconLink.setAttribute("href", href);
+  const iconLink = document.createElement("link");
+  iconLink.setAttribute("rel", "icon");
+  document.head.appendChild(iconLink);
+
+  return [iconLink];
+};
+
+const syncFaviconLinks = (href: string) => {
+  const faviconLinks = ensureFaviconLinks();
+
+  faviconLinks.forEach((faviconLink) => {
+    if (faviconLink.getAttribute("type") !== FAVICON_TYPE) {
+      faviconLink.setAttribute("type", FAVICON_TYPE);
+    }
+
+    if (faviconLink.getAttribute("href") !== href) {
+      faviconLink.setAttribute("href", href);
+    }
+  });
 };
 
 const useRouteFavicon = () => {
@@ -32,8 +53,32 @@ const useRouteFavicon = () => {
       ? BLOG_FAVICON_PATH
       : DEFAULT_FAVICON_PATH;
 
-    upsertFaviconLink("icon", faviconPath);
-    upsertFaviconLink("shortcut icon", faviconPath);
+    syncFaviconLinks(faviconPath);
+
+    const observer = new MutationObserver((mutations) => {
+      const hasIconMutation = mutations.some((mutation) => {
+        if (mutation.type === "attributes") {
+          return isIconLink(mutation.target);
+        }
+
+        return (
+          Array.from(mutation.addedNodes).some(isIconLink) ||
+          Array.from(mutation.removedNodes).some(isIconLink)
+        );
+      });
+
+      if (hasIconMutation) {
+        syncFaviconLinks(faviconPath);
+      }
+    });
+
+    observer.observe(document.head, {
+      childList: true,
+      attributes: true,
+      attributeFilter: ["href", "rel", "type"],
+    });
+
+    return () => observer.disconnect();
   }, [pathname]);
 };
 

--- a/documentation/src/refine-theme/blog-hero.tsx
+++ b/documentation/src/refine-theme/blog-hero.tsx
@@ -8,7 +8,7 @@ export const BlogHero: FC<Props> = ({ className }) => {
     <div
       className={clsx(
         "pl-8",
-        "blog-max:pl-[68px]",
+        "blog-max:pl-[46px]",
         "mt-[80px]",
         "blog-max:mt-[120px]",
         "text-[2.5rem]",

--- a/documentation/src/theme/BlogCategoryPostsPage/index.js
+++ b/documentation/src/theme/BlogCategoryPostsPage/index.js
@@ -24,12 +24,16 @@ function BlogCategoryPostsPageMetadata(props) {
   const isPaginated =
     typeof listMetadata.page === "number" && listMetadata.page > 1;
 
+  const baseTitle = category.seoTitle ?? `${categoryName} - ${siteTitle}`;
+  const baseDescription =
+    category.seoDescription ?? listMetadata.blogDescription;
+
   const title = isPaginated
-    ? `${categoryName} - ${siteTitle} - Page ${listMetadata.page}`
-    : `${categoryName} - ${siteTitle}`;
+    ? `${baseTitle} - Page ${listMetadata.page}`
+    : baseTitle;
   const description = isPaginated
-    ? `${listMetadata.blogDescription} - Page ${listMetadata.page}`
-    : listMetadata.blogDescription;
+    ? `${baseDescription} - Page ${listMetadata.page}`
+    : baseDescription;
 
   return (
     <>


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
- Blog routes can show inconsistent favicon because only specific icon links are updated, and later `<head>` updates may restore a default icon.
- `/blog/categories/:category` pages use generic metadata (`<Category> - <Site Title>` and shared blog description) instead of category-specific SEO copy.
- Related posts are selected only by shared tags, so posts without tags may return weaker related content.
- Blog hero has wider left padding on `blog-max` layouts.

## What is the new behavior?
- Favicon switching is stable on route changes by syncing all `link[rel~="icon"]` tags and re-syncing on `<head>` icon mutations.
- Category SEO metadata is generated in the blog plugin at build time and passed as `seoTitle` / `seoDescription` to category pages.
- Category pages now render custom SEO title/description for:
  - `How To Build`
  - `Tutorials`
  - `AI & Innovation`
  - `Ecosystem / Integrations`
  - `Alternatives`
  - `Engineering`
  - `Announcement`
- Paginated category pages keep the same SEO copy and append `- Page N`.
- Related posts now fall back to same-category matching when tag overlap is unavailable.
- Blog hero left padding on `blog-max` was reduced from `68px` to `46px`.

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
