### PR TITLE
fix(react-hook-form): initialize useFieldArray via reset on first data load (fixes #7401)

### DIFF
--- a/.changeset/curvy-meals-smash.md
+++ b/.changeset/curvy-meals-smash.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/react-hook-form": patch
+---
+
+Fix useFieldArray.fields empty on subsequent loads

--- a/.changeset/curvy-meals-smash.md
+++ b/.changeset/curvy-meals-smash.md
@@ -2,4 +2,4 @@
 "@refinedev/react-hook-form": patch
 ---
 
-Fix useFieldArray.fields empty on subsequent loads
+Fix useFieldArray.fields empty on subsequent loads. The first data load now `reset()`s the form with only the registered subset of the record.

--- a/packages/react-hook-form/src/useForm/index.spec.tsx
+++ b/packages/react-hook-form/src/useForm/index.spec.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 
-import { useForm } from ".";
-import type { IRefineOptions, HttpError } from "@refinedev/core";
+import type { HttpError, IRefineOptions } from "@refinedev/core";
 import * as Core from "@refinedev/core";
-import { MockJSONServer, TestWrapper, act, render, waitFor } from "../../test";
-import { Route, Routes } from "react-router";
-import { Controller, useFieldArray } from "react-hook-form";
 import { screen } from "@testing-library/react";
+import { Controller, useFieldArray } from "react-hook-form";
+import { Route, Routes } from "react-router";
+import { useForm } from ".";
+import { MockJSONServer, TestWrapper, act, render, waitFor } from "../../test";
 
 interface IPost {
   title: string;
@@ -358,7 +358,7 @@ describe("useForm hook", () => {
 
     const EditPage = ({ formLoading }: { formLoading: boolean }) => {
       const { control } = useForm<IPost, HttpError, IPost>({
-        refineCoreProps: { resource: "posts", action: "edit", id: "1" }
+        refineCoreProps: { resource: "posts", action: "edit", id: "1" },
       });
       if (formLoading) return <p>loading</p>;
       return <FieldArrayChild control={control} />;

--- a/packages/react-hook-form/src/useForm/index.spec.tsx
+++ b/packages/react-hook-form/src/useForm/index.spec.tsx
@@ -5,7 +5,8 @@ import type { IRefineOptions, HttpError } from "@refinedev/core";
 import * as Core from "@refinedev/core";
 import { MockJSONServer, TestWrapper, act, render, waitFor } from "../../test";
 import { Route, Routes } from "react-router";
-import { Controller } from "react-hook-form";
+import { Controller, useFieldArray } from "react-hook-form";
+import { screen } from "@testing-library/react";
 
 interface IPost {
   title: string;
@@ -325,6 +326,58 @@ describe("useForm hook", () => {
       await waitFor(() => {
         expect(lateField).toHaveValue("5");
       });
+    } finally {
+      useFormCoreSpy.mockRestore();
+    }
+  });
+
+  it("should populate useFieldArray fields that mount after initial query data sync", async () => {
+    const queryData = {
+      data: {
+        data: { id: "1", tags: [{ value: "react" }, { value: "refine" }] },
+      },
+    };
+
+    const useFormCoreSpy = vi.spyOn(Core, "useForm").mockReturnValue({
+      query: queryData,
+      onFinish: vi.fn().mockResolvedValue({}),
+      onFinishAutoSave: vi.fn().mockResolvedValue({}),
+      formLoading: true, // cached data available immediately; formLoading driven by EditPage prop
+    });
+
+    const FieldArrayChild = ({ control }: { control: any }) => {
+      const { fields } = useFieldArray({ control, name: "tags" });
+      return (
+        <ul>
+          {fields.map((field) => (
+            <li key={field.id} data-testid="tag-item" />
+          ))}
+        </ul>
+      );
+    };
+
+    const EditPage = ({ formLoading }: { formLoading: boolean }) => {
+      const { control } = useForm<IPost, HttpError, IPost>({
+        refineCoreProps: { resource: "posts", action: "edit", id: "1" }
+      });
+      if (formLoading) return <p>loading</p>;
+      return <FieldArrayChild control={control} />;
+    };
+
+    try {
+      const page = (formLoading: boolean) => (
+        <Routes>
+          <Route path="/" element={<EditPage formLoading={formLoading} />} />
+        </Routes>
+      );
+
+      const { rerender } = render(page(true), { wrapper: TestWrapper({}) });
+
+      await act(async () => rerender(page(false)));
+
+      await waitFor(() =>
+        expect(screen.getAllByTestId("tag-item")).toHaveLength(2),
+      );
     } finally {
       useFormCoreSpy.mockRestore();
     }

--- a/packages/react-hook-form/src/useForm/index.spec.tsx
+++ b/packages/react-hook-form/src/useForm/index.spec.tsx
@@ -382,4 +382,208 @@ describe("useForm hook", () => {
       useFormCoreSpy.mockRestore();
     }
   });
+
+  it("should populate useFieldArray fields registered before query data sync", async () => {
+    const useFormCoreSpy = vi.spyOn(Core, "useForm").mockReturnValue({
+      query: {
+        data: {
+          data: { id: "1", tags: [{ value: "react" }, { value: "refine" }] },
+        },
+      },
+      onFinish: vi.fn().mockResolvedValue({}),
+      onFinishAutoSave: vi.fn().mockResolvedValue({}),
+      formLoading: false,
+    } as any);
+
+    const EditPage = () => {
+      const { control, register } = useForm<IPost, HttpError, IPost>({
+        refineCoreProps: { resource: "posts", action: "edit", id: "1" },
+      });
+      const { fields } = useFieldArray({ control, name: "tags" });
+
+      return (
+        <ul>
+          {fields.map((field, index) => (
+            <li key={field.id}>
+              <input
+                data-testid="tag-input"
+                {...register(`tags.${index}.value` as any)}
+              />
+            </li>
+          ))}
+        </ul>
+      );
+    };
+
+    try {
+      render(
+        <Routes>
+          <Route path="/" element={<EditPage />} />
+        </Routes>,
+        { wrapper: TestWrapper({}) },
+      );
+
+      await waitFor(() =>
+        expect(screen.getAllByTestId("tag-input")).toHaveLength(2),
+      );
+      expect(screen.getAllByTestId("tag-input")[0]).toHaveValue("react");
+      expect(screen.getAllByTestId("tag-input")[1]).toHaveValue("refine");
+    } finally {
+      useFormCoreSpy.mockRestore();
+    }
+  });
+
+  it("should not resurrect removed useFieldArray rows from stale query data", async () => {
+    const useFormCoreSpy = vi.spyOn(Core, "useForm").mockReturnValue({
+      query: {
+        data: {
+          data: { id: "1", tags: [{ value: "react" }] },
+        },
+      },
+      onFinish: vi.fn().mockResolvedValue({}),
+      onFinishAutoSave: vi.fn().mockResolvedValue({}),
+      formLoading: false,
+    } as any);
+
+    const FieldArrayChild = ({ control }: { control: any }) => {
+      const { fields, remove, append } = useFieldArray({
+        control,
+        name: "tags",
+      });
+      return (
+        <div>
+          {fields.map((field, index) => (
+            <Controller
+              key={field.id}
+              control={control}
+              name={`tags.${index}.value`}
+              render={({ field: inputField }) => (
+                <input
+                  data-testid="tag-input"
+                  value={inputField.value ?? ""}
+                  onChange={inputField.onChange}
+                />
+              )}
+            />
+          ))}
+          <button
+            type="button"
+            data-testid="remove-row"
+            onClick={() => remove(0)}
+          >
+            remove
+          </button>
+          <button
+            type="button"
+            data-testid="add-row"
+            onClick={() => append({ value: "" })}
+          >
+            add
+          </button>
+        </div>
+      );
+    };
+
+    const EditPage = () => {
+      const { control } = useForm<IPost, HttpError, IPost>({
+        refineCoreProps: { resource: "posts", action: "edit", id: "1" },
+      });
+      return <FieldArrayChild control={control} />;
+    };
+
+    try {
+      const { getByTestId } = render(
+        <Routes>
+          <Route path="/" element={<EditPage />} />
+        </Routes>,
+        { wrapper: TestWrapper({}) },
+      );
+
+      await waitFor(() =>
+        expect(screen.getAllByTestId("tag-input")).toHaveLength(1),
+      );
+      expect(screen.getAllByTestId("tag-input")[0]).toHaveValue("react");
+
+      await act(async () => {
+        getByTestId("remove-row").click();
+      });
+
+      await waitFor(() =>
+        expect(screen.queryAllByTestId("tag-input")).toHaveLength(0),
+      );
+
+      await act(async () => {
+        getByTestId("add-row").click();
+      });
+
+      await waitFor(() =>
+        expect(screen.getAllByTestId("tag-input")).toHaveLength(1),
+      );
+      expect(screen.getAllByTestId("tag-input")[0]).toHaveValue("");
+    } finally {
+      useFormCoreSpy.mockRestore();
+    }
+  });
+
+  it("should only submit registered fields, not all query data fields", async () => {
+    const onFinish = vi.fn().mockResolvedValue({});
+    const useFormCoreSpy = vi.spyOn(Core, "useForm").mockReturnValue({
+      query: {
+        data: {
+          data: {
+            id: "1",
+            title: "Post 1",
+            content: "Content 1",
+            slug: "post-1",
+            category: { id: 1 },
+            internalMetadata: { secret: "should-not-be-submitted" },
+          },
+        },
+      },
+      onFinish,
+      onFinishAutoSave: vi.fn().mockResolvedValue({}),
+      formLoading: false,
+    } as any);
+
+    const EditPage = () => {
+      const { register, saveButtonProps } = useForm<IPost, HttpError, IPost>({
+        refineCoreProps: { resource: "posts", action: "edit", id: "1" },
+      });
+
+      return (
+        <div>
+          <input data-testid="title-field" {...register("title")} />
+          <button
+            data-testid="refine-save-button"
+            type="submit"
+            {...saveButtonProps}
+          >
+            save
+          </button>
+        </div>
+      );
+    };
+
+    try {
+      const { getByTestId } = render(
+        <Routes>
+          <Route path="/" element={<EditPage />} />
+        </Routes>,
+        { wrapper: TestWrapper({}) },
+      );
+
+      await waitFor(() =>
+        expect(getByTestId("title-field")).toHaveValue("Post 1"),
+      );
+
+      await act(async () => {
+        getByTestId("refine-save-button").click();
+      });
+
+      await waitFor(() => expect(onFinish).toHaveBeenCalledTimes(1));
+      expect(onFinish).toHaveBeenCalledWith({ title: "Post 1" });
+    } finally {
+      useFormCoreSpy.mockRestore();
+    }
+  });
 });

--- a/packages/react-hook-form/src/useForm/index.ts
+++ b/packages/react-hook-form/src/useForm/index.ts
@@ -129,6 +129,7 @@ export const useForm = <
     watch,
     setValue,
     getValues,
+    reset,
     handleSubmit: handleSubmitReactHookForm,
     setError,
     formState: { dirtyFields },
@@ -140,6 +141,8 @@ export const useForm = <
   const syncedFieldsRef = React.useRef<Set<string>>(new Set());
   // Track mounted field names so late-registered fields can be detected.
   const mountedFieldsRef = React.useRef<Set<string>>(new Set());
+  // Track whether we have called reset() on initial load, future loads use applyValuesToFields instead to prevent wiping metadata.
+  const hasResetRef = React.useRef(false);
 
   const useFormCoreResult = useFormCore<
     TQueryFnData,
@@ -268,7 +271,14 @@ export const useForm = <
     const applyQueryValues = () => {
       if (!isActive) return;
 
-      applyValuesToFields(getRegisteredFields(), data, false);
+      if (!hasResetRef.current) {
+        hasResetRef.current = true;
+        reset({ ...getValues(), ...data } as unknown as TVariables, {
+          keepDirtyValues: true,
+        });
+      } else {
+        applyValuesToFields(getRegisteredFields(), data, false);
+      }
     };
 
     queryDataRef.current = data;
@@ -285,7 +295,7 @@ export const useForm = <
     return () => {
       isActive = false;
     };
-  }, [query?.data, setValue, getValues]);
+  }, [query?.data, setValue, getValues, reset]);
 
   // Re-sync when new fields register; do not override user edits.
   useEffect(() => {

--- a/packages/react-hook-form/src/useForm/index.ts
+++ b/packages/react-hook-form/src/useForm/index.ts
@@ -1,6 +1,8 @@
 import React, { useEffect } from "react";
+import cloneDeep from "lodash/cloneDeep";
 import get from "lodash/get";
 import has from "lodash/has";
+import set from "lodash/set";
 
 import {
   useForm as useHookForm,
@@ -208,16 +210,20 @@ export const useForm = <
   const { query, onFinish, formLoading, onFinishAutoSave } = useFormCoreResult;
 
   const getMountedFields = () => {
-    const mounted =
-      (
-        control as {
-          _names?: {
-            mount?: Set<string>;
-          };
-        }
-      )._names?.mount ?? new Set<string>();
+    const names = (
+      control as {
+        _names?: {
+          mount?: Set<string>;
+          array?: Set<string>;
+        };
+      }
+    )._names;
 
-    return new Set(mounted);
+    const mounted = new Set<string>(names?.mount ?? []);
+    // useFieldArray registers its name in `_names.array`, not `_names.mount`.
+    names?.array?.forEach((name) => mounted.add(name));
+
+    return mounted;
   };
 
   const getRegisteredFields = () => {
@@ -251,7 +257,17 @@ export const useForm = <
       syncedFieldsRef.current.add(path);
 
       if (has(data, path)) {
-        setValue(path as Path<TVariables>, get(data, path));
+        const value = get(data, path);
+
+        // Mark nested paths synced too, so a later pass can't re-apply stale
+        // query data over user edits (e.g. a removed useFieldArray row).
+        if (typeof value === "object" && value !== null) {
+          Object.keys(flattenObjectKeys(value, path)).forEach((nestedPath) =>
+            syncedFieldsRef.current.add(nestedPath),
+          );
+        }
+
+        setValue(path as Path<TVariables>, value);
       }
     });
   };
@@ -273,9 +289,24 @@ export const useForm = <
 
       if (!hasResetRef.current) {
         hasResetRef.current = true;
-        reset({ ...getValues(), ...data } as unknown as TVariables, {
+
+        // Reset with only the registered subset, so unregistered record
+        // fields never enter (or get submitted by) the form.
+        const initialValues: FieldValues = cloneDeep(getValues());
+        getRegisteredFields().forEach((path) => {
+          if (has(data, path)) {
+            set(initialValues, path, get(data, path));
+          }
+        });
+
+        reset(initialValues as unknown as TVariables, {
           keepDirtyValues: true,
         });
+
+        // Everything the reset wrote counts as synced.
+        Object.keys(flattenObjectKeys(initialValues)).forEach((path) =>
+          syncedFieldsRef.current.add(path),
+        );
       } else {
         applyValuesToFields(getRegisteredFields(), data, false);
       }


### PR DESCRIPTION
Fixes #7401.

## PR Checklist

 - [X]  The commit message follows our guidelines: 
https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

 - [X]  Related issue(s) linked
 - [X]  Tests for the changes have been added
 - [ ]  Docs have been added / updated
 - [X]  Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

When using `useFieldArray` inside a form powered by `useForm`, the fields array is empty on render even though the API response contains data. This happens consistentlyin cases where the component is retriggered when React Query has cached data. 

This seems to mostly affect cases where the `useFieldArray` render depends on `formLoading`, e.g.:

```tsx
const { refineCore: { formLoading } } = useForm(...);
{formLoading && <ComponentContainingUseFieldArray />}
```

See https://codesandbox.io/p/sandbox/t6pxft for a minimal replication.

## What is the new behavior?

`useFieldArray.fields` correctly reflects the array data from the API response.

## Notes for reviewers
 
`useFieldArray` must be mounted and initialized before `setValue` calls can populate it. With cached React Query data, the response is served immediately while also starting a background refetch, so `query.data` is already set when the component mounts, but `formLoading` is `true` (driven by `isFetching`). The [`[query.data]` effect](https://github.com/refinedev/refine/blob/main/packages/react-hook-form/src/useForm/index.ts#L288) fires right away, but if `useFieldArray` is behind a loading guard based on `formLoading` at that point, the `setValue` calls from [applyValuesToFields](https://github.com/refinedev/refine/blob/main/packages/react-hook-form/src/useForm/index.ts#L271) are a no-op. When `formLoading` turns `false`, `query.data` is the same object reference and the effect does not re-fire. In the end, `useFieldArray` mounts but `fields` stays empty.

The fix calls `reset({ ...getValues(), ...data }, { keepDirtyValues: true })` on the first data laod. Unlike `setValue`, `reset` sets the form's default values directly, so `useFieldArray` can initialize from them whenever. Merging with `getValues()` preserves any fields present in the form but absent from the API response. `keepDirtyValues: true` preserves values the user has already edited. Subsequent data loads use the existing `applyValuesToFields`.