### PR TITLE
fix(core): useTranslate to import from @hooks in autoSaveIndicator

### DIFF
--- a/.changeset/fix-translate-import-autosaveindicator.md
+++ b/.changeset/fix-translate-import-autosaveindicator.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": patch
+---
+
+fix: useTranslate to import from @hooks in autoSaveIndicator

--- a/packages/core/src/components/autoSaveIndicator/index.tsx
+++ b/packages/core/src/components/autoSaveIndicator/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { useTranslate } from "@hooks/i18n";
+import { useTranslate } from "@hooks";
 
 import type { BaseRecord, HttpError } from "../../contexts/data/types";
 import type { AutoSaveIndicatorElements } from "../../hooks/form/types";


### PR DESCRIPTION
## Summary

Fixes the same issue described in #6140 /closed by #6154 and #6184, but for the AutoSaveIndicator component.

## Problem

The AutoSaveIndicator component was importing  from  path, which does not exist in the swizzled folder structure. When users run the swizzle command for the AuthPage, the generated code references this path but the  folder is not created with an  subdirectory.

## Solution

Changed the import from:

to:


This follows the same pattern as other auth components (login, register, forgotPassword, updatePassword) where  is imported from the  path.

## Related Issues/PRs
- Fixes #6140 (same issue, different component)
- Related to #6154 and #6184