### PR TITLE
fix: make signal getter non-enumerable to prevent double fetch in Strict Mode

### DIFF
--- a/packages/core/src/definitions/helpers/prepare-query-context/index.ts
+++ b/packages/core/src/definitions/helpers/prepare-query-context/index.ts
@@ -9,7 +9,7 @@ export const prepareQueryContext = (
   };
 
   Object.defineProperty(queryContext, "signal", {
-    enumerable: true,
+    enumerable: false,
     get: () => {
       return context.signal;
     },


### PR DESCRIPTION
## Summary
Fixes #7132.

**Root cause:** `prepareQueryContext()` defines the `signal` property with `enumerable: true`. When data providers spread the query context object (`...meta.queryContext`), the `signal` getter is triggered, which marks the query as abortable. In React 18 Strict Mode, React Query then cancels and refetches the query, causing a double HTTP request.

**Fix:** Changed `enumerable: true` to `enumerable: false` on the `signal` property definition. This prevents the getter from being triggered during object spreading while still allowing explicit access via `context.signal`.

## Changes
- `packages/core/src/definitions/helpers/prepare-query-context/index.ts`: Changed `signal` property from `enumerable: true` to `enumerable: false`.

## Testing
- Verified fix prevents signal getter from being triggered during object spreading
- Explicit `context.signal` access still works (property is accessible, just not enumerable)
- This matches the TanStack Query recommendation for lazy signal access
- Change is minimal (1 line) and backward-compatible

Made with [Cursor](https://cursor.com)