### PR TITLE
fix(mui): add debounce to useDataGrid filter changes

### DIFF
--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -98,6 +98,12 @@ export type UseDataGridProps<
     TError,
     TData
   >["mutationOptions"];
+  /**
+   * Debounce interval in milliseconds for server-side filter changes.
+   * Prevents API requests from firing on every keystroke.
+   * @default 500
+   */
+  filterDebounceMs?: number;
 };
 
 export type UseDataGridReturnType<
@@ -125,7 +131,7 @@ export type UseDataGridReturnType<
 
 const defaultPermanentFilter: CrudFilter[] = [];
 const defaultPermanentSort: CrudSort[] = [];
-const DEFAULT_FILTER_DEBOUNCE_MS = 300;
+const DEFAULT_FILTER_DEBOUNCE_MS = 500;
 
 export function useDataGrid<
   TQueryFnData extends BaseRecord = BaseRecord,
@@ -150,6 +156,7 @@ export function useDataGrid<
   overtimeOptions,
   editable = false,
   updateMutationOptions,
+  filterDebounceMs = DEFAULT_FILTER_DEBOUNCE_MS,
 }: UseDataGridProps<
   TQueryFnData,
   TError,
@@ -267,7 +274,7 @@ export function useDataGrid<
       clearFilterDebounce();
       filterDebounceRef.current = setTimeout(() => {
         applyFilters(crudFilters);
-      }, DEFAULT_FILTER_DEBOUNCE_MS);
+      }, filterDebounceMs);
       return;
     }
     applyFilters(crudFilters);


### PR DESCRIPTION
## Summary

Fixes #7369

- `useDataGrid` had a hardcoded 300ms debounce for server-side filter changes with no way for users to configure it, causing API flooding and poor UX on fast typing
- Added a `filterDebounceMs` option to `UseDataGridProps` so users can tune the debounce interval
- Increased the default from 300ms to 500ms for better keystroke batching

```tsx
const { dataGridProps } = useDataGrid({
  resource: 'users',
  filterDebounceMs: 500, // default, configurable
})
```

## Test Plan

- Type quickly in a DataGrid filter input with server-side filtering enabled
- Verify only one API request fires after typing stops (not one per keystroke)
- Verify `filterDebounceMs` option works when customized to a different value (e.g., 1000)
- Verify client-side filtering is unaffected (no debounce applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)