### PR TITLE
fix: extend BaseKey to support number[] for UUID types

### DIFF
--- a/packages/core/src/__tests__/basekey.test.ts
+++ b/packages/core/src/__tests__/basekey.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import type { BaseKey } from "../contexts/data/types";
+
+describe("BaseKey type support", () => {
+  it("should support string as BaseKey", () => {
+    const id: BaseKey = "uuid-string-123";
+    expect(typeof id).toBe("string");
+  });
+
+  it("should support number as BaseKey", () => {
+    const id: BaseKey = 42;
+    expect(typeof id).toBe("number");
+  });
+
+  it("should support number[] as BaseKey", () => {
+    const id: BaseKey = [1, 2, 3];
+    expect(Array.isArray(id)).toBe(true);
+    expect(id).toEqual([1, 2, 3]);
+  });
+
+  it("should support UUID arrays from OpenAPI", () => {
+    // Simulating OpenAPI-generated UUID type
+    const compositeId: BaseKey = [16807, 29347, 45321];
+    expect(Array.isArray(compositeId)).toBe(true);
+  });
+});

--- a/packages/core/src/contexts/data/types.ts
+++ b/packages/core/src/contexts/data/types.ts
@@ -5,7 +5,7 @@ export type Prettify<T> = {
   [K in keyof T]: T[K];
 } & {};
 
-export type BaseKey = string | number;
+export type BaseKey = string | number | number[];
 export type BaseRecord = {
   id?: BaseKey;
   [key: string]: any;


### PR DESCRIPTION
- Extended BaseKey type from 'string | number' to 'string | number | number[]'
- Allows OpenAPI-generated types using number[] for UUIDs to work without type casting
- Added comprehensive tests for all BaseKey variants
- Resolves #7403

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
