### PR TITLE
feat(documentation): add llms.txt support via docusaurus-plugin-llms

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -203,6 +203,52 @@ const siteConfig = {
         },
       },
     ],
+    [
+      "docusaurus-plugin-llms",
+      {
+        title: "Refine",
+        description:
+          "Refine is an open-source, headless React framework for building enterprise-grade internal tools, admin panels, dashboards, and B2B applications. It provides industry-standard solutions for critical concerns like authentication, access control, routing, networking, state management, and i18n.",
+        docsDir: "docs",
+        generateLLMsTxt: true,
+        generateLLMsFullTxt: true,
+        excludeImports: true,
+        removeDuplicateHeadings: true,
+        includeOrder: [
+          "getting-started/**/*",
+          "guides-concepts/**/*",
+          "data/**/*",
+          "authentication/**/*",
+          "authorization/**/*",
+          "routing/**/*",
+          "realtime/**/*",
+          "notification/**/*",
+          "audit-logs/**/*",
+          "core/**/*",
+          "ui-integrations/**/*",
+          "packages/**/*",
+          "advanced-tutorials/**/*",
+          "examples/**/*",
+          "further-readings/**/*",
+          "migration-guide/**/*",
+        ],
+        ignoreFiles: ["partials/**/*"],
+        rootContent: `Refine is a meta-framework for building enterprise-grade, production-ready internal tools, admin panels, dashboards, and B2B applications using React.
+
+Key features:
+- **Headless by design**: Works with any UI library (shadcn/ui, Ant Design, Material UI, Mantine, Chakra UI, or custom)
+- **Data provider agnostic**: Connects to any REST, GraphQL, or custom API backend
+- **Authentication & Authorization**: Built-in auth provider and access control (Casbin, Cerbos, Permify, etc.)
+- **Routing**: Supports React Router, Next.js, and Remix
+- **Realtime**: Live data updates with built-in support
+- **i18n**: Internationalization support out of the box
+- **Audit Logs**: Track data changes automatically
+
+Documentation: https://refine.dev/core/docs/
+GitHub: https://github.com/refinedev/refine
+License: MIT`,
+      },
+    ],
   ],
   themeConfig: {
     prism: {

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -100,6 +100,7 @@
     "@types/react-dom": "^17.0.11",
     "@types/react-helmet": "^6.1.2",
     "cross-env": "^7.0.3",
+    "docusaurus-plugin-llms": "^0.3.1",
     "fast-xml-parser": "^5.4.1",
     "fs-extra": "^10.1.0",
     "jest": "^29.3.1",

--- a/documentation/pnpm-lock.yaml
+++ b/documentation/pnpm-lock.yaml
@@ -216,6 +216,9 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
+      docusaurus-plugin-llms:
+        specifier: ^0.3.1
+        version: 0.3.1(@docusaurus/core@2.4.0(@docusaurus/types@2.4.0(@swc/core@1.5.5)(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@swc/core@1.5.5)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.4.5))
       fast-xml-parser:
         specifier: ^5.4.1
         version: 5.4.1
@@ -3165,6 +3168,12 @@ packages:
     resolution: {integrity: sha512-alCwO+EtNehA4oeGS+F7bwJXLvG5MwnFgCGkfF3OKRaJ20iZdlASIhz2YVcj4FOg9J+2lppc0D6D01fxP9liKg==}
     peerDependencies:
       '@docusaurus/core': ^2.0.0
+
+  docusaurus-plugin-llms@0.3.1:
+    resolution: {integrity: sha512-2RsDC4czy1pt2kauIACOcLvSaGmjF3X0pgcVtL6fblzzZMgkasQJrOLN0pRur11j7rQkiaiCGR9NsU3mp4M8fg==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      '@docusaurus/core': ^3.0.0
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -6872,6 +6881,11 @@ packages:
   yaml@2.4.2:
     resolution: {integrity: sha512-B3VqDZ+JAg1nZpaEmWtTXUlBneoGx6CPM9b0TENK6aoSu5t73dItudwdgmi6tHlIZZId4dZ9skcAQ2UbcyAeVA==}
     engines: {node: '>= 14'}
+    hasBin: true
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
     hasBin: true
 
   yargs-parser@21.1.1:
@@ -10894,6 +10908,13 @@ snapshots:
       copy-webpack-plugin: 5.1.2(webpack@5.91.0(@swc/core@1.5.5))
     transitivePeerDependencies:
       - webpack
+
+  docusaurus-plugin-llms@0.3.1(@docusaurus/core@2.4.0(@docusaurus/types@2.4.0(@swc/core@1.5.5)(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@swc/core@1.5.5)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.4.5)):
+    dependencies:
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0(@swc/core@1.5.5)(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@swc/core@1.5.5)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.4.5)
+      gray-matter: 4.0.3
+      minimatch: 9.0.4
+      yaml: 2.8.3
 
   dom-accessibility-api@0.5.16: {}
 
@@ -15232,6 +15253,8 @@ snapshots:
   yaml@1.10.2: {}
 
   yaml@2.4.2: {}
+
+  yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

AI assistants crawling Refine docs get HTML noise (navigation, JS, footers) instead of clean content.

## What is the new behavior?

Two files are auto-generated at build time following the [llms.txt spec](https://llmstxt.org/):

- **`/llms.txt`** — structured index of all doc pages (~28K tokens)
- **`/llms-full.txt`** — full docs content in a single Markdown file

Via [`docusaurus-plugin-llms`](https://github.com/rachfop/docusaurus-plugin-llms). Old versions (3.xx, 4.xx) excluded automatically.



## Notes for reviewers

- Plugin only runs during `docusaurus build`, not `docusaurus start`
- Peer dep warning (`@docusaurus/core@^3` vs `2.4.0`) is harmless — only uses the stable `postBuild` hook

