### PR TITLE
feat(docs): add comparison links to blog, common, and tutorial footers

### DIFF
--- a/documentation/src/refine-theme/blog-footer.tsx
+++ b/documentation/src/refine-theme/blog-footer.tsx
@@ -2,7 +2,7 @@ import Link from "@docusaurus/Link";
 import clsx from "clsx";
 import React from "react";
 
-import { socialLinks } from "./footer-data";
+import { comparisonLinks, socialLinks } from "./footer-data";
 import { RefineLogoSingleIcon } from "./icons/refine-logo-single";
 
 export const BlogFooter = () => {
@@ -51,7 +51,8 @@ export const BlogFooter = () => {
             "h-6",
             "flex-row",
             "items-center",
-            "justify-end",
+            "justify-center",
+            "blog-md:justify-end",
             "gap-4",
             "not-prose",
           )}
@@ -150,6 +151,74 @@ export const BlogFooter = () => {
               CORE
             </span>
           </Link>
+
+          {/* Desktop-only comparison links, inline with muted style */}
+          {comparisonLinks.map(({ href, label }) => (
+            <React.Fragment key={href}>
+              <span
+                className={clsx(
+                  "hidden blog-md:inline",
+                  "text-2xl",
+                  "font-thin",
+                  "leading-6",
+                  "text-zinc-300",
+                  "dark:text-zinc-600",
+                )}
+              >
+                /
+              </span>
+              <Link
+                to={href}
+                className={clsx(
+                  "hidden blog-md:block",
+                  "h-6",
+                  "text-sm",
+                  "font-normal",
+                  "leading-6",
+                  "text-zinc-400",
+                  "dark:text-zinc-500",
+                  "whitespace-nowrap",
+                  "hover:no-underline",
+                  "hover:text-zinc-600",
+                  "dark:hover:text-zinc-300",
+                )}
+              >
+                {label}
+              </Link>
+            </React.Fragment>
+          ))}
+        </div>
+
+        {/* Comparison links — separate muted row on mobile, inline on desktop */}
+        <div
+          className={clsx(
+            "flex",
+            "flex-row",
+            "items-center",
+            "justify-center",
+            "gap-6",
+            "blog-md:hidden",
+          )}
+        >
+          {comparisonLinks.map(({ href, label }) => (
+            <Link
+              key={href}
+              to={href}
+              className={clsx(
+                "text-sm",
+                "font-normal",
+                "leading-5",
+                "text-zinc-400",
+                "dark:text-zinc-500",
+                "hover:no-underline",
+                "hover:text-zinc-600",
+                "dark:hover:text-zinc-300",
+                "whitespace-nowrap",
+              )}
+            >
+              {label}
+            </Link>
+          ))}
         </div>
 
         <div

--- a/documentation/src/refine-theme/common-footer.tsx
+++ b/documentation/src/refine-theme/common-footer.tsx
@@ -1,7 +1,7 @@
 import Link from "@docusaurus/Link";
 import clsx from "clsx";
 import React from "react";
-import { socialLinks } from "./footer-data";
+import { comparisonLinks, socialLinks } from "./footer-data";
 import { RefineCoreLogoIcon } from "./icons/refine-logo";
 
 export const CommonFooter = () => {
@@ -50,6 +50,19 @@ export const CommonFooter = () => {
           >
             Tutorial
           </Link>
+          {comparisonLinks.map(({ href, label }) => (
+            <Link
+              key={href}
+              to={href}
+              className={clsx(
+                "appearance-none",
+                "hover:no-underline",
+                "md:mr-12",
+              )}
+            >
+              {label}
+            </Link>
+          ))}
           <div className={clsx("md:mr-4")}>Join us on</div>
           <div
             className={clsx(

--- a/documentation/src/refine-theme/footer-data.tsx
+++ b/documentation/src/refine-theme/footer-data.tsx
@@ -53,6 +53,26 @@ export const menuItems = [
       },
     ],
   },
+  {
+    label: "Compare",
+    items: [
+      {
+        label: "VS",
+        href: "/vs",
+        icon: null,
+      },
+      {
+        label: "Alternatives",
+        href: "/alternatives",
+        icon: null,
+      },
+      {
+        label: "Compare",
+        href: "/compare",
+        icon: null,
+      },
+    ],
+  },
 ];
 
 export const secondaryMenuItems = [
@@ -68,6 +88,12 @@ export const secondaryMenuItems = [
     label: "License",
     href: "https://github.com/refinedev/refine/blob/main/LICENSE",
   },
+];
+
+export const comparisonLinks = [
+  { href: "/vs", label: "VS" },
+  { href: "/alternatives", label: "Alternatives" },
+  { href: "/compare", label: "Compare" },
 ];
 
 export const footerDescription =

--- a/documentation/src/refine-theme/tutorial-footer.tsx
+++ b/documentation/src/refine-theme/tutorial-footer.tsx
@@ -1,7 +1,7 @@
 import Link from "@docusaurus/Link";
 import clsx from "clsx";
 import React from "react";
-import { socialLinks } from "./footer-data";
+import { comparisonLinks, socialLinks } from "./footer-data";
 
 export const TutorialFooter = () => {
   return (
@@ -61,6 +61,19 @@ export const TutorialFooter = () => {
           >
             Documentation
           </Link>
+          {comparisonLinks.map(({ href, label }) => (
+            <Link
+              key={href}
+              to={href}
+              className={clsx(
+                "hover:no-underline",
+                "hover:text-refine-link-light",
+                "dark:hover:text-refine-link-dark",
+              )}
+            >
+              {label}
+            </Link>
+          ))}
           <div
             className={clsx(
               "flex flex-col sm:flex-row justify-center items-center",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

The footer does not include any links to the VS, Alternatives, and Compare pages.

## What is the new behavior?

Comparison links (`/vs`, `/alternatives`, `/compare`) are added to all footers in the documentation site:

- `footer-data.tsx` — `comparisonLinks` array exported; a new "Compare" section added to `menuItems`
- `landing-footer.tsx` — automatically renders the new "Compare" section via `menuItems`
- `blog-footer.tsx` — comparison links appear as a separate muted row on mobile; inline with the nav links on desktop
- `common-footer.tsx` — comparison links appear after the "Tutorial" link
- `tutorial-footer.tsx` — comparison links appear after the "Documentation" link

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
