### PR TITLE
feat(docs): filter templates page generation based on availables

### DIFF
--- a/documentation/plugins/blog-plugin.js
+++ b/documentation/plugins/blog-plugin.js
@@ -111,7 +111,9 @@ const pluginDataDirRoot = path.join(
   CONTENT_BLOG_PLUGIN_DIR,
 );
 const aliasedSource = (source) =>
-  `${BLOG_ALIAS_PREFIX}/${utils.posixPath(path.relative(pluginDataDirRoot, source))}`;
+  `${BLOG_ALIAS_PREFIX}/${utils.posixPath(
+    path.relative(pluginDataDirRoot, source),
+  )}`;
 
 function formatBlogDate(dateValue) {
   if (!dateValue) {
@@ -151,7 +153,10 @@ function paginateBlogPosts({
 
   function permalink(page) {
     return page > 0
-      ? utils.normalizeUrl([basePageUrl, `${PAGINATION_PATH_SEGMENT}/${page + 1}`])
+      ? utils.normalizeUrl([
+          basePageUrl,
+          `${PAGINATION_PATH_SEGMENT}/${page + 1}`,
+        ])
       : basePageUrl;
   }
 
@@ -427,13 +432,17 @@ function validateCategoryAndTags({ allBlogPosts, allowedValues }) {
 
   if (unknownTags.size > 0) {
     messageLines.push(
-      `Unknown tags (${unknownTags.size}): ${[...unknownTags].sort().join(", ")}`,
+      `Unknown tags (${unknownTags.size}): ${[...unknownTags]
+        .sort()
+        .join(", ")}`,
     );
     messageLines.push(...invalidTags);
     messageLines.push("");
   }
 
-  messageLines.push("Update ALLOWED_CATEGORIES / ALLOWED_TAGS in blog-plugin.js.");
+  messageLines.push(
+    "Update ALLOWED_CATEGORIES / ALLOWED_TAGS in blog-plugin.js.",
+  );
 
   throw new Error(messageLines.join("\n"));
 }
@@ -487,12 +496,14 @@ async function blogPluginExtended(...pluginArgs) {
       }
 
       const featuredBlogPosts = allBlogPosts.filter(
-        (post) => post.metadata.frontMatter[IS_FEATURED_FRONTMATTER_KEY] === true,
+        (post) =>
+          post.metadata.frontMatter[IS_FEATURED_FRONTMATTER_KEY] === true,
       );
       const featuredBlogPostIds = featuredBlogPosts.map((post) => post.id);
 
       const blogPosts = allBlogPosts.filter(
-        (post) => post.metadata.frontMatter[IS_FEATURED_FRONTMATTER_KEY] !== true,
+        (post) =>
+          post.metadata.frontMatter[IS_FEATURED_FRONTMATTER_KEY] !== true,
       );
 
       const blogListPaginated = paginateBlogPosts({
@@ -518,7 +529,9 @@ async function blogPluginExtended(...pluginArgs) {
       function getTagsPropPath() {
         if (!tagsPropPathPromise) {
           tagsPropPathPromise = createData(
-            `${utils.docuHash(`${blogTagsListPath}${TAGS_DATA_SUFFIX}`)}${JSON_FILE_EXTENSION}`,
+            `${utils.docuHash(
+              `${blogTagsListPath}${TAGS_DATA_SUFFIX}`,
+            )}${JSON_FILE_EXTENSION}`,
             JSON.stringify(tagsProp, null, 2),
           );
         }
@@ -529,7 +542,9 @@ async function blogPluginExtended(...pluginArgs) {
       function getCategoriesPropPath() {
         if (!categoriesPropPathPromise) {
           categoriesPropPathPromise = createData(
-            `${utils.docuHash(`${blogCategoriesListPath}${CATEGORIES_DATA_SUFFIX}`)}${JSON_FILE_EXTENSION}`,
+            `${utils.docuHash(
+              `${blogCategoriesListPath}${CATEGORIES_DATA_SUFFIX}`,
+            )}${JSON_FILE_EXTENSION}`,
             JSON.stringify(categoriesProp, null, 2),
           );
         }
@@ -669,12 +684,16 @@ async function blogPluginExtended(...pluginArgs) {
             };
 
             const tagPropPath = await createData(
-              `${utils.docuHash(`${metadata.permalink}${ALL_TAGS_DATA_SUFFIX}`)}${JSON_FILE_EXTENSION}`,
+              `${utils.docuHash(
+                `${metadata.permalink}${ALL_TAGS_DATA_SUFFIX}`,
+              )}${JSON_FILE_EXTENSION}`,
               JSON.stringify(tagProp, null, 2),
             );
 
             const listMetadataPath = await createData(
-              `${utils.docuHash(`${metadata.permalink}${ALL_TAGS_DATA_SUFFIX}`)}${LIST_DATA_SUFFIX}${JSON_FILE_EXTENSION}`,
+              `${utils.docuHash(
+                `${metadata.permalink}${ALL_TAGS_DATA_SUFFIX}`,
+              )}${LIST_DATA_SUFFIX}${JSON_FILE_EXTENSION}`,
               JSON.stringify(metadata, null, 2),
             );
 
@@ -709,7 +728,9 @@ async function blogPluginExtended(...pluginArgs) {
             );
 
             const listMetadataPath = await createData(
-              `${utils.docuHash(metadata.permalink)}${LIST_DATA_SUFFIX}${JSON_FILE_EXTENSION}`,
+              `${utils.docuHash(
+                metadata.permalink,
+              )}${LIST_DATA_SUFFIX}${JSON_FILE_EXTENSION}`,
               JSON.stringify(metadata, null, 2),
             );
 
@@ -757,12 +778,16 @@ async function blogPluginExtended(...pluginArgs) {
               seoDescription: category.seo?.description,
             };
             const categoryPropPath = await createData(
-              `${utils.docuHash(`${metadata.permalink}${CATEGORY_DATA_SUFFIX}`)}${JSON_FILE_EXTENSION}`,
+              `${utils.docuHash(
+                `${metadata.permalink}${CATEGORY_DATA_SUFFIX}`,
+              )}${JSON_FILE_EXTENSION}`,
               JSON.stringify(categoryProp, null, 2),
             );
 
             const listMetadataPath = await createData(
-              `${utils.docuHash(`${metadata.permalink}${CATEGORY_DATA_SUFFIX}`)}${LIST_DATA_SUFFIX}${JSON_FILE_EXTENSION}`,
+              `${utils.docuHash(
+                `${metadata.permalink}${CATEGORY_DATA_SUFFIX}`,
+              )}${LIST_DATA_SUFFIX}${JSON_FILE_EXTENSION}`,
               JSON.stringify(metadata, null, 2),
             );
 

--- a/documentation/plugins/templates.js
+++ b/documentation/plugins/templates.js
@@ -58,6 +58,16 @@ async function RefineTemplates() {
 
       // Filtered list routes for UI framework and UI+backend combos.
       for (const uiFramework of exports.TEMPLATE_UI_FRAMEWORKS) {
+        const hasUiTemplates = content.some(
+          (t) => t.uiFramework === uiFramework,
+        );
+        if (!hasUiTemplates) {
+          console.log(
+            `No templates found for UI framework: ${uiFramework}, skipping filter page generation for this UI.`,
+          );
+          continue;
+        }
+
         const uiSlug = exports.toSlug.call(void 0, uiFramework);
         const uiJson = await createData(
           `templates-filter-${uiSlug}.json`,
@@ -75,6 +85,16 @@ async function RefineTemplates() {
         });
 
         for (const backend of exports.TEMPLATE_BACKENDS) {
+          const hasComboTemplates = content.some(
+            (t) => t.uiFramework === uiFramework && t.dataProvider === backend,
+          );
+          if (!hasComboTemplates) {
+            console.log(
+              `No templates found   for UI framework: ${uiFramework} + backend: ${backend}, skipping filter page generation for this combo.`,
+            );
+            continue;
+          }
+
           const backendSlug = exports.toSlug.call(void 0, backend);
           const comboJson = await createData(
             `templates-filter-${uiSlug}-${backendSlug}.json`,

--- a/documentation/plugins/templates.ts
+++ b/documentation/plugins/templates.ts
@@ -57,7 +57,9 @@ export default async function RefineTemplates(): Promise<Plugin> {
         const hasUiTemplates = (content as typeof templates).some(
           (t) => t.uiFramework === uiFramework,
         );
-        if (!hasUiTemplates) continue;
+        if (!hasUiTemplates) {
+          continue;
+        }
 
         const uiSlug = toSlug(uiFramework);
         const uiJson = await createData(
@@ -79,7 +81,9 @@ export default async function RefineTemplates(): Promise<Plugin> {
           const hasComboTemplates = (content as typeof templates).some(
             (t) => t.uiFramework === uiFramework && t.dataProvider === backend,
           );
-          if (!hasComboTemplates) continue;
+          if (!hasComboTemplates) {
+            continue;
+          }
 
           const backendSlug = toSlug(backend);
           const comboJson = await createData(

--- a/documentation/static/_redirects
+++ b/documentation/static/_redirects
@@ -1361,3 +1361,30 @@
 /core/week-of-refine/ /core/ 301
 /core/week-of-refine-strapi/ /core/ 301
 
+/core/templates/ant-design/graphql /core/templates/ant-design 301
+/core/templates/ant-design/appwrite /core/templates/ant-design 301
+/core/templates/ant-design/medusa /core/templates/ant-design 301
+
+/core/templates/material-ui/supabase /core/templates/material-ui 301
+/core/templates/material-ui/graphql /core/templates/material-ui 301
+/core/templates/material-ui/strapi /core/templates/material-ui 301
+/core/templates/material-ui/appwrite /core/templates/material-ui 301
+/core/templates/material-ui/medusa /core/templates/material-ui 301
+
+/core/templates/headless/graphql /core/templates/headless 301
+/core/templates/headless/strapi /core/templates/headless 301
+/core/templates/headless/appwrite /core/templates/headless 301
+/core/templates/headless/medusa /core/templates/headless 301
+
+/core/templates/chakra-ui/supabase /core/templates/chakra-ui 301
+/core/templates/chakra-ui/graphql /core/templates/chakra-ui 301
+/core/templates/chakra-ui/strapi /core/templates/chakra-ui 301
+/core/templates/chakra-ui/appwrite /core/templates/chakra-ui 301
+/core/templates/chakra-ui/medusa /core/templates/chakra-ui 301
+
+/core/templates/mantine/supabase /core/templates/mantine 301
+/core/templates/mantine/graphql /core/templates/mantine 301
+/core/templates/mantine/strapi /core/templates/mantine 301
+/core/templates/mantine/appwrite /core/templates/mantine 301
+/core/templates/mantine/medusa /core/templates/mantine 301
+


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

`/core/templates/<ui>/<backend>` routes are generated for every combination of UI framework and backend, even when no templates exist for that combination (e.g. `/core/templates/material-ui/supabase/` renders an empty page).

## What is the new behavior?

Routes are only generated when at least one template matches the given UI framework + backend combination. Empty filter pages no longer exist.

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
