### PR TITLE
fix(cli): resolve bin path from cwd to support monorepo workspace hoisting

### DIFF
--- a/.changeset/eleven-needles-teach.md
+++ b/.changeset/eleven-needles-teach.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/cli": patch
+---
+
+fix: resolve bin path from cwd to support monorepo workspace hoisting
+
+`resolveBin()` now walks up from `process.cwd()` to find `node_modules/.bin/<name>`, fixing `MODULE_NOT_FOUND` errors when running `refine dev` in npm/bun/yarn workspaces where packages are hoisted to a parent `node_modules`.

--- a/packages/cli/src/commands/runner/projectScripts.test.ts
+++ b/packages/cli/src/commands/runner/projectScripts.test.ts
@@ -1,4 +1,6 @@
-import { vi } from "vitest";
+import { vi, afterEach, describe, test, expect } from "vitest";
+import path from "path";
+import fs from "fs";
 import { projectScripts } from "./projectScripts";
 import { ProjectTypes } from "@definitions/projectTypes";
 
@@ -460,5 +462,50 @@ describe("UNKNOWN project type", () => {
       const args = ["--arg1", "--arg2"];
       expect(projectScripts[projectType].getBuild(args)).toEqual([...args]);
     });
+  });
+});
+
+describe("resolveBin (workspace support)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("should find binary in cwd node_modules/.bin (standard setup)", () => {
+    const mockCwd = "/project";
+    vi.spyOn(process, "cwd").mockReturnValue(mockCwd);
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+      return p === path.join(mockCwd, "node_modules", ".bin", "vite");
+    });
+
+    expect(projectScripts[ProjectTypes.VITE].getBin()).toBe(
+      path.join(mockCwd, "node_modules", ".bin", "vite"),
+    );
+  });
+
+  test("should find binary in parent node_modules/.bin (monorepo workspace setup)", () => {
+    const mockCwd = "/project/apps/admin";
+    const workspaceRoot = "/project";
+    vi.spyOn(process, "cwd").mockReturnValue(mockCwd);
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+      // Binary is NOT in the app's local node_modules, but IS in the workspace root
+      return p === path.join(workspaceRoot, "node_modules", ".bin", "vite");
+    });
+
+    expect(projectScripts[ProjectTypes.VITE].getBin()).toBe(
+      path.join(workspaceRoot, "node_modules", ".bin", "vite"),
+    );
+  });
+
+  test("should find binary for next.js in parent node_modules/.bin (monorepo workspace setup)", () => {
+    const mockCwd = "/project/apps/admin";
+    const workspaceRoot = "/project";
+    vi.spyOn(process, "cwd").mockReturnValue(mockCwd);
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+      return p === path.join(workspaceRoot, "node_modules", ".bin", "next");
+    });
+
+    expect(projectScripts[ProjectTypes.NEXTJS].getBin()).toBe(
+      path.join(workspaceRoot, "node_modules", ".bin", "next"),
+    );
   });
 });

--- a/packages/cli/src/commands/runner/projectScripts.ts
+++ b/packages/cli/src/commands/runner/projectScripts.ts
@@ -1,6 +1,28 @@
+import path from "path";
+import fs from "fs";
 import { ProjectTypes } from "@definitions/projectTypes";
 
 function resolveBin(name: string) {
+  // Walk up from the current working directory to find node_modules/.bin/${name}.
+  // This handles monorepo/workspace setups where packages may be hoisted to a
+  // parent directory's node_modules.
+  let dir = process.cwd();
+  while (true) {
+    if (process.platform === "win32") {
+      const exePath = path.join(dir, "node_modules", ".bin", `${name}.exe`);
+      if (fs.existsSync(exePath)) return exePath;
+      const cmdPath = path.join(dir, "node_modules", ".bin", `${name}.cmd`);
+      if (fs.existsSync(cmdPath)) return cmdPath;
+    } else {
+      const binPath = path.join(dir, "node_modules", ".bin", name);
+      if (fs.existsSync(binPath)) return binPath;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+
+  // Fall back to require.resolve for backward compatibility
   if (process.platform === "win32") {
     try {
       return require.resolve(`.bin/${name}.exe`);


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

When running `refine dev` inside a monorepo workspace (npm workspaces, yarn workspaces, or Bun), the CLI crashes with:

```
Error: Cannot find module '.bin/vite'
```

`resolveBin()` used `require.resolve('.bin/<name>')` which resolves **relative to the CLI module's own location** inside `node_modules`. In a workspace setup, the CLI lives in a different `node_modules` subtree than the project binaries (e.g. `vite`), so the binary is never found.

## What is the new behavior?

`resolveBin()` now walks up the directory tree starting from `process.cwd()`, checking each `node_modules/.bin/<name>` until the binary is found. This correctly handles the workspace hoisting case where the binary lives in a parent directory's `node_modules/.bin/`.

On Windows, both `.exe` and `.cmd` extensions are checked. The original `require.resolve` behavior is kept as a fallback for backward compatibility.

fixes #7314

## Notes for reviewers

The fix is minimal and contained entirely in `packages/cli/src/commands/runner/projectScripts.ts`. Three new tests covering the standard and monorepo scenarios were added to `projectScripts.test.ts`.