### PR TITLE
feat(core): add options.logout.confirm for logout confirmation dialog

### DIFF
--- a/.changeset/warm-foxes-swim.md
+++ b/.changeset/warm-foxes-swim.md
@@ -1,0 +1,6 @@
+---
+"@refinedev/chakra-ui": patch
+"@refinedev/mantine": patch
+---
+
+Add logout confirmation dialog support to Chakra UI and Mantine siders. When `options.logout.confirm` is `true` in `<Refine>` options, clicking logout shows a `window.confirm` dialog before executing logout, consistent with the MUI sider implementation.

--- a/examples/app-crm-minimal/src/App.tsx
+++ b/examples/app-crm-minimal/src/App.tsx
@@ -46,6 +46,7 @@ const App = () => {
                 syncWithLocation: true,
                 warnWhenUnsavedChanges: true,
                 liveMode: "auto",
+                logout: { confirm: true },
               }}
             >
               <Routes>

--- a/examples/app-crm-minimal/src/components/layout/current-user/index.tsx
+++ b/examples/app-crm-minimal/src/components/layout/current-user/index.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
-import { useGetIdentity } from "@refinedev/core";
+import { useGetIdentity, useLogout, useRefineOptions } from "@refinedev/core";
 
-import { SettingOutlined } from "@ant-design/icons";
-import { Button, Popover } from "antd";
+import { LogoutOutlined, SettingOutlined } from "@ant-design/icons";
+import { Button, Modal, Popover } from "antd";
 
 import type { User } from "@/graphql/schema.types";
 
