### PR TITLE
fix(mui): make useDataGrid filter debounce configurable

### DIFF
--- a/.changeset/green-owls-filter.md
+++ b/.changeset/green-owls-filter.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mui": patch
+---
+
+Make `useDataGrid` filter debounce configurable via `filterDebounceMs`.

--- a/packages/mui/src/hooks/useDataGrid/index.spec.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.spec.ts
@@ -10,6 +10,65 @@ import { posts } from "@test/dataMocks";
 import * as core from "@refinedev/core";
 
 describe("useDataGrid Hook", () => {
+  it("should debounce server-side filter updates with the configured duration", async () => {
+    const getList = vi.fn(MockJSONServer.getList);
+
+    const { result } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+          filterDebounceMs: 50,
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: {
+            ...MockJSONServer,
+            getList,
+          },
+          resources: [{ name: "posts" }],
+        }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.tableQuery.isSuccess).toBeTruthy();
+    });
+
+    expect(getList).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.dataGridProps.onFilterModelChange({
+        items: [
+          {
+            field: "title",
+            operator: "contains",
+            value: "refine",
+          },
+        ],
+      });
+    });
+
+    expect(result.current.dataGridProps.filterModel?.items).toEqual([
+      {
+        field: "title",
+        operator: "contains",
+        value: "refine",
+        id: "titlecontains",
+      },
+    ]);
+    expect(getList).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 40));
+    });
+
+    expect(getList).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(getList).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it("controlled filtering with 'onSubmit' and 'onSearch'", async () => {
     type SearchVariables = { title: string; status: string };
 

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -93,6 +93,12 @@ export type UseDataGridProps<
     }
   >;
   editable?: boolean;
+  /**
+   * Debounce duration in milliseconds for server-side filter updates.
+   * Set to `0` to disable debouncing.
+   * @default 300
+   */
+  filterDebounceMs?: number;
   updateMutationOptions?: UseUpdateProps<
     TData,
     TError,
@@ -149,6 +155,7 @@ export function useDataGrid<
   dataProviderName,
   overtimeOptions,
   editable = false,
+  filterDebounceMs = DEFAULT_FILTER_DEBOUNCE_MS,
   updateMutationOptions,
 }: UseDataGridProps<
   TQueryFnData,
@@ -267,7 +274,7 @@ export function useDataGrid<
       clearFilterDebounce();
       filterDebounceRef.current = setTimeout(() => {
         applyFilters(crudFilters);
-      }, DEFAULT_FILTER_DEBOUNCE_MS);
+      }, filterDebounceMs);
       return;
     }
     applyFilters(crudFilters);


### PR DESCRIPTION
## Summary
- add a `filterDebounceMs` option to `useDataGrid` for server-side filtering
- keep the existing 300ms default while allowing consumers to override or disable the debounce
- add a focused spec that verifies the configured debounce delays the server request while keeping the filter UI responsive

## Testing
- pnpm --filter @refinedev/mui test -- src/hooks/useDataGrid/index.spec.ts
- pnpm biome check packages/mui/src/hooks/useDataGrid/index.ts packages/mui/src/hooks/useDataGrid/index.spec.ts

Closes #7369