### PR TITLE
fix(mui): stabilize useDataGrid filterModel identity

### DIFF
--- a/.changeset/stable-mui-datagrid-filter-model-identity.md
+++ b/.changeset/stable-mui-datagrid-filter-model-identity.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/mui": patch
+---
+
+fix(mui): stabilize `filterModel` identity returned from `useDataGrid`
+
+`useDataGrid` returned `dataGridProps.filterModel` as a freshly-allocated object on every render even when the underlying filter state was unchanged. Consumers feeding it into MUI X DataGrid (or to `useEffect` deps keyed on its identity) hit unnecessary work and could trigger effect loops in user code.
+
+Wrapped the `filterModel` computation in `useMemo` keyed on `muiCrudFilters`, the permanent filters, and the column-type map — mirroring the existing memoization already used for `sortModel`. Behavior is otherwise unchanged: the value still updates whenever the underlying filter state or the DataGrid-reported column types actually change.

--- a/packages/mui/src/hooks/useDataGrid/index.spec.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.spec.ts
@@ -308,6 +308,215 @@ describe("useDataGrid Hook", () => {
     });
   });
 
+  it("keeps sortModel reference stable across re-renders when sorters are unchanged", async () => {
+    const { result, rerender } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+          sorters: {
+            initial: [
+              {
+                field: "title",
+                order: "asc",
+              },
+            ],
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: MockJSONServer,
+          resources: [{ name: "posts" }],
+        }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.tableQuery.isSuccess).toBeTruthy();
+    });
+
+    const firstSortModel = result.current.dataGridProps.sortModel;
+
+    rerender();
+
+    expect(result.current.dataGridProps.sortModel).toBe(firstSortModel);
+  });
+
+  it("returns a new sortModel reference when sorters change", async () => {
+    const { result } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+          sorters: {
+            initial: [
+              {
+                field: "title",
+                order: "asc",
+              },
+            ],
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: MockJSONServer,
+          resources: [{ name: "posts" }],
+        }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.tableQuery.isSuccess).toBeTruthy();
+    });
+
+    const initialSortModel = result.current.dataGridProps.sortModel;
+
+    await act(async () => {
+      result.current.dataGridProps.onSortModelChange!(
+        [{ field: "title", sort: "desc" }],
+        {} as any,
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.dataGridProps.sortModel).not.toBe(initialSortModel);
+    });
+    expect(result.current.dataGridProps.sortModel).toEqual([
+      { field: "title", sort: "desc" },
+    ]);
+  });
+
+  it("keeps filterModel reference stable across re-renders when filters are unchanged", async () => {
+    const { result, rerender } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+          filters: {
+            initial: [
+              {
+                field: "title",
+                operator: "contains",
+                value: "hello",
+              },
+            ],
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: MockJSONServer,
+          resources: [{ name: "posts" }],
+        }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.tableQuery.isSuccess).toBeTruthy();
+    });
+
+    const firstFilterModel = result.current.dataGridProps.filterModel;
+
+    rerender();
+
+    expect(result.current.dataGridProps.filterModel).toBe(firstFilterModel);
+  });
+
+  it("returns a new filterModel reference when filters change", async () => {
+    const { result } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+          filters: {
+            initial: [
+              {
+                field: "title",
+                operator: "contains",
+                value: "hello",
+              },
+            ],
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: MockJSONServer,
+          resources: [{ name: "posts" }],
+        }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.tableQuery.isSuccess).toBeTruthy();
+    });
+
+    const initialFilterModel = result.current.dataGridProps.filterModel;
+
+    await act(async () => {
+      result.current.dataGridProps.onFilterModelChange({
+        items: [
+          {
+            field: "title",
+            operator: "contains",
+            value: "world",
+            id: "titlecontains",
+          },
+        ],
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.dataGridProps.filterModel).not.toBe(
+        initialFilterModel,
+      );
+    });
+  });
+
+  it("refreshes filterModel when column types change via onStateChange", async () => {
+    const { result, rerender } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+          filters: {
+            initial: [
+              {
+                field: "age",
+                operator: "eq",
+                value: 25,
+              },
+            ],
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: MockJSONServer,
+          resources: [{ name: "posts" }],
+        }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.tableQuery.isSuccess).toBeTruthy();
+    });
+
+    // Before onStateChange fires, column types are unknown so the "eq"
+    // operator falls back to the string default ("equals").
+    expect(result.current.dataGridProps.filterModel?.items[0]).toEqual(
+      expect.objectContaining({ field: "age", operator: "equals" }),
+    );
+
+    // Simulate the DataGrid reporting its column metadata.
+    act(() => {
+      result.current.dataGridProps.onStateChange!({
+        columns: { lookup: { age: { type: "number" } } },
+      } as any);
+    });
+
+    // onStateChange mutates a ref and does not schedule a re-render on
+    // its own — matching real usage, the next render (here forced via
+    // rerender) picks up the new column-type map and the memoized
+    // filterModel reflects it: "eq" on a number column maps to "=".
+    rerender();
+    expect(result.current.dataGridProps.filterModel?.items[0]).toEqual(
+      expect.objectContaining({ field: "age", operator: "=" }),
+    );
+  });
+
   it("should not change sortModel when page changes", async () => {
     const { result } = renderHook(
       () =>

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -347,6 +347,15 @@ export function useDataGrid<
     [sorters, preferredPermanentSorters],
   );
 
+  const transformedFilterModel = useMemo(
+    () =>
+      transformCrudFiltersToFilterModel(
+        differenceWith(muiCrudFilters, preferredPermanentFilters, isEqual),
+        columnsTypes.current,
+      ),
+    [muiCrudFilters, preferredPermanentFilters, columnsTypes.current],
+  );
+
   return {
     tableQuery,
     dataGridProps: {
@@ -361,10 +370,7 @@ export function useDataGrid<
       filterMode: isServerSideFilteringEnabled ? "server" : "client",
       // Disable DataGrid's debounce for server filtering to prevent input resets.
       filterDebounceMs: isServerSideFilteringEnabled ? 0 : undefined,
-      filterModel: transformCrudFiltersToFilterModel(
-        differenceWith(muiCrudFilters, preferredPermanentFilters, isEqual),
-        columnsTypes.current,
-      ),
+      filterModel: transformedFilterModel,
       onFilterModelChange: handleFilterModelChange,
       onStateChange: (state) => {
         const newColumnsTypes = Object.fromEntries(


### PR DESCRIPTION
useDataGrid returned dataGridProps.filterModel as a freshly-allocated object on every render, even when the underlying filter state was unchanged. Consumers feeding it into MUI X DataGrid or to useEffect deps keyed on its identity hit unnecessary work and could trigger effect loops in user code.

Wrap the filterModel computation in useMemo keyed on muiCrudFilters, the permanent filters, and the column-type map — mirroring the existing memoization already used for sortModel a few lines above. The column- type map is still tracked via the same useRef as before; including columnsTypes.current in the deps array means the next render after onStateChange reassigns the ref picks up the change, matching the previous per-render computation.

Behavior is otherwise unchanged: the value still updates whenever the underlying filter state — or the DataGrid-reported column types — actually changes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
