### PR TITLE
feat(antd): upgrade antd to v6

### DIFF
--- a/.changeset/large-bears-turn.md
+++ b/.changeset/large-bears-turn.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/live-previews": patch
+"@refinedev/inferencer": patch
+"@refinedev/antd": patch
+---
+
+- Bump `antd` to `^6.3.5`
+
+[Resolves #7140](https://github.com/refinedev/refine/issues/7140)

--- a/cypress/e2e/data-provider-strapi-v4/all.cy.ts
+++ b/cypress/e2e/data-provider-strapi-v4/all.cy.ts
@@ -133,7 +133,7 @@ describe("data-provider-strapi-v4", () => {
       cy.getAntdLoadingOverlay().should("not.exist");
 
       cy.getAntdFilterTrigger(0).click();
-      cy.get(".ant-select-selector").eq(1).click();
+      cy.get(".ant-select-content").eq(1).click();
 
       // Wait for dropdown options to be visible and have proper dimensions
       cy.get(".ant-select-dropdown").should("be.visible");

--- a/cypress/e2e/data-provider-supabase/all.cy.ts
+++ b/cypress/e2e/data-provider-supabase/all.cy.ts
@@ -144,7 +144,7 @@ describe("data-provider-supabase", () => {
       cy.getAntdLoadingOverlay().should("not.exist");
 
       cy.getAntdFilterTrigger(0).click();
-      cy.get(".ant-select-selector").click();
+      cy.get(".ant-select-content").click();
       cy.fixture("categories").then((categories) => {
         const category = categories[0];
 

--- a/cypress/e2e/form-antd-use-drawer-form/all.cy.ts
+++ b/cypress/e2e/form-antd-use-drawer-form/all.cy.ts
@@ -17,11 +17,16 @@ describe("form-antd-use-drawer-form", () => {
   };
 
   const isDrawerVisible = () => {
-    return cy.get(".ant-drawer-content").should("be.visible");
+    return cy
+      .get(".ant-drawer-content-wrapper")
+      .should("be.visible")
+      .and("not.have.class", "ant-drawer-content-wrapper-hidden");
   };
 
   const isDrawerNotVisible = () => {
-    return cy.get(".ant-drawer-content").should("not.be.visible");
+    return cy
+      .get(".ant-drawer-content-wrapper")
+      .should("have.class", "ant-drawer-content-wrapper-hidden");
   };
 
   const assertSuccessResponse = (response: any) => {
@@ -82,11 +87,11 @@ describe("form-antd-use-drawer-form", () => {
 
       cy.get("#title.ant-input").eq(1).should("have.value", body?.title);
       cy.get("input#status")
-        .get(".ant-select-selection-item")
-        .should(
-          "contain",
-          body?.status[0].toUpperCase() + body?.status.slice(1),
-        );
+        .closest(".ant-select-content")
+        .invoke("text")
+        .then((text) => {
+          expect(text.trim().toLowerCase()).to.eq(body?.status);
+        });
     });
 
     cy.get("#title.ant-input").eq(1).clear();

--- a/cypress/e2e/form-antd-use-modal-form/all.cy.ts
+++ b/cypress/e2e/form-antd-use-modal-form/all.cy.ts
@@ -81,6 +81,8 @@ describe("form-antd-use-modal-form", () => {
       isModalVisible();
       cy.getAntdLoadingOverlay().should("not.exist");
 
+      // arbitrary wait for field to be populated
+      cy.wait(1000);
       cy.get("#title.ant-input").eq(1).should("have.value", body?.title);
       cy.get("input#status")
         .closest(".ant-select-content")

--- a/cypress/e2e/form-antd-use-modal-form/all.cy.ts
+++ b/cypress/e2e/form-antd-use-modal-form/all.cy.ts
@@ -77,13 +77,12 @@ describe("form-antd-use-modal-form", () => {
       const response = interception?.response;
       const body = response?.body;
 
-      // wait loading state and render to be finished
-      isModalVisible();
-      cy.getAntdLoadingOverlay().should("not.exist");
+      cy.get(".ant-modal-container:visible").last().as("editModal");
+      cy.get("@editModal").find(".ant-spin-spinning").should("not.exist");
+      cy.get("@editModal")
+        .find("input#title")
+        .should("have.value", body?.title);
 
-      // arbitrary wait for field to be populated
-      cy.wait(1000);
-      cy.get("#title.ant-input").eq(1).should("have.value", body?.title);
       cy.get("input#status")
         .closest(".ant-select-content")
         .invoke("text")

--- a/cypress/e2e/form-antd-use-modal-form/all.cy.ts
+++ b/cypress/e2e/form-antd-use-modal-form/all.cy.ts
@@ -22,11 +22,11 @@ describe("form-antd-use-modal-form", () => {
   };
 
   const isModalVisible = () => {
-    return cy.get(".ant-modal-content").should("be.visible");
+    return cy.get(".ant-modal-container").should("be.visible");
   };
 
   const isModalNotVisible = () => {
-    return cy.get(".ant-modal-content").should("not.be.visible");
+    return cy.get(".ant-modal-container").should("not.be.visible");
   };
 
   beforeEach(() => {
@@ -83,11 +83,11 @@ describe("form-antd-use-modal-form", () => {
 
       cy.get("#title.ant-input").eq(1).should("have.value", body?.title);
       cy.get("input#status")
-        .get(".ant-select-selection-item")
-        .should(
-          "contain",
-          body?.status[0].toUpperCase() + body?.status.slice(1),
-        );
+        .closest(".ant-select-content")
+        .invoke("text")
+        .then((text) => {
+          expect(text.trim().toLowerCase()).to.eq(body?.status);
+        });
     });
 
     cy.get("#title.ant-input")

--- a/cypress/e2e/form-antd-use-modal-form/all.cy.ts
+++ b/cypress/e2e/form-antd-use-modal-form/all.cy.ts
@@ -34,6 +34,19 @@ describe("form-antd-use-modal-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
+    cy.intercept(
+      {
+        method: "GET",
+        hostname: "api.fake-rest.refine.dev",
+        pathname: "/posts/*",
+      },
+      (req) => {
+        req.on("response", (res) => {
+          res.setDelay(250);
+        });
+      },
+    ).as("getPostDelayed");
+
     cy.visit("/");
   });
 

--- a/cypress/e2e/form-antd-use-modal-form/all.cy.ts
+++ b/cypress/e2e/form-antd-use-modal-form/all.cy.ts
@@ -34,19 +34,6 @@ describe("form-antd-use-modal-form", () => {
     cy.clearAllLocalStorage();
     cy.clearAllSessionStorage();
 
-    cy.intercept(
-      {
-        method: "GET",
-        hostname: "api.fake-rest.refine.dev",
-        pathname: "/posts/*",
-      },
-      (req) => {
-        req.on("response", (res) => {
-          res.setDelay(250);
-        });
-      },
-    ).as("getPostDelayed");
-
     cy.visit("/");
   });
 

--- a/cypress/e2e/form-antd-use-steps-form/all.cy.ts
+++ b/cypress/e2e/form-antd-use-steps-form/all.cy.ts
@@ -77,8 +77,8 @@ describe("form-antd-use-steps-form", () => {
   it("should preserve form data when navigating between steps", () => {
     cy.getCreateButton().click();
 
-    cy.get(".ant-select-selection-item").should("not.exist");
-    cy.get(`.ant-select-selection-item[title="${mockPost.status}"]`).should(
+    cy.get(".ant-select-content").should("not.exist");
+    cy.get(`.ant-select-content[title="${mockPost.status}"]`).should(
       "not.exist",
     );
 
@@ -88,10 +88,8 @@ describe("form-antd-use-steps-form", () => {
       .click();
 
     cy.get("#title").should("have.value", mockPost.title);
-    cy.get(".ant-select-selection-item").eq(0).should("exist");
-    cy.get(`.ant-select-selection-item[title="${mockPost.status}"]`).should(
-      "exist",
-    );
+    cy.get(".ant-select-content").eq(0).should("exist");
+    cy.get(`.ant-select-content[title="${mockPost.status}"]`).should("exist");
 
     cy.get(".ant-btn").contains(/next/gi).click();
 

--- a/cypress/e2e/inferencer-antd/all.cy.ts
+++ b/cypress/e2e/inferencer-antd/all.cy.ts
@@ -160,7 +160,7 @@ describe("inferencer-antd", () => {
         const category = categories.find(
           (category: any) => category.id === body?.category?.id,
         );
-        cy.get(`.ant-select-selection-item[title="${category?.title}"]`).should(
+        cy.get(`.ant-select-content[title="${category?.title}"]`).should(
           "exist",
         );
       });

--- a/cypress/e2e/inferencer-graphql-hasura/all.cy.ts
+++ b/cypress/e2e/inferencer-graphql-hasura/all.cy.ts
@@ -86,7 +86,7 @@ describe("inferencer-antd", () => {
         const category = categories.data.categories.find(
           (category: any) => category.id === data?.category_id,
         );
-        cy.get(`.ant-select-selection-item[title="${category?.title}"]`).should(
+        cy.get(`.ant-select-content[title="${category?.title}"]`).should(
           "exist",
         );
       });

--- a/cypress/support/commands/antd/index.ts
+++ b/cypress/support/commands/antd/index.ts
@@ -46,7 +46,7 @@ export const getAntdFormItemError = ({ id }: IGetAntdFormItemErrorParams) => {
 };
 
 export const getAntdLoadingOverlay = () => {
-  return cy.get(".ant-spin");
+  return cy.get(".ant-spin-spinning");
 };
 
 export const getAntdPopoverDeleteButton = () => {

--- a/examples/access-control-casbin/package.json
+++ b/examples/access-control-casbin/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "casbin": "^5.15.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/access-control-cerbos/package.json
+++ b/examples/access-control-cerbos/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/access-control-permify/package.json
+++ b/examples/access-control-permify/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/app-crm-minimal/README.MD
+++ b/examples/app-crm-minimal/README.MD
@@ -1373,11 +1373,15 @@ export const CompanyContactsTable = () => {
 
   return (
     <Card
-      headStyle={{
+    styles={{
+      header: {
         borderBottom: "1px solid #D9D9D9",
         marginBottom: "1px",
-      }}
-      bodyStyle={{ padding: 0 }}
+      },
+      body: {
+        padding: 0
+      }
+    }}
       title={
         <Space size="middle">
           <TeamOutlined />

--- a/examples/app-crm-minimal/package.json
+++ b/examples/app-crm-minimal/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@ant-design/cssinjs": "^1.17.2",
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/plots": "^1.2.5",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@dnd-kit/core": "^6.0.8",
@@ -27,7 +27,7 @@
     "@refinedev/nestjs-query": "^2.0.1",
     "@refinedev/react-router": "^2.0.4",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "classnames": "^2.3.2",
     "cross-env": "^7.0.3",
     "dayjs": "^1.10.7",

--- a/examples/app-crm-minimal/src/routes/companies/edit/contacts-table.tsx
+++ b/examples/app-crm-minimal/src/routes/companies/edit/contacts-table.tsx
@@ -68,11 +68,15 @@ export const CompanyContactsTable = () => {
 
   return (
     <Card
-      headStyle={{
-        borderBottom: "1px solid #D9D9D9",
-        marginBottom: "1px",
+      styles={{
+        header: {
+          borderBottom: "1px solid #D9D9D9",
+          marginBottom: "1px",
+        },
+        body: {
+          padding: 0,
+        },
       }}
-      bodyStyle={{ padding: 0 }}
       title={
         <Space size="middle">
           <TeamOutlined />

--- a/examples/app-crm-minimal/src/routes/dashboard/components/deals-chart/index.tsx
+++ b/examples/app-crm-minimal/src/routes/dashboard/components/deals-chart/index.tsx
@@ -69,8 +69,14 @@ export const DashboardDealsChart = () => {
   return (
     <Card
       style={{ height: "100%" }}
-      headStyle={{ padding: "8px 16px" }}
-      bodyStyle={{ padding: "24px 24px 0px 24px" }}
+      styles={{
+        header: {
+          padding: "8px 16px",
+        },
+        body: {
+          padding: "24px 24px 0px 24px",
+        },
+      }}
       title={
         <div
           style={{

--- a/examples/app-crm-minimal/src/routes/dashboard/components/latest-activities/index.tsx
+++ b/examples/app-crm-minimal/src/routes/dashboard/components/latest-activities/index.tsx
@@ -77,9 +77,13 @@ export const DashboardLatestActivities = ({ limit = 5 }: Props) => {
 
   return (
     <Card
-      headStyle={{ padding: "16px" }}
-      bodyStyle={{
-        padding: "0 1rem",
+      styles={{
+        header: {
+          padding: "16px",
+        },
+        body: {
+          padding: "0 1rem",
+        },
       }}
       title={
         <div

--- a/examples/app-crm-minimal/src/routes/dashboard/components/total-count-card/index.tsx
+++ b/examples/app-crm-minimal/src/routes/dashboard/components/total-count-card/index.tsx
@@ -61,8 +61,10 @@ export const DashboardTotalCountCard = ({
   return (
     <Card
       style={{ height: "96px", padding: 0 }}
-      bodyStyle={{
-        padding: "8px 8px 8px 12px",
+      styles={{
+        body: {
+          padding: "8px 8px 8px 12px",
+        },
       }}
       size="small"
     >

--- a/examples/app-crm-minimal/src/routes/dashboard/components/upcoming-events/index.tsx
+++ b/examples/app-crm-minimal/src/routes/dashboard/components/upcoming-events/index.tsx
@@ -42,9 +42,13 @@ export const CalendarUpcomingEvents = () => {
       style={{
         height: "100%",
       }}
-      headStyle={{ padding: "8px 16px" }}
-      bodyStyle={{
-        padding: "0 1rem",
+      styles={{
+        header: {
+          padding: "8px 16px",
+        },
+        body: {
+          padding: "0 1rem",
+        },
       }}
       title={
         <div

--- a/examples/app-crm-minimal/src/routes/tasks/list/kanban/card.tsx
+++ b/examples/app-crm-minimal/src/routes/tasks/list/kanban/card.tsx
@@ -209,10 +209,12 @@ export const ProjectCardSkeleton = () => {
   return (
     <Card
       size="small"
-      bodyStyle={{
-        display: "flex",
-        justifyContent: "center",
-        gap: "8px",
+      styles={{
+        body: {
+          display: "flex",
+          justifyContent: "center",
+          gap: "8px",
+        },
       }}
       title={
         <Skeleton.Button

--- a/examples/auth-antd/package.json
+++ b/examples/auth-antd/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
     "@refinedev/cli": "^2.16.52",
@@ -30,7 +30,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/auth-antd/src/pages/dashboard.tsx
+++ b/examples/auth-antd/src/pages/dashboard.tsx
@@ -20,9 +20,13 @@ export const DashboardPage: React.FC = () => {
         <Card
           title="Identity"
           style={{ height: "300px", borderRadius: "15px" }}
-          headStyle={{ textAlign: "center" }}
+          styles={{
+            header: {
+              textAlign: "center",
+            },
+          }}
         >
-          <Space align="center" direction="horizontal">
+          <Space align="center" orientation="horizontal">
             <Avatar size="large" src={identity?.avatar} />
             <Text>{identity?.name}</Text>
           </Space>
@@ -32,7 +36,11 @@ export const DashboardPage: React.FC = () => {
         <Card
           title="Permissions"
           style={{ height: "300px", borderRadius: "15px" }}
-          headStyle={{ textAlign: "center" }}
+          styles={{
+            header: {
+              textAlign: "center",
+            },
+          }}
         >
           <Text>{permissions.data}</Text>
         </Card>

--- a/examples/auth-auth0/package.json
+++ b/examples/auth-auth0/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "axios": "^1.11.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/auth-auth0/src/pages/login.tsx
+++ b/examples/auth-auth0/src/pages/login.tsx
@@ -13,7 +13,7 @@ export const Login: React.FC = () => {
         alignItems: "center",
       }}
     >
-      <Space direction="vertical" align="center" size="large">
+      <Space orientation="vertical" align="center" size="large">
         <ThemedTitleV2
           collapsed={false}
           wrapperStyles={{

--- a/examples/auth-google-login/package.json
+++ b/examples/auth-google-login/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "axios": "^1.11.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/auth-google-login/src/pages/login.tsx
+++ b/examples/auth-google-login/src/pages/login.tsx
@@ -50,7 +50,7 @@ export const Login: React.FC = () => {
         alignItems: "center",
       }}
     >
-      <Space direction="vertical" align="center" size="large">
+      <Space orientation="vertical" align="center" size="large">
         <ThemedTitleV2
           collapsed={false}
           wrapperStyles={{

--- a/examples/auth-keycloak/package.json
+++ b/examples/auth-keycloak/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "axios": "^1.11.0",
     "keycloak-js": "^25.0.1",
     "react": "^19.1.0",

--- a/examples/auth-keycloak/src/pages/login.tsx
+++ b/examples/auth-keycloak/src/pages/login.tsx
@@ -13,7 +13,7 @@ export const Login: React.FC = () => {
         alignItems: "center",
       }}
     >
-      <Space direction="vertical" align="center" size="large">
+      <Space orientation="vertical" align="center" size="large">
         <ThemedTitleV2
           collapsed={false}
           wrapperStyles={{

--- a/examples/auth-kinde/package.json
+++ b/examples/auth-kinde/package.json
@@ -29,7 +29,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "axios": "^1.11.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/auth-kinde/src/pages/login.tsx
+++ b/examples/auth-kinde/src/pages/login.tsx
@@ -13,7 +13,7 @@ export const Login: React.FC = () => {
         alignItems: "center",
       }}
     >
-      <Space direction="vertical" align="center" size="large">
+      <Space orientation="vertical" align="center" size="large">
         <ThemedTitleV2
           collapsed={false}
           wrapperStyles={{

--- a/examples/auth-otp/package.json
+++ b/examples/auth-otp/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
     "@refinedev/cli": "^2.16.52",
@@ -30,7 +30,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/base-antd/package.json
+++ b/examples/base-antd/package.json
@@ -30,7 +30,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/blog-invoice-generator/package.json
+++ b/examples/blog-invoice-generator/package.json
@@ -23,7 +23,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@react-pdf/renderer": "^3.1.8",
     "@refinedev/antd": "^5.44.0",
@@ -31,7 +31,7 @@
     "@refinedev/core": "^4.56.0",
     "@refinedev/react-router": "^0.1.0",
     "@refinedev/strapi-v4": "^6.0.9",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "axios": "^1.11.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/blog-invoice-generator/src/components/client/create.tsx
+++ b/examples/blog-invoice-generator/src/components/client/create.tsx
@@ -51,8 +51,8 @@ export const CreateClient: React.FC<CreateClientProps> = ({
     <>
       <Drawer
         {...drawerProps}
-        width={breakpoint.sm ? "500px" : "100%"}
-        bodyStyle={{ padding: 0 }}
+        size={breakpoint.sm ? "500px" : "100%"}
+        styles={{ body: { padding: 0 } }}
       >
         <Create saveButtonProps={saveButtonProps}>
           <Form

--- a/examples/blog-invoice-generator/src/components/client/edit.tsx
+++ b/examples/blog-invoice-generator/src/components/client/edit.tsx
@@ -36,8 +36,8 @@ export const EditClient: React.FC<EditClientProps> = ({
   return (
     <Drawer
       {...drawerProps}
-      width={breakpoint.sm ? "500px" : "100%"}
-      bodyStyle={{ padding: 0 }}
+      size={breakpoint.sm ? "500px" : "100%"}
+      styles={{ body: { padding: 0 } }}
     >
       <Edit saveButtonProps={saveButtonProps}>
         <Form

--- a/examples/blog-issue-tracker/package.json
+++ b/examples/blog-issue-tracker/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@ant-design/charts": "^2.6.7",
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
     "@refinedev/cli": "^2.16.52",
@@ -33,7 +33,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/supabase": "^6.0.2",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/blog-job-posting/package.json
+++ b/examples/blog-job-posting/package.json
@@ -29,7 +29,7 @@
     "@refinedev/nestjsx-crud": "^5.0.10",
     "@refinedev/react-router": "^0.1.0",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "cross-env": "^7.0.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/blog-react-dnd/package.json
+++ b/examples/blog-react-dnd/package.json
@@ -32,7 +32,7 @@
     "@refinedev/react-router": "^0.1.0",
     "@refinedev/simple-rest": "^5.0.8",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "cross-env": "^7.0.3",
     "immutability-helper": "^3.1.1",
     "next": "^14.2.26",

--- a/examples/blog-refine-antd-dynamic-form/package.json
+++ b/examples/blog-refine-antd-dynamic-form/package.json
@@ -23,14 +23,14 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^5.44.0",
     "@refinedev/cli": "^2.16.40",
     "@refinedev/core": "^4.56.0",
     "@refinedev/react-router": "^0.1.0",
     "@refinedev/simple-rest": "^5.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2",

--- a/examples/blog-refine-antd-dynamic-form/src/pages/UserCreate.tsx
+++ b/examples/blog-refine-antd-dynamic-form/src/pages/UserCreate.tsx
@@ -62,7 +62,7 @@ export default function UserCreate() {
                   return (
                     <Space
                       key={field.key}
-                      direction="horizontal"
+                      orientation="horizontal"
                       style={{
                         position: "relative",
                         marginRight: "13px",

--- a/examples/blog-refine-antd-dynamic-form/src/pages/UserEdit.tsx
+++ b/examples/blog-refine-antd-dynamic-form/src/pages/UserEdit.tsx
@@ -65,7 +65,7 @@ export default function UserEdit() {
                   return (
                     <Space
                       key={field.key}
-                      direction="horizontal"
+                      orientation="horizontal"
                       style={{
                         display: "flex",
                         position: "relative",

--- a/examples/blog-refine-digital-ocean/package.json
+++ b/examples/blog-refine-digital-ocean/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/plots": "^1.2.5",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^5.44.0",
@@ -32,7 +32,7 @@
     "@refinedev/kbar": "^1.3.12",
     "@refinedev/nestjs-query": "^1.3.3",
     "@refinedev/react-router": "^0.1.0",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "dayjs": "^1.10.7",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/blog-refine-markdown/package.json
+++ b/examples/blog-refine-markdown/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^5.44.0",
     "@refinedev/cli": "^2.16.40",
@@ -32,7 +32,7 @@
     "@refinedev/react-router": "^0.1.0",
     "@refinedev/simple-rest": "^5.0.8",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/calendar-app/package.json
+++ b/examples/calendar-app/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/command-palette-kbar/package.json
+++ b/examples/command-palette-kbar/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
     "@refinedev/cli": "^2.16.52",
@@ -31,7 +31,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/customization-footer/package.json
+++ b/examples/customization-footer/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/customization-login/package.json
+++ b/examples/customization-login/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "cross-env": "^7.0.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/customization-login/src/pages/login/index.tsx
+++ b/examples/customization-login/src/pages/login/index.tsx
@@ -46,7 +46,7 @@ export const Login: React.FC = () => {
             <div className="imageContainer">
               <img src="./refine.svg" alt="Refine Logo" />
             </div>
-            <Card title={CardTitle} headStyle={{ borderBottom: 0 }}>
+            <Card title={CardTitle} styles={{ header: { borderBottom: 0 } }}>
               <Form<ILoginForm>
                 layout="vertical"
                 form={form}

--- a/examples/customization-offlayout-area/package.json
+++ b/examples/customization-offlayout-area/package.json
@@ -22,14 +22,14 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
     "@refinedev/cli": "^2.16.52",
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/customization-rtl/package.json
+++ b/examples/customization-rtl/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/customization-sider/package.json
+++ b/examples/customization-sider/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/customization-theme-antd/package.json
+++ b/examples/customization-theme-antd/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/customization-theme-antd/src/components/Header/index.tsx
+++ b/examples/customization-theme-antd/src/components/Header/index.tsx
@@ -48,7 +48,7 @@ interface HeaderProps {
 const Header: FC<HeaderProps> = (props) => {
   return (
     <Space
-      direction="vertical"
+      orientation="vertical"
       align="end"
       style={{
         padding: "1rem",

--- a/examples/customization-top-menu-layout/package.json
+++ b/examples/customization-top-menu-layout/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/data-provider-airtable/package.json
+++ b/examples/data-provider-airtable/package.json
@@ -29,7 +29,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/data-provider-appwrite-tutorial-docs/package.json
+++ b/examples/data-provider-appwrite-tutorial-docs/package.json
@@ -29,7 +29,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2",

--- a/examples/data-provider-appwrite/package.json
+++ b/examples/data-provider-appwrite/package.json
@@ -29,7 +29,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/data-provider-graphql/package.json
+++ b/examples/data-provider-graphql/package.json
@@ -31,7 +31,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@uiw/react-md-editor": "^4.0.8",
     "@urql/core": "^5.0.6",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "graphql-ws": "^5.9.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/data-provider-hasura/package.json
+++ b/examples/data-provider-hasura/package.json
@@ -30,7 +30,7 @@
     "@refinedev/hasura": "^7.0.1",
     "@refinedev/react-router": "^2.0.4",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "graphql": "^15.6.1",
     "graphql-tag": "^2.12.6",
     "react": "^19.1.0",

--- a/examples/data-provider-multiple/package.json
+++ b/examples/data-provider-multiple/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/data-provider-nestjs-query/package.json
+++ b/examples/data-provider-nestjs-query/package.json
@@ -30,7 +30,7 @@
     "@refinedev/nestjs-query": "^2.0.1",
     "@refinedev/react-router": "^2.0.4",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "graphql": "^15.6.1",
     "graphql-tag": "^2.12.6",
     "graphql-ws": "^5.9.1",

--- a/examples/data-provider-nestjsx-crud/package.json
+++ b/examples/data-provider-nestjsx-crud/package.json
@@ -29,7 +29,7 @@
     "@refinedev/nestjsx-crud": "^6.0.1",
     "@refinedev/react-router": "^2.0.4",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/data-provider-sanity/package.json
+++ b/examples/data-provider-sanity/package.json
@@ -31,7 +31,7 @@
     "@refinedev/simple-rest": "^6.0.1",
     "@sanity/client": "^6.6.0",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2",

--- a/examples/data-provider-strapi-v4/package.json
+++ b/examples/data-provider-strapi-v4/package.json
@@ -30,7 +30,7 @@
     "@refinedev/rest": "^2.1.1",
     "@refinedev/strapi-v4": "^7.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "axios": "^1.11.0",
     "ky": "^1.10.0",
     "react": "^19.1.0",

--- a/examples/data-provider-strapi/package.json
+++ b/examples/data-provider-strapi/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/strapi": "^5.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "axios": "^1.11.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/data-provider-supabase/package.json
+++ b/examples/data-provider-supabase/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
     "@refinedev/cli": "^2.16.52",
@@ -30,7 +30,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/supabase": "^6.0.2",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/field-antd-use-checkbox-group/package.json
+++ b/examples/field-antd-use-checkbox-group/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/field-antd-use-radio-group/package.json
+++ b/examples/field-antd-use-radio-group/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/field-antd-use-select-basic/package.json
+++ b/examples/field-antd-use-select-basic/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/field-antd-use-select-infinite/package.json
+++ b/examples/field-antd-use-select-infinite/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/finefoods-antd/package.json
+++ b/examples/finefoods-antd/package.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "@ant-design/graphs": "^1.2.7",
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/plots": "^1.2.5",
     "@ant-design/use-emotion-css": "^1.0.4",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
@@ -30,7 +30,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "antd-style": "^3.6.1",
     "cross-env": "^7.0.3",
     "dayjs": "^1.10.7",

--- a/examples/finefoods-antd/src/components/customer/infoList/index.tsx
+++ b/examples/finefoods-antd/src/components/customer/infoList/index.tsx
@@ -23,7 +23,7 @@ export const CustomerInfoList = ({ customer }: Props) => {
 
   return (
     <Card
-      bordered={false}
+      variant={"borderless"}
       styles={{
         body: {
           padding: "0 16px 0 16px",
@@ -42,7 +42,7 @@ export const CustomerInfoList = ({ customer }: Props) => {
             title: t("users.fields.addresses"),
             icon: <EnvironmentOutlined />,
             value: (
-              <Space direction="vertical">
+              <Space orientation="vertical">
                 {customer?.addresses.map((address, index) => {
                   const isFirst = index === 0;
 

--- a/examples/finefoods-antd/src/components/dashboard/recentOrders/index.tsx
+++ b/examples/finefoods-antd/src/components/dashboard/recentOrders/index.tsx
@@ -77,7 +77,7 @@ export const RecentOrders: React.FC = () => {
           return (
             <Space
               size={0}
-              direction="vertical"
+              orientation="vertical"
               style={{
                 maxWidth: "220px",
               }}
@@ -117,7 +117,7 @@ export const RecentOrders: React.FC = () => {
           return (
             <Space
               size={0}
-              direction="vertical"
+              orientation="vertical"
               style={{
                 maxWidth: "220px",
               }}

--- a/examples/finefoods-antd/src/components/form/form-item-horizontal/styled.ts
+++ b/examples/finefoods-antd/src/components/form/form-item-horizontal/styled.ts
@@ -3,7 +3,7 @@ import { createStyles } from "antd-style";
 export const useStyles = createStyles(({ token }) => {
   return {
     formItem: {
-      ".ant-input-disabled, .ant-input-number-disabled, .ant-select-outlined.ant-select-disabled .ant-select-selector, .ant-input-number-outlined.ant-input-number-disabled input[disabled]":
+      ".ant-input-disabled, .ant-input-number-disabled, .ant-select-outlined.ant-select-disabled .ant-select-content, .ant-input-number-outlined.ant-input-number-disabled input[disabled]":
         {
           borderColor: "transparent !important",
           backgroundColor: "transparent !important",

--- a/examples/finefoods-antd/src/components/header/index.tsx
+++ b/examples/finefoods-antd/src/components/header/index.tsx
@@ -230,8 +230,10 @@ export const Header: React.FC = () => {
               maxWidth: "550px",
             }}
             options={options}
-            filterOption={false}
-            onSearch={debounce((value: string) => setValue(value), 300)}
+            showSearch={{
+              filterOption: false,
+              onSearch: debounce((value: string) => setValue(value), 300),
+            }}
           >
             <Input
               size="large"

--- a/examples/finefoods-antd/src/components/order/actions/index.tsx
+++ b/examples/finefoods-antd/src/components/order/actions/index.tsx
@@ -84,7 +84,7 @@ export const OrderActions: React.FC<OrderActionProps> = ({ record }) => {
     </Menu>
   );
   return (
-    <Dropdown overlay={moreMenu(record)} trigger={["click"]}>
+    <Dropdown popupRender={moreMenu(record)} trigger={["click"]}>
       <TableActionButton />
     </Dropdown>
   );

--- a/examples/finefoods-antd/src/components/order/actions/index.tsx
+++ b/examples/finefoods-antd/src/components/order/actions/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslate, useUpdate } from "@refinedev/core";
 import { CheckCircleOutlined, CloseCircleOutlined } from "@ant-design/icons";
-import { Dropdown, Menu } from "antd";
+import { Dropdown, Menu, type MenuProps } from "antd";
 import { TableActionButton } from "../../tableActionButton";
 import type { IOrder } from "../../../interfaces";
 
@@ -12,79 +12,78 @@ export const OrderActions: React.FC<OrderActionProps> = ({ record }) => {
   const t = useTranslate();
   const { mutate } = useUpdate({ resource: "orders", id: record.id });
 
-  const moreMenu = (record: IOrder) => (
-    <Menu
-      mode="vertical"
-      onClick={({ domEvent }) => domEvent.stopPropagation()}
-    >
-      <Menu.Item
-        key="accept"
-        style={{
-          fontSize: 15,
-          display: "flex",
-          alignItems: "center",
-          fontWeight: 500,
-        }}
-        disabled={record.status.text !== "Pending"}
-        icon={
-          <CheckCircleOutlined
-            style={{
-              color: "#52c41a",
-              fontSize: 17,
-              fontWeight: 500,
-            }}
-          />
-        }
-        onClick={() => {
-          mutate({
-            values: {
-              status: {
-                id: 2,
-                text: "Ready",
-              },
+  const moreMenuItems = (record: IOrder): MenuProps["items"] => [
+    {
+      key: "accept",
+      label: t("buttons.accept"),
+      style: {
+        fontSize: 15,
+        display: "flex",
+        alignItems: "center",
+        fontWeight: 500,
+      },
+      disabled: record.status.text !== "Pending",
+      icon: (
+        <CheckCircleOutlined
+          style={{
+            color: "#52c41a",
+            fontSize: 17,
+            fontWeight: 500,
+          }}
+        />
+      ),
+      onClick: () => {
+        mutate({
+          values: {
+            status: {
+              id: 2,
+              text: "Ready",
             },
-          });
-        }}
-      >
-        {t("buttons.accept")}
-      </Menu.Item>
-      <Menu.Item
-        key="reject"
-        style={{
-          fontSize: 15,
-          display: "flex",
-          alignItems: "center",
-          fontWeight: 500,
-        }}
-        icon={
-          <CloseCircleOutlined
-            style={{
-              color: "#EE2A1E",
-              fontSize: 17,
-            }}
-          />
-        }
-        disabled={
-          record.status.text === "Delivered" ||
-          record.status.text === "Cancelled"
-        }
-        onClick={() =>
-          mutate({
-            values: {
-              status: {
-                id: 5,
-                text: "Cancelled",
-              },
+          },
+        });
+      },
+    },
+    {
+      key: "reject",
+      label: t("buttons.reject"),
+      style: {
+        fontSize: 15,
+        display: "flex",
+        alignItems: "center",
+        fontWeight: 500,
+      },
+      icon: (
+        <CloseCircleOutlined
+          style={{
+            color: "#EE2A1E",
+            fontSize: 17,
+          }}
+        />
+      ),
+      disabled:
+        record.status.text === "Delivered" ||
+        record.status.text === "Cancelled",
+      onClick: () =>
+        mutate({
+          values: {
+            status: {
+              id: 5,
+              text: "Cancelled",
             },
-          })
-        }
-      >
-        {t("buttons.reject")}
-      </Menu.Item>
-    </Menu>
-  );
+          },
+        }),
+    },
+  ];
+
   return (
-    <Dropdown popupRender={moreMenu(record)} trigger={["click"]}>
+    <Dropdown
+      menu={{
+        mode: "vertical",
+        onClick: ({ domEvent }) => domEvent.stopPropagation(),
+        items: moreMenuItems(record),
+      }}
+      trigger={["click"]}
+    >
       <TableActionButton />
     </Dropdown>
   );

--- a/examples/finefoods-antd/src/components/order/deliveryDetails/index.tsx
+++ b/examples/finefoods-antd/src/components/order/deliveryDetails/index.tsx
@@ -75,36 +75,29 @@ export const OrderDeliveryDetails = ({ order }: Props) => {
         style={{
           padding: "24px",
         }}
-      >
-        {order?.events.map((event, index) => {
+        items={order?.events.map((event, index) => {
           const status = getStepStatus(order, event, index);
           const isLast = index === order?.events.length - 1;
 
-          return (
-            <Steps.Step
-              key={index}
-              style={{
-                paddingBottom: isLast ? "0" : "24px",
-              }}
-              status={status}
-              title={t(`enum.orderStatuses.${event.status}`)}
-              icon={
-                getNotFinishedCurrentStep(order, event, index) && (
-                  <LoadingOutlined />
-                )
-              }
-              description={
-                event.date && (
-                  <Flex wrap={"wrap"} gap={4}>
-                    <div>{dayjs(event.date).format("L")}</div>
-                    <div>{dayjs(event.date).format("LT")}</div>
-                  </Flex>
-                )
-              }
-            />
-          );
+          return {
+            key: `${index}`,
+            style: {
+              paddingBottom: isLast ? "0" : "24px",
+            },
+            status,
+            title: t(`enum.orderStatuses.${event.status}`),
+            icon: getNotFinishedCurrentStep(order, event, index) ? (
+              <LoadingOutlined />
+            ) : undefined,
+            description: event.date ? (
+              <Flex wrap={"wrap"} gap={4}>
+                <div>{dayjs(event.date).format("L")}</div>
+                <div>{dayjs(event.date).format("LT")}</div>
+              </Flex>
+            ) : undefined,
+          };
         })}
-      </Steps>
+      />
       <List
         size="large"
         dataSource={details}

--- a/examples/finefoods-antd/src/components/order/deliveryDetails/index.tsx
+++ b/examples/finefoods-antd/src/components/order/deliveryDetails/index.tsx
@@ -70,7 +70,7 @@ export const OrderDeliveryDetails = ({ order }: Props) => {
   return (
     <Flex vertical>
       <Steps
-        direction={breakpoints.xl ? "vertical" : "horizontal"}
+        orientation={breakpoints.xl ? "vertical" : "horizontal"}
         current={getCurrentStep(order)}
         style={{
           padding: "24px",

--- a/examples/finefoods-antd/src/components/product/drawer-form/index.tsx
+++ b/examples/finefoods-antd/src/components/product/drawer-form/index.tsx
@@ -96,7 +96,7 @@ export const ProductDrawerForm = (props: Props) => {
       {...drawerProps}
       open={true}
       title={title}
-      width={breakpoint.sm ? "378px" : "100%"}
+      size={breakpoint.sm ? "378px" : "100%"}
       zIndex={1001}
       onClose={onDrawerCLose}
     >

--- a/examples/finefoods-antd/src/components/product/drawer-show/index.tsx
+++ b/examples/finefoods-antd/src/components/product/drawer-show/index.tsx
@@ -81,7 +81,7 @@ export const ProductDrawerShow = (props: Props) => {
   return (
     <Drawer
       open={true}
-      width={breakpoint.sm ? "378px" : "100%"}
+      size={breakpoint.sm ? "378px" : "100%"}
       zIndex={1001}
       onClose={handleDrawerClose}
     >

--- a/examples/finefoods-antd/src/components/product/list-card/index.tsx
+++ b/examples/finefoods-antd/src/components/product/list-card/index.tsx
@@ -184,7 +184,7 @@ export const ProductListCard = () => {
           <List.Item style={{ height: "100%" }}>
             <Card
               hoverable
-              bordered={false}
+              variant={"borderless"}
               className={styles.card}
               styles={{
                 body: {

--- a/examples/finefoods-antd/src/components/store/form/fields.tsx
+++ b/examples/finefoods-antd/src/components/store/form/fields.tsx
@@ -175,7 +175,7 @@ export const StoreFormFields = ({
           ]}
         >
           <InputMask mask="(999) 999 99 99">
-            {/* 
+            {/*
                                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                                     // @ts-ignore */}
             {(props: InputProps) => <Input {...props} />}

--- a/examples/finefoods-antd/src/pages/couriers/create.tsx
+++ b/examples/finefoods-antd/src/pages/couriers/create.tsx
@@ -58,8 +58,10 @@ export const CourierCreate = () => {
   return (
     <Modal
       open
-      destroyOnClose
-      maskClosable={false}
+      destroyOnHidden
+      mask={{
+        closable: false,
+      }}
       title={t("couriers.actions.add")}
       styles={{
         header: {
@@ -72,7 +74,7 @@ export const CourierCreate = () => {
           margin: 0,
           borderTop: `1px solid ${token.colorBorderSecondary}`,
         },
-        content: {
+        body: {
           padding: 0,
         },
       }}
@@ -196,7 +198,7 @@ const useFormList = (props: UseFormListProps) => {
           ]}
         >
           <InputMask mask="(999) 999 99 99">
-            {/* 
+            {/*
                                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                                     // @ts-ignore */}
             {(props: InputProps) => (

--- a/examples/finefoods-antd/src/pages/couriers/create.tsx
+++ b/examples/finefoods-antd/src/pages/couriers/create.tsx
@@ -110,11 +110,15 @@ export const CourierCreate = () => {
       onCancel={handleModalClose}
     >
       <Flex style={{ padding: "20px 24px" }}>
-        <Steps {...stepsProps} responsive>
-          <Steps.Step title={t("couriers.steps.personal")} />
-          <Steps.Step title={t("couriers.steps.company")} />
-          <Steps.Step title={t("couriers.steps.vehicle")} />
-        </Steps>
+        <Steps
+          {...stepsProps}
+          responsive
+          items={[
+            { title: t("couriers.steps.personal") },
+            { title: t("couriers.steps.company") },
+            { title: t("couriers.steps.vehicle") },
+          ]}
+        />
       </Flex>
       <Form {...formProps} layout="vertical">
         {formList[current]}

--- a/examples/finefoods-antd/src/pages/customers/show.tsx
+++ b/examples/finefoods-antd/src/pages/customers/show.tsx
@@ -20,7 +20,7 @@ export const CustomerShow = () => {
     <Drawer
       open
       onClose={() => list("users")}
-      width={breakpoint.sm ? "736px" : "100%"}
+      size={breakpoint.sm ? "736px" : "100%"}
     >
       <Flex
         vertical

--- a/examples/form-antd-custom-validation/package.json
+++ b/examples/form-antd-custom-validation/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/form-antd-mutation-mode/package.json
+++ b/examples/form-antd-mutation-mode/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/form-antd-mutation-mode/src/components/mutation-mode-picker/index.tsx
+++ b/examples/form-antd-mutation-mode/src/components/mutation-mode-picker/index.tsx
@@ -24,7 +24,7 @@ const MutationModePicker: React.FC<Props> = ({
           "0 6px 16px 0 rgba(0, 0, 0, 0.08),0 3px 6px -4px rgba(0, 0, 0, 0.12),0 9px 28px 8px rgba(0, 0, 0, 0.05)",
       }}
     >
-      <Space direction="vertical" align="center">
+      <Space orientation="vertical" align="center">
         <Radio.Group
           onChange={(e) => onMutationModeChange(e.target.value)}
           value={currentMutationMode}

--- a/examples/form-antd-use-drawer-form/package.json
+++ b/examples/form-antd-use-drawer-form/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/form-antd-use-drawer-form/src/pages/posts/list.tsx
+++ b/examples/form-antd-use-drawer-form/src/pages/posts/list.tsx
@@ -206,7 +206,7 @@ export const PostList = () => {
       <Drawer
         open={visibleShowDrawer}
         onClose={() => setVisibleShowDrawer(false)}
-        width="500"
+        size="500"
       >
         <Show
           isLoading={showIsLoading}

--- a/examples/form-antd-use-form/package.json
+++ b/examples/form-antd-use-form/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/form-antd-use-modal-form/package.json
+++ b/examples/form-antd-use-modal-form/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/form-antd-use-steps-form/package.json
+++ b/examples/form-antd-use-steps-form/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/i18n-nextjs/package.json
+++ b/examples/i18n-nextjs/package.json
@@ -9,7 +9,7 @@
     "start": "refine start"
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/nextjs-registry": "^1.0.0",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
@@ -19,7 +19,7 @@
     "@refinedev/kbar": "^2.0.1",
     "@refinedev/nextjs-router": "^7.0.5",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "cross-env": "^7.0.3",
     "js-cookie": "^3.0.1",
     "next": "^14.2.26",

--- a/examples/i18n-react/package.json
+++ b/examples/i18n-react/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
     "@refinedev/cli": "^2.16.52",
@@ -30,7 +30,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "i18next": "^20.1.0",
     "i18next-browser-languagedetector": "^6.1.1",
     "i18next-xhr-backend": "^3.2.2",

--- a/examples/import-export-antd/package.json
+++ b/examples/import-export-antd/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/inferencer-antd/package.json
+++ b/examples/inferencer-antd/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
     "@refinedev/cli": "^2.16.52",
@@ -31,7 +31,7 @@
     "@refinedev/kbar": "^2.0.1",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "i18next": "^20.1.0",
     "i18next-browser-languagedetector": "^6.1.1",
     "i18next-xhr-backend": "^3.2.2",

--- a/examples/inferencer-graphql-hasura/package.json
+++ b/examples/inferencer-graphql-hasura/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
     "@refinedev/cli": "^2.16.52",
@@ -31,7 +31,7 @@
     "@refinedev/inferencer": "^7.0.0",
     "@refinedev/kbar": "^2.0.1",
     "@refinedev/react-router": "^2.0.4",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "graphql": "^15.6.1",
     "graphql-request": "^5.2.0",
     "react": "^19.1.0",

--- a/examples/input-custom/package.json
+++ b/examples/input-custom/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/input-date-picker/package.json
+++ b/examples/input-date-picker/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/invoicer/package.json
+++ b/examples/invoicer/package.json
@@ -29,7 +29,7 @@
     "@refinedev/devtools": "^2.0.5",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/strapi-v4": "^7.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "antd-style": "^3.6.1",
     "axios": "^1.11.0",
     "react": "^19.1.0",

--- a/examples/invoicer/src/components/form/form-item-editable-select/styled.ts
+++ b/examples/invoicer/src/components/form/form-item-editable-select/styled.ts
@@ -30,7 +30,7 @@ export const useStyles = createStyles((props) => {
 
     formItemDisabled: {
       ".ant-select-disabled": {
-        ".ant-select-selector": {
+        ".ant-select-content": {
           backgroundColor: "transparent !important",
           borderColor: "transparent !important",
           background: "transparent !important",

--- a/examples/invoicer/src/components/header/search/index.tsx
+++ b/examples/invoicer/src/components/header/search/index.tsx
@@ -74,7 +74,9 @@ export const Search = () => {
         width: "100%",
         maxWidth: "360px",
       }}
-      filterOption={false}
+      showSearch={{
+        filterOption: false,
+      }}
       options={options}
       value={searchText}
       onChange={(text) => setSearchText(text)}

--- a/examples/invoicer/src/pages/accounts/edit.tsx
+++ b/examples/invoicer/src/pages/accounts/edit.tsx
@@ -100,7 +100,7 @@ export const AccountsPageEdit = () => {
         >
           <Col xs={{ span: 24 }} xl={{ span: 8 }}>
             <Card
-              bordered={false}
+              variant={"borderless"}
               styles={{ body: { padding: 0 } }}
               title={
                 <Flex gap={12} align="center">
@@ -169,7 +169,7 @@ export const AccountsPageEdit = () => {
 
           <Col xs={{ span: 24 }} xl={{ span: 16 }}>
             <Card
-              bordered={false}
+              variant={"borderless"}
               title={
                 <Flex gap={12} align="center">
                   <ShopOutlined />
@@ -221,7 +221,7 @@ export const AccountsPageEdit = () => {
             </Card>
 
             <Card
-              bordered={false}
+              variant={"borderless"}
               title={
                 <Flex gap={12} align="center">
                   <ContainerOutlined />

--- a/examples/invoicer/src/pages/clients/edit.tsx
+++ b/examples/invoicer/src/pages/clients/edit.tsx
@@ -88,7 +88,7 @@ export const ClientsPageEdit = () => {
         >
           <Col xs={{ span: 24 }} xl={{ span: 8 }}>
             <Card
-              bordered={false}
+              variant={"borderless"}
               styles={{ body: { padding: 0 } }}
               title={
                 <Flex gap={12} align="center">
@@ -178,7 +178,7 @@ export const ClientsPageEdit = () => {
 
           <Col xs={{ span: 24 }} xl={{ span: 16 }}>
             <Card
-              bordered={false}
+              variant={"borderless"}
               title={
                 <Flex gap={12} align="center">
                   <ContainerOutlined />

--- a/examples/invoicer/src/pages/invoices/create.tsx
+++ b/examples/invoicer/src/pages/invoices/create.tsx
@@ -113,7 +113,7 @@ export const InvoicesPageCreate = () => {
         <Flex vertical gap={32}>
           <Typography.Title level={3}>New Invoice</Typography.Title>
           <Card
-            bordered={false}
+            variant={"borderless"}
             styles={{
               body: {
                 padding: 0,
@@ -166,7 +166,7 @@ export const InvoicesPageCreate = () => {
                     >
                       Title
                       <Divider
-                        type="vertical"
+                        orientation="vertical"
                         className={styles.serviceHeaderDivider}
                       />
                     </Col>
@@ -176,7 +176,7 @@ export const InvoicesPageCreate = () => {
                     >
                       Unit Price
                       <Divider
-                        type="vertical"
+                        orientation="vertical"
                         className={styles.serviceHeaderDivider}
                       />
                     </Col>
@@ -186,7 +186,7 @@ export const InvoicesPageCreate = () => {
                     >
                       Quantity
                       <Divider
-                        type="vertical"
+                        orientation="vertical"
                         className={styles.serviceHeaderDivider}
                       />
                     </Col>
@@ -196,7 +196,7 @@ export const InvoicesPageCreate = () => {
                     >
                       Discount
                       <Divider
-                        type="vertical"
+                        orientation="vertical"
                         className={styles.serviceHeaderDivider}
                       />
                     </Col>

--- a/examples/invoicer/src/pages/invoices/show.tsx
+++ b/examples/invoicer/src/pages/invoices/show.tsx
@@ -61,7 +61,7 @@ export const InvoicesPageShow = () => {
     >
       <div id="invoice-pdf" className={styles.container}>
         <Card
-          bordered={false}
+          variant={"borderless"}
           title={
             <Typography.Text
               style={{

--- a/examples/invoicer/src/providers/config-provider/index.tsx
+++ b/examples/invoicer/src/providers/config-provider/index.tsx
@@ -50,7 +50,7 @@ export const ConfigProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const customTheme: ThemeConfig = {
     // you can change the theme colors here. example: ...RefineThemes.Magenta,
     ...RefineThemes.Purple,
-    cssVar: true,
+    cssVar: {},
     algorithm,
     components: {
       Card: {

--- a/examples/invoicer/src/styles/custom.css
+++ b/examples/invoicer/src/styles/custom.css
@@ -47,7 +47,7 @@
   border-start-end-radius: 0px;
 }
 
-.ant-modal-content {
+.ant-modal-container {
   padding: 0 !important;
 }
 

--- a/examples/live-provider-ably/package.json
+++ b/examples/live-provider-ably/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/ably": "^5.0.1",
     "@refinedev/antd": "^6.0.3",
@@ -31,7 +31,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/loading-overtime/package.json
+++ b/examples/loading-overtime/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/monorepo-module-federation/apps/blog-posts/package.json
+++ b/examples/monorepo-module-federation/apps/blog-posts/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^5.9.0",
     "@refinedev/cli": "^2.5.3",
@@ -31,7 +31,7 @@
     "@refinedev/react-router": "^4.1.0",
     "@refinedev/simple-rest": "^4.5.0",
     "@uiw/react-md-editor": "^3.23.5",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/monorepo-module-federation/apps/categories/package.json
+++ b/examples/monorepo-module-federation/apps/categories/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^5.9.0",
     "@refinedev/cli": "^2.5.3",
@@ -31,7 +31,7 @@
     "@refinedev/react-router": "^4.1.0",
     "@refinedev/simple-rest": "^4.5.0",
     "@uiw/react-md-editor": "^3.23.5",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/monorepo-module-federation/apps/host/package.json
+++ b/examples/monorepo-module-federation/apps/host/package.json
@@ -21,7 +21,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^5.9.0",
     "@refinedev/cli": "^2.5.3",
@@ -29,7 +29,7 @@
     "@refinedev/kbar": "^1.1.0",
     "@refinedev/react-router": "^4.1.0",
     "@refinedev/simple-rest": "^4.5.0",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/monorepo-with-lerna-bootstrap/apps/my-refine-app/package.json
+++ b/examples/monorepo-with-lerna-bootstrap/apps/my-refine-app/package.json
@@ -21,7 +21,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^5.9.0",
     "@refinedev/cli": "^2.5.3",
@@ -30,7 +30,7 @@
     "@refinedev/kbar": "^1.1.0",
     "@refinedev/react-router": "^4.1.0",
     "@refinedev/simple-rest": "^4.5.0",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/monorepo-with-lerna/apps/my-refine-app/package.json
+++ b/examples/monorepo-with-lerna/apps/my-refine-app/package.json
@@ -21,7 +21,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^5.9.0",
     "@refinedev/cli": "^2.5.3",
@@ -30,7 +30,7 @@
     "@refinedev/kbar": "^1.1.0",
     "@refinedev/react-router": "^4.1.0",
     "@refinedev/simple-rest": "^4.5.0",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/monorepo-with-turbo/apps/my-refine-app/package.json
+++ b/examples/monorepo-with-turbo/apps/my-refine-app/package.json
@@ -21,7 +21,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^5.9.0",
     "@refinedev/cli": "^2.5.3",
@@ -30,7 +30,7 @@
     "@refinedev/kbar": "^1.1.0",
     "@refinedev/react-router": "^4.1.0",
     "@refinedev/simple-rest": "^4.5.0",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/multi-level-menu/package.json
+++ b/examples/multi-level-menu/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/pixels-admin/package.json
+++ b/examples/pixels-admin/package.json
@@ -22,14 +22,14 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
     "@refinedev/cli": "^2.16.52",
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/supabase": "^6.0.2",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "casbin": "^5.15.2",
     "dayjs": "^1.10.7",
     "dotenv": "^16.0.3",

--- a/examples/pixels-admin/src/pages/canvases/list.tsx
+++ b/examples/pixels-admin/src/pages/canvases/list.tsx
@@ -189,7 +189,7 @@ export const CanvasList = () => {
         title={<h3 style={{ fontWeight: "bold" }}>Canvas Changes</h3>}
         {...modalProps}
         centered
-        destroyOnClose
+        destroyOnHidden
         onOk={close}
         onCancel={() => {
           close();

--- a/examples/pixels/package.json
+++ b/examples/pixels/package.json
@@ -22,14 +22,14 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
     "@refinedev/cli": "^2.16.52",
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/supabase": "^6.0.2",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "dotenv": "^16.0.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/pixels/src/components/avatar/contributors.tsx
+++ b/examples/pixels/src/components/avatar/contributors.tsx
@@ -17,7 +17,7 @@ export const Contributors: React.FC<ContributorsProps> = ({ pixels }) => {
   }
 
   return (
-    <Avatar.Group maxCount={2}>
+    <Avatar.Group max={{ count: 2 }}>
       {avatarURls.map((avatar_url) => (
         <Avatar key={avatar_url} icon={<UserOutlined />} src={avatar_url} />
       ))}

--- a/examples/pixels/src/components/canvas/create.tsx
+++ b/examples/pixels/src/components/canvas/create.tsx
@@ -48,7 +48,9 @@ export const CreateCanvas: React.FC<CreateCanvasProps> = ({
           height: DEFAULT_CANVAS_SIZE,
         });
       }}
-      bodyStyle={{ borderRadius: "6px" }}
+      styles={{
+        body: { borderRadius: "6px" },
+      }}
     >
       <Form
         {...formProps}

--- a/examples/pixels/src/pages/canvases/show.tsx
+++ b/examples/pixels/src/pages/canvases/show.tsx
@@ -91,7 +91,7 @@ export const CanvasShow: React.FC = () => {
           title="Canvas Changes"
           {...modalProps}
           centered
-          destroyOnClose
+          destroyOnHidden
           onOk={close}
           onCancel={() => {
             close();

--- a/examples/refine-week-invoice-generator/package.json
+++ b/examples/refine-week-invoice-generator/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@react-pdf/renderer": "^3.1.8",
     "@refinedev/antd": "^6.0.3",
@@ -32,7 +32,7 @@
     "@refinedev/kbar": "^2.0.1",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/strapi-v4": "^7.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "axios": "^1.11.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/refine-week-invoice-generator/src/components/client/create.tsx
+++ b/examples/refine-week-invoice-generator/src/components/client/create.tsx
@@ -50,7 +50,7 @@ export const CreateClient: React.FC<CreateClientProps> = ({
     <>
       <Drawer
         {...drawerProps}
-        width={breakpoint.sm ? "500px" : "100%"}
+        size={breakpoint.sm ? "500px" : "100%"}
         styles={{ body: { padding: 0 } }}
       >
         <Create saveButtonProps={saveButtonProps}>

--- a/examples/refine-week-invoice-generator/src/components/client/edit.tsx
+++ b/examples/refine-week-invoice-generator/src/components/client/edit.tsx
@@ -40,7 +40,7 @@ export const EditClient: React.FC<EditClientProps> = ({
   return (
     <Drawer
       {...drawerProps}
-      width={breakpoint.sm ? "500px" : "100%"}
+      size={breakpoint.sm ? "500px" : "100%"}
       styles={{ body: { padding: 0 } }}
     >
       <Edit

--- a/examples/search/package.json
+++ b/examples/search/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
     "@refinedev/cli": "^2.16.52",
@@ -30,7 +30,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "lodash": "^4.17.21",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/search/src/components/header.tsx
+++ b/examples/search/src/components/header.tsx
@@ -110,8 +110,10 @@ export const Header: React.FC = () => {
       <AutoComplete
         style={{ width: "100%", maxWidth: "550px" }}
         options={options}
-        filterOption={false}
-        onSearch={debounce((value: string) => setValue(value), 500)}
+        showSearch={{
+          filterOption: false,
+          onSearch: debounce((value: string) => setValue(value), 500),
+        }}
       >
         <Input
           size="large"

--- a/examples/server-side-form-validation-antd/package.json
+++ b/examples/server-side-form-validation-antd/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/table-antd-advanced/package.json
+++ b/examples/table-antd-advanced/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/table-antd-table-filter/package.json
+++ b/examples/table-antd-table-filter/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
     "@refinedev/cli": "^2.16.52",
@@ -30,7 +30,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "dayjs": "^1.10.7",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/table-antd-use-delete-many/package.json
+++ b/examples/table-antd-use-delete-many/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/table-antd-use-editable-table/package.json
+++ b/examples/table-antd-use-editable-table/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/table-antd-use-table/package.json
+++ b/examples/table-antd-use-table/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/table-antd-use-update-many/package.json
+++ b/examples/table-antd-use-update-many/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/theme-antd-demo/package.json
+++ b/examples/theme-antd-demo/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/theme-antd-demo/src/components/theme-settings/index.tsx
+++ b/examples/theme-antd-demo/src/components/theme-settings/index.tsx
@@ -51,11 +51,11 @@ export const ThemeSettings: FC<Props> = ({ currentTheme, onThemeClick }) => {
       <Modal
         open={visible}
         onCancel={close}
-        destroyOnClose
+        destroyOnHidden
         title="Theme Settings"
         footer={null}
       >
-        <Space direction="vertical" size="large">
+        <Space orientation="vertical" size="large">
           <Space
             style={{
               flexWrap: "wrap",

--- a/examples/tutorial-antd/package.json
+++ b/examples/tutorial-antd/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
     "@refinedev/cli": "^2.16.52",
@@ -30,7 +30,7 @@
     "@refinedev/inferencer": "^7.0.0",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2",

--- a/examples/upload-antd-base64/package.json
+++ b/examples/upload-antd-base64/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/upload-antd-multipart/package.json
+++ b/examples/upload-antd-multipart/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/use-modal-antd/package.json
+++ b/examples/use-modal-antd/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/use-simple-list-antd/package.json
+++ b/examples/use-simple-list-antd/package.json
@@ -28,7 +28,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "dayjs": "^1.10.7",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/with-custom-pages/package.json
+++ b/examples/with-custom-pages/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/with-javascript/package.json
+++ b/examples/with-javascript/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/with-meta-properties/package.json
+++ b/examples/with-meta-properties/package.json
@@ -16,7 +16,7 @@
     "@refinedev/core": "^5.0.12",
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2"

--- a/examples/with-nextjs-next-auth/package.json
+++ b/examples/with-nextjs-next-auth/package.json
@@ -9,7 +9,7 @@
     "start": "refine start"
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/nextjs-registry": "^1.0.0",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
@@ -20,7 +20,7 @@
     "@refinedev/kbar": "^2.0.1",
     "@refinedev/nextjs-router": "^7.0.5",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "cross-env": "^7.0.3",
     "js-cookie": "^3.0.1",
     "next": "^14.2.26",

--- a/examples/with-nextjs/package.json
+++ b/examples/with-nextjs/package.json
@@ -9,7 +9,7 @@
     "start": "refine start"
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/nextjs-registry": "^1.0.0",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@refinedev/antd": "^6.0.3",
@@ -19,7 +19,7 @@
     "@refinedev/kbar": "^2.0.1",
     "@refinedev/nextjs-router": "^7.0.5",
     "@refinedev/simple-rest": "^6.0.1",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "cross-env": "^7.0.3",
     "js-cookie": "^3.0.1",
     "next": "^14.2.26",

--- a/examples/with-nx/package.json
+++ b/examples/with-nx/package.json
@@ -21,7 +21,7 @@
     ]
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@craco/craco": "^7.1.0",
     "@refinedev/antd": "^5.38.1",
@@ -31,7 +31,7 @@
     "@refinedev/kbar": "^1.3.10",
     "@refinedev/react-router": "^4.5.9",
     "@refinedev/simple-rest": "^5.0.6",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2",

--- a/examples/with-remix-antd/package.json
+++ b/examples/with-remix-antd/package.json
@@ -19,7 +19,7 @@
     "@remix-run/node": "^2.4.0",
     "@remix-run/react": "^2.4.0",
     "@remix-run/serve": "^2.4.0",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "cookie": "^0.5.0",
     "js-cookie": "^3.0.1",
     "react": "^19.1.0",

--- a/examples/with-remix-auth/package.json
+++ b/examples/with-remix-auth/package.json
@@ -20,7 +20,7 @@
     "@remix-run/node": "^2.4.0",
     "@remix-run/react": "^2.4.0",
     "@remix-run/serve": "^2.4.0",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "cookie": "^0.5.0",
     "js-cookie": "^3.0.1",
     "react": "^19.1.0",

--- a/examples/with-web3/package.json
+++ b/examples/with-web3/package.json
@@ -29,7 +29,7 @@
     "@refinedev/react-router": "^2.0.4",
     "@refinedev/simple-rest": "^6.0.1",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.0.2",

--- a/examples/with-web3/src/pages/dashboard.tsx
+++ b/examples/with-web3/src/pages/dashboard.tsx
@@ -62,9 +62,9 @@ export const DashboardPage: React.FC = () => {
           <Card
             title="Ethereum Public ID"
             style={{ height: "150px", borderRadius: "15px" }}
-            headStyle={{ textAlign: "center" }}
+            styles={{ header: { textAlign: "center" } }}
           >
-            <Space align="center" direction="horizontal">
+            <Space align="center" orientation="horizontal">
               <Text>{isLoading ? "loading" : data?.address}</Text>
             </Space>
           </Card>
@@ -73,7 +73,7 @@ export const DashboardPage: React.FC = () => {
           <Card
             title="Account Balance"
             style={{ height: "150px", borderRadius: "15px" }}
-            headStyle={{ textAlign: "center" }}
+            styles={{ header: { textAlign: "center" } }}
           >
             <Text>{`${isLoading ? "loading" : data?.balance} Ether`}</Text>
           </Card>

--- a/examples/with-web3/src/pages/login.tsx
+++ b/examples/with-web3/src/pages/login.tsx
@@ -13,7 +13,7 @@ export const Login: React.FC = () => {
         alignItems: "center",
       }}
     >
-      <Space direction="vertical" align="center" size="large">
+      <Space orientation="vertical" align="center" size="large">
         <ThemedTitleV2
           collapsed={false}
           wrapperStyles={{

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -44,11 +44,11 @@
     "types": "node ../shared/generate-declarations.js"
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
-    "@ant-design/pro-layout": "^7.21.1",
+    "@ant-design/icons": "^6.1.1",
+    "@ant-design/pro-components": "^2.8.10",
     "@refinedev/ui-types": "^2.0.1",
     "@tanstack/react-query": "^5.81.5",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "dayjs": "^1.10.7",
     "react-markdown": "^6.0.1",
     "remark-gfm": "^1.0.0",
@@ -82,7 +82,7 @@
     "@refinedev/core": "^5.0.0",
     "@types/react": "^18.0.0 || ^19.0.0",
     "@types/react-dom": "^18.0.0 || ^19.0.0",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "dayjs": "^1.10.7",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"

--- a/packages/antd/src/components/pageHeader/index.tsx
+++ b/packages/antd/src/components/pageHeader/index.tsx
@@ -2,7 +2,7 @@ import React, { useContext, type FC } from "react";
 import {
   PageHeader as AntdPageHeader,
   type PageHeaderProps as AntdPageHeaderProps,
-} from "@ant-design/pro-layout";
+} from "@ant-design/pro-components";
 import { Button, ConfigProvider, Typography } from "antd";
 import { ArrowLeftOutlined, ArrowRightOutlined } from "@ant-design/icons";
 import { RefinePageHeaderClassNames } from "@refinedev/ui-types";

--- a/packages/antd/src/components/pages/error/index.tsx
+++ b/packages/antd/src/components/pages/error/index.tsx
@@ -40,7 +40,7 @@ export const ErrorComponent: React.FC<RefineErrorPageProps> = () => {
       status="404"
       title="404"
       extra={
-        <Space direction="vertical" size="large">
+        <Space orientation="vertical" size="large">
           <Space>
             <Typography.Text>
               {translate(

--- a/packages/antd/src/components/themedLayout/sider/index.tsx
+++ b/packages/antd/src/components/themedLayout/sider/index.tsx
@@ -197,13 +197,15 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
           onClose={() => setMobileSiderOpen(false)}
           placement={direction === "rtl" ? "right" : "left"}
           closable={false}
-          width={200}
+          size={200}
           styles={{
             body: {
               padding: 0,
             },
           }}
-          maskClosable={true}
+          mask={{
+            closable: true,
+          }}
         >
           <Layout>
             <Layout.Sider

--- a/packages/antd/src/hooks/drawer/useDrawer/index.tsx
+++ b/packages/antd/src/hooks/drawer/useDrawer/index.tsx
@@ -27,7 +27,7 @@ export const useDrawer = ({
   return {
     drawerProps: {
       ...drawerProps,
-      onClose: (e: React.MouseEvent | React.KeyboardEvent) => {
+      onClose: (e: React.MouseEvent | React.KeyboardEvent | KeyboardEvent) => {
         drawerProps.onClose?.(e);
         close();
       },

--- a/packages/antd/src/hooks/form/useForm.ts
+++ b/packages/antd/src/hooks/form/useForm.ts
@@ -264,32 +264,11 @@ export const useForm = <
   const warnWhenUnsavedChanges =
     warnWhenUnsavedChangesProp ?? warnWhenUnsavedChangesRefine;
 
-  // populate form with data when id changes
+  // populate form with data when query is ready or id changes
   // form populated via initialValues prop
   React.useEffect(() => {
     form.resetFields();
-  }, [id]);
-
-  // populate form with data when query is ready
-  // ensures form fields are updated when data arrives
-  React.useEffect(() => {
-    const isEditAction = action === "edit" || action === "clone";
-    const queryValues = query?.data?.data;
-
-    if (!isEditAction) {
-      return;
-    }
-
-    if (typeof id === "undefined") {
-      return;
-    }
-
-    if (!queryValues) {
-      return;
-    }
-
-    form.setFieldsValue(queryValues as any);
-  }, [action, id, query?.data?.data, form]);
+  }, [query?.data?.data, id]);
 
   const onKeyUp = (event: React.KeyboardEvent<HTMLFormElement>) => {
     if (submitOnEnter && event.key === "Enter") {

--- a/packages/antd/src/hooks/form/useForm.ts
+++ b/packages/antd/src/hooks/form/useForm.ts
@@ -264,11 +264,32 @@ export const useForm = <
   const warnWhenUnsavedChanges =
     warnWhenUnsavedChangesProp ?? warnWhenUnsavedChangesRefine;
 
-  // populate form with data when query is ready or id changes
+  // populate form with data when id changes
   // form populated via initialValues prop
   React.useEffect(() => {
     form.resetFields();
-  }, [query?.data?.data, id]);
+  }, [id]);
+
+  // populate form with data when query is ready
+  // ensures form fields are updated when data arrives
+  React.useEffect(() => {
+    const isEditAction = action === "edit" || action === "clone";
+    const queryValues = query?.data?.data;
+
+    if (!isEditAction) {
+      return;
+    }
+
+    if (typeof id === "undefined") {
+      return;
+    }
+
+    if (!queryValues) {
+      return;
+    }
+
+    form.setFieldsValue(queryValues as any);
+  }, [action, id, query?.data?.data, form]);
 
   const onKeyUp = (event: React.KeyboardEvent<HTMLFormElement>) => {
     if (submitOnEnter && event.key === "Enter") {

--- a/packages/antd/src/hooks/import/index.tsx
+++ b/packages/antd/src/hooks/import/index.tsx
@@ -99,7 +99,7 @@ export const useImport = <
 
           notification.open({
             description,
-            message: null,
+            title: null,
             key: `${resource}-import`,
             duration: 0,
           });

--- a/packages/antd/src/hooks/modal/useModal/index.tsx
+++ b/packages/antd/src/hooks/modal/useModal/index.tsx
@@ -30,7 +30,11 @@ export const useModal = ({
   return {
     modalProps: {
       ...modalProps,
-      onCancel: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      onCancel: (
+        e:
+          | React.MouseEvent<HTMLButtonElement>
+          | React.KeyboardEvent<HTMLElement>,
+      ) => {
         modalProps.onCancel?.(e);
         close();
       },

--- a/packages/antd/src/hooks/table/useTable/useTable.spec.tsx
+++ b/packages/antd/src/hooks/table/useTable/useTable.spec.tsx
@@ -12,7 +12,7 @@ const defaultPagination = {
   current: 1,
   total: 2,
   simple: true,
-  position: ["bottomCenter"],
+  placement: ["bottomCenter"],
 };
 
 const customPagination = {
@@ -20,7 +20,7 @@ const customPagination = {
   pageSize: 1,
   total: 2,
   simple: true,
-  position: ["bottomCenter"],
+  placement: ["bottomCenter"],
 };
 
 const routerProvider = {

--- a/packages/antd/src/hooks/table/useTable/useTable.ts
+++ b/packages/antd/src/hooks/table/useTable/useTable.ts
@@ -233,7 +233,7 @@ export const useTable = <
         pageSize,
         current: currentPage,
         simple: !breakpoint.sm,
-        position: !breakpoint.sm ? ["bottomCenter"] : ["bottomRight"],
+        placement: !breakpoint.sm ? ["bottomCenter"] : ["bottomEnd"],
         total: data?.total,
       };
     }

--- a/packages/inferencer/package.json
+++ b/packages/inferencer/package.json
@@ -154,7 +154,7 @@
     "vitest": "^2.1.8"
   },
   "peerDependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@chakra-ui/react": "^2.5.1",
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
@@ -175,7 +175,7 @@
     "@tanstack/react-table": "^8.2.6",
     "@types/react": "^18.0.0 || ^19.0.0",
     "@types/react-dom": "^18.0.0 || ^19.0.0",
-    "antd": "^5.0.3",
+    "antd": "^6.3.5",
     "dayjs": "^1.10.7",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",

--- a/packages/inferencer/src/inferencers/antd/__tests__/__snapshots__/create.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/antd/__tests__/__snapshots__/create.test.tsx.snap
@@ -5,14 +5,16 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
   <div>
     <div>
       <div
-        class="ant-page-header css-dev-only-do-not-override-1vjf2v5 ant-page-header-has-breadcrumb ant-page-header-ghost"
+        class="ant-page-header css-dev-only-do-not-override-ch9ese ant-page-header-has-breadcrumb ant-page-header-ghost"
         style="padding: 0px;"
       >
         <nav
-          class="ant-breadcrumb css-dev-only-do-not-override-1vjf2v5"
+          class="ant-breadcrumb css-dev-only-do-not-override-ch9ese css-var-root"
         >
           <ol>
-            <li>
+            <li
+              class="ant-breadcrumb-item"
+            >
               <span
                 class="ant-breadcrumb-link"
               >
@@ -33,7 +35,9 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
             >
               /
             </li>
-            <li>
+            <li
+              class="ant-breadcrumb-item"
+            >
               <span
                 class="ant-breadcrumb-link"
               >
@@ -49,21 +53,21 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
           </ol>
         </nav>
         <div
-          class="ant-page-header-heading css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-heading css-dev-only-do-not-override-ch9ese"
         >
           <div
-            class="ant-page-header-heading-left css-dev-only-do-not-override-1vjf2v5"
+            class="ant-page-header-heading-left css-dev-only-do-not-override-ch9ese"
           >
             <div
-              class="ant-page-header-back css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-back css-dev-only-do-not-override-ch9ese"
             >
               <div
                 aria-label="back"
-                class="ant-page-header-back-button css-dev-only-do-not-override-1vjf2v5"
+                class="ant-page-header-back-button css-dev-only-do-not-override-ch9ese"
                 role="button"
               >
                 <button
-                  class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-icon-only"
+                  class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-icon-only"
                   type="button"
                 >
                   <span
@@ -93,29 +97,29 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
               </div>
             </div>
             <span
-              class="ant-page-header-heading-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-title css-dev-only-do-not-override-ch9ese"
             >
               <h4
-                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               >
                 Create Post
               </h4>
             </span>
             <span
-              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-ch9ese"
             >
               <h5
-                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               />
             </span>
           </div>
           <span
-            class="ant-page-header-heading-extra css-dev-only-do-not-override-1vjf2v5"
+            class="ant-page-header-heading-extra css-dev-only-do-not-override-ch9ese"
           >
             <div
-              class="ant-space css-dev-only-do-not-override-1vjf2v5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+              class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
             >
               <div
                 class="ant-space-item"
@@ -124,31 +128,33 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
           </span>
         </div>
         <div
-          class="ant-page-header-content css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-content css-dev-only-do-not-override-ch9ese"
         >
           <div
-            class="ant-spin-nested-loading css-dev-only-do-not-override-1vjf2v5"
+            aria-busy="false"
+            aria-live="polite"
+            class="ant-spin css-dev-only-do-not-override-ch9ese css-var-root"
           >
             <div
               class="ant-spin-container"
             >
               <div
-                class="ant-card css-dev-only-do-not-override-1vjf2v5"
+                class="ant-card css-dev-only-do-not-override-ch9ese css-var-root"
               >
                 <div
                   class="ant-card-body"
                 >
                   <form
-                    class="ant-form ant-form-vertical css-dev-only-do-not-override-mzwlov"
+                    class="ant-form ant-form-vertical css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese"
                   >
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -159,7 +165,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -169,7 +175,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="title"
                                 type="text"
                                 value=""
@@ -180,13 +186,13 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -197,7 +203,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -207,7 +213,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="slug"
                                 type="text"
                                 value=""
@@ -218,13 +224,13 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -235,7 +241,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -245,7 +251,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                             >
                               <textarea
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="content"
                                 rows="5"
                               />
@@ -255,13 +261,13 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -272,7 +278,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -282,7 +288,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="hit"
                                 type="text"
                                 value=""
@@ -293,13 +299,13 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -310,7 +316,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -319,43 +325,34 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                aria-required="true"
-                                class="ant-select ant-select-outlined ant-select-in-form-item css-dev-only-do-not-override-mzwlov ant-select-single ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-outlined ant-select-in-form-item css-var-root ant-select-css-var css-dev-only-do-not-override-ch9ese ant-select-single ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
-                                  class="ant-select-selector"
+                                  class="ant-select-content"
                                 >
-                                  <span
-                                    class="ant-select-selection-search"
-                                  >
-                                    <input
-                                      aria-autocomplete="list"
-                                      aria-controls="category_id_list"
-                                      aria-expanded="false"
-                                      aria-haspopup="listbox"
-                                      aria-owns="category_id_list"
-                                      aria-required="true"
-                                      autocomplete="off"
-                                      class="ant-select-selection-search-input"
-                                      id="category_id"
-                                      role="combobox"
-                                      type="search"
-                                      value=""
-                                    />
-                                  </span>
-                                  <span
-                                    class="ant-select-selection-placeholder"
+                                  <div
+                                    class="ant-select-placeholder"
+                                    style="visibility: visible;"
+                                  />
+                                  <input
+                                    aria-autocomplete="list"
+                                    aria-expanded="false"
+                                    aria-haspopup="listbox"
+                                    aria-required="true"
+                                    autocomplete="off"
+                                    class="ant-select-input"
+                                    id="category_id"
+                                    role="combobox"
+                                    type="search"
+                                    value=""
                                   />
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-arrow"
-                                  style="user-select: none;"
-                                  unselectable="on"
+                                <div
+                                  class="ant-select-suffix"
                                 >
                                   <span
                                     aria-label="down"
-                                    class="anticon anticon-down ant-select-suffix"
+                                    class="anticon anticon-down"
                                     role="img"
                                   >
                                     <svg
@@ -372,7 +369,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                                       />
                                     </svg>
                                   </span>
-                                </span>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -380,13 +377,13 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -397,7 +394,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -406,43 +403,34 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                aria-required="true"
-                                class="ant-select ant-select-outlined ant-select-in-form-item css-dev-only-do-not-override-mzwlov ant-select-single ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-outlined ant-select-in-form-item css-var-root ant-select-css-var css-dev-only-do-not-override-ch9ese ant-select-single ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
-                                  class="ant-select-selector"
+                                  class="ant-select-content"
                                 >
-                                  <span
-                                    class="ant-select-selection-search"
-                                  >
-                                    <input
-                                      aria-autocomplete="list"
-                                      aria-controls="user_id_list"
-                                      aria-expanded="false"
-                                      aria-haspopup="listbox"
-                                      aria-owns="user_id_list"
-                                      aria-required="true"
-                                      autocomplete="off"
-                                      class="ant-select-selection-search-input"
-                                      id="user_id"
-                                      role="combobox"
-                                      type="search"
-                                      value=""
-                                    />
-                                  </span>
-                                  <span
-                                    class="ant-select-selection-placeholder"
+                                  <div
+                                    class="ant-select-placeholder"
+                                    style="visibility: visible;"
+                                  />
+                                  <input
+                                    aria-autocomplete="list"
+                                    aria-expanded="false"
+                                    aria-haspopup="listbox"
+                                    aria-required="true"
+                                    autocomplete="off"
+                                    class="ant-select-input"
+                                    id="user_id"
+                                    role="combobox"
+                                    type="search"
+                                    value=""
                                   />
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-arrow"
-                                  style="user-select: none;"
-                                  unselectable="on"
+                                <div
+                                  class="ant-select-suffix"
                                 >
                                   <span
                                     aria-label="down"
-                                    class="anticon anticon-down ant-select-suffix"
+                                    class="anticon anticon-down"
                                     role="img"
                                   >
                                     <svg
@@ -459,7 +447,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                                       />
                                     </svg>
                                   </span>
-                                </span>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -467,13 +455,13 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -484,7 +472,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -494,7 +482,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="status"
                                 type="text"
                                 value=""
@@ -505,13 +493,13 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -522,7 +510,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -532,7 +520,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="status_color"
                                 type="text"
                                 value=""
@@ -543,13 +531,13 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -560,7 +548,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -569,7 +557,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-mzwlov"
+                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-ch9ese css-var-root ant-picker-css-var"
                               >
                                 <div
                                   class="ant-picker-input"
@@ -614,13 +602,13 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -631,7 +619,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -640,7 +628,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-mzwlov"
+                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-ch9ese css-var-root ant-picker-css-var"
                               >
                                 <div
                                   class="ant-picker-input"
@@ -685,13 +673,13 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class=""
@@ -701,7 +689,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -710,10 +698,10 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <span
-                                class="ant-upload-wrapper css-dev-only-do-not-override-mzwlov"
+                                class="ant-upload-wrapper css-dev-only-do-not-override-ch9ese css-var-root"
                               >
                                 <div
-                                  class="css-dev-only-do-not-override-mzwlov ant-upload ant-upload-drag"
+                                  class="css-dev-only-do-not-override-ch9ese ant-upload ant-upload-drag"
                                 >
                                   <span
                                     class="ant-upload ant-upload-btn"
@@ -725,6 +713,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                                       aria-required="true"
                                       id="image"
                                       multiple=""
+                                      name="file"
                                       style="display: none;"
                                       type="file"
                                     />
@@ -749,13 +738,13 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -766,7 +755,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -775,62 +764,45 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                aria-required="true"
-                                class="ant-select ant-select-outlined ant-select-in-form-item css-dev-only-do-not-override-mzwlov ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-outlined ant-select-in-form-item css-var-root ant-select-css-var css-dev-only-do-not-override-ch9ese ant-select-multiple ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
-                                  class="ant-select-selector"
+                                  class="ant-select-content"
                                 >
                                   <div
-                                    class="ant-select-selection-overflow"
+                                    class="ant-select-content-item ant-select-content-item-prefix"
+                                    style="opacity: 1;"
                                   >
                                     <div
-                                      class="ant-select-selection-overflow-item ant-select-selection-overflow-item-suffix"
-                                      style="opacity: 1;"
-                                    >
-                                      <div
-                                        class="ant-select-selection-search"
-                                        style="width: 0px;"
-                                      >
-                                        <input
-                                          aria-autocomplete="list"
-                                          aria-controls="tags_list"
-                                          aria-expanded="false"
-                                          aria-haspopup="listbox"
-                                          aria-owns="tags_list"
-                                          aria-required="true"
-                                          autocomplete="off"
-                                          class="ant-select-selection-search-input"
-                                          id="tags"
-                                          readonly=""
-                                          role="combobox"
-                                          style="opacity: 0;"
-                                          type="search"
-                                          unselectable="on"
-                                          value=""
-                                        />
-                                        <span
-                                          aria-hidden="true"
-                                          class="ant-select-selection-search-mirror"
-                                        >
-                                           
-                                        </span>
-                                      </div>
-                                    </div>
+                                      class="ant-select-placeholder"
+                                      style="visibility: visible;"
+                                    />
                                   </div>
-                                  <span
-                                    class="ant-select-selection-placeholder"
-                                  />
+                                  <div
+                                    class="ant-select-content-item ant-select-content-item-suffix"
+                                    style="opacity: 1;"
+                                  >
+                                    <input
+                                      aria-autocomplete="list"
+                                      aria-expanded="false"
+                                      aria-haspopup="listbox"
+                                      aria-required="true"
+                                      autocomplete="off"
+                                      class="ant-select-input"
+                                      id="tags"
+                                      role="combobox"
+                                      style="--select-input-width: 0;"
+                                      type="search"
+                                      value=""
+                                    />
+                                  </div>
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-arrow"
-                                  style="user-select: none;"
-                                  unselectable="on"
+                                <div
+                                  class="ant-select-suffix"
                                 >
                                   <span
                                     aria-label="down"
-                                    class="anticon anticon-down ant-select-suffix"
+                                    class="anticon anticon-down"
                                     role="img"
                                   >
                                     <svg
@@ -847,7 +819,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                                       />
                                     </svg>
                                   </span>
-                                </span>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -855,13 +827,13 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -872,7 +844,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -882,7 +854,7 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="language"
                                 type="text"
                                 value=""
@@ -902,14 +874,14 @@ exports[`AntdCreateInferencer > should match the snapshot 1`] = `
                   >
                     <span>
                       <div
-                        class="ant-space css-dev-only-do-not-override-1vjf2v5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                        class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
                         style="float: right; margin-right: 24px;"
                       >
                         <div
                           class="ant-space-item"
                         >
                           <button
-                            class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid refine-save-button"
+                            class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid refine-save-button"
                             type="submit"
                           >
                             <span

--- a/packages/inferencer/src/inferencers/antd/__tests__/__snapshots__/edit.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/antd/__tests__/__snapshots__/edit.test.tsx.snap
@@ -5,14 +5,16 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
   <div>
     <div>
       <div
-        class="ant-page-header css-dev-only-do-not-override-1vjf2v5 ant-page-header-has-breadcrumb ant-page-header-ghost"
+        class="ant-page-header css-dev-only-do-not-override-ch9ese ant-page-header-has-breadcrumb ant-page-header-ghost"
         style="padding: 0px;"
       >
         <nav
-          class="ant-breadcrumb css-dev-only-do-not-override-1vjf2v5"
+          class="ant-breadcrumb css-dev-only-do-not-override-ch9ese css-var-root"
         >
           <ol>
-            <li>
+            <li
+              class="ant-breadcrumb-item"
+            >
               <span
                 class="ant-breadcrumb-link"
               >
@@ -33,7 +35,9 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
             >
               /
             </li>
-            <li>
+            <li
+              class="ant-breadcrumb-item"
+            >
               <span
                 class="ant-breadcrumb-link"
               >
@@ -49,21 +53,21 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
           </ol>
         </nav>
         <div
-          class="ant-page-header-heading css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-heading css-dev-only-do-not-override-ch9ese"
         >
           <div
-            class="ant-page-header-heading-left css-dev-only-do-not-override-1vjf2v5"
+            class="ant-page-header-heading-left css-dev-only-do-not-override-ch9ese"
           >
             <div
-              class="ant-page-header-back css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-back css-dev-only-do-not-override-ch9ese"
             >
               <div
                 aria-label="back"
-                class="ant-page-header-back-button css-dev-only-do-not-override-1vjf2v5"
+                class="ant-page-header-back-button css-dev-only-do-not-override-ch9ese"
                 role="button"
               >
                 <button
-                  class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-icon-only"
+                  class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-icon-only"
                   type="button"
                 >
                   <span
@@ -93,35 +97,35 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
               </div>
             </div>
             <span
-              class="ant-page-header-heading-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-title css-dev-only-do-not-override-ch9ese"
             >
               <h4
-                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               >
                 Edit Post
               </h4>
             </span>
             <span
-              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-ch9ese"
             >
               <h5
-                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               />
             </span>
           </div>
           <span
-            class="ant-page-header-heading-extra css-dev-only-do-not-override-1vjf2v5"
+            class="ant-page-header-heading-extra css-dev-only-do-not-override-ch9ese"
           >
             <div
-              class="ant-space css-dev-only-do-not-override-1vjf2v5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+              class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
             >
               <div
                 class="ant-space-item"
               >
                 <div
-                  class="ant-space css-dev-only-do-not-override-1vjf2v5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                  class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
                   style="flex-wrap: wrap;"
                 >
                   <div
@@ -131,7 +135,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                       href="/posts"
                     >
                       <button
-                        class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-color-default ant-btn-variant-outlined refine-list-button"
+                        class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined refine-list-button"
                         title=""
                         type="button"
                       >
@@ -168,7 +172,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                     class="ant-space-item"
                   >
                     <button
-                      class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-color-default ant-btn-variant-outlined refine-refresh-button"
+                      class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined refine-refresh-button"
                       type="button"
                     >
                       <span
@@ -205,31 +209,33 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
           </span>
         </div>
         <div
-          class="ant-page-header-content css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-content css-dev-only-do-not-override-ch9ese"
         >
           <div
-            class="ant-spin-nested-loading css-dev-only-do-not-override-1vjf2v5"
+            aria-busy="false"
+            aria-live="polite"
+            class="ant-spin css-dev-only-do-not-override-ch9ese css-var-root"
           >
             <div
               class="ant-spin-container"
             >
               <div
-                class="ant-card css-dev-only-do-not-override-1vjf2v5"
+                class="ant-card css-dev-only-do-not-override-ch9ese css-var-root"
               >
                 <div
                   class="ant-card-body"
                 >
                   <form
-                    class="ant-form ant-form-vertical css-dev-only-do-not-override-mzwlov"
+                    class="ant-form ant-form-vertical css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese"
                   >
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -240,7 +246,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -250,7 +256,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input ant-input-disabled css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input ant-input-disabled css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 disabled=""
                                 id="id"
                                 readonly=""
@@ -263,13 +269,13 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -280,7 +286,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -290,7 +296,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="title"
                                 type="text"
                                 value="Nobis exercitationem officia quia est."
@@ -301,13 +307,13 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -318,7 +324,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -328,7 +334,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="slug"
                                 type="text"
                                 value="provident-culpa-facere"
@@ -339,13 +345,13 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -356,7 +362,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -366,7 +372,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                             >
                               <textarea
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="content"
                                 rows="5"
                               >
@@ -378,13 +384,13 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -395,7 +401,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -405,7 +411,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="hit"
                                 type="text"
                                 value="920557"
@@ -416,13 +422,13 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -433,7 +439,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -442,46 +448,32 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                aria-required="true"
-                                class="ant-select ant-select-outlined ant-select-in-form-item css-dev-only-do-not-override-mzwlov ant-select-single ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-outlined ant-select-in-form-item css-var-root ant-select-css-var css-dev-only-do-not-override-ch9ese ant-select-single ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
-                                  class="ant-select-selector"
+                                  class="ant-select-content ant-select-content-has-value"
+                                  title="Numquam Saepe Illo"
                                 >
-                                  <span
-                                    class="ant-select-selection-search"
-                                  >
-                                    <input
-                                      aria-autocomplete="list"
-                                      aria-controls="category_id_list"
-                                      aria-expanded="false"
-                                      aria-haspopup="listbox"
-                                      aria-owns="category_id_list"
-                                      aria-required="true"
-                                      autocomplete="off"
-                                      class="ant-select-selection-search-input"
-                                      id="category_id"
-                                      role="combobox"
-                                      type="search"
-                                      value=""
-                                    />
-                                  </span>
-                                  <span
-                                    class="ant-select-selection-item"
-                                    title="Numquam Saepe Illo"
-                                  >
-                                    Numquam Saepe Illo
-                                  </span>
+                                  Numquam Saepe Illo
+                                  <input
+                                    aria-autocomplete="list"
+                                    aria-expanded="false"
+                                    aria-haspopup="listbox"
+                                    aria-required="true"
+                                    autocomplete="off"
+                                    class="ant-select-input"
+                                    id="category_id"
+                                    role="combobox"
+                                    type="search"
+                                    value=""
+                                  />
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-arrow"
-                                  style="user-select: none;"
-                                  unselectable="on"
+                                <div
+                                  class="ant-select-suffix"
                                 >
                                   <span
                                     aria-label="down"
-                                    class="anticon anticon-down ant-select-suffix"
+                                    class="anticon anticon-down"
                                     role="img"
                                   >
                                     <svg
@@ -498,7 +490,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                                       />
                                     </svg>
                                   </span>
-                                </span>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -506,13 +498,13 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -523,7 +515,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -532,46 +524,32 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                aria-required="true"
-                                class="ant-select ant-select-outlined ant-select-in-form-item css-dev-only-do-not-override-mzwlov ant-select-single ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-outlined ant-select-in-form-item css-var-root ant-select-css-var css-dev-only-do-not-override-ch9ese ant-select-single ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
-                                  class="ant-select-selector"
+                                  class="ant-select-content ant-select-content-has-value"
+                                  title="Eriberto"
                                 >
-                                  <span
-                                    class="ant-select-selection-search"
-                                  >
-                                    <input
-                                      aria-autocomplete="list"
-                                      aria-controls="user_id_list"
-                                      aria-expanded="false"
-                                      aria-haspopup="listbox"
-                                      aria-owns="user_id_list"
-                                      aria-required="true"
-                                      autocomplete="off"
-                                      class="ant-select-selection-search-input"
-                                      id="user_id"
-                                      role="combobox"
-                                      type="search"
-                                      value=""
-                                    />
-                                  </span>
-                                  <span
-                                    class="ant-select-selection-item"
-                                    title="Eriberto"
-                                  >
-                                    Eriberto
-                                  </span>
+                                  Eriberto
+                                  <input
+                                    aria-autocomplete="list"
+                                    aria-expanded="false"
+                                    aria-haspopup="listbox"
+                                    aria-required="true"
+                                    autocomplete="off"
+                                    class="ant-select-input"
+                                    id="user_id"
+                                    role="combobox"
+                                    type="search"
+                                    value=""
+                                  />
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-arrow"
-                                  style="user-select: none;"
-                                  unselectable="on"
+                                <div
+                                  class="ant-select-suffix"
                                 >
                                   <span
                                     aria-label="down"
-                                    class="anticon anticon-down ant-select-suffix"
+                                    class="anticon anticon-down"
                                     role="img"
                                   >
                                     <svg
@@ -588,7 +566,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                                       />
                                     </svg>
                                   </span>
-                                </span>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -596,13 +574,13 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -613,7 +591,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -623,7 +601,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="status"
                                 type="text"
                                 value="draft"
@@ -634,13 +612,13 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -651,7 +629,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -661,7 +639,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="status_color"
                                 type="text"
                                 value="orange"
@@ -672,13 +650,13 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -689,7 +667,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -698,7 +676,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-mzwlov"
+                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-ch9ese css-var-root ant-picker-css-var"
                               >
                                 <div
                                   class="ant-picker-input"
@@ -768,13 +746,13 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -785,7 +763,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -794,7 +772,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-mzwlov"
+                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-ch9ese css-var-root ant-picker-css-var"
                               >
                                 <div
                                   class="ant-picker-input"
@@ -864,13 +842,13 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class=""
@@ -880,7 +858,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -889,10 +867,10 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <span
-                                class="ant-upload-wrapper css-dev-only-do-not-override-mzwlov"
+                                class="ant-upload-wrapper css-dev-only-do-not-override-ch9ese css-var-root"
                               >
                                 <div
-                                  class="css-dev-only-do-not-override-mzwlov ant-upload ant-upload-drag"
+                                  class="css-dev-only-do-not-override-ch9ese ant-upload ant-upload-drag"
                                 >
                                   <span
                                     class="ant-upload ant-upload-btn"
@@ -904,6 +882,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                                       aria-required="true"
                                       id="image"
                                       multiple=""
+                                      name="file"
                                       style="display: none;"
                                       type="file"
                                     />
@@ -952,7 +931,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                                         class="ant-upload-list-item-actions picture"
                                       >
                                         <button
-                                          class="ant-btn css-dev-only-do-not-override-mzwlov ant-btn-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
+                                          class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
                                           title="Remove file"
                                           type="button"
                                         >
@@ -992,13 +971,13 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -1009,7 +988,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -1018,101 +997,78 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                aria-required="true"
-                                class="ant-select ant-select-outlined ant-select-in-form-item css-dev-only-do-not-override-mzwlov ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-outlined ant-select-in-form-item css-var-root ant-select-css-var css-dev-only-do-not-override-ch9ese ant-select-multiple ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
-                                  class="ant-select-selector"
+                                  class="ant-select-content"
                                 >
                                   <div
-                                    class="ant-select-selection-overflow"
+                                    class="ant-select-content-item"
+                                    style="opacity: 1;"
                                   >
-                                    <div
-                                      class="ant-select-selection-overflow-item"
-                                      style="opacity: 1;"
+                                    <span
+                                      class="ant-select-selection-item"
+                                      title="Nobis Et Ut"
                                     >
                                       <span
-                                        class="ant-select-selection-item"
-                                        title="Nobis Et Ut"
+                                        class="ant-select-selection-item-content"
+                                      >
+                                        Nobis Et Ut
+                                      </span>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-selection-item-remove"
+                                        style="user-select: none;"
+                                        unselectable="on"
                                       >
                                         <span
-                                          class="ant-select-selection-item-content"
+                                          aria-label="close"
+                                          class="anticon anticon-close"
+                                          role="img"
                                         >
-                                          Nobis Et Ut
-                                        </span>
-                                        <span
-                                          aria-hidden="true"
-                                          class="ant-select-selection-item-remove"
-                                          style="user-select: none;"
-                                          unselectable="on"
-                                        >
-                                          <span
-                                            aria-label="close"
-                                            class="anticon anticon-close"
-                                            role="img"
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="close"
+                                            fill="currentColor"
+                                            fill-rule="evenodd"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="64 64 896 896"
+                                            width="1em"
                                           >
-                                            <svg
-                                              aria-hidden="true"
-                                              data-icon="close"
-                                              fill="currentColor"
-                                              fill-rule="evenodd"
-                                              focusable="false"
-                                              height="1em"
-                                              viewBox="64 64 896 896"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                                              />
-                                            </svg>
-                                          </span>
+                                            <path
+                                              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                                            />
+                                          </svg>
                                         </span>
                                       </span>
-                                    </div>
-                                    <div
-                                      class="ant-select-selection-overflow-item ant-select-selection-overflow-item-suffix"
-                                      style="opacity: 1;"
-                                    >
-                                      <div
-                                        class="ant-select-selection-search"
-                                        style="width: 0px;"
-                                      >
-                                        <input
-                                          aria-autocomplete="list"
-                                          aria-controls="tags_list"
-                                          aria-expanded="false"
-                                          aria-haspopup="listbox"
-                                          aria-owns="tags_list"
-                                          aria-required="true"
-                                          autocomplete="off"
-                                          class="ant-select-selection-search-input"
-                                          id="tags"
-                                          readonly=""
-                                          role="combobox"
-                                          style="opacity: 0;"
-                                          type="search"
-                                          unselectable="on"
-                                          value=""
-                                        />
-                                        <span
-                                          aria-hidden="true"
-                                          class="ant-select-selection-search-mirror"
-                                        >
-                                           
-                                        </span>
-                                      </div>
-                                    </div>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="ant-select-content-item ant-select-content-item-suffix"
+                                    style="opacity: 1;"
+                                  >
+                                    <input
+                                      aria-autocomplete="list"
+                                      aria-expanded="false"
+                                      aria-haspopup="listbox"
+                                      aria-required="true"
+                                      autocomplete="off"
+                                      class="ant-select-input"
+                                      id="tags"
+                                      role="combobox"
+                                      style="--select-input-width: 0;"
+                                      type="search"
+                                      value=""
+                                    />
                                   </div>
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-arrow"
-                                  style="user-select: none;"
-                                  unselectable="on"
+                                <div
+                                  class="ant-select-suffix"
                                 >
                                   <span
                                     aria-label="down"
-                                    class="anticon anticon-down ant-select-suffix"
+                                    class="anticon anticon-down"
                                     role="img"
                                   >
                                     <svg
@@ -1129,7 +1085,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                                       />
                                     </svg>
                                   </span>
-                                </span>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -1137,13 +1093,13 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -1154,7 +1110,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -1164,7 +1120,7 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="language"
                                 type="text"
                                 value="2"
@@ -1184,14 +1140,14 @@ exports[`AntdEditInferencer > should match the snapshot 1`] = `
                   >
                     <span>
                       <div
-                        class="ant-space css-dev-only-do-not-override-1vjf2v5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                        class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
                         style="flex-wrap: wrap; float: right; margin-right: 24px;"
                       >
                         <div
                           class="ant-space-item"
                         >
                           <button
-                            class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid refine-save-button"
+                            class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid refine-save-button"
                             type="button"
                           >
                             <span

--- a/packages/inferencer/src/inferencers/antd/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/antd/__tests__/__snapshots__/index.test.tsx.snap
@@ -5,48 +5,50 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
   <div>
     <div>
       <div
-        class="ant-page-header css-dev-only-do-not-override-1vjf2v5 ant-page-header-has-breadcrumb ant-page-header-ghost"
+        class="ant-page-header css-dev-only-do-not-override-ch9ese ant-page-header-has-breadcrumb ant-page-header-ghost"
         style="padding: 0px;"
       >
         <div
-          class="ant-page-header-heading css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-heading css-dev-only-do-not-override-ch9ese"
         >
           <div
-            class="ant-page-header-heading-left css-dev-only-do-not-override-1vjf2v5"
+            class="ant-page-header-heading-left css-dev-only-do-not-override-ch9ese"
           >
             <span
-              class="ant-page-header-heading-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-title css-dev-only-do-not-override-ch9ese"
             >
               <h4
-                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               />
             </span>
             <span
-              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-ch9ese"
             >
               <h5
-                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               />
             </span>
           </div>
         </div>
         <div
-          class="ant-page-header-content css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-content css-dev-only-do-not-override-ch9ese"
         >
           <div>
             <div
-              class="ant-table-wrapper css-dev-only-do-not-override-mzwlov"
+              class="css-var-root ant-table-css-var ant-table-wrapper css-dev-only-do-not-override-ch9ese"
             >
               <div
-                class="ant-spin-nested-loading css-dev-only-do-not-override-mzwlov"
+                aria-busy="false"
+                aria-live="polite"
+                class="ant-spin css-dev-only-do-not-override-ch9ese css-var-root"
               >
                 <div
                   class="ant-spin-container"
                 >
                   <div
-                    class="ant-table css-dev-only-do-not-override-mzwlov ant-table-scroll-horizontal"
+                    class="ant-table css-var-root ant-table-css-var css-dev-only-do-not-override-ch9ese ant-table-fix-start-shadow ant-table-fix-end-shadow ant-table-scroll-horizontal"
                   >
                     <div
                       class="ant-table-container"
@@ -58,7 +60,6 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                         <table
                           style="width: auto; min-width: 100%; table-layout: auto;"
                         >
-                          <colgroup />
                           <thead
                             class="ant-table-thead"
                           >
@@ -155,130 +156,130 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                             <tr
                               aria-hidden="true"
                               class="ant-table-measure-row"
-                              style="height: 0px; font-size: 0px;"
+                              style="height: 0px;"
                             >
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
@@ -334,7 +335,7 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <span
-                                  class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                                 >
                                   04/02/2022
                                 </span>
@@ -343,7 +344,7 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <span
-                                  class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                                 >
                                   08/10/2021
                                 </span>
@@ -352,48 +353,25 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <div
-                                  class="ant-image css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-image css-dev-only-do-not-override-ch9ese css-var-root ant-image-css-var"
+                                  role="button"
+                                  tabindex="0"
                                 >
                                   <img
-                                    class="ant-image-img css-dev-only-do-not-override-1vjf2v5"
+                                    class="ant-image-img css-dev-only-do-not-override-ch9ese"
                                     src="http://loremflickr.com/640/480/abstract"
                                     style="max-width: 100px;"
                                   />
                                   <div
-                                    class="ant-image-mask"
-                                  >
-                                    <div
-                                      class="ant-image-mask-info"
-                                    >
-                                      <span
-                                        aria-label="eye"
-                                        class="anticon anticon-eye"
-                                        role="img"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          data-icon="eye"
-                                          fill="currentColor"
-                                          focusable="false"
-                                          height="1em"
-                                          viewBox="64 64 896 896"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
-                                          />
-                                        </svg>
-                                      </span>
-                                      Preview
-                                    </div>
-                                  </div>
+                                    class="ant-image-cover ant-image-cover-center"
+                                  />
                                 </div>
                               </td>
                               <td
                                 class="ant-table-cell"
                               >
                                 <span
-                                  class="ant-tag css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-tag ant-tag-filled css-dev-only-do-not-override-ch9ese css-var-root"
                                 >
                                   Nobis Et Ut
                                 </span>
@@ -407,7 +385,7 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <div
-                                  class="ant-space css-dev-only-do-not-override-mzwlov ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                  class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
                                 >
                                   <div
                                     class="ant-space-item"
@@ -416,7 +394,7 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                                       href=""
                                     >
                                       <button
-                                        class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-edit-button"
+                                        class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-edit-button"
                                         title=""
                                         type="button"
                                       >
@@ -453,7 +431,7 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                                       href=""
                                     >
                                       <button
-                                        class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-show-button"
+                                        class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-show-button"
                                         title=""
                                         type="button"
                                       >
@@ -487,8 +465,7 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                                     class="ant-space-item"
                                   >
                                     <button
-                                      aria-describedby="test-id"
-                                      class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-delete-button"
+                                      class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-delete-button"
                                       title=""
                                       type="button"
                                     >
@@ -570,7 +547,7 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <span
-                                  class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                                 >
                                   09/24/2022
                                 </span>
@@ -579,7 +556,7 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <span
-                                  class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                                 >
                                   09/01/2021
                                 </span>
@@ -588,53 +565,30 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <div
-                                  class="ant-image css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-image css-dev-only-do-not-override-ch9ese css-var-root ant-image-css-var"
+                                  role="button"
+                                  tabindex="0"
                                 >
                                   <img
-                                    class="ant-image-img css-dev-only-do-not-override-1vjf2v5"
+                                    class="ant-image-img css-dev-only-do-not-override-ch9ese"
                                     src="http://loremflickr.com/640/480/abstract"
                                     style="max-width: 100px;"
                                   />
                                   <div
-                                    class="ant-image-mask"
-                                  >
-                                    <div
-                                      class="ant-image-mask-info"
-                                    >
-                                      <span
-                                        aria-label="eye"
-                                        class="anticon anticon-eye"
-                                        role="img"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          data-icon="eye"
-                                          fill="currentColor"
-                                          focusable="false"
-                                          height="1em"
-                                          viewBox="64 64 896 896"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
-                                          />
-                                        </svg>
-                                      </span>
-                                      Preview
-                                    </div>
-                                  </div>
+                                    class="ant-image-cover ant-image-cover-center"
+                                  />
                                 </div>
                               </td>
                               <td
                                 class="ant-table-cell"
                               >
                                 <span
-                                  class="ant-tag css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-tag ant-tag-filled css-dev-only-do-not-override-ch9ese css-var-root"
                                 >
                                   Error Eos Et
                                 </span>
                                 <span
-                                  class="ant-tag css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-tag ant-tag-filled css-dev-only-do-not-override-ch9ese css-var-root"
                                 >
                                   Nobis Et Ut
                                 </span>
@@ -648,7 +602,7 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <div
-                                  class="ant-space css-dev-only-do-not-override-mzwlov ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                  class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
                                 >
                                   <div
                                     class="ant-space-item"
@@ -657,7 +611,7 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                                       href=""
                                     >
                                       <button
-                                        class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-edit-button"
+                                        class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-edit-button"
                                         title=""
                                         type="button"
                                       >
@@ -694,7 +648,7 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                                       href=""
                                     >
                                       <button
-                                        class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-show-button"
+                                        class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-show-button"
                                         title=""
                                         type="button"
                                       >
@@ -728,8 +682,7 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                                     class="ant-space-item"
                                   >
                                     <button
-                                      aria-describedby="test-id"
-                                      class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-delete-button"
+                                      class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-delete-button"
                                       title=""
                                       type="button"
                                     >
@@ -767,7 +720,7 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                     </div>
                   </div>
                   <ul
-                    class="ant-pagination ant-table-pagination ant-table-pagination-center css-dev-only-do-not-override-mzwlov ant-pagination-simple"
+                    class="ant-pagination ant-table-pagination ant-table-pagination-center css-dev-only-do-not-override-ch9ese css-var-root ant-pagination-simple"
                   >
                     <li
                       aria-disabled="true"
@@ -809,6 +762,7 @@ exports[`AntdInferencer > should match the snapshot 1`] = `
                       title="1/1"
                     >
                       <input
+                        aria-label="Go to"
                         size="3"
                         type="text"
                         value="1"
@@ -7897,25 +7851,25 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
   <div>
     <div>
       <div
-        class="ant-page-header css-dev-only-do-not-override-1vjf2v5 ant-page-header-has-breadcrumb ant-page-header-ghost"
+        class="ant-page-header css-dev-only-do-not-override-ch9ese ant-page-header-has-breadcrumb ant-page-header-ghost"
         style="padding: 0px;"
       >
         <div
-          class="ant-page-header-heading css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-heading css-dev-only-do-not-override-ch9ese"
         >
           <div
-            class="ant-page-header-heading-left css-dev-only-do-not-override-1vjf2v5"
+            class="ant-page-header-heading-left css-dev-only-do-not-override-ch9ese"
           >
             <div
-              class="ant-page-header-back css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-back css-dev-only-do-not-override-ch9ese"
             >
               <div
                 aria-label="back"
-                class="ant-page-header-back-button css-dev-only-do-not-override-1vjf2v5"
+                class="ant-page-header-back-button css-dev-only-do-not-override-ch9ese"
                 role="button"
               >
                 <button
-                  class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-icon-only"
+                  class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-icon-only"
                   type="button"
                 >
                   <span
@@ -7945,29 +7899,29 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
               </div>
             </div>
             <span
-              class="ant-page-header-heading-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-title css-dev-only-do-not-override-ch9ese"
             >
               <h4
-                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               >
                 Create 
               </h4>
             </span>
             <span
-              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-ch9ese"
             >
               <h5
-                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               />
             </span>
           </div>
           <span
-            class="ant-page-header-heading-extra css-dev-only-do-not-override-1vjf2v5"
+            class="ant-page-header-heading-extra css-dev-only-do-not-override-ch9ese"
           >
             <div
-              class="ant-space css-dev-only-do-not-override-1vjf2v5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+              class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
             >
               <div
                 class="ant-space-item"
@@ -7976,31 +7930,33 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
           </span>
         </div>
         <div
-          class="ant-page-header-content css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-content css-dev-only-do-not-override-ch9ese"
         >
           <div
-            class="ant-spin-nested-loading css-dev-only-do-not-override-1vjf2v5"
+            aria-busy="false"
+            aria-live="polite"
+            class="ant-spin css-dev-only-do-not-override-ch9ese css-var-root"
           >
             <div
               class="ant-spin-container"
             >
               <div
-                class="ant-card css-dev-only-do-not-override-1vjf2v5"
+                class="ant-card css-dev-only-do-not-override-ch9ese css-var-root"
               >
                 <div
                   class="ant-card-body"
                 >
                   <form
-                    class="ant-form ant-form-vertical css-dev-only-do-not-override-mzwlov"
+                    class="ant-form ant-form-vertical css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese"
                   >
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -8011,7 +7967,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -8021,7 +7977,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="title"
                                 type="text"
                                 value=""
@@ -8032,13 +7988,13 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -8049,7 +8005,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -8059,7 +8015,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="slug"
                                 type="text"
                                 value=""
@@ -8070,13 +8026,13 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -8087,7 +8043,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -8097,7 +8053,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                             >
                               <textarea
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="content"
                                 rows="5"
                               />
@@ -8107,13 +8063,13 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -8124,7 +8080,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -8134,7 +8090,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="hit"
                                 type="text"
                                 value=""
@@ -8145,13 +8101,13 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -8162,7 +8118,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -8171,43 +8127,34 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                aria-required="true"
-                                class="ant-select ant-select-outlined ant-select-in-form-item css-dev-only-do-not-override-mzwlov ant-select-single ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-outlined ant-select-in-form-item css-var-root ant-select-css-var css-dev-only-do-not-override-ch9ese ant-select-single ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
-                                  class="ant-select-selector"
+                                  class="ant-select-content"
                                 >
-                                  <span
-                                    class="ant-select-selection-search"
-                                  >
-                                    <input
-                                      aria-autocomplete="list"
-                                      aria-controls="category_id_list"
-                                      aria-expanded="false"
-                                      aria-haspopup="listbox"
-                                      aria-owns="category_id_list"
-                                      aria-required="true"
-                                      autocomplete="off"
-                                      class="ant-select-selection-search-input"
-                                      id="category_id"
-                                      role="combobox"
-                                      type="search"
-                                      value=""
-                                    />
-                                  </span>
-                                  <span
-                                    class="ant-select-selection-placeholder"
+                                  <div
+                                    class="ant-select-placeholder"
+                                    style="visibility: visible;"
+                                  />
+                                  <input
+                                    aria-autocomplete="list"
+                                    aria-expanded="false"
+                                    aria-haspopup="listbox"
+                                    aria-required="true"
+                                    autocomplete="off"
+                                    class="ant-select-input"
+                                    id="category_id"
+                                    role="combobox"
+                                    type="search"
+                                    value=""
                                   />
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-arrow"
-                                  style="user-select: none;"
-                                  unselectable="on"
+                                <div
+                                  class="ant-select-suffix"
                                 >
                                   <span
                                     aria-label="down"
-                                    class="anticon anticon-down ant-select-suffix"
+                                    class="anticon anticon-down"
                                     role="img"
                                   >
                                     <svg
@@ -8224,7 +8171,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                                       />
                                     </svg>
                                   </span>
-                                </span>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -8232,13 +8179,13 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -8249,7 +8196,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -8258,43 +8205,34 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                aria-required="true"
-                                class="ant-select ant-select-outlined ant-select-in-form-item css-dev-only-do-not-override-mzwlov ant-select-single ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-outlined ant-select-in-form-item css-var-root ant-select-css-var css-dev-only-do-not-override-ch9ese ant-select-single ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
-                                  class="ant-select-selector"
+                                  class="ant-select-content"
                                 >
-                                  <span
-                                    class="ant-select-selection-search"
-                                  >
-                                    <input
-                                      aria-autocomplete="list"
-                                      aria-controls="user_id_list"
-                                      aria-expanded="false"
-                                      aria-haspopup="listbox"
-                                      aria-owns="user_id_list"
-                                      aria-required="true"
-                                      autocomplete="off"
-                                      class="ant-select-selection-search-input"
-                                      id="user_id"
-                                      role="combobox"
-                                      type="search"
-                                      value=""
-                                    />
-                                  </span>
-                                  <span
-                                    class="ant-select-selection-placeholder"
+                                  <div
+                                    class="ant-select-placeholder"
+                                    style="visibility: visible;"
+                                  />
+                                  <input
+                                    aria-autocomplete="list"
+                                    aria-expanded="false"
+                                    aria-haspopup="listbox"
+                                    aria-required="true"
+                                    autocomplete="off"
+                                    class="ant-select-input"
+                                    id="user_id"
+                                    role="combobox"
+                                    type="search"
+                                    value=""
                                   />
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-arrow"
-                                  style="user-select: none;"
-                                  unselectable="on"
+                                <div
+                                  class="ant-select-suffix"
                                 >
                                   <span
                                     aria-label="down"
-                                    class="anticon anticon-down ant-select-suffix"
+                                    class="anticon anticon-down"
                                     role="img"
                                   >
                                     <svg
@@ -8311,7 +8249,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                                       />
                                     </svg>
                                   </span>
-                                </span>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -8319,13 +8257,13 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -8336,7 +8274,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -8346,7 +8284,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="status"
                                 type="text"
                                 value=""
@@ -8357,13 +8295,13 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -8374,7 +8312,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -8384,7 +8322,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="status_color"
                                 type="text"
                                 value=""
@@ -8395,13 +8333,13 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -8412,7 +8350,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -8421,7 +8359,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-mzwlov"
+                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-ch9ese css-var-root ant-picker-css-var"
                               >
                                 <div
                                   class="ant-picker-input"
@@ -8466,13 +8404,13 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -8483,7 +8421,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -8492,7 +8430,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-mzwlov"
+                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-ch9ese css-var-root ant-picker-css-var"
                               >
                                 <div
                                   class="ant-picker-input"
@@ -8537,13 +8475,13 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class=""
@@ -8553,7 +8491,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -8562,10 +8500,10 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <span
-                                class="ant-upload-wrapper css-dev-only-do-not-override-mzwlov"
+                                class="ant-upload-wrapper css-dev-only-do-not-override-ch9ese css-var-root"
                               >
                                 <div
-                                  class="css-dev-only-do-not-override-mzwlov ant-upload ant-upload-drag"
+                                  class="css-dev-only-do-not-override-ch9ese ant-upload ant-upload-drag"
                                 >
                                   <span
                                     class="ant-upload ant-upload-btn"
@@ -8577,6 +8515,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                                       aria-required="true"
                                       id="image"
                                       multiple=""
+                                      name="file"
                                       style="display: none;"
                                       type="file"
                                     />
@@ -8601,13 +8540,13 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -8618,7 +8557,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -8627,62 +8566,45 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                aria-required="true"
-                                class="ant-select ant-select-outlined ant-select-in-form-item css-dev-only-do-not-override-mzwlov ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-outlined ant-select-in-form-item css-var-root ant-select-css-var css-dev-only-do-not-override-ch9ese ant-select-multiple ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
-                                  class="ant-select-selector"
+                                  class="ant-select-content"
                                 >
                                   <div
-                                    class="ant-select-selection-overflow"
+                                    class="ant-select-content-item ant-select-content-item-prefix"
+                                    style="opacity: 1;"
                                   >
                                     <div
-                                      class="ant-select-selection-overflow-item ant-select-selection-overflow-item-suffix"
-                                      style="opacity: 1;"
-                                    >
-                                      <div
-                                        class="ant-select-selection-search"
-                                        style="width: 0px;"
-                                      >
-                                        <input
-                                          aria-autocomplete="list"
-                                          aria-controls="tags_list"
-                                          aria-expanded="false"
-                                          aria-haspopup="listbox"
-                                          aria-owns="tags_list"
-                                          aria-required="true"
-                                          autocomplete="off"
-                                          class="ant-select-selection-search-input"
-                                          id="tags"
-                                          readonly=""
-                                          role="combobox"
-                                          style="opacity: 0;"
-                                          type="search"
-                                          unselectable="on"
-                                          value=""
-                                        />
-                                        <span
-                                          aria-hidden="true"
-                                          class="ant-select-selection-search-mirror"
-                                        >
-                                           
-                                        </span>
-                                      </div>
-                                    </div>
+                                      class="ant-select-placeholder"
+                                      style="visibility: visible;"
+                                    />
                                   </div>
-                                  <span
-                                    class="ant-select-selection-placeholder"
-                                  />
+                                  <div
+                                    class="ant-select-content-item ant-select-content-item-suffix"
+                                    style="opacity: 1;"
+                                  >
+                                    <input
+                                      aria-autocomplete="list"
+                                      aria-expanded="false"
+                                      aria-haspopup="listbox"
+                                      aria-required="true"
+                                      autocomplete="off"
+                                      class="ant-select-input"
+                                      id="tags"
+                                      role="combobox"
+                                      style="--select-input-width: 0;"
+                                      type="search"
+                                      value=""
+                                    />
+                                  </div>
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-arrow"
-                                  style="user-select: none;"
-                                  unselectable="on"
+                                <div
+                                  class="ant-select-suffix"
                                 >
                                   <span
                                     aria-label="down"
-                                    class="anticon anticon-down ant-select-suffix"
+                                    class="anticon anticon-down"
                                     role="img"
                                   >
                                     <svg
@@ -8699,7 +8621,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                                       />
                                     </svg>
                                   </span>
-                                </span>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -8707,13 +8629,13 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -8724,7 +8646,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -8734,7 +8656,7 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="language"
                                 type="text"
                                 value=""
@@ -8754,14 +8676,14 @@ exports[`AntdInferencer > should match the snapshot 2`] = `
                   >
                     <span>
                       <div
-                        class="ant-space css-dev-only-do-not-override-1vjf2v5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                        class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
                         style="float: right; margin-right: 24px;"
                       >
                         <div
                           class="ant-space-item"
                         >
                           <button
-                            class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid refine-save-button"
+                            class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid refine-save-button"
                             type="submit"
                           >
                             <span
@@ -16358,52 +16280,52 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
   <div>
     <div>
       <div
-        class="ant-page-header css-dev-only-do-not-override-1vjf2v5 ant-page-header-has-breadcrumb ant-page-header-ghost"
+        class="ant-page-header css-dev-only-do-not-override-ch9ese ant-page-header-has-breadcrumb ant-page-header-ghost"
         style="padding: 0px;"
       >
         <div
-          class="ant-page-header-heading css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-heading css-dev-only-do-not-override-ch9ese"
         >
           <div
-            class="ant-page-header-heading-left css-dev-only-do-not-override-1vjf2v5"
+            class="ant-page-header-heading-left css-dev-only-do-not-override-ch9ese"
           >
             <span
-              class="ant-page-header-heading-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-title css-dev-only-do-not-override-ch9ese"
             >
               <h4
-                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               >
                 Edit 
               </h4>
             </span>
             <span
-              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-ch9ese"
             >
               <h5
-                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               />
             </span>
           </div>
           <span
-            class="ant-page-header-heading-extra css-dev-only-do-not-override-1vjf2v5"
+            class="ant-page-header-heading-extra css-dev-only-do-not-override-ch9ese"
           >
             <div
-              class="ant-space css-dev-only-do-not-override-1vjf2v5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+              class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
             >
               <div
                 class="ant-space-item"
               >
                 <div
-                  class="ant-space css-dev-only-do-not-override-1vjf2v5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                  class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
                   style="flex-wrap: wrap;"
                 >
                   <div
                     class="ant-space-item"
                   >
                     <button
-                      class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-color-default ant-btn-variant-outlined refine-refresh-button"
+                      class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined refine-refresh-button"
                       type="button"
                     >
                       <span
@@ -16440,31 +16362,33 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
           </span>
         </div>
         <div
-          class="ant-page-header-content css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-content css-dev-only-do-not-override-ch9ese"
         >
           <div
-            class="ant-spin-nested-loading css-dev-only-do-not-override-1vjf2v5"
+            aria-busy="false"
+            aria-live="polite"
+            class="ant-spin css-dev-only-do-not-override-ch9ese css-var-root"
           >
             <div
               class="ant-spin-container"
             >
               <div
-                class="ant-card css-dev-only-do-not-override-1vjf2v5"
+                class="ant-card css-dev-only-do-not-override-ch9ese css-var-root"
               >
                 <div
                   class="ant-card-body"
                 >
                   <form
-                    class="ant-form ant-form-vertical css-dev-only-do-not-override-mzwlov"
+                    class="ant-form ant-form-vertical css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese"
                   >
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -16475,7 +16399,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -16485,7 +16409,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input ant-input-disabled css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input ant-input-disabled css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 disabled=""
                                 id="id"
                                 readonly=""
@@ -16498,13 +16422,13 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -16515,7 +16439,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -16525,7 +16449,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="title"
                                 type="text"
                                 value="Nobis exercitationem officia quia est."
@@ -16536,13 +16460,13 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -16553,7 +16477,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -16563,7 +16487,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="slug"
                                 type="text"
                                 value="provident-culpa-facere"
@@ -16574,13 +16498,13 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -16591,7 +16515,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -16601,7 +16525,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                             >
                               <textarea
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="content"
                                 rows="5"
                               >
@@ -16613,13 +16537,13 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -16630,7 +16554,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -16640,7 +16564,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="hit"
                                 type="text"
                                 value="920557"
@@ -16651,13 +16575,13 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -16668,7 +16592,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -16677,46 +16601,32 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                aria-required="true"
-                                class="ant-select ant-select-outlined ant-select-in-form-item css-dev-only-do-not-override-mzwlov ant-select-single ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-outlined ant-select-in-form-item css-var-root ant-select-css-var css-dev-only-do-not-override-ch9ese ant-select-single ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
-                                  class="ant-select-selector"
+                                  class="ant-select-content ant-select-content-has-value"
+                                  title="Numquam Saepe Illo"
                                 >
-                                  <span
-                                    class="ant-select-selection-search"
-                                  >
-                                    <input
-                                      aria-autocomplete="list"
-                                      aria-controls="category_id_list"
-                                      aria-expanded="false"
-                                      aria-haspopup="listbox"
-                                      aria-owns="category_id_list"
-                                      aria-required="true"
-                                      autocomplete="off"
-                                      class="ant-select-selection-search-input"
-                                      id="category_id"
-                                      role="combobox"
-                                      type="search"
-                                      value=""
-                                    />
-                                  </span>
-                                  <span
-                                    class="ant-select-selection-item"
-                                    title="Numquam Saepe Illo"
-                                  >
-                                    Numquam Saepe Illo
-                                  </span>
+                                  Numquam Saepe Illo
+                                  <input
+                                    aria-autocomplete="list"
+                                    aria-expanded="false"
+                                    aria-haspopup="listbox"
+                                    aria-required="true"
+                                    autocomplete="off"
+                                    class="ant-select-input"
+                                    id="category_id"
+                                    role="combobox"
+                                    type="search"
+                                    value=""
+                                  />
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-arrow"
-                                  style="user-select: none;"
-                                  unselectable="on"
+                                <div
+                                  class="ant-select-suffix"
                                 >
                                   <span
                                     aria-label="down"
-                                    class="anticon anticon-down ant-select-suffix"
+                                    class="anticon anticon-down"
                                     role="img"
                                   >
                                     <svg
@@ -16733,7 +16643,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                                       />
                                     </svg>
                                   </span>
-                                </span>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -16741,13 +16651,13 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -16758,7 +16668,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -16767,46 +16677,32 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                aria-required="true"
-                                class="ant-select ant-select-outlined ant-select-in-form-item css-dev-only-do-not-override-mzwlov ant-select-single ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-outlined ant-select-in-form-item css-var-root ant-select-css-var css-dev-only-do-not-override-ch9ese ant-select-single ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
-                                  class="ant-select-selector"
+                                  class="ant-select-content ant-select-content-has-value"
+                                  title="Eriberto"
                                 >
-                                  <span
-                                    class="ant-select-selection-search"
-                                  >
-                                    <input
-                                      aria-autocomplete="list"
-                                      aria-controls="user_id_list"
-                                      aria-expanded="false"
-                                      aria-haspopup="listbox"
-                                      aria-owns="user_id_list"
-                                      aria-required="true"
-                                      autocomplete="off"
-                                      class="ant-select-selection-search-input"
-                                      id="user_id"
-                                      role="combobox"
-                                      type="search"
-                                      value=""
-                                    />
-                                  </span>
-                                  <span
-                                    class="ant-select-selection-item"
-                                    title="Eriberto"
-                                  >
-                                    Eriberto
-                                  </span>
+                                  Eriberto
+                                  <input
+                                    aria-autocomplete="list"
+                                    aria-expanded="false"
+                                    aria-haspopup="listbox"
+                                    aria-required="true"
+                                    autocomplete="off"
+                                    class="ant-select-input"
+                                    id="user_id"
+                                    role="combobox"
+                                    type="search"
+                                    value=""
+                                  />
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-arrow"
-                                  style="user-select: none;"
-                                  unselectable="on"
+                                <div
+                                  class="ant-select-suffix"
                                 >
                                   <span
                                     aria-label="down"
-                                    class="anticon anticon-down ant-select-suffix"
+                                    class="anticon anticon-down"
                                     role="img"
                                   >
                                     <svg
@@ -16823,7 +16719,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                                       />
                                     </svg>
                                   </span>
-                                </span>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -16831,13 +16727,13 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -16848,7 +16744,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -16858,7 +16754,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="status"
                                 type="text"
                                 value="draft"
@@ -16869,13 +16765,13 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -16886,7 +16782,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -16896,7 +16792,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="status_color"
                                 type="text"
                                 value="orange"
@@ -16907,13 +16803,13 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -16924,7 +16820,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -16933,7 +16829,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-mzwlov"
+                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-ch9ese css-var-root ant-picker-css-var"
                               >
                                 <div
                                   class="ant-picker-input"
@@ -17003,13 +16899,13 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -17020,7 +16916,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -17029,7 +16925,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-mzwlov"
+                                class="ant-picker ant-picker-outlined css-dev-only-do-not-override-ch9ese css-var-root ant-picker-css-var"
                               >
                                 <div
                                   class="ant-picker-input"
@@ -17099,13 +16995,13 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class=""
@@ -17115,7 +17011,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -17124,10 +17020,10 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <span
-                                class="ant-upload-wrapper css-dev-only-do-not-override-mzwlov"
+                                class="ant-upload-wrapper css-dev-only-do-not-override-ch9ese css-var-root"
                               >
                                 <div
-                                  class="css-dev-only-do-not-override-mzwlov ant-upload ant-upload-drag"
+                                  class="css-dev-only-do-not-override-ch9ese ant-upload ant-upload-drag"
                                 >
                                   <span
                                     class="ant-upload ant-upload-btn"
@@ -17139,6 +17035,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                                       aria-required="true"
                                       id="image"
                                       multiple=""
+                                      name="file"
                                       style="display: none;"
                                       type="file"
                                     />
@@ -17187,7 +17084,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                                         class="ant-upload-list-item-actions picture"
                                       >
                                         <button
-                                          class="ant-btn css-dev-only-do-not-override-mzwlov ant-btn-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
+                                          class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
                                           title="Remove file"
                                           type="button"
                                         >
@@ -17227,13 +17124,13 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -17244,7 +17141,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -17253,101 +17150,78 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                aria-required="true"
-                                class="ant-select ant-select-outlined ant-select-in-form-item css-dev-only-do-not-override-mzwlov ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-outlined ant-select-in-form-item css-var-root ant-select-css-var css-dev-only-do-not-override-ch9ese ant-select-multiple ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
-                                  class="ant-select-selector"
+                                  class="ant-select-content"
                                 >
                                   <div
-                                    class="ant-select-selection-overflow"
+                                    class="ant-select-content-item"
+                                    style="opacity: 1;"
                                   >
-                                    <div
-                                      class="ant-select-selection-overflow-item"
-                                      style="opacity: 1;"
+                                    <span
+                                      class="ant-select-selection-item"
+                                      title="Nobis Et Ut"
                                     >
                                       <span
-                                        class="ant-select-selection-item"
-                                        title="Nobis Et Ut"
+                                        class="ant-select-selection-item-content"
+                                      >
+                                        Nobis Et Ut
+                                      </span>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-selection-item-remove"
+                                        style="user-select: none;"
+                                        unselectable="on"
                                       >
                                         <span
-                                          class="ant-select-selection-item-content"
+                                          aria-label="close"
+                                          class="anticon anticon-close"
+                                          role="img"
                                         >
-                                          Nobis Et Ut
-                                        </span>
-                                        <span
-                                          aria-hidden="true"
-                                          class="ant-select-selection-item-remove"
-                                          style="user-select: none;"
-                                          unselectable="on"
-                                        >
-                                          <span
-                                            aria-label="close"
-                                            class="anticon anticon-close"
-                                            role="img"
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="close"
+                                            fill="currentColor"
+                                            fill-rule="evenodd"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="64 64 896 896"
+                                            width="1em"
                                           >
-                                            <svg
-                                              aria-hidden="true"
-                                              data-icon="close"
-                                              fill="currentColor"
-                                              fill-rule="evenodd"
-                                              focusable="false"
-                                              height="1em"
-                                              viewBox="64 64 896 896"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                                              />
-                                            </svg>
-                                          </span>
+                                            <path
+                                              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                                            />
+                                          </svg>
                                         </span>
                                       </span>
-                                    </div>
-                                    <div
-                                      class="ant-select-selection-overflow-item ant-select-selection-overflow-item-suffix"
-                                      style="opacity: 1;"
-                                    >
-                                      <div
-                                        class="ant-select-selection-search"
-                                        style="width: 0px;"
-                                      >
-                                        <input
-                                          aria-autocomplete="list"
-                                          aria-controls="tags_list"
-                                          aria-expanded="false"
-                                          aria-haspopup="listbox"
-                                          aria-owns="tags_list"
-                                          aria-required="true"
-                                          autocomplete="off"
-                                          class="ant-select-selection-search-input"
-                                          id="tags"
-                                          readonly=""
-                                          role="combobox"
-                                          style="opacity: 0;"
-                                          type="search"
-                                          unselectable="on"
-                                          value=""
-                                        />
-                                        <span
-                                          aria-hidden="true"
-                                          class="ant-select-selection-search-mirror"
-                                        >
-                                           
-                                        </span>
-                                      </div>
-                                    </div>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="ant-select-content-item ant-select-content-item-suffix"
+                                    style="opacity: 1;"
+                                  >
+                                    <input
+                                      aria-autocomplete="list"
+                                      aria-expanded="false"
+                                      aria-haspopup="listbox"
+                                      aria-required="true"
+                                      autocomplete="off"
+                                      class="ant-select-input"
+                                      id="tags"
+                                      role="combobox"
+                                      style="--select-input-width: 0;"
+                                      type="search"
+                                      value=""
+                                    />
                                   </div>
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-arrow"
-                                  style="user-select: none;"
-                                  unselectable="on"
+                                <div
+                                  class="ant-select-suffix"
                                 >
                                   <span
                                     aria-label="down"
-                                    class="anticon anticon-down ant-select-suffix"
+                                    class="anticon anticon-down"
                                     role="img"
                                   >
                                     <svg
@@ -17364,7 +17238,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                                       />
                                     </svg>
                                   </span>
-                                </span>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -17372,13 +17246,13 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-dev-only-do-not-override-mzwlov"
+                      class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ch9ese ant-form-item-vertical"
                     >
                       <div
-                        class="ant-row ant-form-item-row css-dev-only-do-not-override-mzwlov"
+                        class="ant-row ant-form-item-row css-dev-only-do-not-override-ch9ese css-var-root"
                       >
                         <div
-                          class="ant-col ant-form-item-label css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-label css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <label
                             class="ant-form-item-required"
@@ -17389,7 +17263,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                           </label>
                         </div>
                         <div
-                          class="ant-col ant-form-item-control css-dev-only-do-not-override-mzwlov"
+                          class="ant-col ant-form-item-control css-dev-only-do-not-override-ch9ese css-var-root"
                         >
                           <div
                             class="ant-form-item-control-input"
@@ -17399,7 +17273,7 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                             >
                               <input
                                 aria-required="true"
-                                class="ant-input css-dev-only-do-not-override-mzwlov ant-input-outlined"
+                                class="ant-input css-dev-only-do-not-override-ch9ese ant-input-outlined css-var-root ant-input-css-var"
                                 id="language"
                                 type="text"
                                 value="2"
@@ -17419,14 +17293,14 @@ exports[`AntdInferencer > should match the snapshot 3`] = `
                   >
                     <span>
                       <div
-                        class="ant-space css-dev-only-do-not-override-1vjf2v5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                        class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
                         style="flex-wrap: wrap; float: right; margin-right: 24px;"
                       >
                         <div
                           class="ant-space-item"
                         >
                           <button
-                            class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid refine-save-button"
+                            class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid refine-save-button"
                             type="button"
                           >
                             <span
@@ -25672,52 +25546,52 @@ exports[`AntdInferencer > should match the snapshot 4`] = `
   <div>
     <div>
       <div
-        class="ant-page-header css-dev-only-do-not-override-1vjf2v5 ant-page-header-has-breadcrumb ant-page-header-ghost"
+        class="ant-page-header css-dev-only-do-not-override-ch9ese ant-page-header-has-breadcrumb ant-page-header-ghost"
         style="padding: 0px;"
       >
         <div
-          class="ant-page-header-heading css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-heading css-dev-only-do-not-override-ch9ese"
         >
           <div
-            class="ant-page-header-heading-left css-dev-only-do-not-override-1vjf2v5"
+            class="ant-page-header-heading-left css-dev-only-do-not-override-ch9ese"
           >
             <span
-              class="ant-page-header-heading-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-title css-dev-only-do-not-override-ch9ese"
             >
               <h4
-                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               >
                 Show 
               </h4>
             </span>
             <span
-              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-ch9ese"
             >
               <h5
-                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               />
             </span>
           </div>
           <span
-            class="ant-page-header-heading-extra css-dev-only-do-not-override-1vjf2v5"
+            class="ant-page-header-heading-extra css-dev-only-do-not-override-ch9ese"
           >
             <div
-              class="ant-space css-dev-only-do-not-override-1vjf2v5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+              class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
             >
               <div
                 class="ant-space-item"
               >
                 <div
-                  class="ant-space css-dev-only-do-not-override-1vjf2v5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                  class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
                   style="flex-wrap: wrap;"
                 >
                   <div
                     class="ant-space-item"
                   >
                     <button
-                      class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-color-default ant-btn-variant-outlined refine-refresh-button"
+                      class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined refine-refresh-button"
                       type="button"
                     >
                       <span
@@ -25754,52 +25628,54 @@ exports[`AntdInferencer > should match the snapshot 4`] = `
           </span>
         </div>
         <div
-          class="ant-page-header-content css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-content css-dev-only-do-not-override-ch9ese"
         >
           <div
-            class="ant-spin-nested-loading css-dev-only-do-not-override-1vjf2v5"
+            aria-busy="false"
+            aria-live="polite"
+            class="ant-spin css-dev-only-do-not-override-ch9ese css-var-root"
           >
             <div
               class="ant-spin-container"
             >
               <div
-                class="ant-card css-dev-only-do-not-override-1vjf2v5"
+                class="ant-card css-dev-only-do-not-override-ch9ese css-var-root"
               >
                 <div
                   class="ant-card-body"
                 >
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Id
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     11
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Title
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Nobis exercitationem officia quia est.
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Slug
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     provident-culpa-facere
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Content
                   </h5>
@@ -25807,135 +25683,112 @@ exports[`AntdInferencer > should match the snapshot 4`] = `
                     Non velit blanditiis optio quo quaerat nam aperiam. Odit tempore consequatur voluptatibus molestias. Est nemo aut. Fugit aliquam enim eveniet veritatis. Magni et aut. Consequatur aliquid rerum vero. Quaerat debitis enim magnam. Dolorem est delectus architecto et accusantium. Velit quia vero. Aut necessitatibus quia at consequatur soluta accusantium.
                   </p>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Hit
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     920,557
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Category
                   </h5>
                   Numquam Saepe Illo
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     User
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Eriberto Leannon
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Status
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     draft
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Status Color
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     orange
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Created At
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     04/02/2022
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Published At
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     08/10/2021
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Image
                   </h5>
                   <div
-                    class="ant-image css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-image css-dev-only-do-not-override-ch9ese css-var-root ant-image-css-var"
+                    role="button"
+                    tabindex="0"
                   >
                     <img
-                      class="ant-image-img css-dev-only-do-not-override-1vjf2v5"
+                      class="ant-image-img css-dev-only-do-not-override-ch9ese"
                       src="http://loremflickr.com/640/480/abstract"
                       style="max-width: 200px;"
                     />
                     <div
-                      class="ant-image-mask"
-                    >
-                      <div
-                        class="ant-image-mask-info"
-                      >
-                        <span
-                          aria-label="eye"
-                          class="anticon anticon-eye"
-                          role="img"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            data-icon="eye"
-                            fill="currentColor"
-                            focusable="false"
-                            height="1em"
-                            viewBox="64 64 896 896"
-                            width="1em"
-                          >
-                            <path
-                              d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
-                            />
-                          </svg>
-                        </span>
-                        Preview
-                      </div>
-                    </div>
+                      class="ant-image-cover ant-image-cover-center"
+                    />
                   </div>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Tags
                   </h5>
                   <span
-                    class="ant-tag css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-tag ant-tag-filled css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Error Eos Et
                   </span>
                   <span
-                    class="ant-tag css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-tag ant-tag-filled css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Nobis Et Ut
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Language
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     2
                   </span>

--- a/packages/inferencer/src/inferencers/antd/__tests__/__snapshots__/list.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/antd/__tests__/__snapshots__/list.test.tsx.snap
@@ -5,39 +5,39 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
   <div>
     <div>
       <div
-        class="ant-page-header css-dev-only-do-not-override-1vjf2v5 ant-page-header-has-breadcrumb ant-page-header-ghost"
+        class="ant-page-header css-dev-only-do-not-override-ch9ese ant-page-header-has-breadcrumb ant-page-header-ghost"
         style="padding: 0px;"
       >
         <div
-          class="ant-page-header-heading css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-heading css-dev-only-do-not-override-ch9ese"
         >
           <div
-            class="ant-page-header-heading-left css-dev-only-do-not-override-1vjf2v5"
+            class="ant-page-header-heading-left css-dev-only-do-not-override-ch9ese"
           >
             <span
-              class="ant-page-header-heading-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-title css-dev-only-do-not-override-ch9ese"
             >
               <h4
-                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               >
                 Posts
               </h4>
             </span>
             <span
-              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-ch9ese"
             >
               <h5
-                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               />
             </span>
           </div>
           <span
-            class="ant-page-header-heading-extra css-dev-only-do-not-override-1vjf2v5"
+            class="ant-page-header-heading-extra css-dev-only-do-not-override-ch9ese"
           >
             <div
-              class="ant-space css-dev-only-do-not-override-1vjf2v5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+              class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
             >
               <div
                 class="ant-space-item"
@@ -46,7 +46,7 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                   href="/posts/create"
                 >
                   <button
-                    class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid refine-create-button"
+                    class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid refine-create-button"
                     title=""
                     type="button"
                   >
@@ -86,20 +86,22 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
           </span>
         </div>
         <div
-          class="ant-page-header-content css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-content css-dev-only-do-not-override-ch9ese"
         >
           <div>
             <div
-              class="ant-table-wrapper css-dev-only-do-not-override-mzwlov"
+              class="css-var-root ant-table-css-var ant-table-wrapper css-dev-only-do-not-override-ch9ese"
             >
               <div
-                class="ant-spin-nested-loading css-dev-only-do-not-override-mzwlov"
+                aria-busy="false"
+                aria-live="polite"
+                class="ant-spin css-dev-only-do-not-override-ch9ese css-var-root"
               >
                 <div
                   class="ant-spin-container"
                 >
                   <div
-                    class="ant-table css-dev-only-do-not-override-mzwlov ant-table-scroll-horizontal"
+                    class="ant-table css-var-root ant-table-css-var css-dev-only-do-not-override-ch9ese ant-table-fix-start-shadow ant-table-fix-end-shadow ant-table-scroll-horizontal"
                   >
                     <div
                       class="ant-table-container"
@@ -111,7 +113,6 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                         <table
                           style="width: auto; min-width: 100%; table-layout: auto;"
                         >
-                          <colgroup />
                           <thead
                             class="ant-table-thead"
                           >
@@ -208,130 +209,130 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                             <tr
                               aria-hidden="true"
                               class="ant-table-measure-row"
-                              style="height: 0px; font-size: 0px;"
+                              style="height: 0px;"
                             >
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
                               </td>
                               <td
-                                style="padding: 0px; border: 0px; height: 0px;"
+                                style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
                               >
                                 <div
-                                  style="height: 0px; overflow: hidden;"
+                                  style="height: 0px; overflow: hidden; font-weight: bold;"
                                 >
                                    
                                 </div>
@@ -387,7 +388,7 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <span
-                                  class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                                 >
                                   04/02/2022
                                 </span>
@@ -396,7 +397,7 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <span
-                                  class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                                 >
                                   08/10/2021
                                 </span>
@@ -405,48 +406,25 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <div
-                                  class="ant-image css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-image css-dev-only-do-not-override-ch9ese css-var-root ant-image-css-var"
+                                  role="button"
+                                  tabindex="0"
                                 >
                                   <img
-                                    class="ant-image-img css-dev-only-do-not-override-1vjf2v5"
+                                    class="ant-image-img css-dev-only-do-not-override-ch9ese"
                                     src="http://loremflickr.com/640/480/abstract"
                                     style="max-width: 100px;"
                                   />
                                   <div
-                                    class="ant-image-mask"
-                                  >
-                                    <div
-                                      class="ant-image-mask-info"
-                                    >
-                                      <span
-                                        aria-label="eye"
-                                        class="anticon anticon-eye"
-                                        role="img"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          data-icon="eye"
-                                          fill="currentColor"
-                                          focusable="false"
-                                          height="1em"
-                                          viewBox="64 64 896 896"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
-                                          />
-                                        </svg>
-                                      </span>
-                                      Preview
-                                    </div>
-                                  </div>
+                                    class="ant-image-cover ant-image-cover-center"
+                                  />
                                 </div>
                               </td>
                               <td
                                 class="ant-table-cell"
                               >
                                 <span
-                                  class="ant-tag css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-tag ant-tag-filled css-dev-only-do-not-override-ch9ese css-var-root"
                                 >
                                   Nobis Et Ut
                                 </span>
@@ -460,7 +438,7 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <div
-                                  class="ant-space css-dev-only-do-not-override-mzwlov ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                  class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
                                 >
                                   <div
                                     class="ant-space-item"
@@ -469,7 +447,7 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                                       href="/posts/edit/11"
                                     >
                                       <button
-                                        class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-edit-button"
+                                        class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-edit-button"
                                         title=""
                                         type="button"
                                       >
@@ -506,7 +484,7 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                                       href="/posts/show/11"
                                     >
                                       <button
-                                        class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-show-button"
+                                        class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-show-button"
                                         title=""
                                         type="button"
                                       >
@@ -540,8 +518,7 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                                     class="ant-space-item"
                                   >
                                     <button
-                                      aria-describedby="test-id"
-                                      class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-delete-button"
+                                      class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-delete-button"
                                       title=""
                                       type="button"
                                     >
@@ -623,7 +600,7 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <span
-                                  class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                                 >
                                   09/24/2022
                                 </span>
@@ -632,7 +609,7 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <span
-                                  class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                                 >
                                   09/01/2021
                                 </span>
@@ -641,53 +618,30 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <div
-                                  class="ant-image css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-image css-dev-only-do-not-override-ch9ese css-var-root ant-image-css-var"
+                                  role="button"
+                                  tabindex="0"
                                 >
                                   <img
-                                    class="ant-image-img css-dev-only-do-not-override-1vjf2v5"
+                                    class="ant-image-img css-dev-only-do-not-override-ch9ese"
                                     src="http://loremflickr.com/640/480/abstract"
                                     style="max-width: 100px;"
                                   />
                                   <div
-                                    class="ant-image-mask"
-                                  >
-                                    <div
-                                      class="ant-image-mask-info"
-                                    >
-                                      <span
-                                        aria-label="eye"
-                                        class="anticon anticon-eye"
-                                        role="img"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          data-icon="eye"
-                                          fill="currentColor"
-                                          focusable="false"
-                                          height="1em"
-                                          viewBox="64 64 896 896"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
-                                          />
-                                        </svg>
-                                      </span>
-                                      Preview
-                                    </div>
-                                  </div>
+                                    class="ant-image-cover ant-image-cover-center"
+                                  />
                                 </div>
                               </td>
                               <td
                                 class="ant-table-cell"
                               >
                                 <span
-                                  class="ant-tag css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-tag ant-tag-filled css-dev-only-do-not-override-ch9ese css-var-root"
                                 >
                                   Error Eos Et
                                 </span>
                                 <span
-                                  class="ant-tag css-dev-only-do-not-override-1vjf2v5"
+                                  class="ant-tag ant-tag-filled css-dev-only-do-not-override-ch9ese css-var-root"
                                 >
                                   Nobis Et Ut
                                 </span>
@@ -701,7 +655,7 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                                 class="ant-table-cell"
                               >
                                 <div
-                                  class="ant-space css-dev-only-do-not-override-mzwlov ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                  class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
                                 >
                                   <div
                                     class="ant-space-item"
@@ -710,7 +664,7 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                                       href="/posts/edit/21"
                                     >
                                       <button
-                                        class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-edit-button"
+                                        class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-edit-button"
                                         title=""
                                         type="button"
                                       >
@@ -747,7 +701,7 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                                       href="/posts/show/21"
                                     >
                                       <button
-                                        class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-show-button"
+                                        class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-show-button"
                                         title=""
                                         type="button"
                                       >
@@ -781,8 +735,7 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                                     class="ant-space-item"
                                   >
                                     <button
-                                      aria-describedby="test-id"
-                                      class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-delete-button"
+                                      class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only refine-delete-button"
                                       title=""
                                       type="button"
                                     >
@@ -820,7 +773,7 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                     </div>
                   </div>
                   <ul
-                    class="ant-pagination ant-table-pagination ant-table-pagination-center css-dev-only-do-not-override-mzwlov ant-pagination-simple"
+                    class="ant-pagination ant-table-pagination ant-table-pagination-center css-dev-only-do-not-override-ch9ese css-var-root ant-pagination-simple"
                   >
                     <li
                       aria-disabled="true"
@@ -862,6 +815,7 @@ exports[`AntdListInferencer > should match the snapshot 1`] = `
                       title="1/1"
                     >
                       <input
+                        aria-label="Go to"
                         size="3"
                         type="text"
                         value="1"

--- a/packages/inferencer/src/inferencers/antd/__tests__/__snapshots__/show.test.tsx.snap
+++ b/packages/inferencer/src/inferencers/antd/__tests__/__snapshots__/show.test.tsx.snap
@@ -5,14 +5,16 @@ exports[`AntdShowInferencer > should match the snapshot 1`] = `
   <div>
     <div>
       <div
-        class="ant-page-header css-dev-only-do-not-override-1vjf2v5 ant-page-header-has-breadcrumb ant-page-header-ghost"
+        class="ant-page-header css-dev-only-do-not-override-ch9ese ant-page-header-has-breadcrumb ant-page-header-ghost"
         style="padding: 0px;"
       >
         <nav
-          class="ant-breadcrumb css-dev-only-do-not-override-1vjf2v5"
+          class="ant-breadcrumb css-dev-only-do-not-override-ch9ese css-var-root"
         >
           <ol>
-            <li>
+            <li
+              class="ant-breadcrumb-item"
+            >
               <span
                 class="ant-breadcrumb-link"
               >
@@ -33,7 +35,9 @@ exports[`AntdShowInferencer > should match the snapshot 1`] = `
             >
               /
             </li>
-            <li>
+            <li
+              class="ant-breadcrumb-item"
+            >
               <span
                 class="ant-breadcrumb-link"
               >
@@ -49,21 +53,21 @@ exports[`AntdShowInferencer > should match the snapshot 1`] = `
           </ol>
         </nav>
         <div
-          class="ant-page-header-heading css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-heading css-dev-only-do-not-override-ch9ese"
         >
           <div
-            class="ant-page-header-heading-left css-dev-only-do-not-override-1vjf2v5"
+            class="ant-page-header-heading-left css-dev-only-do-not-override-ch9ese"
           >
             <div
-              class="ant-page-header-back css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-back css-dev-only-do-not-override-ch9ese"
             >
               <div
                 aria-label="back"
-                class="ant-page-header-back-button css-dev-only-do-not-override-1vjf2v5"
+                class="ant-page-header-back-button css-dev-only-do-not-override-ch9ese"
                 role="button"
               >
                 <button
-                  class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-icon-only"
+                  class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-icon-only"
                   type="button"
                 >
                   <span
@@ -93,35 +97,35 @@ exports[`AntdShowInferencer > should match the snapshot 1`] = `
               </div>
             </div>
             <span
-              class="ant-page-header-heading-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-title css-dev-only-do-not-override-ch9ese"
             >
               <h4
-                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography refine-pageHeader-title css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               >
                 Show Post
               </h4>
             </span>
             <span
-              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-1vjf2v5"
+              class="ant-page-header-heading-sub-title css-dev-only-do-not-override-ch9ese"
             >
               <h5
-                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-1vjf2v5"
+                class="ant-typography ant-typography-secondary refine-pageHeader-subTitle css-dev-only-do-not-override-ch9ese css-var-root"
                 style="margin-bottom: 0px;"
               />
             </span>
           </div>
           <span
-            class="ant-page-header-heading-extra css-dev-only-do-not-override-1vjf2v5"
+            class="ant-page-header-heading-extra css-dev-only-do-not-override-ch9ese"
           >
             <div
-              class="ant-space css-dev-only-do-not-override-1vjf2v5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+              class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
             >
               <div
                 class="ant-space-item"
               >
                 <div
-                  class="ant-space css-dev-only-do-not-override-1vjf2v5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                  class="ant-space css-dev-only-do-not-override-ch9ese ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-root"
                   style="flex-wrap: wrap;"
                 >
                   <div
@@ -131,7 +135,7 @@ exports[`AntdShowInferencer > should match the snapshot 1`] = `
                       href="/posts"
                     >
                       <button
-                        class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-color-default ant-btn-variant-outlined refine-list-button"
+                        class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined refine-list-button"
                         title=""
                         type="button"
                       >
@@ -168,7 +172,7 @@ exports[`AntdShowInferencer > should match the snapshot 1`] = `
                     class="ant-space-item"
                   >
                     <button
-                      class="ant-btn css-dev-only-do-not-override-1vjf2v5 ant-btn-default ant-btn-color-default ant-btn-variant-outlined refine-refresh-button"
+                      class="ant-btn css-dev-only-do-not-override-ch9ese css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined refine-refresh-button"
                       type="button"
                     >
                       <span
@@ -205,52 +209,54 @@ exports[`AntdShowInferencer > should match the snapshot 1`] = `
           </span>
         </div>
         <div
-          class="ant-page-header-content css-dev-only-do-not-override-1vjf2v5"
+          class="ant-page-header-content css-dev-only-do-not-override-ch9ese"
         >
           <div
-            class="ant-spin-nested-loading css-dev-only-do-not-override-1vjf2v5"
+            aria-busy="false"
+            aria-live="polite"
+            class="ant-spin css-dev-only-do-not-override-ch9ese css-var-root"
           >
             <div
               class="ant-spin-container"
             >
               <div
-                class="ant-card css-dev-only-do-not-override-1vjf2v5"
+                class="ant-card css-dev-only-do-not-override-ch9ese css-var-root"
               >
                 <div
                   class="ant-card-body"
                 >
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Id
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     11
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Title
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Nobis exercitationem officia quia est.
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Slug
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     provident-culpa-facere
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Content
                   </h5>
@@ -258,135 +264,112 @@ exports[`AntdShowInferencer > should match the snapshot 1`] = `
                     Non velit blanditiis optio quo quaerat nam aperiam. Odit tempore consequatur voluptatibus molestias. Est nemo aut. Fugit aliquam enim eveniet veritatis. Magni et aut. Consequatur aliquid rerum vero. Quaerat debitis enim magnam. Dolorem est delectus architecto et accusantium. Velit quia vero. Aut necessitatibus quia at consequatur soluta accusantium.
                   </p>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Hit
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     920,557
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Category
                   </h5>
                   Numquam Saepe Illo
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     User
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Eriberto Leannon
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Status
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     draft
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Status Color
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     orange
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Created At
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     04/02/2022
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Published At
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     08/10/2021
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Image
                   </h5>
                   <div
-                    class="ant-image css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-image css-dev-only-do-not-override-ch9ese css-var-root ant-image-css-var"
+                    role="button"
+                    tabindex="0"
                   >
                     <img
-                      class="ant-image-img css-dev-only-do-not-override-1vjf2v5"
+                      class="ant-image-img css-dev-only-do-not-override-ch9ese"
                       src="http://loremflickr.com/640/480/abstract"
                       style="max-width: 200px;"
                     />
                     <div
-                      class="ant-image-mask"
-                    >
-                      <div
-                        class="ant-image-mask-info"
-                      >
-                        <span
-                          aria-label="eye"
-                          class="anticon anticon-eye"
-                          role="img"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            data-icon="eye"
-                            fill="currentColor"
-                            focusable="false"
-                            height="1em"
-                            viewBox="64 64 896 896"
-                            width="1em"
-                          >
-                            <path
-                              d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
-                            />
-                          </svg>
-                        </span>
-                        Preview
-                      </div>
-                    </div>
+                      class="ant-image-cover ant-image-cover-center"
+                    />
                   </div>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Tags
                   </h5>
                   <span
-                    class="ant-tag css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-tag ant-tag-filled css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Error Eos Et
                   </span>
                   <span
-                    class="ant-tag css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-tag ant-tag-filled css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Nobis Et Ut
                   </span>
                   <h5
-                    class="ant-typography css-dev-only-do-not-override-mzwlov"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     Language
                   </h5>
                   <span
-                    class="ant-typography css-dev-only-do-not-override-1vjf2v5"
+                    class="ant-typography css-dev-only-do-not-override-ch9ese css-var-root"
                   >
                     2
                   </span>

--- a/packages/live-previews/package.json
+++ b/packages/live-previews/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run --silent"
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.1",
     "@auth0/auth0-react": "^1.5.0",
     "@chakra-ui/react": "^2.5.1",
     "@emotion/react": "^11.8.2",
@@ -49,7 +49,7 @@
     "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-table": "^8.2.6",
     "@uiw/react-md-editor": "^4.0.8",
-    "antd": "^5.23.0",
+    "antd": "^6.3.5",
     "axios": "^1.11.0",
     "base64url": "^3.0.1",
     "casbin": "^5.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,7 +111,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -131,8 +131,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       casbin:
         specifier: ^5.15.2
         version: 5.29.0
@@ -178,7 +178,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@cerbos/http':
         specifier: ^0.6.0
         version: 0.6.0
@@ -201,8 +201,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -236,7 +236,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -256,8 +256,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -293,14 +293,14 @@ importers:
         specifier: ^1.17.2
         version: 1.20.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/plots':
         specifier: ^1.2.5
         version: 1.2.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@dnd-kit/core':
         specifier: ^6.0.8
         version: 6.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -332,8 +332,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       classnames:
         specifier: ^2.3.2
         version: 2.5.1
@@ -475,11 +475,11 @@ importers:
   examples/auth-antd:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -499,8 +499,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -534,7 +534,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@auth0/auth0-react':
         specifier: ^1.5.0
         version: 1.12.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -557,8 +557,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       axios:
         specifier: ^1.11.0
         version: 1.11.0
@@ -656,7 +656,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -676,8 +676,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       axios:
         specifier: ^1.11.0
         version: 1.11.0
@@ -766,7 +766,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@react-keycloak/web':
         specifier: ^3.4.0
         version: 3.4.0(keycloak-js@25.0.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
@@ -789,8 +789,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       axios:
         specifier: ^1.11.0
         version: 1.11.0
@@ -830,7 +830,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refine-auth/kinde-react':
         specifier: ^1.0.2
         version: 1.0.3(@refinedev/core@packages+core)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -850,8 +850,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       axios:
         specifier: ^1.11.0
         version: 1.11.0
@@ -1024,11 +1024,11 @@ importers:
   examples/auth-otp:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -1048,8 +1048,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -1083,7 +1083,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -1106,8 +1106,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -1400,7 +1400,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -1417,8 +1417,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -1451,11 +1451,11 @@ importers:
   examples/command-palette-kbar:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -1478,8 +1478,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -1685,7 +1685,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -1702,8 +1702,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -1737,7 +1737,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@craco/craco':
         specifier: ^7.1.0
         version: 7.1.0(@types/node@20.5.1)(postcss@8.4.38)(react-scripts@5.0.1(@babel/plugin-syntax-flow@7.27.1(@babel/core@7.24.4))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.4))(@types/babel__core@7.20.5)(@types/webpack@4.41.38)(bufferutil@4.0.8)(eslint@9.35.0(jiti@2.5.1))(react@19.1.0)(sass@1.75.0)(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(type-fest@4.41.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(webpack-hot-middleware@2.26.1))(typescript@5.8.3)
@@ -1760,8 +1760,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1794,11 +1794,11 @@ importers:
   examples/customization-offlayout-area:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -1815,8 +1815,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -1850,7 +1850,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -1870,8 +1870,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -1905,7 +1905,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -1922,8 +1922,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -1957,7 +1957,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -1977,8 +1977,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -2213,7 +2213,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -2230,8 +2230,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -2265,7 +2265,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/airtable':
         specifier: ^5.0.1
         version: link:../../packages/airtable
@@ -2285,8 +2285,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -2320,7 +2320,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -2340,8 +2340,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -2375,7 +2375,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -2395,8 +2395,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -2436,7 +2436,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -2459,8 +2459,8 @@ importers:
         specifier: ^5.0.6
         version: 5.0.6(graphql@16.9.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       graphql-ws:
         specifier: ^5.9.1
         version: 5.16.0(graphql@16.9.0)
@@ -2509,7 +2509,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -2529,8 +2529,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       graphql:
         specifier: ^15.6.1
         version: 15.8.0
@@ -2582,7 +2582,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -2602,8 +2602,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -2637,7 +2637,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -2657,8 +2657,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       graphql:
         specifier: ^15.6.1
         version: 15.8.0
@@ -2713,7 +2713,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -2733,8 +2733,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -2768,7 +2768,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -2794,8 +2794,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -2832,7 +2832,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -2852,8 +2852,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       axios:
         specifier: ^1.11.0
         version: 1.11.0
@@ -2905,7 +2905,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -2928,8 +2928,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       axios:
         specifier: ^1.11.0
         version: 1.11.0
@@ -2971,11 +2971,11 @@ importers:
   examples/data-provider-supabase:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -2995,8 +2995,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -3030,7 +3030,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -3050,8 +3050,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -3085,7 +3085,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -3105,8 +3105,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -3140,7 +3140,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -3160,8 +3160,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -3195,7 +3195,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -3215,8 +3215,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -3319,17 +3319,17 @@ importers:
         specifier: ^1.2.7
         version: 1.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/plots':
         specifier: ^1.2.5
         version: 1.2.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/use-emotion-css':
         specifier: ^1.0.4
-        version: 1.0.4(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.4(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@emotion/react':
         specifier: ^11.8.2
         version: 11.11.4(@types/react@19.1.8)(react@19.1.0)
@@ -3361,11 +3361,11 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd-style:
         specifier: ^3.6.1
-        version: 3.6.2(@types/react@19.1.8)(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 3.6.2(@types/react@19.1.8)(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -3638,7 +3638,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -3658,8 +3658,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -3693,7 +3693,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -3713,8 +3713,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -3748,7 +3748,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -3765,8 +3765,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -3800,7 +3800,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -3820,8 +3820,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -3855,7 +3855,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -3872,8 +3872,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -3907,7 +3907,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -3927,8 +3927,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -5174,14 +5174,14 @@ importers:
   examples/i18n-nextjs:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/nextjs-registry':
         specifier: ^1.0.0
-        version: 1.0.0(@ant-design/cssinjs@1.24.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@14.2.26(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.75.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.0(@ant-design/cssinjs@2.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@14.2.26(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.75.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -5204,8 +5204,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -5253,11 +5253,11 @@ importers:
   examples/i18n-react:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -5277,8 +5277,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       i18next:
         specifier: ^20.1.0
         version: 20.6.1
@@ -5324,7 +5324,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -5344,8 +5344,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -5512,11 +5512,11 @@ importers:
   examples/inferencer-antd:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -5539,8 +5539,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       i18next:
         specifier: ^20.1.0
         version: 20.6.1
@@ -5694,11 +5694,11 @@ importers:
   examples/inferencer-graphql-hasura:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -5721,8 +5721,8 @@ importers:
         specifier: ^2.0.4
         version: link:../../packages/react-router
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       graphql:
         specifier: ^15.6.1
         version: 15.8.0
@@ -6062,7 +6062,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -6082,8 +6082,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -6117,7 +6117,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -6137,8 +6137,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -6172,7 +6172,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -6192,11 +6192,11 @@ importers:
         specifier: ^7.0.1
         version: link:../../packages/strapi-v4
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd-style:
         specifier: ^3.6.1
-        version: 3.6.2(@types/react@19.1.8)(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 3.6.2(@types/react@19.1.8)(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       axios:
         specifier: ^1.11.0
         version: 1.11.0
@@ -6241,11 +6241,11 @@ importers:
   examples/live-provider-ably:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/ably':
         specifier: ^5.0.1
         version: link:../../packages/ably
@@ -6268,8 +6268,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -6303,7 +6303,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -6323,8 +6323,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -6383,7 +6383,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -6403,8 +6403,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -6437,11 +6437,11 @@ importers:
   examples/pixels:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -6458,8 +6458,8 @@ importers:
         specifier: ^6.0.2
         version: link:../../packages/supabase
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       dotenv:
         specifier: ^16.0.3
         version: 16.4.5
@@ -6495,11 +6495,11 @@ importers:
   examples/pixels-admin:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -6516,8 +6516,8 @@ importers:
         specifier: ^6.0.2
         version: link:../../packages/supabase
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       casbin:
         specifier: ^5.15.2
         version: 5.29.0
@@ -6668,11 +6668,11 @@ importers:
   examples/refine-week-invoice-generator:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@react-pdf/renderer':
         specifier: ^3.1.8
         version: 3.4.4(encoding@0.1.13)(react@19.1.0)
@@ -6698,8 +6698,8 @@ importers:
         specifier: ^7.0.1
         version: link:../../packages/strapi-v4
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       axios:
         specifier: ^1.11.0
         version: 1.11.0
@@ -6735,11 +6735,11 @@ importers:
   examples/search:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -6759,8 +6759,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -6800,7 +6800,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -6820,8 +6820,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -7108,7 +7108,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -7128,8 +7128,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -7162,11 +7162,11 @@ importers:
   examples/table-antd-table-filter:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -7186,8 +7186,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       dayjs:
         specifier: ^1.10.7
         version: 1.11.10
@@ -7224,7 +7224,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -7244,8 +7244,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -7279,7 +7279,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -7296,8 +7296,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -7331,7 +7331,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -7348,8 +7348,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -7383,7 +7383,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -7403,8 +7403,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -8334,7 +8334,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -8708,7 +8708,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -8728,8 +8728,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -8963,11 +8963,11 @@ importers:
   examples/tutorial-antd:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -8987,8 +8987,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -9362,7 +9362,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -9379,8 +9379,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -9414,7 +9414,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -9434,8 +9434,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -9935,7 +9935,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -9952,8 +9952,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -9987,7 +9987,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -10004,8 +10004,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       dayjs:
         specifier: ^1.10.7
         version: 1.11.10
@@ -10130,7 +10130,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -10150,8 +10150,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -10185,7 +10185,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -10205,8 +10205,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -10322,7 +10322,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -10339,8 +10339,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -10373,14 +10373,14 @@ importers:
   examples/with-nextjs:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/nextjs-registry':
         specifier: ^1.0.0
-        version: 1.0.0(@ant-design/cssinjs@1.24.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@14.2.26(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.75.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.0(@ant-design/cssinjs@2.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@14.2.26(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.75.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -10403,8 +10403,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -10449,14 +10449,14 @@ importers:
   examples/with-nextjs-next-auth:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/nextjs-registry':
         specifier: ^1.0.0
-        version: 1.0.0(@ant-design/cssinjs@1.24.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@14.2.26(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.75.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.0(@ant-design/cssinjs@2.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@14.2.26(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.75.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -10482,8 +10482,8 @@ importers:
         specifier: ^6.0.1
         version: link:../../packages/simple-rest
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -10648,7 +10648,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -10674,8 +10674,8 @@ importers:
         specifier: ^2.4.0
         version: 2.9.1(typescript@5.8.3)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       cookie:
         specifier: ^0.5.0
         version: 0.5.0
@@ -10712,7 +10712,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -10741,8 +10741,8 @@ importers:
         specifier: ^2.4.0
         version: 2.9.1(typescript@5.8.3)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       cookie:
         specifier: ^0.5.0
         version: 0.5.0
@@ -11013,7 +11013,7 @@ importers:
     dependencies:
       '@ant-design/v5-patch-for-react-19':
         specifier: ^1.0.3
-        version: 1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/antd':
         specifier: ^6.0.3
         version: link:../../packages/antd
@@ -11033,8 +11033,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -11171,11 +11171,11 @@ importers:
   packages/antd:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@ant-design/pro-layout':
-        specifier: ^7.21.1
-        version: 7.21.1(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-components':
+        specifier: ^2.8.10
+        version: 2.8.10(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(rc-field-form@2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@refinedev/ui-types':
         specifier: ^2.0.1
         version: link:../ui-types
@@ -11183,8 +11183,8 @@ importers:
         specifier: ^5.81.5
         version: 5.81.5(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       dayjs:
         specifier: ^1.10.7
         version: 1.11.10
@@ -12385,8 +12385,8 @@ importers:
   packages/inferencer:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@chakra-ui/react':
         specifier: ^2.5.1
         version: 2.8.2(@emotion/react@11.11.4(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(framer-motion@7.10.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -12427,8 +12427,8 @@ importers:
         specifier: ^8.2.6
         version: 8.16.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.0.3
-        version: 5.16.4(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       dayjs:
         specifier: ^1.10.7
         version: 1.11.10
@@ -12615,8 +12615,8 @@ importers:
   packages/live-previews:
     dependencies:
       '@ant-design/icons':
-        specifier: ^5.5.1
-        version: 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.1.1
+        version: 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@auth0/auth0-react':
         specifier: ^1.5.0
         version: 1.12.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -12726,8 +12726,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
-        specifier: ^5.23.0
-        version: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^6.3.5
+        version: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       axios:
         specifier: ^1.11.0
         version: 1.11.0
@@ -14090,26 +14090,20 @@ packages:
   '@ant-design/colors@4.0.5':
     resolution: {integrity: sha512-3mnuX2prnWOWvpFTS2WH2LoouWlOgtnIpc6IarWN6GOzzLF8dW/U8UctuvIPhoboETehZfJ61XP+CGakBEPJ3Q==}
 
-  '@ant-design/colors@7.0.2':
-    resolution: {integrity: sha512-7KJkhTiPiLHSu+LmMJnehfJ6242OCxSlR3xHVBecYxnMW8MS/878NXct1GqYARyL59fyeFdKRxXTfvR9SnDgJg==}
-
   '@ant-design/colors@7.2.1':
     resolution: {integrity: sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==}
 
-  '@ant-design/cssinjs-utils@1.1.3':
-    resolution: {integrity: sha512-nOoQMLW1l+xR1Co8NFVYiP8pZp3VjIIzqV6D6ShYF2ljtdwWJn5WSsH+7kvCktXL/yhEtWURKOfH5Xz/gzlwsg==}
+  '@ant-design/colors@8.0.1':
+    resolution: {integrity: sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ==}
+
+  '@ant-design/cssinjs-utils@2.1.2':
+    resolution: {integrity: sha512-5fTHQ158jJJ5dC/ECeyIdZUzKxE/mpEMRZxthyG1sw/AKRHKgJBg00Yi6ACVXgycdje7KahRNvNET/uBccwCnA==}
     peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
+      react: '>=18'
+      react-dom: '>=18'
 
   '@ant-design/cssinjs@1.20.0':
     resolution: {integrity: sha512-uG3iWzJxgNkADdZmc6W0Ci3iQAUOvLMcM8SnnmWq3r6JeocACft4ChnY/YWvI2Y+rG/68QBla/O+udke1yH3vg==}
-    peerDependencies:
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
-
-  '@ant-design/cssinjs@1.21.1':
-    resolution: {integrity: sha512-tyWnlK+XH7Bumd0byfbCiZNK43HEubMoCcu9VxwsAwiHdHTgWa+tMN0/yvxa+e8EzuFP1WdUNNPclRpVtD33lg==}
     peerDependencies:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
@@ -14120,8 +14114,18 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
 
+  '@ant-design/cssinjs@2.1.2':
+    resolution: {integrity: sha512-2Hy8BnCEH31xPeSLbhhB2ctCPXE2ZnASdi+KbSeS79BNbUhL9hAEe20SkUk+BR8aKTmqb6+FKFruk7w8z0VoRQ==}
+    peerDependencies:
+      react: '>=16.0.0'
+      react-dom: '>=16.0.0'
+
   '@ant-design/fast-color@2.0.6':
     resolution: {integrity: sha512-y2217gk4NqL35giHl72o6Zzqji9O7vHh9YmhUVkPtAOpoTCH4uWxo/pr4VE8t0+ChEPs0qo4eJRC5Q1eXWo3vA==}
+    engines: {node: '>=8.x'}
+
+  '@ant-design/fast-color@3.0.1':
+    resolution: {integrity: sha512-esKJegpW4nckh0o6kV3Tkb7NPIZYbPnnFxmQDUmL08ukXZAvV85TZBr70eGuke/CIArLaP6aw8lt9KILjnWuOw==}
     engines: {node: '>=8.x'}
 
   '@ant-design/graphs@1.4.1':
@@ -14133,15 +14137,15 @@ packages:
   '@ant-design/icons-svg@4.4.2':
     resolution: {integrity: sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==}
 
-  '@ant-design/icons@5.5.1':
-    resolution: {integrity: sha512-0UrM02MA2iDIgvLatWrj6YTCYe0F/cwXvVE0E2SqGrL7PZireQwgEKTKBisWpZyal5eXZLvuM98kju6YtYne8w==}
+  '@ant-design/icons@5.6.1':
+    resolution: {integrity: sha512-0/xS39c91WjPAZOWsvi1//zjx6kAp4kxWwctR6kuU6p133w8RU0D2dSCvZC19uQyharg/sAvYxGYWl01BbZZfg==}
     engines: {node: '>=8'}
     peerDependencies:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
 
-  '@ant-design/icons@5.6.1':
-    resolution: {integrity: sha512-0/xS39c91WjPAZOWsvi1//zjx6kAp4kxWwctR6kuU6p133w8RU0D2dSCvZC19uQyharg/sAvYxGYWl01BbZZfg==}
+  '@ant-design/icons@6.1.1':
+    resolution: {integrity: sha512-AMT4N2y++TZETNHiM77fs4a0uPVCJGuL5MTonk13Pvv7UN7sID1cNEZOc1qNqx6zLKAOilTEFAdAoAFKa0U//Q==}
     engines: {node: '>=8'}
     peerDependencies:
       react: '>=16.0.0'
@@ -14162,31 +14166,87 @@ packages:
       react: '>=16.8.4'
       react-dom: '>=16.8.4'
 
-  '@ant-design/pro-layout@7.21.1':
-    resolution: {integrity: sha512-9B+MBPTYZbhe5xdUxgfikoUZtB/77R3hAve8iI4fVNBoc4KAm/wpejasvKgWZn/8gRht8KOXfmfe2ngjz/BWOA==}
+  '@ant-design/pro-card@2.10.0':
+    resolution: {integrity: sha512-sLONn1odmE0Wkbse8pol4WiaEzBV8JU5s3FAMflPpycfUcbSaa1ktXzQ7LCo2SAvOS7gkfmpFjBPtrfbigKh4g==}
+    peerDependencies:
+      antd: ^4.24.15 || ^5.11.2
+      react: '>=17.0.0'
+
+  '@ant-design/pro-components@2.8.10':
+    resolution: {integrity: sha512-QHnnIXdmC5GTAtm6i8eeJy5yT9npPlFyxpDm+duiDrTRKRFaAQBduArxlH3DA/hoRCCypzPONxfK9BQNIhIyZA==}
     peerDependencies:
       antd: ^4.24.15 || ^5.11.2
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
 
-  '@ant-design/pro-provider@2.15.1':
-    resolution: {integrity: sha512-UiNhQ3Yl+h8liC24LLWpqbcdhC9ggiXvHeCYrqBHjOx2WNFWpWO5JP0327k3RQjShprt+jZQ/cdNHx6s7BToXA==}
+  '@ant-design/pro-descriptions@2.6.10':
+    resolution: {integrity: sha512-+4MbiOfumnWlW0Awm4m8JML5o3lR649FD24AaivCmr8BQvIAAXdTITnDMXEg8BqvdP4KOvNsStZrvYfqoev33A==}
+    peerDependencies:
+      antd: ^4.24.15 || ^5.11.2
+      react: '>=17.0.0'
+
+  '@ant-design/pro-field@3.1.0':
+    resolution: {integrity: sha512-+Dgp31WjD+iwg9KIRAMgNkfQivkJKMcYBrIBmho1e8ep/O0HgWSp48g70tBIWi/Lfem/Ky2schF7O8XCFouczw==}
+    peerDependencies:
+      antd: ^4.24.15 || ^5.11.2
+      react: '>=17.0.0'
+
+  '@ant-design/pro-form@2.32.0':
+    resolution: {integrity: sha512-GZnVAMeYv+YHJb17lJ7rX5PYuQPvEA6EotQnPbHi9tGLN3PfexcAd21rqzuO+OrulU2x7TEMDIxtY9MzvvOGbg==}
+    peerDependencies:
+      antd: ^4.24.15 || ^5.11.2
+      rc-field-form: '>=1.22.0'
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
+  '@ant-design/pro-layout@7.22.7':
+    resolution: {integrity: sha512-fvmtNA1r9SaasVIQIQt611VSlNxtVxDbQ3e+1GhYQza3tVJi/3gCZuDyfMfTnbLmf3PaW/YvLkn7MqDbzAzoLA==}
     peerDependencies:
       antd: ^4.24.15 || ^5.11.2
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
 
-  '@ant-design/pro-utils@2.16.1':
-    resolution: {integrity: sha512-GaBEgP638fvddO0YqevuIT3O8pQIrqfHhlQ4UDnf1JkhVxuVxP3XdwDituQWnyRoxLPSjNBZBOBghBBMb8nWsg==}
+  '@ant-design/pro-list@2.6.10':
+    resolution: {integrity: sha512-xSWwnqCr+hPEYR4qY7nFUaxO5RQBxNlFaPNmobP2i+Im31slk9JuAusgWeIYO0mNhLJuLbxd8CCma2AZij3fBQ==}
     peerDependencies:
       antd: ^4.24.15 || ^5.11.2
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
 
-  '@ant-design/react-slick@1.1.2':
-    resolution: {integrity: sha512-EzlvzE6xQUBrZuuhSAFTdsr4P2bBBHGZwKFemEfq8gIGyIQCxalYfZW/T2ORbtQx5rU69o+WycP3exY/7T1hGA==}
+  '@ant-design/pro-provider@2.16.2':
+    resolution: {integrity: sha512-0KmCH1EaOND787Jz6VRMYtLNZmqfT0JPjdUfxhyOxFfnBRfrjyfZgIa6CQoAJLEUMWv57PccWS8wRHVUUk2Yiw==}
     peerDependencies:
-      react: '>=16.9.0'
+      antd: ^4.24.15 || ^5.11.2
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
+  '@ant-design/pro-skeleton@2.2.1':
+    resolution: {integrity: sha512-3M2jNOZQZWEDR8pheY00OkHREfb0rquvFZLCa6DypGmiksiuuYuR9Y4iA82ZF+mva2FmpHekdwbje/GpbxqBeg==}
+    peerDependencies:
+      antd: ^4.24.15 || ^5.11.2
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
+  '@ant-design/pro-table@3.21.0':
+    resolution: {integrity: sha512-sI81d3FYRv5sXamUc+M5CsHZ9CchuUQgOAPzo5H4oPAVL5h+mkYGRsBzPsxQX7khTNpWjrAtPoRm5ipx3vvWog==}
+    peerDependencies:
+      antd: ^4.24.15 || ^5.11.2
+      rc-field-form: '>=1.22.0'
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
+  '@ant-design/pro-utils@2.18.0':
+    resolution: {integrity: sha512-8+ikyrN8L8a8Ph4oeHTOJEiranTj18+9+WHCHjKNdEfukI7Rjn8xpYdLJWb2AUJkb9d4eoAqjd5+k+7w81Df0w==}
+    peerDependencies:
+      antd: ^4.24.15 || ^5.11.2
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
+  '@ant-design/react-slick@2.0.0':
+    resolution: {integrity: sha512-HMS9sRoEmZey8LsE/Yo6+klhlzU12PisjrVcydW3So7RdklyEd2qehyU6a7Yp+OYN72mgsYs3NFCyP2lCPFVqg==}
+    peerDependencies:
+      react: ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@ant-design/use-emotion-css@1.0.4':
     resolution: {integrity: sha512-PekXeeHCpSNi6ziV62gy2Yy2MijssiVMaCJbbyOmPbeZJYQmB4FecJwlB+e2WuIbSHQdM3O9pyN4Cx3GJKxJkA==}
@@ -15387,10 +15447,6 @@ packages:
     resolution: {integrity: sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@7.25.7':
-    resolution: {integrity: sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/runtime@7.26.0':
     resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
     engines: {node: '>=6.9.0'}
@@ -16034,6 +16090,11 @@ packages:
 
   '@changesets/write@0.3.0':
     resolution: {integrity: sha512-slGLb21fxZVUYbyea+94uFiD6ntQW0M2hIKNznFizDhZPDgn2c/fv1UzzlW43RVzh1BEDuIqW6hzlJ1OflNmcw==}
+
+  '@chenshuai2144/sketch-color@1.0.9':
+    resolution: {integrity: sha512-obzSy26cb7Pm7OprWyVpgMpIlrZpZ0B7vbrU0RMbvRg0YAI890S5Xy02Aj1Nhl4+KTbi1lVYHt6HQP8Hm9s+1w==}
+    peerDependencies:
+      react: '>=16.12.0'
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -19350,24 +19411,91 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
-  '@rc-component/async-validator@5.0.4':
-    resolution: {integrity: sha512-qgGdcVIF604M9EqjNF0hbUTz42bz/RDtxWdWuU5EQe3hi7M8ob54B6B35rOsvX5eSvIHIzT9iH1R3n+hk3CGfg==}
+  '@rc-component/async-validator@5.1.0':
+    resolution: {integrity: sha512-n4HcR5siNUXRX23nDizbZBQPO0ZM/5oTtmKZ6/eqL0L2bo747cklFdZGRN2f+c9qWGICwDzrhW0H7tE9PptdcA==}
     engines: {node: '>=14.x'}
 
-  '@rc-component/color-picker@1.5.3':
-    resolution: {integrity: sha512-+tGGH3nLmYXTalVe0L8hSZNs73VTP5ueSHwUlDC77KKRaN7G4DS4wcpG5DTDzdcV/Yas+rzA6UGgIyzd8fS4cw==}
+  '@rc-component/cascader@1.14.0':
+    resolution: {integrity: sha512-Ip9356xwZUR2nbW5PRVGif4B/bDve4pLa/N+PGbvBaTnjbvmN4PFMBGQSmlDlzKP1ovxaYMvwF/dI9lXNLT4iQ==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@rc-component/checkbox@2.0.0':
+    resolution: {integrity: sha512-3CXGPpAR9gsPKeO2N78HAPOzU30UdemD6HGJoWVJOpa6WleaGB5kzZj3v6bdTZab31YuWgY/RxV3VKPctn0DwQ==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@rc-component/color-picker@2.0.1':
-    resolution: {integrity: sha512-WcZYwAThV/b2GISQ8F+7650r5ZZJ043E57aVBFkQ+kSY4C6wdofXgB0hBx+GPGpIU0Z81eETNoDUJMr7oy/P8Q==}
+  '@rc-component/collapse@1.2.0':
+    resolution: {integrity: sha512-ZRYSKSS39qsFx93p26bde7JUZJshsUBEQRlRXPuJYlAiNX0vyYlF5TsAm8JZN3LcF8XvKikdzPbgAtXSbkLUkw==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@rc-component/color-picker@3.1.1':
+    resolution: {integrity: sha512-OHaCHLHszCegdXmIq2ZRIZBN/EtpT6Wm8SG/gpzLATHbVKc/avvuKi+zlOuk05FTWvgaMmpxAko44uRJ3M+2pg==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@rc-component/context@1.4.0':
-    resolution: {integrity: sha512-kFcNxg9oLRMoL3qki0OMxK+7g5mypjgaaJp/pkOis/6rVxma9nJBF/8kCIuTYHUQNr0ii7MxqE33wirPZLJQ2w==}
+  '@rc-component/context@2.0.1':
+    resolution: {integrity: sha512-HyZbYm47s/YqtP6pKXNMjPEMaukyg7P0qVfgMLzr7YiFNMHbK2fKTAGzms9ykfGHSfyf75nBbgWw+hHkp+VImw==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/dialog@1.8.4':
+    resolution: {integrity: sha512-Ay6PM7phkTkquplG8fWfUGFZ2GTLx9diTl4f0d8Eqxd7W1u1KjE9AQooFQHOHnhZf0Ya3z51+5EKCWHmt/dNEw==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@rc-component/drawer@1.4.2':
+    resolution: {integrity: sha512-1ib+fZEp6FBu+YvcIktm+nCQ+Q+qIpwpoaJH6opGr4ofh2QMq+qdr5DLC4oCf5qf3pcWX9lUWPYX652k4ini8Q==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@rc-component/dropdown@1.0.2':
+    resolution: {integrity: sha512-6PY2ecUSYhDPhkNHHb4wfeAya04WhpmUSKzdR60G+kMNVUCX2vjT/AgTS0Lz0I/K6xrPMJ3enQbwVpeN3sHCgg==}
+    peerDependencies:
+      react: '>=16.11.0'
+      react-dom: '>=16.11.0'
+
+  '@rc-component/form@1.8.0':
+    resolution: {integrity: sha512-eUD5KKYnIZWmJwRA0vnyO/ovYUfHGU1svydY1OrqU5fw8Oz9Tdqvxvrlh0wl6xI/EW69dT7II49xpgOWzK3T5A==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/image@1.8.1':
+    resolution: {integrity: sha512-JfPCijmMl+EaMvbftsEs/4VHmTyJKsZBh5ujFowSA45i9NTVYS1vuHtgpVV/QrGa27kXwbVOZriffCe/PNKuMw==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/input-number@1.6.2':
+    resolution: {integrity: sha512-Gjcq7meZlCOiWN1t1xCC+7/s85humHVokTBI7PJgTfoyw5OWF74y3e6P8PHX104g9+b54jsodFIzyaj6p8LI9w==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/input@1.1.2':
+    resolution: {integrity: sha512-Q61IMR47piUBudgixJ30CciKIy9b1H95qe7GgEKOmSJVJXvFRWJllJfQry9tif+MX2cWFXWJf/RXz4kaCeq/Fg==}
+    peerDependencies:
+      react: '>=16.0.0'
+      react-dom: '>=16.0.0'
+
+  '@rc-component/mentions@1.6.0':
+    resolution: {integrity: sha512-KIkQNP6habNuTsLhUv0UGEOwG67tlmE7KNIJoQZZNggEZl5lQJTytFDb69sl5CK3TDdISCTjKP3nGEBKgT61CQ==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/menu@1.2.0':
+    resolution: {integrity: sha512-VWwDuhvYHSnTGj4n6bV3ISrLACcPAzdPOq3d0BzkeiM5cve8BEYfvkEhNoM0PLzv51jpcejeyrLXeMVIJ+QJlg==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
@@ -19376,50 +19504,191 @@ packages:
     resolution: {integrity: sha512-jS4E7T9Li2GuYwI6PyiVXmxTiM6b07rlD9Ge8uGZSCz3WlzcG5ZK7g5bbuKNeZ9pgUuPK/5guV781ujdVpm4HQ==}
     engines: {node: '>=8.x'}
 
-  '@rc-component/mutate-observer@1.1.0':
-    resolution: {integrity: sha512-QjrOsDXQusNwGZPf4/qRQasg7UFEj06XiCJ8iuiq/Io7CrHrgVi6Uuetw60WAMG1799v+aM8kyc+1L/GBbHSlw==}
+  '@rc-component/motion@1.3.2':
+    resolution: {integrity: sha512-itfd+GztzJYAb04Z4RkEub1TbJAfZc2Iuy8p44U44xD1F5+fNYFKI3897ijlbIyfvXkTmMm+KGcjkQQGMHywEQ==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/mutate-observer@2.0.1':
+    resolution: {integrity: sha512-AyarjoLU5YlxuValRi+w8JRH2Z84TBbFO2RoGWz9d8bSu0FqT8DtugH3xC3BV7mUwlmROFauyWuXFuq4IFbH+w==}
     engines: {node: '>=8.x'}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@rc-component/portal@1.1.2':
-    resolution: {integrity: sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==}
+  '@rc-component/notification@1.2.0':
+    resolution: {integrity: sha512-OX3J+zVU7rvoJCikjrfW7qOUp7zlDeFBK2eA3SFbGSkDqo63Sl4Ss8A04kFP+fxHSxMDIS9jYVEZtU1FNCFuBA==}
     engines: {node: '>=8.x'}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@rc-component/qrcode@1.0.0':
-    resolution: {integrity: sha512-L+rZ4HXP2sJ1gHMGHjsg9jlYBX/SLN2D6OxP9Zn3qgtpMWtO2vUfxVFwiogHpAIqs54FnALxraUy/BCO1yRIgg==}
+  '@rc-component/overflow@1.0.0':
+    resolution: {integrity: sha512-GSlBeoE0XTBi5cf3zl8Qh7Uqhn7v8RrlJ8ajeVpEkNe94HWy5l5BQ0Mwn2TVUq9gdgbfEMUmTX7tJFAg7mz0Rw==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/pagination@1.2.0':
+    resolution: {integrity: sha512-YcpUFE8dMLfSo6OARJlK6DbHHvrxz7pMGPGmC/caZSJJz6HRKHC1RPP001PRHCvG9Z/veD039uOQmazVuLJzlw==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/picker@1.9.1':
+    resolution: {integrity: sha512-9FBYYsvH3HMLICaPDA/1Th5FLaDkFa7qAtangIdlhKb3ZALaR745e9PsOhheJb6asS4QXc12ffiAcjdkZ4C5/g==}
+    engines: {node: '>=12.x'}
+    peerDependencies:
+      date-fns: '>= 2.x'
+      dayjs: '>= 1.x'
+      luxon: '>= 3.x'
+      moment: '>= 2.x'
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      date-fns:
+        optional: true
+      dayjs:
+        optional: true
+      luxon:
+        optional: true
+      moment:
+        optional: true
+
+  '@rc-component/portal@2.2.0':
+    resolution: {integrity: sha512-oc6FlA+uXCMiwArHsJyHcIkX4q6uKyndrPol2eWX8YPkAnztHOPsFIRtmWG4BMlGE5h7YIRE3NiaJ5VS8Lb1QQ==}
+    engines: {node: '>=12.x'}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@rc-component/progress@1.0.2':
+    resolution: {integrity: sha512-WZUnH9eGxH1+xodZKqdrHke59uyGZSWgj5HBM5Kwk5BrTMuAORO7VJ2IP5Qbm9aH3n9x3IcesqHHR0NWPBC7fQ==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/qrcode@1.1.1':
+    resolution: {integrity: sha512-LfLGNymzKdUPjXUbRP+xOhIWY4jQ+YMj5MmWAcgcAq1Ij8XP7tRmAXqyuv96XvLUBE/5cA8hLFl9eO1JQMujrA==}
     engines: {node: '>=8.x'}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@rc-component/tour@1.14.2':
-    resolution: {integrity: sha512-A75DZ8LVvahBIvxooj3Gvf2sxe+CGOkmzPNX7ek0i0AJHyKZ1HXe5ieIGo3m0FMdZfVOlbCJ952Duq8VKAHk6g==}
+  '@rc-component/rate@1.0.1':
+    resolution: {integrity: sha512-bkXxeBqDpl5IOC7yL7GcSYjQx9G8H+6kLYQnNZWeBYq2OYIv1MONd6mqKTjnnJYpV0cQIU2z3atdW0j1kttpTw==}
     engines: {node: '>=8.x'}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@rc-component/tour@1.15.1':
-    resolution: {integrity: sha512-Tr2t7J1DKZUpfJuDZWHxyxWpfmj8EZrqSgyMZ+BCdvKZ6r1UDsfU46M/iWAAFBy961Ssfom2kv5f3UcjIL2CmQ==}
+  '@rc-component/resize-observer@1.1.2':
+    resolution: {integrity: sha512-t/Bb0W8uvL4PYKAB3YcChC+DlHh0Wt5kM7q/J+0qpVEUMLe7Hk5zuvc9km0hMnTFPSx5Z7Wu/fzCLN6erVLE8Q==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/segmented@1.3.0':
+    resolution: {integrity: sha512-5J/bJ01mbDnoA6P/FW8SxUvKn+OgUSTZJPzCNnTBntG50tzoP7DydGhqxp7ggZXZls7me3mc2EQDXakU3iTVFg==}
+    peerDependencies:
+      react: '>=16.0.0'
+      react-dom: '>=16.0.0'
+
+  '@rc-component/select@1.6.15':
+    resolution: {integrity: sha512-SyVCWnqxCQZZcQvQJ/CxSjx2bGma6ds/HtnpkIfZVnt6RoEgbqUmHgD6vrzNarNXwbLXerwVzWwq8F3d1sst7g==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+
+  '@rc-component/slider@1.0.1':
+    resolution: {integrity: sha512-uDhEPU1z3WDfCJhaL9jfd2ha/Eqpdfxsn0Zb0Xcq1NGQAman0TWaR37OWp2vVXEOdV2y0njSILTMpTfPV1454g==}
     engines: {node: '>=8.x'}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@rc-component/trigger@2.1.1':
-    resolution: {integrity: sha512-UjHkedkgtEcgQu87w1VuWug1idoDJV7VUt0swxHXRcmei2uu1AuUzGBPEUlmOmXGJ+YtTgZfVLi7kuAUKoZTMA==}
+  '@rc-component/steps@1.2.2':
+    resolution: {integrity: sha512-/yVIZ00gDYYPHSY0JP+M+s3ZvuXLu2f9rEjQqiUDs7EcYsUYrpJ/1bLj9aI9R7MBR3fu/NGh6RM9u2qGfqp+Nw==}
     engines: {node: '>=8.x'}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@rc-component/trigger@2.3.0':
-    resolution: {integrity: sha512-iwaxZyzOuK0D7lS+0AQEtW52zUWxoGqTGkke3dRyb8pYiShmRpCjB/8TzPI4R6YySCH7Vm9BZj/31VPiiQTLBg==}
+  '@rc-component/switch@1.0.3':
+    resolution: {integrity: sha512-Jgi+EbOBquje/XNdofr7xbJQZPYJP+BlPfR0h+WN4zFkdtB2EWqEfvkXJWeipflwjWip0/17rNbxEAqs8hVHfw==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/table@1.9.1':
+    resolution: {integrity: sha512-FVI5ZS/GdB3BcgexfCYKi3iHhZS3Fr59EtsxORszYGrfpH1eWr33eDNSYkVfLI6tfJ7vftJDd9D5apfFWqkdJg==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@rc-component/tabs@1.7.0':
+    resolution: {integrity: sha512-J48cs2iBi7Ho3nptBxxIqizEliUC+ExE23faspUQKGQ550vaBlv3aGF8Epv/UB1vFWeoJDTW/dNzgIU0Qj5i/w==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/textarea@1.1.2':
+    resolution: {integrity: sha512-9rMUEODWZDMovfScIEHXWlVZuPljZ2pd1LKNjslJVitn4SldEzq5vO1CL3yy3Dnib6zZal2r2DPtjy84VVpF6A==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/tooltip@1.4.0':
+    resolution: {integrity: sha512-8Rx5DCctIlLI4raR0I0xHjVTf1aF48+gKCNeAAo5bmF5VoR5YED+A/XEqzXv9KKqrJDRcd3Wndpxh2hyzrTtSg==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@rc-component/tour@2.3.0':
+    resolution: {integrity: sha512-K04K9r32kUC+auBSQfr+Fss4SpSIS9JGe56oq/ALAX0p+i2ylYOI1MgR83yBY7v96eO6ZFXcM/igCQmubps0Ow==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/tree-select@1.8.0':
+    resolution: {integrity: sha512-iYsPq3nuLYvGqdvFAW+l+I9ASRIOVbMXyA8FGZg2lGym/GwkaWeJGzI4eJ7c9IOEhRj0oyfIN4S92Fl3J05mjQ==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+
+  '@rc-component/tree@1.2.4':
+    resolution: {integrity: sha512-5Gli43+m4R7NhpYYz3Z61I6LOw9yI6CNChxgVtvrO6xB1qML7iE6QMLVMB3+FTjo2yF6uFdAHtqWPECz/zbX5w==}
+    engines: {node: '>=10.x'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+
+  '@rc-component/trigger@3.9.0':
+    resolution: {integrity: sha512-X8btpwfrT27AgrZVOz4swclhEHTZcqaHeQMXXBgveagOiakTa36uObXbdwerXffgV8G9dH1fAAE0DHtVQs8EHg==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@rc-component/upload@1.1.0':
+    resolution: {integrity: sha512-LIBV90mAnUE6VK5N4QvForoxZc4XqEYZimcp7fk+lkE4XwHHyJWxpIXQQwMU8hJM+YwBbsoZkGksL1sISWHQxw==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/util@1.10.1':
+    resolution: {integrity: sha512-q++9S6rUa5Idb/xIBNz6jtvumw5+O5YV5V0g4iK9mn9jWs4oGJheE3ZN1kAnE723AXyaD8v95yeOASmdk8Jnng==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@rc-component/virtual-list@1.0.2':
+    resolution: {integrity: sha512-uvTol/mH74FYsn5loDGJxo+7kjkO4i+y4j87Re1pxJBs0FaeuMuLRzQRGaXwnMcV1CxpZLi2Z56Rerj2M00fjQ==}
     engines: {node: '>=8.x'}
     peerDependencies:
       react: '>=16.9.0'
@@ -21229,6 +21498,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  add-dom-event-listener@1.1.0:
+    resolution: {integrity: sha512-WCxx1ixHT0GQU9hb0KI/mhgRQhnU+U3GvwY6ZvVjYq8rsihIGoaIOUbY0yMPBxLH5MDtr0kz3fisWGNcbWW7Jw==}
+
   add-stream@1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
 
@@ -21365,17 +21637,11 @@ packages:
       antd: '>=5.8.1'
       react: '>=18'
 
-  antd@5.16.4:
-    resolution: {integrity: sha512-H3LtVz5hiNgs0lL8U6pzi11rluR6RDRw1cm2pWX6CsvgZmybWsaTBV2h+d+zmgFfuch53TWs5uztLdAldIoYYw==}
+  antd@6.3.5:
+    resolution: {integrity: sha512-8BPz9lpZWQm42PTx7yL4KxWAotVuqINiKcoYRcLtdd5BFmAcAZicVyFTnBJyRDlzGZFZeRW3foGu6jXYFnej6Q==}
     peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  antd@5.26.7:
-    resolution: {integrity: sha512-iCyXN6+i2CUVEOSzzJKfbKeg115qoJhGvSkCh5uzAf9hANwHUOJQhsMn+KtN+Lx/2NQ6wfM7nGZ+7NPNO5Pn1w==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -21454,9 +21720,6 @@ packages:
   array-includes@3.1.9:
     resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
     engines: {node: '>= 0.4'}
-
-  array-tree-filter@2.1.0:
-    resolution: {integrity: sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw==}
 
   array-union@1.0.2:
     resolution: {integrity: sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==}
@@ -21563,9 +21826,6 @@ packages:
 
   async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
-
-  async-validator@4.2.5:
-    resolution: {integrity: sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==}
 
   async@3.2.5:
     resolution: {integrity: sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==}
@@ -24698,12 +24958,12 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
@@ -25633,6 +25893,9 @@ packages:
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
+
+  is-mobile@5.0.0:
+    resolution: {integrity: sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==}
 
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
@@ -27988,9 +28251,6 @@ packages:
     resolution: {integrity: sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==}
     engines: {node: ^10.13.0 || >=12.0.0}
 
-  omit.js@2.0.2:
-    resolution: {integrity: sha512-hJmu9D+bNB40YpL9jYebQl4lsTW6yEHRTroJzNLqQJYHm7c+NQnJGfZmIWh8S3q3KoaxV1aLhV6B3+0N0/kyJg==}
-
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -28316,6 +28576,10 @@ packages:
 
   path-to-regexp@8.0.0:
     resolution: {integrity: sha512-GAWaqWlTjYK/7SVpIUA6CTxmcg65SP30sbjdCvyYReosRkk7Z/LyHWwkK3Vu0FcIi0FNTADUs4eh1AsU5s10cg==}
+    engines: {node: '>=16'}
+
+  path-to-regexp@8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
     engines: {node: '>=16'}
 
   path-type@3.0.0:
@@ -29126,11 +29390,6 @@ packages:
 
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
-  qrcode.react@3.1.0:
-    resolution: {integrity: sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-
   qs@6.10.4:
     resolution: {integrity: sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==}
     engines: {node: '>=0.6'}
@@ -29208,252 +29467,15 @@ packages:
     resolution: {integrity: sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==}
     engines: {node: '>= 0.10'}
 
-  rc-cascader@3.24.1:
-    resolution: {integrity: sha512-RgKuYgEGPx+6wCgguYFHjMsDZdCyydZd58YJRCfYQ8FObqLnZW0x/vUcEyPjhWIj1EhjV958IcR+NFPDbbj9kg==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-cascader@3.34.0:
-    resolution: {integrity: sha512-KpXypcvju9ptjW9FaN2NFcA2QH9E9LHKq169Y0eWtH4e/wHQ5Wh5qZakAgvb8EKZ736WZ3B0zLLOBsrsja5Dag==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-checkbox@3.2.0:
-    resolution: {integrity: sha512-8inzw4y9dAhZmv/Ydl59Qdy5tdp9CKg4oPVcRigi+ga/yKPZS5m5SyyQPtYSgbcqHRYOdUhiPSeKfktc76du1A==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-checkbox@3.5.0:
-    resolution: {integrity: sha512-aOAQc3E98HteIIsSqm6Xk2FPKIER6+5vyEFMZfo73TqM+VVAIqOkHoPjgKLqSNtVLWScoaM7vY2ZrGEheI79yg==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-collapse@3.7.3:
-    resolution: {integrity: sha512-60FJcdTRn0X5sELF18TANwtVi7FtModq649H11mYF1jh83DniMoM4MqY627sEKRCTm4+WXfGDcB7hY5oW6xhyw==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-collapse@3.9.0:
-    resolution: {integrity: sha512-swDdz4QZ4dFTo4RAUMLL50qP0EY62N2kvmk2We5xYdRwcRn8WcYtuetCJpwpaCbUfUt5+huLpVxhvmnK+PHrkA==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-dialog@9.4.0:
-    resolution: {integrity: sha512-AScCexaLACvf8KZRqCPz12BJ8olszXOS4lKlkMyzDQHS1m0zj1KZMYgmMCh39ee0Dcv8kyrj8mTqxuLyhH+QuQ==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-dialog@9.6.0:
-    resolution: {integrity: sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-drawer@7.1.0:
-    resolution: {integrity: sha512-nBE1rF5iZvpavoyqhSSz2mk/yANltA7g3aF0U45xkx381n3we/RKs9cJfNKp9mSWCedOKWt9FLEwZDaAaOGn2w==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-drawer@7.3.0:
-    resolution: {integrity: sha512-DX6CIgiBWNpJIMGFO8BAISFkxiuKitoizooj4BDyee8/SnBn0zwO2FHrNDpqqepj0E/TFTDpmEBCyFuTgC7MOg==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-dropdown@4.2.0:
-    resolution: {integrity: sha512-odM8Ove+gSh0zU27DUj5cG1gNKg7mLWBYzB5E4nNLrLwBmYEgYP43vHKDGOVZcJSVElQBI0+jTQgjnq0NfLjng==}
-    peerDependencies:
-      react: '>=16.11.0'
-      react-dom: '>=16.11.0'
-
-  rc-dropdown@4.2.1:
-    resolution: {integrity: sha512-YDAlXsPv3I1n42dv1JpdM7wJ+gSUBfeyPK59ZpBD9jQhK9jVuxpjj3NmWQHOBceA1zEPVX84T2wbdb2SD0UjmA==}
-    peerDependencies:
-      react: '>=16.11.0'
-      react-dom: '>=16.11.0'
-
-  rc-field-form@1.44.0:
-    resolution: {integrity: sha512-el7w87fyDUsca63Y/s8qJcq9kNkf/J5h+iTdqG5WsSHLH0e6Usl7QuYSmSVzJMgtp40mOVZIY/W/QP9zwrp1FA==}
+  rc-field-form@2.7.1:
+    resolution: {integrity: sha512-vKeSifSJ6HoLaAB+B8aq/Qgm8a3dyxROzCtKNCsBQgiverpc4kWDQihoUwzUj+zNWJOykwSY4dNX3QrGwtVb9A==}
     engines: {node: '>=8.x'}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  rc-field-form@2.7.0:
-    resolution: {integrity: sha512-hgKsCay2taxzVnBPZl+1n4ZondsV78G++XVsMIJCAoioMjlMQR9YwAp7JZDIECzIu2Z66R+f4SFIRrO2DjDNAA==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-image@7.12.0:
-    resolution: {integrity: sha512-cZ3HTyyckPnNnUb9/DRqduqzLfrQRyi+CdHjdqgsyDpI3Ln5UX1kXnAhPBSJj9pVRzwRFgqkN7p9b6HBDjmu/Q==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-image@7.6.0:
-    resolution: {integrity: sha512-tL3Rvd1sS+frZQ01i+tkeUPaOeFz2iG9/scAt/Cfs0hyCRVA/w0Pu1J/JxIX8blalvmHE0bZQRYdOmRAzWu4Hg==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-input-number@9.0.0:
-    resolution: {integrity: sha512-RfcDBDdWFFetouWFXBA+WPEC8LzBXyngr9b+yTLVIygfFu7HiLRGn/s/v9wwno94X7KFvnb28FNynMGj9XJlDQ==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-input-number@9.5.0:
-    resolution: {integrity: sha512-bKaEvB5tHebUURAEXw35LDcnRZLq3x1k7GxfAqBMzmpHkDGzjAtnUL8y4y5N15rIFIg5IJgwr211jInl3cipag==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-input@1.4.5:
-    resolution: {integrity: sha512-AjzykhwnwYTRSwwgCu70CGKBIAv6bP2nqnFptnNTprph/TF1BAs0Qxl91mie/BR6n827WIJB6ZjaRf9iiMwAfw==}
-    peerDependencies:
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
-
-  rc-input@1.8.0:
-    resolution: {integrity: sha512-KXvaTbX+7ha8a/k+eg6SYRVERK0NddX8QX7a7AnRvUa/rEH0CNMlpcBzBkhI0wp2C8C4HlMoYl8TImSN+fuHKA==}
-    peerDependencies:
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
-
-  rc-mentions@2.11.1:
-    resolution: {integrity: sha512-upb4AK1SRFql7qGnbLEvJqLMugVVIyjmwBJW9L0eLoN9po4JmJZaBzmKA4089fNtsU8k6l/tdZiVafyooeKnLw==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-mentions@2.20.0:
-    resolution: {integrity: sha512-w8HCMZEh3f0nR8ZEd466ATqmXFCMGMN5UFCzEUL0bM/nGw/wOS2GgRzKBcm19K++jDyuWCOJOdgcKGXU3fXfbQ==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-menu@9.13.0:
-    resolution: {integrity: sha512-1l8ooCB3HcYJKCltC/s7OxRKRjgymdl9htrCeGZcXNaMct0RxZRK6OPV3lPhVksIvAGMgzPd54ClpZ5J4b8cZA==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-menu@9.16.1:
-    resolution: {integrity: sha512-ghHx6/6Dvp+fw8CJhDUHFHDJ84hJE3BXNCzSgLdmNiFErWSOaZNsihDAsKq9ByTALo/xkNIwtDFGIl6r+RPXBg==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-motion@2.9.0:
-    resolution: {integrity: sha512-XIU2+xLkdIr1/h6ohPZXyPBMvOmuyFZQ/T0xnawz+Rh+gh4FINcnZmMT5UTIj6hgI0VLDjTaPeRd+smJeSPqiQ==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-motion@2.9.5:
-    resolution: {integrity: sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-notification@5.4.0:
-    resolution: {integrity: sha512-li19y9RoYJciF3WRFvD+DvWS70jdL8Fr+Gfb/OshK+iY6iTkwzoigmSIp76/kWh5tF5i/i9im12X3nsF85GYdA==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-notification@5.6.4:
-    resolution: {integrity: sha512-KcS4O6B4qzM3KH7lkwOB7ooLPZ4b6J+VMmQgT51VZCeEcmghdeR4IrMcFq0LG+RPdnbe/ArT086tGM8Snimgiw==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-overflow@1.3.2:
-    resolution: {integrity: sha512-nsUm78jkYAoPygDAcGZeC2VwIg/IBGSodtOY3pMof4W3M9qRJgqaDYm03ZayHlde3I6ipliAxbN0RUcGf5KOzw==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-pagination@4.0.4:
-    resolution: {integrity: sha512-GGrLT4NgG6wgJpT/hHIpL9nELv27A1XbSZzECIuQBQTVSf4xGKxWr6I/jhpRPauYEWEbWVw22ObG6tJQqwJqWQ==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-pagination@5.1.0:
-    resolution: {integrity: sha512-8416Yip/+eclTFdHXLKTxZvn70duYVGTvUUWbckCCZoIl3jagqke3GLsFrMs0bsQBikiYpZLD9206Ej4SOdOXQ==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-picker@4.11.3:
-    resolution: {integrity: sha512-MJ5teb7FlNE0NFHTncxXQ62Y5lytq6sh5nUw0iH8OkHL/TjARSEvSHpr940pWgjGANpjCwyMdvsEV55l5tYNSg==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      date-fns: '>= 2.x'
-      dayjs: '>= 1.x'
-      luxon: '>= 3.x'
-      moment: '>= 2.x'
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-    peerDependenciesMeta:
-      date-fns:
-        optional: true
-      dayjs:
-        optional: true
-      luxon:
-        optional: true
-      moment:
-        optional: true
-
-  rc-picker@4.4.2:
-    resolution: {integrity: sha512-MdbAXvwiGyhb+bHe66qPps8xPQivzEgcyCp3/MPK4T+oER0gOmVRCEDxaD4FhYG/7GLH3rDrHpu79BvEn2JFTQ==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      date-fns: '>= 2.x'
-      dayjs: '>= 1.x'
-      luxon: '>= 3.x'
-      moment: '>= 2.x'
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-    peerDependenciesMeta:
-      date-fns:
-        optional: true
-      dayjs:
-        optional: true
-      luxon:
-        optional: true
-      moment:
-        optional: true
-
-  rc-progress@4.0.0:
-    resolution: {integrity: sha512-oofVMMafOCokIUIBnZLNcOZFsABaUw8PPrf1/y0ZBvKZNpOiu5h4AO9vv11Sw0p4Hb3D0yGWuEattcQGtNJ/aw==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-rate@2.12.0:
-    resolution: {integrity: sha512-g092v5iZCdVzbjdn28FzvWebK2IutoVoiTeqoLTj9WM7SjA/gOJIw5/JFZMRyJYYVe1jLAU2UhAfstIpCNRozg==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-rate@2.13.1:
-    resolution: {integrity: sha512-QUhQ9ivQ8Gy7mtMZPAjLbxBt5y9GRp65VcUyGUMF3N3fhiftivPHdpuDIaWIMOTEprAjZPC08bls1dQB+I1F2Q==}
-    engines: {node: '>=8.x'}
+  rc-resize-observer@0.2.6:
+    resolution: {integrity: sha512-YX6nYnd6fk7zbuvT6oSDMKiZjyngjHoy+fz+vL3Tez38d/G5iGdaDJa2yE7345G6sc4Mm1IGRUIwclvltddhmA==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
@@ -29464,161 +29486,14 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  rc-resize-observer@1.4.3:
-    resolution: {integrity: sha512-YZLjUbyIWox8E9i9C3Tm7ia+W7euPItNWSPX5sCcQTYbnwDb5uNpnLHQCG1f22oZWUhLw4Mv2tFmeWe68CDQRQ==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-segmented@2.3.0:
-    resolution: {integrity: sha512-I3FtM5Smua/ESXutFfb8gJ8ZPcvFR+qUgeeGFQHBOvRiRKyAk4aBE5nfqrxXx+h8/vn60DQjOt6i4RNtrbOobg==}
-    peerDependencies:
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
-
-  rc-segmented@2.7.0:
-    resolution: {integrity: sha512-liijAjXz+KnTRVnxxXG2sYDGd6iLL7VpGGdR8gwoxAXy2KglviKCxLWZdjKYJzYzGSUwKDSTdYk8brj54Bn5BA==}
-    peerDependencies:
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
-
-  rc-select@14.13.1:
-    resolution: {integrity: sha512-A1VHqjIOemxLnUGRxLGVqXBs8jGcJemI5NXxOJwU5PQc1wigAu1T4PRLgMkTPDOz8gPhlY9dwsPzMgakMc2QjQ==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-
-  rc-select@14.16.8:
-    resolution: {integrity: sha512-NOV5BZa1wZrsdkKaiK7LHRuo5ZjZYMDxPP6/1+09+FB4KoNi8jcG1ZqLE3AVCxEsYMBe65OBx71wFoHRTP3LRg==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-
-  rc-slider@10.6.2:
-    resolution: {integrity: sha512-FjkoFjyvUQWcBo1F3RgSglky3ar0+qHLM41PlFVYB4Bj3RD8E/Mv7kqMouLFBU+3aFglMzzctAIWRwajEuueSw==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-slider@11.1.8:
-    resolution: {integrity: sha512-2gg/72YFSpKP+Ja5AjC5DPL1YnV8DEITDQrcc1eASrUYjl0esptaBVJBh5nLTXCCp15eD8EuGjwezVGSHhs9tQ==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-steps@6.0.1:
-    resolution: {integrity: sha512-lKHL+Sny0SeHkQKKDJlAjV5oZ8DwCdS2hFhAkIjuQt1/pB81M0cA0ErVFdHq9+jmPmFw1vJB2F5NBzFXLJxV+g==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-switch@4.1.0:
-    resolution: {integrity: sha512-TI8ufP2Az9oEbvyCeVE4+90PDSljGyuwix3fV58p7HV2o4wBnVToEyomJRVyTaZeqNPAp+vqeo4Wnj5u0ZZQBg==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-table@7.45.4:
-    resolution: {integrity: sha512-6aSbGrnkN2GLSt3s1x+wa4f3j/VEgg1uKPpaLY5qHH1/nFyreS2V7DFJ0TfUb18allf2FQl7oVYEjTixlBXEyQ==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-table@7.51.1:
-    resolution: {integrity: sha512-5iq15mTHhvC42TlBLRCoCBLoCmGlbRZAlyF21FonFnS/DIC8DeRqnmdyVREwt2CFbPceM0zSNdEeVfiGaqYsKw==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-tabs@14.1.1:
-    resolution: {integrity: sha512-5nOr9PVpJy2SWHTLgv1+kESDOb0tFzl0cYU9r9d8LfL0Wg9i/n1B558rmkxdQHgBwMqxmwoyPSAbQROxMQe8nw==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-tabs@15.6.1:
-    resolution: {integrity: sha512-/HzDV1VqOsUWyuC0c6AkxVYFjvx9+rFPKZ32ejxX0Uc7QCzcEjTA9/xMgv4HemPKwzBNX8KhGVbbumDjnj92aA==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-textarea@1.10.2:
-    resolution: {integrity: sha512-HfaeXiaSlpiSp0I/pvWpecFEHpVysZ9tpDLNkxQbMvMz6gsr7aVZ7FpWP9kt4t7DB+jJXesYS0us1uPZnlRnwQ==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-textarea@1.6.3:
-    resolution: {integrity: sha512-8k7+8Y2GJ/cQLiClFMg8kUXOOdvcFQrnGeSchOvI2ZMIVvX5a3zQpLxoODL0HTrvU63fPkRmMuqaEcOF9dQemA==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-tooltip@6.2.0:
-    resolution: {integrity: sha512-iS/3iOAvtDh9GIx1ulY7EFUXUtktFccNLsARo3NPgLf0QW9oT0w3dA9cYWlhqAKmD+uriEwdWz1kH0Qs4zk2Aw==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-tooltip@6.4.0:
-    resolution: {integrity: sha512-kqyivim5cp8I5RkHmpsp1Nn/Wk+1oeloMv9c7LXNgDxUpGm+RbXJGL+OPvDlcRnx9DBeOe4wyOIl4OKUERyH1g==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-tree-select@5.19.0:
-    resolution: {integrity: sha512-f4l5EsmSGF3ggj76YTzKNPY9SnXfFaer7ZccTSGb3urUf54L+cCqyT+UsPr+S5TAr8mZSxJ7g3CgkCe+cVQ6sw==}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-
-  rc-tree-select@5.27.0:
-    resolution: {integrity: sha512-2qTBTzwIT7LRI1o7zLyrCzmo5tQanmyGbSaGTIf7sYimCklAToVVfpMC6OAldSKolcnjorBYPNSKQqJmN3TCww==}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-
-  rc-tree@5.13.1:
-    resolution: {integrity: sha512-FNhIefhftobCdUJshO7M8uZTA9F4OPGVXqGfZkkD/5soDeOhwO06T/aKTrg0WD8gRg/pyfq+ql3aMymLHCTC4A==}
-    engines: {node: '>=10.x'}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-
-  rc-tree@5.8.5:
-    resolution: {integrity: sha512-PRfcZtVDNkR7oh26RuNe1hpw11c1wfgzwmPFL0lnxGnYefe9lDAO6cg5wJKIAwyXFVt5zHgpjYmaz0CPy1ZtKg==}
-    engines: {node: '>=10.x'}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-
-  rc-tree@5.8.7:
-    resolution: {integrity: sha512-cpsIQZ4nNYwpj6cqPRt52e/69URuNdgQF9wZ10InmEf8W3+i0A41OVmZWwHuX9gegQSqj+DPmaDkZFKQZ+ZV1w==}
-    engines: {node: '>=10.x'}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-
   rc-upload@4.5.2:
     resolution: {integrity: sha512-QO3ne77DwnAPKFn0bA5qJM81QBjQi0e0NHdkvpFyY73Bea2NfITiotqJqVjHgeYPOJu5lLVR32TNGP084aSoXA==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  rc-upload@4.9.2:
-    resolution: {integrity: sha512-nHx+9rbd1FKMiMRYsqQ3NkXUv7COHPBo3X1Obwq9SWS6/diF/A0aJ5OHubvwUAIDs+4RMleljV0pcrNUc823GQ==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
+  rc-util@4.21.1:
+    resolution: {integrity: sha512-Z+vlkSQVc1l8O2UjR3WQ+XdWlhj5q9BMQNLk2iOBch75CqPfrJyGtcWMcnhRlNuDu0Ndtt4kLVO8JI8BrABobg==}
 
   rc-util@5.39.1:
     resolution: {integrity: sha512-OW/ERynNDgNr4y0oiFmtes3rbEamXw7GHGbkbNd9iRr7kgT03T6fT0b9WpJ3mbxKhyOcAHnGcIoh5u/cjrC2OQ==}
@@ -29626,28 +29501,8 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  rc-util@5.41.0:
-    resolution: {integrity: sha512-xtlCim9RpmVv0Ar2Nnc3WfJCxjQkTf3xHPWoFdjp1fSs2NirQwqiQrfqdU9HUe0kdfb168M/T8Dq0IaX50xeKg==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
   rc-util@5.44.4:
     resolution: {integrity: sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-virtual-list@3.11.5:
-    resolution: {integrity: sha512-iZRW99m5jAxtwKNPLwUrPryurcnKpXBdTyhuBp6ythf7kg/otKO5cCiIvL55GQwU0QGSlouQS0tnkciRMJUwRQ==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-virtual-list@3.14.2:
-    resolution: {integrity: sha512-rA+W5xryhklJAcmswNyuKB3ZGeB855io+yOFQK5u/RXhjdshGblfKpNkQr4/9fBhZns0+uiL/0/s6IP2krtSmg==}
-    engines: {node: '>=8.x'}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
@@ -30017,6 +29872,11 @@ packages:
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
+
+  reactcss@1.2.3:
+    resolution: {integrity: sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==}
+    peerDependencies:
+      react: '*'
 
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
@@ -31593,10 +31453,6 @@ packages:
   throttle-debounce@2.3.0:
     resolution: {integrity: sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==}
     engines: {node: '>=8'}
-
-  throttle-debounce@5.0.0:
-    resolution: {integrity: sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==}
-    engines: {node: '>=12.22'}
 
   throttle-debounce@5.0.2:
     resolution: {integrity: sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==}
@@ -33196,19 +33052,19 @@ snapshots:
     dependencies:
       tinycolor2: 1.6.0
 
-  '@ant-design/colors@7.0.2':
-    dependencies:
-      '@ctrl/tinycolor': 3.6.1
-
   '@ant-design/colors@7.2.1':
     dependencies:
       '@ant-design/fast-color': 2.0.6
 
-  '@ant-design/cssinjs-utils@1.1.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@ant-design/colors@8.0.1':
     dependencies:
-      '@ant-design/cssinjs': 1.24.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@babel/runtime': 7.26.0
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/fast-color': 3.0.1
+
+  '@ant-design/cssinjs-utils@2.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@ant-design/cssinjs': 2.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.28.6
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
@@ -33224,9 +33080,9 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       stylis: 4.3.2
 
-  '@ant-design/cssinjs@1.21.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@ant-design/cssinjs@1.24.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@emotion/hash': 0.8.0
       '@emotion/unitless': 0.7.5
       classnames: 2.5.1
@@ -33236,21 +33092,23 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       stylis: 4.3.4
 
-  '@ant-design/cssinjs@1.24.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@ant-design/cssinjs@2.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@emotion/hash': 0.8.0
       '@emotion/unitless': 0.7.5
-      classnames: 2.5.1
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
       csstype: 3.1.3
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       stylis: 4.3.4
 
   '@ant-design/fast-color@2.0.6':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
+
+  '@ant-design/fast-color@3.0.1': {}
 
   '@ant-design/graphs@1.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -33265,30 +33123,29 @@ snapshots:
 
   '@ant-design/icons-svg@4.4.2': {}
 
-  '@ant-design/icons@5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@ant-design/colors': 7.0.2
-      '@ant-design/icons-svg': 4.4.2
-      '@babel/runtime': 7.25.7
-      classnames: 2.5.1
-      rc-util: 5.41.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
   '@ant-design/icons@5.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@ant-design/colors': 7.2.1
       '@ant-design/icons-svg': 4.4.2
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       classnames: 2.5.1
       rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@ant-design/nextjs-registry@1.0.0(@ant-design/cssinjs@1.24.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@14.2.26(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.75.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@ant-design/icons@6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@ant-design/cssinjs': 1.24.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      antd: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/colors': 8.0.1
+      '@ant-design/icons-svg': 4.4.2
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@ant-design/nextjs-registry@1.0.0(@ant-design/cssinjs@2.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@14.2.26(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.75.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@ant-design/cssinjs': 2.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      antd: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next: 14.2.26(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.75.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -33301,46 +33158,184 @@ snapshots:
       react-content-loader: 5.1.4(react@19.1.0)
       react-dom: 19.1.0(react@19.1.0)
 
-  '@ant-design/pro-layout@7.21.1(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@ant-design/pro-card@2.10.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@ant-design/cssinjs': 1.21.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@ant-design/icons': 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@ant-design/pro-provider': 2.15.1(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@ant-design/pro-utils': 2.16.1(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@babel/runtime': 7.25.7
+      '@ant-design/cssinjs': 1.24.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/icons': 5.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-provider': 2.16.2(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-utils': 2.18.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.28.6
+      antd: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      classnames: 2.5.1
+      rc-resize-observer: 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+    transitivePeerDependencies:
+      - react-dom
+
+  '@ant-design/pro-components@2.8.10(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(rc-field-form@2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@ant-design/pro-card': 2.10.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-descriptions': 2.6.10(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(rc-field-form@2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-field': 3.1.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-form': 2.32.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(rc-field-form@2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-layout': 7.22.7(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-list': 2.6.10(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(rc-field-form@2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-provider': 2.16.2(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-skeleton': 2.2.1(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-table': 3.21.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(rc-field-form@2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-utils': 2.18.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.28.6
+      antd: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    transitivePeerDependencies:
+      - rc-field-form
+
+  '@ant-design/pro-descriptions@2.6.10(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(rc-field-form@2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@ant-design/pro-field': 3.1.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-form': 2.32.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(rc-field-form@2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-provider': 2.16.2(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-skeleton': 2.2.1(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-utils': 2.18.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.28.6
+      antd: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      rc-resize-observer: 0.2.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+    transitivePeerDependencies:
+      - rc-field-form
+      - react-dom
+
+  '@ant-design/pro-field@3.1.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@ant-design/icons': 5.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-provider': 2.16.2(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-utils': 2.18.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.28.6
+      '@chenshuai2144/sketch-color': 1.0.9(react@19.1.0)
+      antd: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      classnames: 2.5.1
+      dayjs: 1.11.13
+      lodash: 4.17.21
+      lodash-es: 4.17.21
+      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      swr: 2.2.5(react@19.1.0)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@ant-design/pro-form@2.32.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(rc-field-form@2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@ant-design/icons': 5.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-field': 3.1.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-provider': 2.16.2(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-utils': 2.18.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.28.6
+      '@chenshuai2144/sketch-color': 1.0.9(react@19.1.0)
+      '@umijs/use-params': 1.0.9(react@19.1.0)
+      antd: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      classnames: 2.5.1
+      dayjs: 1.11.13
+      lodash: 4.17.21
+      lodash-es: 4.17.21
+      rc-field-form: 2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      rc-resize-observer: 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@ant-design/pro-layout@7.22.7(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@ant-design/cssinjs': 1.24.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/icons': 5.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-provider': 2.16.2(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-utils': 2.18.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.28.6
       '@umijs/route-utils': 4.0.1
       '@umijs/use-params': 1.0.9(react@19.1.0)
-      antd: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      antd: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       classnames: 2.5.1
       lodash: 4.17.21
       lodash-es: 4.17.21
-      omit.js: 2.0.2
-      path-to-regexp: 8.0.0
+      path-to-regexp: 8.2.0
       rc-resize-observer: 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.41.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       swr: 2.2.5(react@19.1.0)
       warning: 4.0.3
 
-  '@ant-design/pro-provider@2.15.1(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@ant-design/pro-list@2.6.10(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(rc-field-form@2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@ant-design/cssinjs': 1.24.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@babel/runtime': 7.26.0
+      '@ant-design/icons': 5.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-card': 2.10.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-field': 3.1.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-table': 3.21.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(rc-field-form@2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-utils': 2.18.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.28.6
+      antd: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      classnames: 2.5.1
+      dayjs: 1.11.13
+      rc-resize-observer: 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      rc-util: 4.21.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    transitivePeerDependencies:
+      - rc-field-form
+
+  '@ant-design/pro-provider@2.16.2(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@ant-design/cssinjs': 1.24.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.28.6
       '@ctrl/tinycolor': 3.6.1
-      antd: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      antd: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       dayjs: 1.11.13
       rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       swr: 2.2.5(react@19.1.0)
 
-  '@ant-design/pro-utils@2.16.1(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@ant-design/pro-skeleton@2.2.1(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      antd: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@ant-design/pro-table@3.21.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(rc-field-form@2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@ant-design/cssinjs': 1.24.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/icons': 5.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-card': 2.10.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-field': 3.1.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-form': 2.32.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(rc-field-form@2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-provider': 2.16.2(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-utils': 2.18.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.28.6
+      '@dnd-kit/core': 6.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.0)
+      antd: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      classnames: 2.5.1
+      dayjs: 1.11.13
+      lodash: 4.17.21
+      lodash-es: 4.17.21
+      rc-field-form: 2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      rc-resize-observer: 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@ant-design/pro-utils@2.18.0(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@ant-design/icons': 5.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@ant-design/pro-provider': 2.15.1(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@babel/runtime': 7.26.0
-      antd: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/pro-provider': 2.16.2(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.28.6
+      antd: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       classnames: 2.5.1
       dayjs: 1.11.13
       lodash: 4.17.21
@@ -33351,25 +33346,25 @@ snapshots:
       safe-stable-stringify: 2.4.3
       swr: 2.2.5(react@19.1.0)
 
-  '@ant-design/react-slick@1.1.2(react@19.1.0)':
+  '@ant-design/react-slick@2.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
+      '@babel/runtime': 7.28.6
+      clsx: 2.1.1
       json2mq: 0.2.0
       react: 19.1.0
-      resize-observer-polyfill: 1.5.1
+      react-dom: 19.1.0(react@19.1.0)
       throttle-debounce: 5.0.2
 
-  '@ant-design/use-emotion-css@1.0.4(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@ant-design/use-emotion-css@1.0.4(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@emotion/css': 11.11.2
-      antd: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      antd: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@ant-design/v5-patch-for-react-19@1.0.3(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@ant-design/v5-patch-for-react-19@1.0.3(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      antd: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      antd: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
@@ -33697,7 +33692,7 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/generator': 7.28.0
       '@babel/parser': 7.28.0
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@babel/traverse': 7.28.0
       '@babel/types': 7.28.2
       babel-preset-fbjs: 3.4.0(@babel/core@7.28.0)
@@ -33721,7 +33716,7 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/generator': 7.28.0
       '@babel/parser': 7.28.0
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@babel/traverse': 7.28.0
       '@babel/types': 7.28.2
       babel-preset-fbjs: 3.4.0(@babel/core@7.28.0)
@@ -36121,10 +36116,6 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@babel/runtime@7.25.7':
-    dependencies:
-      regenerator-runtime: 0.14.1
-
   '@babel/runtime@7.26.0':
     dependencies:
       regenerator-runtime: 0.14.1
@@ -36966,7 +36957,7 @@ snapshots:
 
   '@changesets/apply-release-plan@7.0.0':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@changesets/config': 3.0.0
       '@changesets/get-version-range-type': 0.4.0
       '@changesets/git': 3.0.0(patch_hash=nu3pnoo55obvdtzwuff3eqw2pe)
@@ -36982,7 +36973,7 @@ snapshots:
 
   '@changesets/assemble-release-plan@6.0.0':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.0.0
       '@changesets/types': 6.0.0
@@ -37067,7 +37058,7 @@ snapshots:
 
   '@changesets/get-release-plan@4.0.0':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@changesets/assemble-release-plan': 6.0.0
       '@changesets/config': 3.0.0
       '@changesets/pre': 2.0.0
@@ -37079,7 +37070,7 @@ snapshots:
 
   '@changesets/git@3.0.0(patch_hash=nu3pnoo55obvdtzwuff3eqw2pe)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@changesets/errors': 0.2.0
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
@@ -37098,7 +37089,7 @@ snapshots:
 
   '@changesets/pre@2.0.0':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@changesets/errors': 0.2.0
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
@@ -37106,7 +37097,7 @@ snapshots:
 
   '@changesets/read@0.6.0':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@changesets/git': 3.0.0(patch_hash=nu3pnoo55obvdtzwuff3eqw2pe)
       '@changesets/logger': 0.1.0
       '@changesets/parse': 0.4.0
@@ -37123,11 +37114,17 @@ snapshots:
 
   '@changesets/write@0.3.0':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@changesets/types': 6.0.0
       fs-extra: 7.0.1
       human-id: 1.0.2
       prettier: 2.8.8
+
+  '@chenshuai2144/sketch-color@1.0.9(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      reactcss: 1.2.3(react@19.1.0)
+      tinycolor2: 1.6.0
 
   '@colors/colors@1.5.0':
     optional: true
@@ -39788,14 +39785,14 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -39965,7 +39962,7 @@ snapshots:
 
   '@mui/private-theming@6.1.6(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@mui/utils': 6.1.7(@types/react@19.1.8)(react@19.1.0)
       prop-types: 15.8.1
       react: 19.1.0
@@ -39974,7 +39971,7 @@ snapshots:
 
   '@mui/private-theming@6.1.7(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@mui/utils': 6.1.7(@types/react@19.1.8)(react@19.1.0)
       prop-types: 15.8.1
       react: 19.1.0
@@ -39983,7 +39980,7 @@ snapshots:
 
   '@mui/styled-engine@6.1.6(@emotion/react@11.11.4(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@emotion/cache': 11.13.1
       '@emotion/serialize': 1.3.2
       '@emotion/sheet': 1.4.0
@@ -39996,7 +39993,7 @@ snapshots:
 
   '@mui/styled-engine@6.1.7(@emotion/react@11.11.4(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@emotion/cache': 11.13.1
       '@emotion/serialize': 1.3.2
       '@emotion/sheet': 1.4.0
@@ -40025,7 +40022,7 @@ snapshots:
 
   '@mui/system@6.1.7(@emotion/react@11.11.4(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@mui/private-theming': 6.1.7(@types/react@19.1.8)(react@19.1.0)
       '@mui/styled-engine': 6.1.7(@emotion/react@11.11.4(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(react@19.1.0)
       '@mui/types': 7.2.19(@types/react@19.1.8)
@@ -40063,7 +40060,7 @@ snapshots:
 
   '@mui/utils@6.1.7(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@mui/types': 7.2.19(@types/react@19.1.8)
       '@types/prop-types': 15.7.13
       clsx: 2.1.1
@@ -40209,7 +40206,7 @@ snapshots:
 
   '@mui/x-internals@7.23.0(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@mui/utils': 6.1.7(@types/react@19.1.8)(react@19.1.0)
       react: 19.1.0
     transitivePeerDependencies:
@@ -40217,7 +40214,7 @@ snapshots:
 
   '@mui/x-internals@7.23.5(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@mui/utils': 6.1.7(@types/react@19.1.8)(react@19.1.0)
       react: 19.1.0
     transitivePeerDependencies:
@@ -40235,7 +40232,7 @@ snapshots:
 
   '@mui/x-license@7.23.2(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@mui/utils': 6.1.7(@types/react@19.1.8)(react@19.1.0)
       react: 19.1.0
     transitivePeerDependencies:
@@ -40718,16 +40715,16 @@ snapshots:
 
   '@probe.gl/env@3.6.0':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
 
   '@probe.gl/log@3.6.0':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@probe.gl/env': 3.6.0
 
   '@probe.gl/stats@3.6.0':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
 
   '@qualifyze/airtable-formulator@1.3.1':
     dependencies:
@@ -40735,13 +40732,13 @@ snapshots:
 
   '@radix-ui/number@1.0.0':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
 
   '@radix-ui/number@1.1.1': {}
 
   '@radix-ui/primitive@1.0.0':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -40853,12 +40850,12 @@ snapshots:
 
   '@radix-ui/react-compose-refs@1.0.0(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       react: 19.1.0
 
   '@radix-ui/react-compose-refs@1.0.1(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
@@ -40885,7 +40882,7 @@ snapshots:
 
   '@radix-ui/react-context@1.0.0(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       react: 19.1.0
 
   '@radix-ui/react-context@1.1.2(@types/react@19.1.8)(react@19.1.0)':
@@ -40918,7 +40915,7 @@ snapshots:
 
   '@radix-ui/react-direction@1.0.0(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       react: 19.1.0
 
   '@radix-ui/react-direction@1.1.1(@types/react@19.1.8)(react@19.1.0)':
@@ -41114,7 +41111,7 @@ snapshots:
 
   '@radix-ui/react-portal@1.0.4(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -41134,7 +41131,7 @@ snapshots:
 
   '@radix-ui/react-presence@1.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@radix-ui/react-compose-refs': 1.0.0(react@19.1.0)
       '@radix-ui/react-use-layout-effect': 1.0.0(react@19.1.0)
       react: 19.1.0
@@ -41152,14 +41149,14 @@ snapshots:
 
   '@radix-ui/react-primitive@1.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@radix-ui/react-slot': 1.0.1(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
   '@radix-ui/react-primitive@1.0.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@radix-ui/react-slot': 1.0.2(@types/react@19.1.8)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -41312,13 +41309,13 @@ snapshots:
 
   '@radix-ui/react-slot@1.0.1(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@radix-ui/react-compose-refs': 1.0.0(react@19.1.0)
       react: 19.1.0
 
   '@radix-ui/react-slot@1.0.2(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.1.8)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
@@ -41410,7 +41407,7 @@ snapshots:
 
   '@radix-ui/react-use-callback-ref@1.0.0(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       react: 19.1.0
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.8)(react@19.1.0)':
@@ -41450,7 +41447,7 @@ snapshots:
 
   '@radix-ui/react-use-layout-effect@1.0.0(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       react: 19.1.0
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.8)(react@19.1.0)':
@@ -41490,102 +41487,352 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@rc-component/async-validator@5.0.4':
+  '@rc-component/async-validator@5.1.0':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
 
-  '@rc-component/color-picker@1.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@rc-component/cascader@1.14.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
-      '@ctrl/tinycolor': 3.6.1
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/select': 1.6.15(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/tree': 1.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@rc-component/color-picker@2.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@rc-component/checkbox@2.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@ant-design/fast-color': 2.0.6
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@rc-component/context@1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@rc-component/collapse@1.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.28.6
+      '@rc-component/motion': 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/color-picker@3.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@ant-design/fast-color': 3.0.1
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/context@2.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/dialog@1.8.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/motion': 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/portal': 2.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/drawer@1.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/motion': 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/portal': 2.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/dropdown@1.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/trigger': 3.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/form@1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/async-validator': 5.1.0
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/image@1.8.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/motion': 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/portal': 2.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/input-number@1.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/mini-decimal': 1.1.0
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/input@1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/mentions@1.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/input': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/menu': 1.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/textarea': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/trigger': 3.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/menu@1.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/motion': 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/overflow': 1.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/trigger': 3.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
   '@rc-component/mini-decimal@1.1.0':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
 
-  '@rc-component/mutate-observer@1.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@rc-component/motion@1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@rc-component/portal@1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@rc-component/mutate-observer@2.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@rc-component/qrcode@1.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@rc-component/notification@1.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/motion': 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@rc-component/tour@1.14.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@rc-component/overflow@1.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/portal': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@rc-component/trigger': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.28.6
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@rc-component/tour@1.15.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@rc-component/pagination@1.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/portal': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@rc-component/trigger': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@rc-component/trigger@2.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@rc-component/picker@1.9.1(date-fns@4.1.0)(dayjs@1.11.13)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/portal': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-resize-observer: 1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/overflow': 1.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/trigger': 3.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      date-fns: 4.1.0
+      dayjs: 1.11.13
+      luxon: 3.4.4
+      moment: 2.30.1
+
+  '@rc-component/portal@2.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@rc-component/trigger@2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@rc-component/progress@1.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/portal': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-resize-observer: 1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/qrcode@1.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/rate@1.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/resize-observer@1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/segmented@1.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@rc-component/motion': 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/select@1.6.15(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/overflow': 1.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/trigger': 3.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/virtual-list': 1.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/slider@1.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/steps@1.2.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/switch@1.0.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/table@1.9.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/context': 2.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/virtual-list': 1.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/tabs@1.7.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/dropdown': 1.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/menu': 1.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/motion': 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/textarea@1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/input': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/tooltip@1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/trigger': 3.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/tour@2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/portal': 2.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/trigger': 3.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/tree-select@1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/select': 1.6.15(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/tree': 1.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/tree@1.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/motion': 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/virtual-list': 1.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/trigger@3.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/motion': 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/portal': 2.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/upload@1.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/util@1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      is-mobile: 5.0.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-is: 18.3.1
+
+  '@rc-component/virtual-list@1.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
@@ -41609,11 +41856,11 @@ snapshots:
 
   '@react-pdf/fns@2.2.1':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
 
   '@react-pdf/font@2.5.1(encoding@0.1.13)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@react-pdf/types': 2.5.0
       cross-fetch: 3.1.8(encoding@0.1.13)
       fontkit: 2.0.2
@@ -41623,7 +41870,7 @@ snapshots:
 
   '@react-pdf/image@2.3.6(encoding@0.1.13)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@react-pdf/png-js': 2.3.1
       cross-fetch: 3.1.8(encoding@0.1.13)
       jay-peg: 1.0.2
@@ -41632,7 +41879,7 @@ snapshots:
 
   '@react-pdf/layout@3.12.1(encoding@0.1.13)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@react-pdf/fns': 2.2.1
       '@react-pdf/image': 2.3.6(encoding@0.1.13)
       '@react-pdf/pdfkit': 3.1.10
@@ -41649,7 +41896,7 @@ snapshots:
 
   '@react-pdf/pdfkit@3.1.10':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@react-pdf/png-js': 2.3.1
       browserify-zlib: 0.2.0
       crypto-js: 4.2.0
@@ -41665,7 +41912,7 @@ snapshots:
 
   '@react-pdf/render@3.4.4':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@react-pdf/fns': 2.2.1
       '@react-pdf/primitives': 3.1.1
       '@react-pdf/textkit': 4.4.1
@@ -41696,7 +41943,7 @@ snapshots:
 
   '@react-pdf/stylesheet@4.2.5':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@react-pdf/fns': 2.2.1
       '@react-pdf/types': 2.5.0
       color-string: 1.9.1
@@ -41706,7 +41953,7 @@ snapshots:
 
   '@react-pdf/textkit@4.4.1':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@react-pdf/fns': 2.2.1
       bidi-js: 1.0.3
       hyphen: 1.10.4
@@ -43885,6 +44132,10 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  add-dom-event-listener@1.1.0:
+    dependencies:
+      object-assign: 4.1.1
+
   add-stream@1.0.0: {}
 
   address@1.2.2: {}
@@ -44006,7 +44257,7 @@ snapshots:
 
   ansicolors@0.3.2: {}
 
-  antd-style@3.6.2(@types/react@19.1.8)(antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  antd-style@3.6.2(@types/react@19.1.8)(antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@ant-design/cssinjs': 1.20.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@babel/runtime': 7.24.4
@@ -44016,119 +44267,61 @@ snapshots:
       '@emotion/serialize': 1.1.4
       '@emotion/server': 11.11.0(@emotion/css@11.11.2)
       '@emotion/utils': 1.2.1
-      antd: 5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      antd: 6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       use-merge-value: 1.2.0(react@19.1.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
 
-  antd@5.16.4(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  antd@6.3.5(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@ant-design/colors': 7.0.2
-      '@ant-design/cssinjs': 1.20.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@ant-design/icons': 5.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@ant-design/react-slick': 1.1.2(react@19.1.0)
-      '@babel/runtime': 7.24.4
-      '@ctrl/tinycolor': 3.6.1
-      '@rc-component/color-picker': 1.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@rc-component/mutate-observer': 1.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@rc-component/tour': 1.14.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@rc-component/trigger': 2.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      copy-to-clipboard: 3.3.3
+      '@ant-design/colors': 8.0.1
+      '@ant-design/cssinjs': 2.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/cssinjs-utils': 2.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/fast-color': 3.0.1
+      '@ant-design/icons': 6.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@ant-design/react-slick': 2.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.28.6
+      '@rc-component/cascader': 1.14.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/checkbox': 2.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/collapse': 1.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/color-picker': 3.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/dialog': 1.8.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/drawer': 1.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/dropdown': 1.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/form': 1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/image': 1.8.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/input': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/input-number': 1.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/mentions': 1.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/menu': 1.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/motion': 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/mutate-observer': 2.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/notification': 1.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/pagination': 1.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/picker': 1.9.1(date-fns@4.1.0)(dayjs@1.11.13)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/progress': 1.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/qrcode': 1.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/rate': 1.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/segmented': 1.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/select': 1.6.15(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/slider': 1.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/steps': 1.2.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/switch': 1.0.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/table': 1.9.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/tabs': 1.7.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/textarea': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/tooltip': 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/tour': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/tree': 1.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/tree-select': 1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/trigger': 3.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/upload': 1.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rc-component/util': 1.10.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      clsx: 2.1.1
       dayjs: 1.11.13
-      qrcode.react: 3.1.0(react@19.1.0)
-      rc-cascader: 3.24.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-checkbox: 3.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-collapse: 3.7.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-dialog: 9.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-drawer: 7.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-dropdown: 4.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-field-form: 1.44.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-image: 7.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-input: 1.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-input-number: 9.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-mentions: 2.11.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-menu: 9.13.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-motion: 2.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-notification: 5.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-pagination: 4.0.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-picker: 4.4.2(date-fns@4.1.0)(dayjs@1.11.13)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-progress: 4.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-rate: 2.12.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-resize-observer: 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-segmented: 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-select: 14.13.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-slider: 10.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-steps: 6.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-switch: 4.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-table: 7.45.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-tabs: 14.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-textarea: 1.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-tooltip: 6.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-tree: 5.8.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-tree-select: 5.19.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-upload: 4.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.39.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      scroll-into-view-if-needed: 3.1.0
-      throttle-debounce: 5.0.0
-    transitivePeerDependencies:
-      - date-fns
-      - luxon
-      - moment
-
-  antd@5.26.7(date-fns@4.1.0)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@ant-design/colors': 7.2.1
-      '@ant-design/cssinjs': 1.24.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@ant-design/cssinjs-utils': 1.1.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@ant-design/fast-color': 2.0.6
-      '@ant-design/icons': 5.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@ant-design/react-slick': 1.1.2(react@19.1.0)
-      '@babel/runtime': 7.26.0
-      '@rc-component/color-picker': 2.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@rc-component/mutate-observer': 1.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@rc-component/qrcode': 1.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@rc-component/tour': 1.15.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@rc-component/trigger': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      copy-to-clipboard: 3.3.3
-      dayjs: 1.11.13
-      rc-cascader: 3.34.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-checkbox: 3.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-collapse: 3.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-dialog: 9.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-drawer: 7.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-dropdown: 4.2.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-field-form: 2.7.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-image: 7.12.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-input: 1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-input-number: 9.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-mentions: 2.20.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-menu: 9.16.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-notification: 5.6.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-pagination: 5.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-picker: 4.11.3(date-fns@4.1.0)(dayjs@1.11.13)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-progress: 4.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-rate: 2.13.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-resize-observer: 1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-segmented: 2.7.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-select: 14.16.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-slider: 11.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-steps: 6.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-switch: 4.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-table: 7.51.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-tabs: 15.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-textarea: 1.10.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-tooltip: 6.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-tree: 5.13.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-tree-select: 5.27.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-upload: 4.9.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       scroll-into-view-if-needed: 3.1.0
@@ -44220,8 +44413,6 @@ snapshots:
       get-intrinsic: 1.3.0
       is-string: 1.1.1
       math-intrinsics: 1.1.0
-
-  array-tree-filter@2.1.0: {}
 
   array-union@1.0.2:
     dependencies:
@@ -44373,8 +44564,6 @@ snapshots:
 
   async-limiter@1.0.1: {}
 
-  async-validator@4.2.5: {}
-
   async@3.2.5: {}
 
   asyncairtable@2.3.1(encoding@0.1.13):
@@ -44492,7 +44681,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       cosmiconfig: 7.1.0
       resolve: 1.22.8
 
@@ -44657,7 +44846,7 @@ snapshots:
       '@babel/preset-env': 7.24.4(@babel/core@7.24.4)
       '@babel/preset-react': 7.24.1(@babel/core@7.24.4)
       '@babel/preset-typescript': 7.24.1(@babel/core@7.24.4)
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       babel-plugin-macros: 3.1.0
       babel-plugin-transform-react-remove-prop-types: 0.4.24
     transitivePeerDependencies:
@@ -46192,7 +46381,7 @@ snapshots:
 
   date-fns@2.30.0:
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
 
   date-fns@4.1.0: {}
 
@@ -46418,7 +46607,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       csstype: 3.1.3
 
   dom-serializer@0.2.2:
@@ -46999,7 +47188,7 @@ snapshots:
       '@typescript-eslint/parser': 5.48.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
       eslint: 9.35.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.48.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.48.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-react: 7.37.5(eslint@9.35.0(jiti@2.5.1))
@@ -47050,7 +47239,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.48.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -47065,14 +47254,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.48.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.48.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.48.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
       '@typescript-eslint/parser': 5.48.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
       eslint: 9.35.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.48.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -47169,7 +47358,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.35.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.48.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.48.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.48.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -47219,7 +47408,7 @@ snapshots:
 
   eslint-plugin-jsx-a11y@6.8.0(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       aria-query: 5.3.0
       array-includes: 3.1.8
       array.prototype.flatmap: 1.3.2
@@ -49604,6 +49793,8 @@ snapshots:
 
   is-map@2.0.3: {}
 
+  is-mobile@5.0.0: {}
+
   is-module@1.0.0: {}
 
   is-negative-zero@2.0.3: {}
@@ -51528,7 +51719,7 @@ snapshots:
 
   media-query-parser@2.0.2:
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
 
   media-typer@0.3.0: {}
 
@@ -52985,8 +53176,6 @@ snapshots:
 
   oidc-token-hash@5.0.3: {}
 
-  omit.js@2.0.2: {}
-
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -53350,6 +53539,8 @@ snapshots:
   path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.0.0: {}
+
+  path-to-regexp@8.2.0: {}
 
   path-type@3.0.0:
     dependencies:
@@ -54034,7 +54225,7 @@ snapshots:
 
   probe.gl@3.6.0:
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@probe.gl/env': 3.6.0
       '@probe.gl/log': 3.6.0
       '@probe.gl/stats': 3.6.0
@@ -54158,10 +54349,6 @@ snapshots:
 
   q@1.5.1: {}
 
-  qrcode.react@3.1.0(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-
   qs@6.10.4:
     dependencies:
       side-channel: 1.0.6
@@ -54252,578 +54439,31 @@ snapshots:
       iconv-lite: 0.7.0
       unpipe: 1.0.0
 
-  rc-cascader@3.24.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  rc-field-form@2.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@babel/runtime': 7.26.0
-      array-tree-filter: 2.1.0
-      classnames: 2.5.1
-      rc-select: 14.13.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-tree: 5.8.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.28.6
+      '@rc-component/async-validator': 5.1.0
       rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  rc-cascader@3.34.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  rc-resize-observer@0.2.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-select: 14.16.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-tree: 5.13.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-checkbox@3.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       classnames: 2.5.1
       rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-
-  rc-checkbox@3.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-collapse@3.7.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-collapse@3.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-dialog@9.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/portal': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-dialog@9.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/portal': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-drawer@7.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/portal': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-drawer@7.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/portal': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-dropdown@4.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/trigger': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-dropdown@4.2.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/trigger': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-field-form@1.44.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      async-validator: 4.2.5
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-field-form@2.7.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/async-validator': 5.0.4
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-image@7.12.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/portal': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-dialog: 9.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-image@7.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/portal': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-dialog: 9.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-input-number@9.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/mini-decimal': 1.1.0
-      classnames: 2.5.1
-      rc-input: 1.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-input-number@9.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/mini-decimal': 1.1.0
-      classnames: 2.5.1
-      rc-input: 1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-input@1.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-input@1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-mentions@2.11.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/trigger': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-input: 1.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-menu: 9.13.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-textarea: 1.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-mentions@2.20.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/trigger': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-input: 1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-menu: 9.16.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-textarea: 1.10.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-menu@9.13.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/trigger': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-overflow: 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-menu@9.16.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/trigger': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-overflow: 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-motion@2.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-motion@2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-notification@5.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-notification@5.6.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-overflow@1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-resize-observer: 1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-pagination@4.0.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-pagination@5.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-picker@4.11.3(date-fns@4.1.0)(dayjs@1.11.13)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/trigger': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-overflow: 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-resize-observer: 1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-    optionalDependencies:
-      date-fns: 4.1.0
-      dayjs: 1.11.13
-      luxon: 3.4.4
-      moment: 2.30.1
-
-  rc-picker@4.4.2(date-fns@4.1.0)(dayjs@1.11.13)(luxon@3.4.4)(moment@2.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/trigger': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-overflow: 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-resize-observer: 1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-    optionalDependencies:
-      date-fns: 4.1.0
-      dayjs: 1.11.13
-      luxon: 3.4.4
-      moment: 2.30.1
-
-  rc-progress@4.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-rate@2.12.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-rate@2.13.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
+      resize-observer-polyfill: 1.5.1
 
   rc-resize-observer@1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       classnames: 2.5.1
       rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       resize-observer-polyfill: 1.5.1
-
-  rc-resize-observer@1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      resize-observer-polyfill: 1.5.1
-
-  rc-segmented@2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-segmented@2.7.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-select@14.13.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/trigger': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-overflow: 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-virtual-list: 3.11.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-select@14.16.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/trigger': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-overflow: 1.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-virtual-list: 3.14.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-slider@10.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-slider@11.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-steps@6.0.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-switch@4.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-table@7.45.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/context': 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-resize-observer: 1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-virtual-list: 3.11.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-table@7.51.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/context': 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-resize-observer: 1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-virtual-list: 3.14.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-tabs@14.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-dropdown: 4.2.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-menu: 9.13.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-resize-observer: 1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-tabs@15.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-dropdown: 4.2.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-menu: 9.16.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-resize-observer: 1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-textarea@1.10.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-input: 1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-resize-observer: 1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-textarea@1.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-input: 1.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-resize-observer: 1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-tooltip@6.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/trigger': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-tooltip@6.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@rc-component/trigger': 2.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-tree-select@5.19.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-select: 14.13.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-tree: 5.8.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-tree-select@5.27.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-select: 14.16.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-tree: 5.13.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-tree@5.13.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-virtual-list: 3.14.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-tree@5.8.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-virtual-list: 3.11.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-tree@5.8.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-virtual-list: 3.14.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
 
   rc-upload@4.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -54833,52 +54473,27 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  rc-upload@4.9.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  rc-util@4.21.1:
     dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
+      add-dom-event-listener: 1.1.0
+      prop-types: 15.8.1
+      react-is: 16.13.1
+      react-lifecycles-compat: 3.0.4
+      shallowequal: 1.1.0
 
   rc-util@5.39.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-is: 18.3.1
-
-  rc-util@5.41.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.24.6
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-is: 18.3.0
 
   rc-util@5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-is: 18.3.1
-
-  rc-virtual-list@3.11.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-resize-observer: 1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  rc-virtual-list@3.14.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      classnames: 2.5.1
-      rc-resize-observer: 1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
 
   rc@1.2.8:
     dependencies:
@@ -54898,7 +54513,7 @@ snapshots:
 
   react-clientside-effect@1.2.6(react@19.1.0):
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       react: 19.1.0
 
   react-content-loader@5.1.4(react@19.1.0):
@@ -54979,7 +54594,7 @@ snapshots:
 
   react-error-boundary@3.1.4(react@19.1.0):
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       react: 19.1.0
 
   react-error-overlay@6.0.11: {}
@@ -54988,7 +54603,7 @@ snapshots:
 
   react-focus-lock@2.12.1(@types/react@19.1.8)(react@19.1.0):
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       focus-lock: 1.3.5
       prop-types: 15.8.1
       react: 19.1.0
@@ -55381,6 +54996,11 @@ snapshots:
 
   react@19.1.0: {}
 
+  reactcss@1.2.3(react@19.1.0):
+    dependencies:
+      lodash: 4.17.21
+      react: 19.1.0
+
   read-cache@1.0.0:
     dependencies:
       pify: 2.3.0
@@ -55571,7 +55191,7 @@ snapshots:
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
 
   regex-parser@2.3.0: {}
 
@@ -55700,7 +55320,7 @@ snapshots:
 
   relay-runtime@12.0.0(encoding@0.1.13):
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       fbjs: 3.0.5(encoding@0.1.13)
       invariant: 2.2.4
     transitivePeerDependencies:
@@ -57262,7 +56882,7 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 19.1.0
-      use-sync-external-store: 1.5.0(react@19.1.0)
+      use-sync-external-store: 1.6.0(react@19.1.0)
 
   symbol-tree@3.2.4: {}
 
@@ -57456,8 +57076,6 @@ snapshots:
   throat@6.0.2: {}
 
   throttle-debounce@2.3.0: {}
-
-  throttle-debounce@5.0.0: {}
 
   throttle-debounce@5.0.2: {}
 
@@ -59143,7 +58761,7 @@ snapshots:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.12.0)
       '@babel/core': 7.28.0
       '@babel/preset-env': 7.24.4(@babel/core@7.28.0)
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.6
       '@rollup/plugin-babel': 5.3.1(@babel/core@7.28.0)(@types/babel__core@7.20.5)(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 11.2.1(rollup@2.79.1)
       '@rollup/plugin-replace': 2.4.2(rollup@2.79.1)


### PR DESCRIPTION
- change deprecated ppts

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
antd v6 wasn't supported

## What is the new behavior?
antd v6 is now supported

resolves #7140 

## Notes for reviewers
I made a separate PR since #7177 wasn't updated

Regarding the only failing test case, `should edit a record` in `cypress/e2e/form-antd-use-modal-form/all.cy.ts`,  from my tests it appears flaky:
- When running in `headed`  mode, the test passes
<img width="1346" height="885" alt="image" src="https://github.com/user-attachments/assets/72d6b1d0-c410-475e-850f-61482a4aa304" />

- It is similar to the passing `should edit a record` seen  in `cypress/e2e/form-antd-use-drawer-form/all.cy.ts`, yet it fails in headless mode
- The failure seems to be caused by a timing issue, because with a `cy.wait(1000)` before the check, it occasionally passes
- Both inputs are strangely unpopulated in headless mode, and adding an arbitrary wait time would be a bad pattern.
<img width="1258" height="570" alt="image" src="https://github.com/user-attachments/assets/78ec5b85-c9f0-4a05-8e69-18a058c2b0bb" />

<!-- Add any notes/questions you may have for reviewers -->
