### PR TITLE
feat: expose stringifyOptions in createDataProvider (fixes #7360)

### DIFF
--- a/.changeset/curly-fishes-boil.md
+++ b/.changeset/curly-fishes-boil.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/rest": patch
+---
+
+feat: expose stringifyOptions in createDataProvider (fixes #7360)

--- a/packages/rest/src/create-data-provider.ts
+++ b/packages/rest/src/create-data-provider.ts
@@ -27,6 +27,9 @@ export const createDataProvider = (
   kyOptions: KyOptions = {},
 ): CreateDataProvider => {
   const options = dm(defaultCreateDataProviderOptions, baseOptions);
+  const stringifyOptions = options.stringifyOptions ?? {
+    encodeValuesOnly: true,
+  };
 
   const ky = kyBase.create({
     prefixUrl: apiURL,
@@ -51,7 +54,7 @@ export const createDataProvider = (
 
         const response = await ky(endpoint, {
           headers,
-          searchParams: qs.stringify(query, { encodeValuesOnly: true }),
+          searchParams: qs.stringify(query, stringifyOptions),
         });
 
         const data = await options.getList.mapResponse(
@@ -75,7 +78,7 @@ export const createDataProvider = (
 
         const response = await ky(endpoint, {
           headers,
-          searchParams: qs.stringify(query, { encodeValuesOnly: true }),
+          searchParams: qs.stringify(query, stringifyOptions),
         });
 
         const data = await options.getOne.mapResponse(response, params);
@@ -95,7 +98,7 @@ export const createDataProvider = (
 
             const response = await ky(endpoint, {
               headers,
-              searchParams: qs.stringify(query, { encodeValuesOnly: true }),
+              searchParams: qs.stringify(query, stringifyOptions),
             });
 
             if (response.ok) {
@@ -127,7 +130,7 @@ export const createDataProvider = (
         const response = await ky(endpoint, {
           method: "post",
           headers,
-          searchParams: qs.stringify(query, { encodeValuesOnly: true }),
+          searchParams: qs.stringify(query, stringifyOptions),
           body: JSON.stringify(body),
         });
 
@@ -157,7 +160,7 @@ export const createDataProvider = (
             const response = await ky(endpoint, {
               method: "post",
               headers,
-              searchParams: qs.stringify(query, { encodeValuesOnly: true }),
+              searchParams: qs.stringify(query, stringifyOptions),
               body: JSON.stringify(body),
             });
 
@@ -199,7 +202,7 @@ export const createDataProvider = (
         const response = await ky(endpoint, {
           method,
           headers,
-          searchParams: qs.stringify(query, { encodeValuesOnly: true }),
+          searchParams: qs.stringify(query, stringifyOptions),
           body: JSON.stringify(body),
         });
 
@@ -231,7 +234,7 @@ export const createDataProvider = (
             const response = await ky(endpoint, {
               method,
               headers,
-              searchParams: qs.stringify(query, { encodeValuesOnly: true }),
+              searchParams: qs.stringify(query, stringifyOptions),
               body: JSON.stringify(body),
             });
 
@@ -265,7 +268,7 @@ export const createDataProvider = (
         const response = await ky(endpoint, {
           method: "delete",
           headers,
-          searchParams: qs.stringify(query, { encodeValuesOnly: true }),
+          searchParams: qs.stringify(query, stringifyOptions),
         });
 
         if (response.ok) {
@@ -292,7 +295,7 @@ export const createDataProvider = (
             const response = await ky(endpoint, {
               method: "delete",
               headers,
-              searchParams: qs.stringify(query, { encodeValuesOnly: true }),
+              searchParams: qs.stringify(query, stringifyOptions),
             });
 
             if (options.deleteMany.mapResponse) {
@@ -323,7 +326,7 @@ export const createDataProvider = (
         const query = await options.custom.buildQueryParams(params);
         if (query) {
           client = client.extend({
-            searchParams: qs.stringify(query, { encodeValuesOnly: true }),
+            searchParams: qs.stringify(query, stringifyOptions),
           });
         }
 

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -12,6 +12,7 @@ import type {
   UpdateParams,
 } from "@refinedev/core";
 import type { KyResponse } from "ky";
+import type { IStringifyOptions } from "qs";
 
 export type AnyObject = Record<string, any>;
 
@@ -32,6 +33,7 @@ type TransformError<P> = (
 ) => Promise<HttpError>;
 
 export type CreateDataProviderOptions = {
+  stringifyOptions?: IStringifyOptions;
   getList?: {
     getEndpoint?: GetEndpoint<GetListParams>;
     buildHeaders?: BuildHeaders<GetListParams>;


### PR DESCRIPTION
## Background

When `buildQueryParams` returns an object with array values (e.g., for an `in` filter), the `@refinedev/rest` data provider serializes them using `qs.stringify` with a hardcoded `{ encodeValuesOnly: true }` option. This produces bracket notation (`?status[0]=active&status[1]=inactive`), which many REST backends (particularly Django REST Framework) do not understand — they expect repeated parameters (`?status=active&status=inactive`).

There is currently no way to configure the `qs.stringify` options from outside the library.

## Solution

Add an optional `stringifyOptions` property to `CreateDataProviderOptions` (typed as `IStringifyOptions` from `qs`). When provided, these options are merged as the base for all `qs.stringify` calls across every data provider method (`getList`, `getOne`, `getMany`, `create`, `createMany`, `update`, `updateMany`, `deleteOne`, `deleteMany`, `custom`).

When not provided, the behavior is unchanged (`encodeValuesOnly: true` is the default).

## Changes

- `packages/rest/src/types.ts` — Added `stringifyOptions?: IStringifyOptions` to `CreateDataProviderOptions`
- `packages/rest/src/create-data-provider.ts` — Extract `stringifyOptions` from merged options (default `{ encodeValuesOnly: true }`) and pass to all `qs.stringify` calls

## Usage Example

```ts
createDataProvider("https://api.example.com", {
  stringifyOptions: { arrayFormat: "repeat", encodeValuesOnly: true },
});
// Produces: ?status=active&status=inactive
// Instead of: ?status[0]=active&status[1]=inactive
```

## Verification

- Backward compatible: omitting `stringifyOptions` produces identical behavior
- Type-safe: `IStringifyOptions` from `qs` provides full autocomplete
- All 10 `qs.stringify` call sites now use the configurable options