### PR TITLE
fix(mui): prevent nested anchors in ThemedTitle

### DIFF
--- a/packages/mui/src/components/themedLayout/title/index.tsx
+++ b/packages/mui/src/components/themedLayout/title/index.tsx
@@ -26,6 +26,7 @@ export const ThemedTitle: React.FC<RefineLayoutThemedTitleProps> = ({
     <Link to="/" style={{ textDecoration: "none" }}>
       <MuiLink
         underline="none"
+        component="div"
         sx={{
           display: "flex",
           alignItems: "center",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

`ThemedTitle` in `@refinedev/mui` renders Refine's `Link` as the outer navigation element and MUI's `Link` as the inner element.

Since both render as `<a>` tags by default, the output becomes invalid nested anchor HTML:

```html
<a href="/">
  <a>...</a>
</a>
```

This causes a React 19 hydration error in Next.js:

```txt
<a> cannot be a descendant of <a>
Hydration failed because the server rendered HTML didn't match the client.
```

## What is the new behavior?

The inner `MuiLink` now renders as a `div` by using `component="div"`.

This keeps the outer Refine `Link` responsible for navigation while preventing nested `<a>` tags.

The resulting HTML is now valid:

```html
<a href="/">
  <div>...</div>
</a>
```

I verified this with a Next.js 16 + React 19 reproduction app:

- Before the fix: browser console showed the nested `<a>` error: `<a> cannot be a descendant of <a>`.
- After the fix: the nested `<a>` warning no longer appears.
- The title/logo still renders correctly.

Fixes #7418

## Notes for reviewers

No docs were added because this is a small internal rendering fix.

No test was added because I could not find an existing targeted test setup for this component. The change was manually verified using the reproduction steps from the linked issue.