### PR TITLE
fix(core): keep query context signal lazy when merging meta

### DIFF
--- a/.changeset/chatty-cameras-remain.md
+++ b/.changeset/chatty-cameras-remain.md
@@ -1,0 +1,11 @@
+---
+"@refinedev/core": patch
+---
+
+fix(core): keep query context signal lazy when merging meta
+
+`prepareQueryContext` was previously spread into new `meta` objects inside core data hooks. Because `signal` is exposed as a getter, object spread eagerly accessed it during merge and marked the query as abortable earlier than intended.
+
+This keeps `signal` lazy by merging `meta` inside `prepareQueryContext` and preserving the getter on the returned object. The fix is applied across the affected hooks in `@refinedev/core`, and a regression test was added for the lazy `signal` behavior.
+
+Resolves #7132

--- a/packages/core/src/definitions/helpers/prepare-query-context/index.spec.ts
+++ b/packages/core/src/definitions/helpers/prepare-query-context/index.spec.ts
@@ -1,0 +1,23 @@
+import { prepareQueryContext } from ".";
+
+describe("prepareQueryContext", () => {
+  it("should keep signal lazy when merging it into meta", () => {
+    const signal = new AbortController().signal;
+    const signalGetter = vi.fn(() => signal);
+    const context = {
+      queryKey: ["posts", "list"],
+      get signal() {
+        return signalGetter();
+      },
+    } as any;
+
+    const meta = prepareQueryContext(context, { foo: "bar" });
+
+    expect(meta.foo).toBe("bar");
+    expect(meta.queryKey).toEqual(["posts", "list"]);
+    expect(signalGetter).not.toHaveBeenCalled();
+
+    expect(meta.signal).toBe(signal);
+    expect(signalGetter).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/definitions/helpers/prepare-query-context/index.ts
+++ b/packages/core/src/definitions/helpers/prepare-query-context/index.ts
@@ -4,13 +4,19 @@ type Context =
   | QueryFunctionContext<QueryKey, any>
   | QueryFunctionContext<QueryKey, never>;
 
+type QueryContextMeta<TMeta extends Record<string, unknown> | undefined> = (
+  TMeta extends Record<string, unknown> ? TMeta : Record<string, never>
+) &
+  Pick<Context, "queryKey" | "signal">;
+
 export const prepareQueryContext = (
   context: Context,
-): Pick<Context, "queryKey" | "signal"> => {
-  const queryContext: Pick<Context, "queryKey" | "signal"> = {
+  meta?: Record<string, unknown>,
+): QueryContextMeta<typeof meta> => {
+  const queryContext = {
+    ...(meta ?? {}),
     queryKey: context.queryKey,
-    signal: undefined as any,
-  };
+  } as QueryContextMeta<typeof meta>;
 
   Object.defineProperty(queryContext, "signal", {
     enumerable: true,

--- a/packages/core/src/hooks/data/useCustom.ts
+++ b/packages/core/src/hooks/data/useCustom.ts
@@ -173,10 +173,7 @@ export const useCustom = <
           url,
           method,
           ...config,
-          meta: {
-            ...combinedMeta,
-            ...prepareQueryContext(context as any),
-          },
+          meta: prepareQueryContext(context as any, combinedMeta),
         }),
       ...queryOptions,
       meta: {

--- a/packages/core/src/hooks/data/useInfiniteList.ts
+++ b/packages/core/src/hooks/data/useInfiniteList.ts
@@ -254,10 +254,7 @@ export const useInfiniteList = <
           (context.pageParam as number) ?? prefferedPagination.currentPage,
       };
 
-      const meta = {
-        ...combinedMeta,
-        ...prepareQueryContext(context),
-      };
+      const meta = prepareQueryContext(context, combinedMeta);
 
       return getList<TQueryFnData>({
         resource: resource?.name || "",

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -254,10 +254,7 @@ export const useList = <
       })
       .get(),
     queryFn: (context) => {
-      const meta = {
-        ...combinedMeta,
-        ...prepareQueryContext(context),
-      };
+      const meta = prepareQueryContext(context, combinedMeta);
       return getList<TQueryFnData>({
         resource: resource?.name ?? "",
         pagination: prefferedPagination,

--- a/packages/core/src/hooks/data/useMany.ts
+++ b/packages/core/src/hooks/data/useMany.ts
@@ -188,10 +188,7 @@ export const useMany = <
       })
       .get(),
     queryFn: (context) => {
-      const meta = {
-        ...combinedMeta,
-        ...prepareQueryContext(context as any),
-      };
+      const meta = prepareQueryContext(context as any, combinedMeta);
 
       if (getMany) {
         return getMany({

--- a/packages/core/src/hooks/data/useOne.ts
+++ b/packages/core/src/hooks/data/useOne.ts
@@ -185,10 +185,7 @@ export const useOne = <
       getOne<TQueryFnData>({
         resource: resource?.name ?? "",
         id: id!,
-        meta: {
-          ...combinedMeta,
-          ...prepareQueryContext(context as any),
-        },
+        meta: prepareQueryContext(context as any, combinedMeta),
       }),
     ...queryOptions,
     enabled: isEnabled,


### PR DESCRIPTION
## Summary

This keeps `queryContext.signal` lazy when merging query context into `meta`.

Previously we spread `prepareQueryContext(context)` into a new `meta` object inside multiple core data hooks. Because `signal` is defined as a getter, object spread eagerly accessed it during merge. That marks the query as abortable earlier than intended and can trigger the duplicate request behavior described in #7132.

Closes #7132.

## Changes

- update `prepareQueryContext` to accept an optional `meta` object and merge into it internally
- preserve `signal` as a lazy getter on the returned object
- switch affected hooks to use the helper directly:
  - `useList`
  - `useOne`
  - `useMany`
  - `useInfiniteList`
  - `useCustom`
- add a regression test for lazy `signal` access

## Validation

- `corepack pnpm --filter @refinedev/devtools-shared --filter @refinedev/devtools-internal build`
- `corepack pnpm --dir packages/core test -- src/definitions/helpers/prepare-query-context/index.spec.ts src/hooks/data/useList.spec.tsx src/hooks/data/useOne.spec.tsx src/hooks/data/useMany.spec.tsx src/hooks/data/useCustom.spec.tsx src/hooks/data/useInfiniteList.spec.tsx`
- `corepack pnpm --dir packages/core build`
