### PR TITLE
fix(antd): add onParse for useTable filter-to-form sync

### DIFF
--- a/.changeset/tiny-avocados-hammer.md
+++ b/.changeset/tiny-avocados-hammer.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/antd": patch
+---
+
+add onParse to map URL filters back to search form values (supports type conversion + complex fields like range)

--- a/packages/antd/src/hooks/table/useTable/useTable.spec.tsx
+++ b/packages/antd/src/hooks/table/useTable/useTable.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { CrudFilters } from "@refinedev/core";
+import type { CrudFilters, HttpError } from "@refinedev/core";
 import isEqual from "lodash/isEqual";
 import { renderHook, waitFor } from "@testing-library/react";
 import { Form, Input } from "antd";
@@ -336,7 +336,112 @@ describe("useTable Hook", () => {
     });
 
     await waitFor(() => {
-      expect(getByDisplayValue("Some Name To Look For")).toBeInTheDocument();
+      expect(getByDisplayValue("Some Name To Look For")).toBeTruthy();
+    });
+  });
+
+  it("should parse form values from filters with `onParse`", async () => {
+    type SearchVariables = {
+      category?: number;
+      createdAt?: [string, string];
+    };
+
+    let formInstance:
+      | ReturnType<typeof Form.useForm<SearchVariables>>[0]
+      | undefined;
+
+    const Component = () => {
+      const { searchFormProps } = useTable<
+        { id: number },
+        HttpError,
+        SearchVariables
+      >({
+        resource: "posts",
+        syncWithLocation: true,
+        onParse: (filters) => {
+          const categoryFilter = filters.find(
+            (filter) =>
+              "field" in filter &&
+              filter.field === "category.id" &&
+              filter.operator === "eq",
+          );
+          const createdAtGte = filters.find(
+            (filter) =>
+              "field" in filter &&
+              filter.field === "createdAt" &&
+              filter.operator === "gte",
+          );
+          const createdAtLte = filters.find(
+            (filter) =>
+              "field" in filter &&
+              filter.field === "createdAt" &&
+              filter.operator === "lte",
+          );
+
+          return {
+            category: categoryFilter ? Number(categoryFilter.value) : undefined,
+            createdAt:
+              createdAtGte && createdAtLte
+                ? [String(createdAtGte.value), String(createdAtLte.value)]
+                : undefined,
+          };
+        },
+      });
+
+      formInstance = searchFormProps.form;
+
+      return (
+        <Form {...searchFormProps}>
+          <Form.Item name="category" noStyle>
+            <Input />
+          </Form.Item>
+          <Form.Item name="createdAt" noStyle>
+            <Input />
+          </Form.Item>
+        </Form>
+      );
+    };
+
+    render(<Component />, {
+      wrapper: TestWrapper({
+        routerProvider: {
+          parse: () => {
+            return () => ({
+              resource: {
+                name: "posts",
+              },
+              params: {
+                filters: [
+                  {
+                    field: "category.id",
+                    operator: "eq",
+                    value: "1",
+                  },
+                  {
+                    field: "createdAt",
+                    operator: "gte",
+                    value: "2026-04-07T18:30:00.000Z",
+                  },
+                  {
+                    field: "createdAt",
+                    operator: "lte",
+                    value: "2026-05-08T18:30:00.000Z",
+                  },
+                ],
+              },
+            });
+          },
+        },
+      }),
+    });
+
+    await waitFor(() => {
+      expect(formInstance).toBeDefined();
+      expect(formInstance!.getFieldValue("category")).toBe(1);
+      expect(formInstance!.getFieldValue("createdAt")).toEqual([
+        "2026-04-07T18:30:00.000Z",
+        "2026-05-08T18:30:00.000Z",
+      ]);
     });
   });
 

--- a/packages/antd/src/hooks/table/useTable/useTable.ts
+++ b/packages/antd/src/hooks/table/useTable/useTable.ts
@@ -29,6 +29,7 @@ import type { FilterValue, SorterResult } from "../../../definitions/table";
 export type useTableProps<TQueryFnData, TError, TSearchVariables, TData> =
   useTablePropsCore<TQueryFnData, TError, TData> & {
     onSearch?: (data: TSearchVariables) => CrudFilters | Promise<CrudFilters>;
+    onParse?: (filters: CrudFilters) => Partial<TSearchVariables>;
   };
 
 export type useTableReturnType<
@@ -61,6 +62,7 @@ export const useTable = <
   TData extends BaseRecord = TQueryFnData,
 >({
   onSearch,
+  onParse,
   pagination: paginationFromProp,
   filters: filtersFromProp,
   sorters: sortersFromProp,
@@ -126,6 +128,12 @@ export const useTable = <
 
   React.useEffect(() => {
     if (shouldSyncWithLocation) {
+      if (onParse) {
+        formSF.form.setFieldsValue(onParse(filters) as any);
+
+        return;
+      }
+
       // get registered fields of form
       const registeredFields = formSF.form.getFieldsValue() as Record<
         string,
@@ -149,7 +157,7 @@ export const useTable = <
       // set values to form
       formSF.form.setFieldsValue(filterFilterMap as any);
     }
-  }, [shouldSyncWithLocation]);
+  }, [shouldSyncWithLocation, filters, formSF.form, onParse]);
 
   const onChange = (
     paginationState: TablePaginationConfig,


### PR DESCRIPTION
What is the current behavior?
When using @refinedev/antd useTable with syncWithLocation: true and onSearch, reverse hydration (CrudFilters from URL -> search form values) is handled by a simple field-name match and raw value assignment.

This causes issues for:

typed fields (e.g. number expected but URL value is string),
complex fields (e.g. RangePicker where one form field maps to gte/lte filters),
date range refresh path can crash with date.isValid is not a function because the form receives invalid shape/type for range values.
What is the new behavior?
Adds optional onParse to useTable in @refinedev/antd:

onParse?: (filters: CrudFilters) => Partial<TSearchVariables>
With syncWithLocation, if onParse is provided, it is used to map URL/restored filters back to form values before setFieldsValue.
If not provided, existing fallback behavior is preserved.

Also adds tests that verify:

custom parsing is applied,
type conversion (string -> number),
reconstruction of grouped values (e.g. createdAt from gte/lte).
fixes #7360 

Notes for reviewers
Scope is intentionally limited to packages/antd (useTable integration layer).
Backward compatibility is preserved through fallback logic.
Changeset included: .changeset/tiny-avocados-hammer.md.
Repro used: table-antd-table-filter with URL containing createdAt gte/lte filters after refresh.


Attached a screenshot of the runtime error seen on refresh with URL-synced date filters:

Uncaught TypeError: date.isValid is not a function

This happens in RefRangePicker when restored filter values are not parsed into the expected date value shape.

