### PR TITLE
feat(core): add namespace options to useTranslation

### DIFF
--- a/.changeset/rude-dragons-buy.md
+++ b/.changeset/rude-dragons-buy.md
@@ -1,0 +1,6 @@
+---
+"@refinedev/react-router": patch
+"@refinedev/core": patch
+---
+
+- add i18n namespace option directly to useTranslation, useTranslate, useDocumentTitle hooks.

--- a/documentation/docs/i18n/i18n-provider/index.md
+++ b/documentation/docs/i18n/i18n-provider/index.md
@@ -127,6 +127,24 @@ const title = translate("posts.fields.title", { ns: "resources" }, "Title");
 // ...
 ```
 
+- Example using namespace option
+
+Using the `ns` option in the hook initializer sets a default namespace for all translations:
+
+```tsx
+import { useTranslation } from "@refinedev/core";
+
+// ...
+
+const { translate } = useTranslation({ ns: "resources" });
+
+// ...
+
+const title = translate("posts.fields.title", "Title");
+
+// ...
+```
+
 You can use the [`useTranslation`][use-translation] hook to call `translate` method.
 
 ### changeLocale

--- a/packages/core/src/hooks/i18n/useTranslate.spec.tsx
+++ b/packages/core/src/hooks/i18n/useTranslate.spec.tsx
@@ -56,7 +56,11 @@ describe("useTranslate", () => {
 
       return (
         <div>
-          {translate("title-key", { option1: "option1" }, "fallback-title")}
+          {translate(
+            "products.title.key",
+            { option1: "option1" },
+            "fallback-title",
+          )}
         </div>
       );
     };
@@ -74,7 +78,7 @@ describe("useTranslate", () => {
 
     expect(getByText("hello")).toBeTruthy();
     expect(translateMock).toHaveBeenCalledWith(
-      "title-key",
+      "products.title.key",
       { ns: "common", option1: "option1" },
       "fallback-title",
     );

--- a/packages/core/src/hooks/i18n/useTranslate.spec.tsx
+++ b/packages/core/src/hooks/i18n/useTranslate.spec.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { vi } from "vitest";
 
 import { useTranslate } from "@hooks";
 import { TestWrapper, render } from "@test";
@@ -45,5 +46,37 @@ describe("useTranslate", () => {
     });
 
     expect(getByText("merhaba test")).toBeTruthy();
+  });
+
+  it("passes ns with options to i18nProvider", () => {
+    const translateMock = vi.fn(() => "hello");
+
+    const TestNsComponent = () => {
+      const translate = useTranslate({ ns: "common" });
+
+      return (
+        <div>
+          {translate("title-key", { option1: "option1" }, "fallback-title")}
+        </div>
+      );
+    };
+
+    const { getByText } = render(<TestNsComponent />, {
+      wrapper: TestWrapper({
+        resources: [{ name: "products" }],
+        i18nProvider: {
+          translate: translateMock,
+          changeLocale: () => Promise.resolve(),
+          getLocale: () => "en",
+        },
+      }),
+    });
+
+    expect(getByText("hello")).toBeTruthy();
+    expect(translateMock).toHaveBeenCalledWith(
+      "title-key",
+      { ns: "common", option1: "option1" },
+      "fallback-title",
+    );
   });
 });

--- a/packages/core/src/hooks/i18n/useTranslate.ts
+++ b/packages/core/src/hooks/i18n/useTranslate.ts
@@ -29,8 +29,13 @@ export const useTranslate = ({ ns }: UseTranslationProps = {}) => {
       let defaultMessage = _defaultMessage;
 
       if (typeof options === "string" && defaultMessage === undefined) {
-        options = undefined;
         defaultMessage = options;
+
+        if (ns) {
+          options = { ns };
+        } else {
+          options = undefined;
+        }
       }
 
       if (ns && options && typeof options !== "string") {

--- a/packages/core/src/hooks/i18n/useTranslate.ts
+++ b/packages/core/src/hooks/i18n/useTranslate.ts
@@ -1,6 +1,7 @@
 import { useContext, useMemo } from "react";
 
 import { I18nContext } from "@contexts/i18n";
+import type { UseTranslationProps } from "./useTranslation";
 
 /**
  * If you need to translate the texts in your own components, refine provides the `useTranslate` hook.
@@ -8,7 +9,7 @@ import { I18nContext } from "@contexts/i18n";
  *
  * @see {@link https://refine.dev/docs/api-reference/core/hooks/translate/useTranslate} for more details.
  */
-export const useTranslate = () => {
+export const useTranslate = ({ ns }: UseTranslationProps = {}) => {
   const { i18nProvider } = useContext(I18nContext);
 
   const fn = useMemo(() => {
@@ -21,14 +22,26 @@ export const useTranslate = () => {
 
     function translate(
       key: string,
-      options?: string | any,
-      defaultMessage?: string,
+      _options?: string | any,
+      _defaultMessage?: string,
     ) {
+      let options = _options;
+      let defaultMessage = _defaultMessage;
+
+      if (typeof options === "string" && defaultMessage === undefined) {
+        options = undefined;
+        defaultMessage = options;
+      }
+
+      if (ns && options && typeof options !== "string") {
+        options = { ns, ...options };
+      }
+
       return (
         i18nProvider?.translate(key, options, defaultMessage) ??
         defaultMessage ??
-        (typeof options === "string" && typeof defaultMessage === "undefined"
-          ? options
+        (typeof _options === "string" && typeof _defaultMessage === "undefined"
+          ? _options
           : key)
       );
     }

--- a/packages/core/src/hooks/i18n/useTranslation.spec.tsx
+++ b/packages/core/src/hooks/i18n/useTranslation.spec.tsx
@@ -50,14 +50,18 @@ describe("useTranslation", () => {
 
       return (
         <div>
-          {translate("title-key", { opiton1: "option1" }, "fallback-title")}
+          {translate(
+            "products.title.key",
+            { opiton1: "option1" },
+            "fallback-title",
+          )}
         </div>
       );
     };
 
     render(<TestComponentWithNs />, {
       wrapper: TestWrapper({
-        resources: [{ name: "product" }],
+        resources: [{ name: "products" }],
         i18nProvider: {
           translate: translateMock,
           changeLocale: vi.fn(),
@@ -68,7 +72,7 @@ describe("useTranslation", () => {
 
     expect(translateMock).toHaveBeenCalledTimes(1);
     expect(translateMock).toHaveBeenCalledWith(
-      "title-key",
+      "products.title.key",
       { ns: "common", opiton1: "option1" },
       "fallback-title",
     );

--- a/packages/core/src/hooks/i18n/useTranslation.spec.tsx
+++ b/packages/core/src/hooks/i18n/useTranslation.spec.tsx
@@ -42,7 +42,63 @@ describe("useTranslation", () => {
     expect(changeLocale).toHaveBeenCalledWith("en");
   });
 
+  it("should not pass options to translate", () => {
+    const translateMock = vi.fn();
+
+    const TestComponentWithNs: React.FC = () => {
+      const { translate } = useTranslation();
+
+      return <div>{translate("products.title.key", "fallback-title")}</div>;
+    };
+
+    render(<TestComponentWithNs />, {
+      wrapper: TestWrapper({
+        resources: [{ name: "products" }],
+        i18nProvider: {
+          translate: translateMock,
+          changeLocale: vi.fn(),
+          getLocale: vi.fn(),
+        },
+      }),
+    });
+
+    expect(translateMock).toHaveBeenCalledTimes(1);
+    expect(translateMock).toHaveBeenCalledWith(
+      "products.title.key",
+      undefined,
+      "fallback-title",
+    );
+  });
+
   it("should pass ns option to translate", () => {
+    const translateMock = vi.fn();
+
+    const TestComponentWithNs: React.FC = () => {
+      const { translate } = useTranslation({ ns: "common" });
+
+      return <div>{translate("products.title.key", "fallback-title")}</div>;
+    };
+
+    render(<TestComponentWithNs />, {
+      wrapper: TestWrapper({
+        resources: [{ name: "products" }],
+        i18nProvider: {
+          translate: translateMock,
+          changeLocale: vi.fn(),
+          getLocale: vi.fn(),
+        },
+      }),
+    });
+
+    expect(translateMock).toHaveBeenCalledTimes(1);
+    expect(translateMock).toHaveBeenCalledWith(
+      "products.title.key",
+      { ns: "common" },
+      "fallback-title",
+    );
+  });
+
+  it("should pass all options to translate", () => {
     const translateMock = vi.fn();
 
     const TestComponentWithNs: React.FC = () => {
@@ -52,7 +108,7 @@ describe("useTranslation", () => {
         <div>
           {translate(
             "products.title.key",
-            { opiton1: "option1" },
+            { option1: "1", option2: "2" },
             "fallback-title",
           )}
         </div>
@@ -73,7 +129,7 @@ describe("useTranslation", () => {
     expect(translateMock).toHaveBeenCalledTimes(1);
     expect(translateMock).toHaveBeenCalledWith(
       "products.title.key",
-      { ns: "common", opiton1: "option1" },
+      { ns: "common", option1: "1", option2: "2" },
       "fallback-title",
     );
   });

--- a/packages/core/src/hooks/i18n/useTranslation.spec.tsx
+++ b/packages/core/src/hooks/i18n/useTranslation.spec.tsx
@@ -41,4 +41,36 @@ describe("useTranslation", () => {
     expect(changeLocale).toHaveBeenCalledTimes(1);
     expect(changeLocale).toHaveBeenCalledWith("en");
   });
+
+  it("should pass ns option to translate", () => {
+    const translateMock = vi.fn();
+
+    const TestComponentWithNs: React.FC = () => {
+      const { translate } = useTranslation({ ns: "common" });
+
+      return (
+        <div>
+          {translate("title-key", { opiton1: "option1" }, "fallback-title")}
+        </div>
+      );
+    };
+
+    render(<TestComponentWithNs />, {
+      wrapper: TestWrapper({
+        resources: [{ name: "product" }],
+        i18nProvider: {
+          translate: translateMock,
+          changeLocale: vi.fn(),
+          getLocale: vi.fn(),
+        },
+      }),
+    });
+
+    expect(translateMock).toHaveBeenCalledTimes(1);
+    expect(translateMock).toHaveBeenCalledWith(
+      "title-key",
+      { ns: "common", opiton1: "option1" },
+      "fallback-title",
+    );
+  });
 });

--- a/packages/core/src/hooks/i18n/useTranslation.tsx
+++ b/packages/core/src/hooks/i18n/useTranslation.tsx
@@ -2,6 +2,10 @@ import { useGetLocale } from "./useGetLocale";
 import { useSetLocale } from "./useSetLocale";
 import { useTranslate } from "./useTranslate";
 
+export interface UseTranslationProps {
+  ns?: string | string[];
+}
+
 /**
  * It combines `useTranslate`, `useSetLocale` and `useGetLocale` hooks for a better developer experience.
  * It returns `i18nProvider` methods under the hood.
@@ -11,8 +15,8 @@ import { useTranslate } from "./useTranslate";
  *
  * @see {@link https://refine.dev/docs/i18n/i18n-provider/} for more details.
  */
-export const useTranslation = () => {
-  const translate = useTranslate();
+export const useTranslation = ({ ns }: UseTranslationProps = {}) => {
+  const translate = useTranslate({ ns });
   const changeLocale = useSetLocale();
   const getLocale = useGetLocale();
 

--- a/packages/react-router/src/use-document-title.ts
+++ b/packages/react-router/src/use-document-title.ts
@@ -1,26 +1,37 @@
-import { useTranslate } from "@refinedev/core";
-import { useEffect } from "react";
+import { useTranslate, type UseTranslationProps } from "@refinedev/core";
+import { useCallback, useEffect } from "react";
 
 type Title = string | { i18nKey: string };
 
-export const useDocumentTitle = (title?: Title) => {
-  const translate = useTranslate();
+interface useDocumentTitleOptions {
+  ns?: UseTranslationProps["ns"];
+
+  /**
+   * Passed to defaultMessage for translate from useTranslate
+   */
+  defaultTitle?: string;
+}
+
+export const useDocumentTitle = (
+  title?: Title,
+  options?: useDocumentTitleOptions,
+) => {
+  const translate = useTranslate({ ns: options?.ns });
+
+  const getTitleCB = (title: Title) => {
+    const key = typeof title === "string" ? title : title.i18nKey;
+
+    return translate(key, options?.defaultTitle);
+  };
+  const getTitle = useCallback(getTitleCB, [translate, options?.defaultTitle]);
 
   useEffect(() => {
     if (!title) return;
 
-    if (typeof title === "string") {
-      document.title = translate(title);
-    } else {
-      document.title = translate(title.i18nKey);
-    }
-  }, [title]);
+    document.title = getTitle(title);
+  }, [title, getTitle]);
 
   return (title: Title) => {
-    if (typeof title === "string") {
-      document.title = translate(title);
-    } else {
-      document.title = translate(title.i18nKey);
-    }
+    document.title = getTitle(title);
   };
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
- namespace had to be specified for each key translation
- useDocumentTitle had no fallback

## What is the new behavior?
- all translations use the namespace from the hook call
- useDocumentTitle now has a fallback title

resolves #7195 #7198

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->

Is anyone else facing this issue? I haven't contributed to testing since the vitest migration

<img width="1029" height="472" alt="image" src="https://github.com/user-attachments/assets/9ecb7281-0ed8-4870-b9c9-a5bc7b8f3808" />
