### PR TITLE
feat(mui): add configurable filter debounce to useDataGrid

### DIFF
--- a/packages/mui/src/hooks/useDataGrid/index.spec.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.spec.ts
@@ -368,4 +368,142 @@ describe("useDataGrid Hook", () => {
       },
     ]);
   });
+
+  it("should debounce server-side filter updates with the default delay", async () => {
+    vi.useFakeTimers();
+
+    const setFilters = vi.fn();
+    const setCurrentPage = vi.fn();
+    const useTableSpy = vi.spyOn(core, "useTable").mockReturnValue({
+      tableQuery: {
+        data: { data: [], total: 0 },
+        isFetched: true,
+        isLoading: false,
+      },
+      currentPage: 1,
+      setCurrentPage,
+      pageSize: 25,
+      setPageSize: vi.fn(),
+      filters: [],
+      setFilters,
+      sorters: [],
+      setSorters: vi.fn(),
+      pageCount: 0,
+      createLinkForSyncWithLocation: vi.fn(),
+      overtime: {},
+      result: {},
+    } as any);
+
+    const { result, unmount } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+        }),
+      {
+        wrapper: TestWrapper({}),
+      },
+    );
+
+    act(() => {
+      result.current.dataGridProps.onFilterModelChange({
+        items: [
+          {
+            field: "title",
+            operator: "contains",
+            value: "john",
+          },
+        ],
+      } as any);
+    });
+
+    expect(setFilters).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+
+    expect(setFilters).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(setFilters).toHaveBeenCalledWith([
+      {
+        field: "title",
+        operator: "contains",
+        value: "john",
+      },
+    ]);
+    expect(setCurrentPage).toHaveBeenCalledWith(1);
+    expect(result.current.dataGridProps.filterDebounceMs).toBe(0);
+
+    unmount();
+    useTableSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("should respect custom filterDebounceMs for server-side filtering", async () => {
+    vi.useFakeTimers();
+
+    const setFilters = vi.fn();
+    const useTableSpy = vi.spyOn(core, "useTable").mockReturnValue({
+      tableQuery: {
+        data: { data: [], total: 0 },
+        isFetched: true,
+        isLoading: false,
+      },
+      currentPage: 1,
+      setCurrentPage: vi.fn(),
+      pageSize: 25,
+      setPageSize: vi.fn(),
+      filters: [],
+      setFilters,
+      sorters: [],
+      setSorters: vi.fn(),
+      pageCount: 0,
+      createLinkForSyncWithLocation: vi.fn(),
+      overtime: {},
+      result: {},
+    } as any);
+
+    const { result, unmount } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+          filterDebounceMs: 1000,
+        }),
+      {
+        wrapper: TestWrapper({}),
+      },
+    );
+
+    act(() => {
+      result.current.dataGridProps.onFilterModelChange({
+        items: [
+          {
+            field: "title",
+            operator: "contains",
+            value: "john",
+          },
+        ],
+      } as any);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+
+    expect(setFilters).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(setFilters).toHaveBeenCalledTimes(1);
+
+    unmount();
+    useTableSpy.mockRestore();
+    vi.useRealTimers();
+  });
 });

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -93,6 +93,7 @@ export type UseDataGridProps<
     }
   >;
   editable?: boolean;
+  filterDebounceMs?: number;
   updateMutationOptions?: UseUpdateProps<
     TData,
     TError,
@@ -125,7 +126,7 @@ export type UseDataGridReturnType<
 
 const defaultPermanentFilter: CrudFilter[] = [];
 const defaultPermanentSort: CrudSort[] = [];
-const DEFAULT_FILTER_DEBOUNCE_MS = 300;
+const DEFAULT_FILTER_DEBOUNCE_MS = 500;
 
 export function useDataGrid<
   TQueryFnData extends BaseRecord = BaseRecord,
@@ -149,6 +150,7 @@ export function useDataGrid<
   dataProviderName,
   overtimeOptions,
   editable = false,
+  filterDebounceMs = DEFAULT_FILTER_DEBOUNCE_MS,
   updateMutationOptions,
 }: UseDataGridProps<
   TQueryFnData,
@@ -267,7 +269,7 @@ export function useDataGrid<
       clearFilterDebounce();
       filterDebounceRef.current = setTimeout(() => {
         applyFilters(crudFilters);
-      }, DEFAULT_FILTER_DEBOUNCE_MS);
+      }, filterDebounceMs);
       return;
     }
     applyFilters(crudFilters);


### PR DESCRIPTION
## Summary
- add configurable filter debounce support to useDataGrid
- default server-side filter debounce to 500ms
- add tests for default and custom debounce behavior

## Testing
- pnpm --filter @refinedev/mui test -- useDataGrid