### PR TITLE
feat(hasura): add support for Hasura JSONB/array operators and arbitr…

### DIFF
--- a/.changeset/purple-tools-punch.md
+++ b/.changeset/purple-tools-punch.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/hasura": minor
+---
+
+Add support for Hasura JSONB/array operators

--- a/documentation/docs/data/packages/hasura/index.md
+++ b/documentation/docs/data/packages/hasura/index.md
@@ -49,6 +49,16 @@ const App = () => (
 );
 ```
 
+### Supported Operators
+
+The `@refinedev/hasura` data provider correctly maps typical Crud operations to their equivalent Hasura `_` actions (e.g. `eq` -> `_eq`).
+
+Additionally, native JSONB and Array operators are also supported, mapping easily right out-of-the-box:
+
+- JSONB & Arrays: `_contains`, `_contained_in`, `_has_key`, `_has_keys_any`, `_has_keys_all`.
+
+If an unsupported or custom operator string is used in a Refine query filter, the data provider automatically safely falls back—detecting the arbitrary operator and appending a `_` prefix (if not provided). It passes the arbitrary JSON payload directly downstream, neatly matching Hashura's conventions without throwing errors.
+
 ### Developer Experience
 
 We suggest using `GraphQL Code Generator` to generate types for your queries and mutations. You can check out the [GraphQL Code Generator Documentation](https://the-guild.dev/graphql/codegen/docs/getting-started) to learn more about it.

--- a/packages/hasura/src/utils/generateFilters.ts
+++ b/packages/hasura/src/utils/generateFilters.ts
@@ -29,9 +29,25 @@ export type HasuraFilterCondition =
   | "_similar"
   | "_nsimilar"
   | "_regex"
-  | "_iregex";
+  | "_iregex"
+  | "_contains"
+  | "_contained_in"
+  | "_has_key"
+  | "_has_keys_any"
+  | "_has_keys_all";
 
-export type HasuraCrudOperators = CrudOperators | "not";
+export type HasuraCrudOperators =
+  | CrudOperators
+  | "not"
+  | "contained_in"
+  | "has_key"
+  | "has_keys_any"
+  | "has_keys_all"
+  | "_contains"
+  | "_contained_in"
+  | "_has_key"
+  | "_has_keys_any"
+  | "_has_keys_all";
 
 export type HasuraLogicalFilter = Omit<LogicalFilter, "operator"> & {
   operator: Exclude<HasuraCrudOperators, "or" | "and" | "not">;
@@ -77,6 +93,15 @@ const hasuraFilters: Partial<
   nstartswiths: "_nsimilar",
   endswiths: "_similar",
   nendswiths: "_nsimilar",
+  contained_in: "_contained_in",
+  has_key: "_has_key",
+  has_keys_any: "_has_keys_any",
+  has_keys_all: "_has_keys_all",
+  _contains: "_contains",
+  _contained_in: "_contained_in",
+  _has_key: "_has_key",
+  _has_keys_any: "_has_keys_any",
+  _has_keys_all: "_has_keys_all",
 };
 
 export const handleFilterValue = (
@@ -131,13 +156,15 @@ export const generateNestedFilterQuery = (
     const { field, value } = filter;
 
     const defaultNamingConvention = namingConvention === "hasura-default";
-    const hasuraOperator = defaultNamingConvention
+    let hasuraOperator = defaultNamingConvention
       ? hasuraFilters[filter.operator]
       : convertHasuraOperatorToGraphqlDefaultNaming(
           hasuraFilters[filter.operator],
         );
     if (!hasuraOperator) {
-      throw new Error(`Operator ${operator} is not supported`);
+      hasuraOperator = filter.operator.startsWith("_")
+        ? (filter.operator as HasuraFilterCondition)
+        : (`_${filter.operator}` as HasuraFilterCondition);
     }
 
     const fieldsArray = field.split(".");

--- a/packages/hasura/test/utils/generateFilters.spec.ts
+++ b/packages/hasura/test/utils/generateFilters.spec.ts
@@ -132,6 +132,13 @@ describe("handleFilterValue", () => {
     ["ncontains", "test", "%test%"],
     ["ncontainss", "test", "%test%"],
     ["eq", "test", "test"],
+    ["_contains", { a: 1 }, { a: 1 }],
+    ["_contains", ["a", "b"], ["a", "b"]],
+    ["_contained_in", { a: 1 }, { a: 1 }],
+    ["_contained_in", ["a", "b"], ["a", "b"]],
+    ["_has_key", "a", "a"],
+    ["_has_keys_any", ["a", "b"], ["a", "b"]],
+    ["_has_keys_all", ["a", "b"], ["a", "b"]],
   ];
 
   it.each(testCases)(


### PR DESCRIPTION
## Description

This PR introduces explicit support for Postgres JSONB and array operators (`_contains`, `_contained_in`, `_has_key`, `_has_keys_any`, and `_has_keys_all`) to the `@refinedev/hasura` data provider. Additionally, it adds robust fallback handling for arbitrary generic operators.

## PR Checklist

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

Currently, trying to use essential JSONB or array operators in filters causes the data provider to throw an "Operator X is not supported" error. Users are restricted to a highly specific subset of [CrudOperators](cci:2://file:///home/syta/Documents/epi3/repos/refine/packages/hasura/src/utils/generateFilters.ts:38:0-49:20) available in the core library mapping, limiting their ability to interface fully with Hasura's rich querying syntax. 

## What is the new behavior?

The `hasuraFilters` mapping and [generateFilters.ts](cci:7://file:///home/syta/Documents/epi3/repos/refine/packages/hasura/src/utils/generateFilters.ts:0:0-0:0) now officially support the missing JSONB/array operators. 
Furthermore, instead of explicitly throwing errors on unrecognized operators, the [generateNestedFilterQuery](cci:1://file:///home/syta/Documents/epi3/repos/refine/packages/hasura/src/utils/generateFilters.ts:143:0-183:2) function now gracefully passes arbitrary operators through to the query payload. It intelligently acts as a fallback layer, attaching a `_` prefix if needed, ensuring developers can invoke Custom Hasura Operations seamlessly out-of-the-box.

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
Tested cases covering objects and array filters for the new `_contains` / `_contained_in` operators were added in `generateFilters.spec.ts`.
