### PR TITLE
feat(mui): add filters.syncFilterModel option to useDataGrid

### DIFF
--- a/.changeset/quiet-otters-listen.md
+++ b/.changeset/quiet-otters-listen.md
@@ -1,0 +1,26 @@
+---
+"@refinedev/mui": patch
+---
+
+feat: add `filters.syncFilterModel` option to `useDataGrid`
+
+`useDataGrid` controls `dataGridProps.filterModel` from an internal state that
+was only updated by the DataGrid's own filter panel and by `search()`. As a
+result, calls to the returned `setFilters` (or filter changes synced from the
+URL via `syncWithLocation`) updated `filters` but left `filterModel` stale, so
+external filter UIs could not drive the grid's visible filter state.
+
+Add an opt-in `filters.syncFilterModel` flag. When `true`, the hook reflects
+`filters` changes in `dataGridProps.filterModel`. The default is `false` to
+preserve compatibility with apps that mix column-header filtering and
+external filter inputs — see #5860 for the original reasoning behind the
+controlled-but-unsynced behavior.
+
+```tsx
+const { dataGridProps } = useDataGrid({
+  resource: "posts",
+  filters: {
+    syncFilterModel: true,
+  },
+});
+```

--- a/packages/mui/src/hooks/useDataGrid/index.spec.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.spec.ts
@@ -308,6 +308,78 @@ describe("useDataGrid Hook", () => {
     });
   });
 
+  it("when filters.syncFilterModel is true, external setFilters updates dataGridProps.filterModel", async () => {
+    const { result } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+          filters: {
+            syncFilterModel: true,
+          },
+        }),
+      {
+        wrapper: TestWrapper({}),
+      },
+    );
+
+    await waitFor(() => {
+      expect(!result.current.tableQuery?.isLoading).toBeTruthy();
+    });
+
+    await act(async () => {
+      result.current.setFilters([
+        {
+          field: "title",
+          operator: "contains",
+          value: "test",
+        },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.dataGridProps.filterModel?.items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            field: "title",
+            value: "test",
+          }),
+        ]),
+      );
+    });
+  });
+
+  it("by default, external setFilters does not update dataGridProps.filterModel", async () => {
+    const { result } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+        }),
+      {
+        wrapper: TestWrapper({}),
+      },
+    );
+
+    await waitFor(() => {
+      expect(!result.current.tableQuery?.isLoading).toBeTruthy();
+    });
+
+    const initialItems = result.current.dataGridProps.filterModel?.items;
+
+    await act(async () => {
+      result.current.setFilters([
+        {
+          field: "title",
+          operator: "contains",
+          value: "test",
+        },
+      ]);
+    });
+
+    expect(result.current.dataGridProps.filterModel?.items).toEqual(
+      initialItems,
+    );
+  });
+
   it("should not change sortModel when page changes", async () => {
     const { result } = renderHook(
       () =>

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -90,6 +90,16 @@ export type UseDataGridProps<
        * @default "replace"
        */
       defaultBehavior?: "replace" | "merge";
+      /**
+       * When `true`, changes to `filters` made outside the DataGrid (via the
+       * returned `setFilters`, `search`, or `syncWithLocation`) are reflected
+       * in `dataGridProps.filterModel`. Defaults to `false` to preserve
+       * compatibility with apps that mix DataGrid column-header filtering and
+       * external filter inputs, where forcing a sync would clobber in-progress
+       * header edits.
+       * @default false
+       */
+      syncFilterModel?: boolean;
     }
   >;
   editable?: boolean;
@@ -199,6 +209,13 @@ export function useDataGrid<
   });
 
   const [muiCrudFilters, setMuiCrudFilters] = useState<CrudFilters>(filters);
+
+  const syncFilterModel = filtersFromProp?.syncFilterModel ?? false;
+
+  useEffect(() => {
+    if (!syncFilterModel) return;
+    setMuiCrudFilters((prev) => (isEqual(prev, filters) ? prev : filters));
+  }, [filters, syncFilterModel]);
 
   const { data, isFetched, isLoading } = tableQuery;
 


### PR DESCRIPTION
useDataGrid controls dataGridProps.filterModel from an internal muiCrudFilters state that is only updated by the DataGrid's own filter panel and by search(). Calls to the returned setFilters (or filter changes synced from the URL via syncWithLocation) updated filters but left filterModel stale, so apps driving filters from external UIs could not reflect their state in the grid.

Add an opt-in filters.syncFilterModel flag. When true, a useEffect mirrors filters into muiCrudFilters via isEqual guard, so external mutations land in filterModel without a no-op re-render on the debounced internal path. The default is false to preserve the behavior agreed on in the original bug report, where unconditional syncing was rejected because it can clobber in-progress column-header edits in apps that mix DataGrid filter inputs and external setFilters calls.

Refs: #5860

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
