### PR TITLE
fix(core): forward custom getList response fields in result

### DIFF
--- a/.changeset/quick-maps-accept.md
+++ b/.changeset/quick-maps-accept.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+fix(core): preserve custom `getList` response fields in `useList` and `useTable` results.
+
+We had an edge case where custom fields returned from `getList` were available on `query.data` but dropped from `result`. Now those extra fields are preserved in both `useList` and `useTable`.

--- a/packages/core/src/hooks/data/useList.spec.tsx
+++ b/packages/core/src/hooks/data/useList.spec.tsx
@@ -245,6 +245,7 @@ describe("useList Hook", () => {
     });
 
     expect(result.current.query.data?.foo).toBe("bar");
+    expect(result.current.result.foo).toBe("bar");
   });
 
   it("should only pass meta from the hook parameter and query parameters to the dataProvider", async () => {

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -99,6 +99,7 @@ export type UseListReturnType<TData, TError> = {
   result: {
     data: TData[];
     total: number | undefined;
+    [key: string]: any;
   };
 } & UseLoadingOvertimeReturnType;
 
@@ -329,6 +330,7 @@ export const useList = <
   return {
     query: queryResponse,
     result: {
+      ...queryResponse?.data,
       data: queryResponse?.data?.data || EMPTY_ARRAY,
       total: queryResponse?.data?.total,
     },

--- a/packages/core/src/hooks/useTable/index.spec.ts
+++ b/packages/core/src/hooks/useTable/index.spec.ts
@@ -56,6 +56,38 @@ describe("useTable Hook", () => {
     expect(tableResult.total).toBe(2);
   });
 
+  it("should preserve additional result fields from useList", async () => {
+    const { result } = renderHook(
+      () =>
+        useTable({
+          resource: "posts",
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: {
+            default: {
+              ...MockJSONServer.default,
+              getList: () =>
+                Promise.resolve({
+                  data: [],
+                  total: 0,
+                  foo: "bar",
+                }),
+            },
+          },
+          resources: [{ name: "posts" }],
+          routerProvider,
+        }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.tableQuery.isSuccess).toBeTruthy();
+    });
+
+    expect(result.current.result.foo).toBe("bar");
+  });
+
   it("with initial pagination parameters", async () => {
     const { result } = renderHook(
       () =>

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -158,6 +158,7 @@ export type useTableReturnType<
   result: {
     data: TData[];
     total: number | undefined;
+    [key: string]: any;
   };
 } & UseLoadingOvertimeReturnType;
 
@@ -435,6 +436,7 @@ export function useTable<
     createLinkForSyncWithLocation,
     overtime: queryResult.overtime,
     result: {
+      ...queryResult.result,
       data: queryResult.result?.data || EMPTY_ARRAY,
       total: queryResult.result?.total,
     },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

`useList` and `useTable` only keep `data` and `total` in `result`.

Extra fields from `getList` are lost.

## What is the new behavior?

`useList` and `useTable` now keep extra `getList` fields in `result` too.

This makes custom response data available from `result`.

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
