### PR TITLE
fix(react-hook-form): useFieldArray fields empty on second visit

### DIFF
--- a/packages/react-hook-form/src/useForm/index.ts
+++ b/packages/react-hook-form/src/useForm/index.ts
@@ -129,6 +129,7 @@ export const useForm = <
     watch,
     setValue,
     getValues,
+    reset,
     handleSubmit: handleSubmitReactHookForm,
     setError,
     formState: { dirtyFields },
@@ -268,7 +269,7 @@ export const useForm = <
     const applyQueryValues = () => {
       if (!isActive) return;
 
-      applyValuesToFields(getRegisteredFields(), data, false);
+      reset(data, { keepDirtyValues: true });
     };
 
     queryDataRef.current = data;


### PR DESCRIPTION
Hey! Saw #7401 and figured I'd take a look.

The issue is that `applyValuesToFields(getRegisteredFields(), data, false)` misses `useFieldArray` fields when navigating back to the edit form. The problem: on the second visit, fieldArray fields register after the `queueMicrotask` callback runs, so `getRegisteredFields()` doesn't include them.

The fix replaces the manual `setValue` loop with RHF's `reset(data, { keepDirtyValues: true })`. `reset` handles field arrays natively and doesn't depend on field registration timing.

Changes:
- Added `reset` to the destructuring from `useHookFormResult`
- Replaced `applyValuesToFields(getRegisteredFields(), data, false)` with `reset(data, { keepDirtyValues: true })`

This matches the fix suggested in the issue. Let me know if anything needs tweaking.
