### PR TITLE
fix: pass meta params to useButtonCanAccess in useDeleteButton

### DIFF
--- a/packages/core/src/hooks/button/delete-button/index.tsx
+++ b/packages/core/src/hooks/button/delete-button/index.tsx
@@ -54,6 +54,7 @@ export function useDeleteButton(props: DeleteButtonProps): DeleteButtonValues {
     accessControl: props.accessControl,
     id,
     resource,
+    meta: props.meta,
   });
 
   const label = translate("buttons.delete", "Delete");


### PR DESCRIPTION

## Fixes #7285

### Description
useDeleteButton hook does not pass meta params to useButtonCanAccess, causing custom permission validation rules to fail when they depend on meta params.

### Changes
- `packages/core/src/hooks/button/delete-button/index.tsx`: Pass `meta: props.meta` to `useButtonCanAccess`
