### PR TITLE
fix: reset field array values on data refetch during SPA navigation

### DIFF
--- a/.changeset/fix-field-array-spa-reset.md
+++ b/.changeset/fix-field-array-spa-reset.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/react-hook-form": patch
+---
+
+Fix `useFieldArray` staying empty when query data is available before the field array mounts (e.g. cached React Query data with `formLoading`).

--- a/packages/react-hook-form/src/useForm/index.spec.tsx
+++ b/packages/react-hook-form/src/useForm/index.spec.tsx
@@ -5,7 +5,8 @@ import type { IRefineOptions, HttpError } from "@refinedev/core";
 import * as Core from "@refinedev/core";
 import { MockJSONServer, TestWrapper, act, render, waitFor } from "../../test";
 import { Route, Routes } from "react-router";
-import { Controller } from "react-hook-form";
+import { Controller, useFieldArray } from "react-hook-form";
+import { screen } from "@testing-library/react";
 
 interface IPost {
   title: string;
@@ -325,6 +326,63 @@ describe("useForm hook", () => {
       await waitFor(() => {
         expect(lateField).toHaveValue("5");
       });
+    } finally {
+      useFormCoreSpy.mockRestore();
+    }
+  });
+
+  it("should populate useFieldArray fields that mount after initial query data sync", async () => {
+    const queryData = {
+      data: {
+        data: { id: "1", tags: [{ value: "react" }, { value: "refine" }] },
+      },
+    };
+
+    const useFormCoreSpy = vi.spyOn(Core, "useForm").mockReturnValue({
+      query: queryData,
+      onFinish: vi.fn().mockResolvedValue({}),
+      onFinishAutoSave: vi.fn().mockResolvedValue({}),
+      formLoading: true,
+    } as any);
+
+    interface IPostTagRows {
+      id?: string;
+      tags: { value: string }[];
+    }
+
+    const FieldArrayChild = ({ control }: { control: any }) => {
+      const { fields } = useFieldArray({ control, name: "tags" });
+      return (
+        <ul>
+          {fields.map((field) => (
+            <li key={field.id} data-testid="tag-item" />
+          ))}
+        </ul>
+      );
+    };
+
+    const EditPage = ({ formLoading }: { formLoading: boolean }) => {
+      const { control } = useForm<IPostTagRows, HttpError, IPostTagRows>({
+        refineCoreProps: { resource: "posts", action: "edit", id: "1" },
+      });
+      if (formLoading) return <p>loading</p>;
+      return <FieldArrayChild control={control} />;
+    };
+
+    try {
+      const page = (loading: boolean) => (
+        <Routes>
+          <Route path="/" element={<EditPage formLoading={loading} />} />
+        </Routes>
+      );
+
+      const { rerender } = render(page(true), { wrapper: TestWrapper({}) });
+
+      await act(async () => rerender(page(false)));
+
+      await waitFor(() =>
+        expect(screen.getAllByTestId("tag-item")).toHaveLength(2),
+      );
     } finally {
       useFormCoreSpy.mockRestore();
     }

--- a/packages/react-hook-form/src/useForm/index.ts
+++ b/packages/react-hook-form/src/useForm/index.ts
@@ -129,6 +129,7 @@ export const useForm = <
     watch,
     setValue,
     getValues,
+    reset,
     handleSubmit: handleSubmitReactHookForm,
     setError,
     formState: { dirtyFields },
@@ -140,6 +141,11 @@ export const useForm = <
   const syncedFieldsRef = React.useRef<Set<string>>(new Set());
   // Track mounted field names so late-registered fields can be detected.
   const mountedFieldsRef = React.useRef<Set<string>>(new Set());
+  /**
+   * First successful query sync uses `reset()` so default values include arrays before `useFieldArray`
+   * mounts (e.g. behind `formLoading`). Later syncs use `applyValuesToFields` to avoid wiping RHF metadata.
+   */
+  const hasResetRef = React.useRef(false);
 
   const useFormCoreResult = useFormCore<
     TQueryFnData,
@@ -260,6 +266,7 @@ export const useForm = <
       queryDataRef.current = undefined;
       syncedFieldsRef.current = new Set();
       mountedFieldsRef.current = new Set();
+      hasResetRef.current = false;
       return;
     }
 
@@ -268,7 +275,14 @@ export const useForm = <
     const applyQueryValues = () => {
       if (!isActive) return;
 
-      applyValuesToFields(getRegisteredFields(), data, false);
+      if (!hasResetRef.current) {
+        hasResetRef.current = true;
+        reset({ ...getValues(), ...data } as unknown as TVariables, {
+          keepDirtyValues: true,
+        });
+      } else {
+        applyValuesToFields(getRegisteredFields(), data, false);
+      }
     };
 
     queryDataRef.current = data;
@@ -285,7 +299,7 @@ export const useForm = <
     return () => {
       isActive = false;
     };
-  }, [query?.data, setValue, getValues]);
+  }, [query?.data, setValue, getValues, reset]);
 
   // Re-sync when new fields register; do not override user edits.
   useEffect(() => {


### PR DESCRIPTION
## Problem
When using `useForm` with `useFieldArray`, field arrays are populated correctly on first visit but empty on subsequent SPA navigations because the form state isn't properly refreshed with new query data.

## Change
Ensure the form is properly reset with fresh data when the query refetches on navigation, preserving field array population across SPA visits.

Fixes #7401.

Made with [Cursor](https://cursor.com)