@@ -14,6 +14,24 @@ import { AccountSettings } from "../account-settings";
 export const CurrentUser = () => {
   const [opened, setOpened] = React.useState(false);
   const { data: user } = useGetIdentity<User>();
+  const { mutate: logout } = useLogout();
+  const { logout: logoutOptions } = useRefineOptions();
+
+  const handleLogout = () => {
+    if (logoutOptions.confirm) {
+      Modal.confirm({
+        title: "Logout",
+        content: "Are you sure you want to logout?",
+        okText: "Logout",
+        okType: "danger",
+        cancelText: "Cancel",
+        centered: true,
+        onOk: () => logout(),
+      });
+    } else {
+      logout();
+    }
+  };
 
   const content = (
     <div
@@ -47,6 +65,16 @@ export const CurrentUser = () => {
           onClick={() => setOpened(true)}
         >
           Account settings
+        </Button>
+        <Button
+          style={{ textAlign: "left" }}
+          icon={<LogoutOutlined />}
+          type="text"
+          block
+          danger
+          onClick={handleLogout}
+        >
+          Logout
         </Button>
       </div>
     </div>

--- a/examples/app-crm-minimal/src/routes/dashboard/index.tsx
+++ b/examples/app-crm-minimal/src/routes/dashboard/index.tsx
@@ -30,21 +30,21 @@ export const DashboardPage = () => {
           <DashboardTotalCountCard
             resource="companies"
             isLoading={isLoading}
-            totalCount={data?.data.companies.totalCount}
+            totalCount={data?.data?.companies?.totalCount}
           />
         </Col>
         <Col xs={24} sm={24} xl={8}>
           <DashboardTotalCountCard
             resource="contacts"
             isLoading={isLoading}
-            totalCount={data?.data.contacts.totalCount}
+            totalCount={data?.data?.contacts?.totalCount}
           />
         </Col>
         <Col xs={24} sm={24} xl={8}>
           <DashboardTotalCountCard
             resource="deals"
             isLoading={isLoading}
-            totalCount={data?.data.deals.totalCount}
+            totalCount={data?.data?.deals?.totalCount}
           />
         </Col>
       </Row>

--- a/packages/antd/src/components/themedLayout/sider/index.tsx
+++ b/packages/antd/src/components/themedLayout/sider/index.tsx
@@ -5,6 +5,7 @@ import {
   Grid,
   Drawer,
   Button,
+  Modal,
   theme,
   ConfigProvider,
 } from "antd";
@@ -24,6 +25,7 @@ import {
   useMenu,
   useLink,
   useWarnAboutChange,
+  useRefineOptions,
 } from "@refinedev/core";
 
 import { drawerButtonStyles } from "./styles";
@@ -55,6 +57,7 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
   const { menuItems, selectedKey, defaultOpenKeys } = useMenu({ meta });
   const breakpoint = Grid.useBreakpoint();
   const { mutate: mutateLogout } = useLogout();
+  const { logout: logoutOptions } = useRefineOptions();
 
   const isMobile =
     typeof breakpoint.lg === "undefined" ? false : !breakpoint.lg;
@@ -123,17 +126,30 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
 
   const handleLogout = () => {
     if (warnWhen) {
-      const confirm = window.confirm(
+      const confirmed = window.confirm(
         translate(
           "warnWhenUnsavedChanges",
           "Are you sure you want to leave? You have unsaved changes.",
         ),
       );
 
-      if (confirm) {
+      if (confirmed) {
         setWarnWhen(false);
         mutateLogout();
       }
+    } else if (logoutOptions.confirm) {
+      Modal.confirm({
+        title: translate("buttons.logout", "Logout"),
+        content: translate(
+          "buttons.logout.confirm",
+          "Are you sure you want to logout?",
+        ),
+        okText: translate("buttons.logout", "Logout"),
+        okType: "danger",
+        cancelText: translate("buttons.cancel", "Cancel"),
+        centered: true,
+        onOk: () => mutateLogout(),
+      });
     } else {
       mutateLogout();
     }

--- a/packages/chakra-ui/src/components/themedLayout/sider/index.tsx
+++ b/packages/chakra-ui/src/components/themedLayout/sider/index.tsx
@@ -6,6 +6,7 @@ import {
   useLink,
   useLogout,
   useMenu,
+  useRefineOptions,
   useTranslate,
   useWarnAboutChange,
 } from "@refinedev/core";
@@ -47,6 +48,7 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
   const t = useTranslate();
   const { warnWhen, setWarnWhen } = useWarnAboutChange();
   const { mutate: mutateLogout } = useLogout();
+  const { logout: logoutOptions } = useRefineOptions();
 
   const RenderToTitle = TitleFromProps ?? DefaultTitle;
 
@@ -200,6 +202,14 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
 
       if (confirm) {
         setWarnWhen(false);
+        mutateLogout();
+      }
+    } else if (logoutOptions.confirm) {
+      const confirmed = window.confirm(
+        t("buttons.logout.confirm", "Are you sure you want to logout?"),
+      );
+
+      if (confirmed) {
         mutateLogout();
       }
     } else {

--- a/packages/core/src/contexts/refine/index.tsx
+++ b/packages/core/src/contexts/refine/index.tsx
@@ -58,6 +58,9 @@ export const defaultRefineOptions: IRefineContextOptions = {
   disableServerSideValidation: false,
   disableRouteChangeHandler: false,
   title: defaultTitle,
+  logout: {
+    confirm: false,
+  },
 };
 
 export const RefineContext = React.createContext<IRefineContext>({

--- a/packages/core/src/contexts/refine/types.ts
+++ b/packages/core/src/contexts/refine/types.ts
@@ -102,6 +102,16 @@ export interface IRefineOptions {
     icon?: React.ReactNode;
     text?: React.ReactNode;
   };
+  /**
+   * Configure logout behavior across all Refine UI packages.
+   */
+  logout?: {
+    /**
+     * When `true`, a confirmation dialog is shown before logout executes.
+     * @default false
+     */
+    confirm?: boolean;
+  };
 }
 
 export interface IRefineContextOptions {
@@ -124,6 +134,9 @@ export interface IRefineContextOptions {
   title: {
     icon?: React.ReactNode;
     text?: React.ReactNode;
+  };
+  logout: {
+    confirm: boolean;
   };
 }
 

--- a/packages/core/src/definitions/helpers/handleRefineOptions/index.ts
+++ b/packages/core/src/definitions/helpers/handleRefineOptions/index.ts
@@ -101,6 +101,9 @@ export const handleRefineOptions = ({
       options?.disableRouteChangeHandler ??
       disableRouteChangeHandler ??
       defaultRefineOptions.disableRouteChangeHandler,
+    logout: {
+      confirm: options?.logout?.confirm ?? defaultRefineOptions.logout.confirm,
+    },
   };
 
   const disableTelemetryWithDefault =

--- a/packages/mantine/src/components/themedLayout/sider/index.tsx
+++ b/packages/mantine/src/components/themedLayout/sider/index.tsx
@@ -6,7 +6,7 @@ import {
   useLogout,
   useMenu,
   useActiveAuthProvider,
-  useRefineContext,
+  useRefineOptions,
   useTranslate,
   useWarnAboutChange,
 } from "@refinedev/core";
@@ -53,6 +53,7 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
   const authProvider = useActiveAuthProvider();
   const { warnWhen, setWarnWhen } = useWarnAboutChange();
   const { mutate: mutateLogout } = useLogout();
+  const { logout: logoutOptions } = useRefineOptions();
 
   const RenderToTitle = TitleFromProps ?? DefaultTitle;
 
@@ -160,6 +161,14 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
 
       if (confirm) {
         setWarnWhen(false);
+        mutateLogout();
+      }
+    } else if (logoutOptions.confirm) {
+      const confirmed = window.confirm(
+        t("buttons.logout.confirm", "Are you sure you want to logout?"),
+      );
+
+      if (confirmed) {
         mutateLogout();
       }
     } else {

--- a/packages/mui/src/components/themedLayout/sider/index.tsx
+++ b/packages/mui/src/components/themedLayout/sider/index.tsx
@@ -28,6 +28,7 @@ import {
   useMenu,
   useActiveAuthProvider,
   useWarnAboutChange,
+  useRefineOptions,
 } from "@refinedev/core";
 import type { RefineThemedLayoutSiderProps } from "../types";
 
@@ -62,6 +63,7 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
   const authProvider = useActiveAuthProvider();
   const { warnWhen, setWarnWhen } = useWarnAboutChange();
   const { mutate: mutateLogout } = useLogout();
+  const { logout: logoutOptions } = useRefineOptions();
 
   const defaultExpandMenuItems = (() => {
     const defaultOpenKeys = {};
@@ -298,15 +300,23 @@ export const ThemedSider: React.FC<RefineThemedLayoutSiderProps> = ({
 
   const handleLogout = () => {
     if (warnWhen) {
-      const confirm = window.confirm(
+      const confirmed = window.confirm(
         t(
           "warnWhenUnsavedChanges",
           "Are you sure you want to leave? You have unsaved changes.",
         ),
       );
 
-      if (confirm) {
+      if (confirmed) {
         setWarnWhen(false);
+        mutateLogout();
+      }
+    } else if (logoutOptions.confirm) {
+      const confirmed = window.confirm(
+        t("buttons.logout.confirm", "Are you sure you want to logout?"),
+      );
+
+      if (confirmed) {
         mutateLogout();
       }
     } else {

--- a/packages/ui-tests/src/tests/layout/sider.tsx
+++ b/packages/ui-tests/src/tests/layout/sider.tsx
@@ -42,6 +42,7 @@ export const layoutSiderTests = (
     beforeEach(() => {
       vi.spyOn(console, "warn").mockImplementation(() => {});
       vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.spyOn(window, "confirm").mockImplementation(() => true);
     });
 
     it("should render successful", async () => {
@@ -95,6 +96,63 @@ export const layoutSiderTests = (
       });
 
       expect(logoutMockedAuthProvider.logout).toHaveBeenCalledTimes(1);
+    });
+
+    it("should show confirmation dialog when logout.confirm option is true", async () => {
+      const confirmSpy = vi
+        .spyOn(window, "confirm")
+        .mockImplementation(() => true);
+
+      const logoutMockedAuthProvider = {
+        ...mockAuthProvider,
+        logout: vi
+          .fn()
+          .mockImplementation(() => Promise.resolve({ success: true })),
+      };
+
+      const { getAllByText } = render(<SiderElement />, {
+        wrapper: testWrapper({
+          authProvider: logoutMockedAuthProvider,
+          options: {
+            logout: { confirm: true },
+          },
+        }),
+      });
+
+      await act(async () => {
+        getAllByText("Logout")[0].click();
+      });
+
+      expect(confirmSpy).toHaveBeenCalledWith(
+        "Are you sure you want to logout?",
+      );
+      expect(logoutMockedAuthProvider.logout).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not logout when logout.confirm dialog is cancelled", async () => {
+      vi.spyOn(window, "confirm").mockImplementation(() => false);
+
+      const logoutMockedAuthProvider = {
+        ...mockAuthProvider,
+        logout: vi
+          .fn()
+          .mockImplementation(() => Promise.resolve({ success: true })),
+      };
+
+      const { getAllByText } = render(<SiderElement />, {
+        wrapper: testWrapper({
+          authProvider: logoutMockedAuthProvider,
+          options: {
+            logout: { confirm: true },
+          },
+        }),
+      });
+
+      await act(async () => {
+        getAllByText("Logout")[0].click();
+      });
+
+      expect(logoutMockedAuthProvider.logout).not.toHaveBeenCalled();
     });
 
     it("should render only allowed menu items", async () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features
Related issue: N/A (UX improvement proposal)

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
Clicking logout in the sider or header immediately logs the user out with no confirmation. Users can accidentally log out while navigating.


## What is the new behavior?
A new `logout.confirm` option can be set in `<Refine options={{ logout: { confirm: true } }}>`. When enabled, a confirmation dialog is shown before logout executes. Defaults to false — no breaking change.

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
This is a UX improvement. The option defaults to false so existing behavior is fully preserved. 

- antd sider uses Modal.confirm (consistent with Ant Design patterns)
- mui sider uses window.confirm (can be upgraded to a MUI dialog if preferred)
- The example app-crm-minimal demonstrates the feature end-to-end

Happy to add tests, docs, and a changeset if maintainers want to move forward.

