### PR TITLE
fix(core): pass meta to useButtonCanAccess in useDeleteButton

### DIFF
--- a/.changeset/serious-berries-check.md
+++ b/.changeset/serious-berries-check.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+fix: pass meta to useButtonCanAccess in useDeleteButton
+
+`useDeleteButton` was not forwarding the `meta` prop to `useButtonCanAccess`, causing access control checks that rely on `meta` params (e.g. tenant-aware permissions) to fail silently.

--- a/packages/core/src/hooks/button/delete-button/index.spec.tsx
+++ b/packages/core/src/hooks/button/delete-button/index.spec.tsx
@@ -1,4 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
 
 import { MockJSONServer, TestWrapper } from "@test";
 
@@ -99,6 +100,36 @@ describe("useDeleteButton", () => {
 
     await waitFor(() => {
       expect(result.current.loading).toBeFalsy();
+    });
+  });
+
+  it("should pass meta to useButtonCanAccess", async () => {
+    const canMock = vi.fn().mockResolvedValue({ can: true });
+
+    const { result } = renderHook(
+      () =>
+        useDeleteButton({
+          id: 123,
+          resource: "posts",
+          meta: { tenantId: "tenant-1" },
+        }),
+      {
+        wrapper: TestWrapper({
+          accessControlProvider: {
+            can: canMock,
+          },
+        }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(canMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            meta: { tenantId: "tenant-1" },
+          }),
+        }),
+      );
     });
   });
 

--- a/packages/core/src/hooks/button/delete-button/index.tsx
+++ b/packages/core/src/hooks/button/delete-button/index.tsx
@@ -54,6 +54,7 @@ export function useDeleteButton(props: DeleteButtonProps): DeleteButtonValues {
     accessControl: props.accessControl,
     id,
     resource,
+    meta: props.meta,
   });
 
   const label = translate("buttons.delete", "Delete");


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

`useDeleteButton` does not forward the `meta` prop to `useButtonCanAccess`, so access control checks via `useCan` receive `undefined` for `params.meta`. This breaks any custom access control rule that relies on `meta` (e.g. tenant-aware permission systems).

## What is the new behavior?

`meta: props.meta` is now passed to `useButtonCanAccess`, matching the same pattern already used by `navigation-button`. Access control checks now receive the correct `meta` params.

fixes #7285

## Notes for reviewers

One-line fix. The `navigation-button` hook already does this correctly at line 60 — this just applies the same pattern to `delete-button`.