### PR TITLE
feat(tutorial): add organized tutorial contents section with links

### DIFF
--- a/documentation/plugins/templates.js
+++ b/documentation/plugins/templates.js
@@ -62,9 +62,6 @@ async function RefineTemplates() {
           (t) => t.uiFramework === uiFramework,
         );
         if (!hasUiTemplates) {
-          console.log(
-            `No templates found for UI framework: ${uiFramework}, skipping filter page generation for this UI.`,
-          );
           continue;
         }
 
@@ -89,9 +86,6 @@ async function RefineTemplates() {
             (t) => t.uiFramework === uiFramework && t.dataProvider === backend,
           );
           if (!hasComboTemplates) {
-            console.log(
-              `No templates found   for UI framework: ${uiFramework} + backend: ${backend}, skipping filter page generation for this combo.`,
-            );
             continue;
           }
 

--- a/documentation/tutorial/essentials/intro/index.md
+++ b/documentation/tutorial/essentials/intro/index.md
@@ -23,4 +23,69 @@ Pick the UI framework you want to continue with:
 
 You can find the corresponding material that is taught in this tutorial for the other UI frameworks in the [documentation](/core/docs/guides-concepts/ui-libraries).
 
+## Tutorial Contents
+
+Below you can find all the tutorial sections organized by topic:
+
+### Essentials
+
+- [Your First Refine App](/core/tutorial/essentials/setup/)
+- [Fetching a Record](/core/tutorial/essentials/data-fetching/fetching-data/)
+- [Updating a Record](/core/tutorial/essentials/data-fetching/updating-data/)
+- [Listing Records](/core/tutorial/essentials/data-fetching/listing-data/)
+- [Forms](/core/tutorial/essentials/forms/)
+- [Tables](/core/tutorial/essentials/tables/)
+
+### Authentication
+
+- [Introduction](/core/tutorial/authentication/intro/)
+- [Protecting Content](/core/tutorial/authentication/protecting-content/)
+- [Logging In & Out](/core/tutorial/authentication/logging-in-out/)
+- [Using User Identity](/core/tutorial/authentication/user-identity/)
+- [Data Provider Integration](/core/tutorial/authentication/data-provider-integration/)
+
+### Routing with React Router
+
+- [Introduction](/core/tutorial/routing/intro/react-router/)
+- [Authentication](/core/tutorial/routing/authentication/react-router/)
+- [Defining Resources](/core/tutorial/routing/resource-definition/react-router/)
+- [Navigation](/core/tutorial/routing/navigation/react-router/)
+- [Inferring Parameters](/core/tutorial/routing/inferring-parameters/react-router/)
+- [Redirects](/core/tutorial/routing/redirects/react-router/)
+- [Syncing State with Location](/core/tutorial/routing/syncing-state/react-router/)
+
+### UI Libraries with Ant Design
+
+- [Introduction](/core/tutorial/ui-libraries/intro/ant-design/react-router/)
+- [Using Layouts](/core/tutorial/ui-libraries/layout/ant-design/react-router/)
+- [Refactoring](/core/tutorial/ui-libraries/refactoring/ant-design/react-router/)
+- [CRUD Components](/core/tutorial/ui-libraries/crud-components/ant-design/react-router/)
+- [Notifications](/core/tutorial/ui-libraries/notifications/ant-design/react-router/)
+- [Authentication](/core/tutorial/ui-libraries/authentication/ant-design/react-router/)
+
+### UI Libraries with Material UI
+
+- [Introduction](/core/tutorial/ui-libraries/intro/material-ui/react-router/)
+- [Using Layouts](/core/tutorial/ui-libraries/layout/material-ui/react-router/)
+- [Refactoring](/core/tutorial/ui-libraries/refactoring/material-ui/react-router/)
+- [CRUD Components](/core/tutorial/ui-libraries/crud-components/material-ui/react-router/)
+- [Notifications](/core/tutorial/ui-libraries/notifications/material-ui/react-router/)
+- [Authentication](/core/tutorial/ui-libraries/authentication/material-ui/react-router/)
+
+### Next Steps with Ant Design
+
+- [Introduction](/core/tutorial/next-steps/intro/ant-design/)
+- [Using Inferencer](/core/tutorial/next-steps/inferencer/react-router/ant-design/)
+- [Using CLI](/core/tutorial/next-steps/cli/react-router/ant-design/)
+- [Using Devtools](/core/tutorial/next-steps/devtools/react-router/ant-design/)
+- [Summary](/core/tutorial/next-steps/summary/react-router/ant-design/)
+
+### Next Steps with Material UI
+
+- [Introduction](/core/tutorial/next-steps/intro/material-ui/)
+- [Using Inferencer](/core/tutorial/next-steps/inferencer/react-router/material-ui/)
+- [Using CLI](/core/tutorial/next-steps/cli/react-router/material-ui/)
+- [Using Devtools](/core/tutorial/next-steps/devtools/react-router/material-ui/)
+- [Summary](/core/tutorial/next-steps/summary/react-router/material-ui/)
+
 </Sandpack>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

40 tutorial pages are flagged as orphan pages by crawlers because the `TutorialNavigation` component renders links inside a closed dropdown with `max-height: 0` and `opacity: 0`. Search engines cannot discover these hidden, JavaScript-dependent links.

## What is the new behavior?

Added a "Tutorial Contents" section to `tutorial/essentials/intro/index.md` with static HTML links to all 40 tutorial pages, organized by topic. These links are SSR-rendered, always visible, and crawlable, resolving the orphan page issue.

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
