### PR TITLE
fix(mui): clear stale filter value on DataGrid filter row field swap

### DIFF
--- a/.changeset/silent-mui-datagrid-filter-field-swap.md
+++ b/.changeset/silent-mui-datagrid-filter-field-swap.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/mui": patch
+---
+
+fix(mui): clear stale filter value when a DataGrid filter row's field is swapped
+
+In `useDataGrid`, when the user changes the column on an existing row in the MUI X DataGrid filter panel, MUI keeps the previously entered `value`. That value is meaningless under the new field (enums, foreign-key references, booleans, etc.) and was forwarded to the data provider as a `CrudFilter`, producing invalid queries.
+
+`onFilterModelChange` now compares the incoming filter model against the previous one when the item count is unchanged. Rows are matched by `GridFilterItem.id` (falling back to position when an id is absent) so single-step row swaps and reorders aren't misread as field changes. If a row's `field` changed but its `value` was carried over, the value is cleared before the model is translated to a `CrudFilter`. The cached previous model is also reset when filters are replaced out-of-band via `search()`. Add/remove row paths are untouched.

--- a/packages/mui/src/hooks/useDataGrid/index.spec.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.spec.ts
@@ -308,6 +308,342 @@ describe("useDataGrid Hook", () => {
     });
   });
 
+  describe("onFilterModelChange — field swap value clearing", () => {
+    it("clears the carried-over value when only the field changes at the same position", async () => {
+      const { result } = renderHook(
+        () =>
+          useDataGrid({
+            resource: "posts",
+            filters: { mode: "off" },
+          }),
+        { wrapper: TestWrapper({}) },
+      );
+
+      await waitFor(() => {
+        expect(!result.current.tableQuery?.isLoading).toBeTruthy();
+      });
+
+      // User picks field "title" with value "X".
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange(
+          {
+            items: [
+              { id: 1, field: "title", operator: "contains", value: "X" },
+            ],
+          },
+          {} as any,
+        );
+      });
+
+      expect(result.current.filters).toEqual([
+        { field: "title", operator: "contains", value: "X" },
+      ]);
+
+      // User changes the field to "status" — MUI carries over the old value "X".
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange(
+          {
+            items: [
+              { id: 1, field: "status", operator: "contains", value: "X" },
+            ],
+          },
+          {} as any,
+        );
+      });
+
+      // The stale value must NOT leak into the data provider as a filter on
+      // the new field.
+      expect(result.current.filters).toEqual([]);
+    });
+
+    it("preserves the value when only the value changes (same field)", async () => {
+      const { result } = renderHook(
+        () =>
+          useDataGrid({
+            resource: "posts",
+            filters: { mode: "off" },
+          }),
+        { wrapper: TestWrapper({}) },
+      );
+
+      await waitFor(() => {
+        expect(!result.current.tableQuery?.isLoading).toBeTruthy();
+      });
+
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange(
+          {
+            items: [
+              { id: 1, field: "title", operator: "contains", value: "X" },
+            ],
+          },
+          {} as any,
+        );
+      });
+
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange(
+          {
+            items: [
+              { id: 1, field: "title", operator: "contains", value: "Y" },
+            ],
+          },
+          {} as any,
+        );
+      });
+
+      expect(result.current.filters).toEqual([
+        { field: "title", operator: "contains", value: "Y" },
+      ]);
+    });
+
+    it("does not clear values when a row is added or removed", async () => {
+      const { result } = renderHook(
+        () =>
+          useDataGrid({
+            resource: "posts",
+            filters: { mode: "off" },
+          }),
+        { wrapper: TestWrapper({}) },
+      );
+
+      await waitFor(() => {
+        expect(!result.current.tableQuery?.isLoading).toBeTruthy();
+      });
+
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange(
+          {
+            items: [
+              { id: 1, field: "title", operator: "contains", value: "X" },
+            ],
+          },
+          {} as any,
+        );
+      });
+
+      // Adding a second row must not nuke the first row's value.
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange(
+          {
+            items: [
+              { id: 1, field: "title", operator: "contains", value: "X" },
+              { id: 2, field: "status", operator: "contains", value: "draft" },
+            ],
+          },
+          {} as any,
+        );
+      });
+
+      expect(result.current.filters).toEqual([
+        { field: "title", operator: "contains", value: "X" },
+        { field: "status", operator: "contains", value: "draft" },
+      ]);
+
+      // Removing the first row must not nuke the remaining row's value, even
+      // though a naive position-by-position diff would see the field change at
+      // index 0.
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange(
+          {
+            items: [
+              { id: 2, field: "status", operator: "contains", value: "draft" },
+            ],
+          },
+          {} as any,
+        );
+      });
+
+      expect(result.current.filters).toEqual([
+        { field: "status", operator: "contains", value: "draft" },
+      ]);
+    });
+
+    it("matches items by GridFilterItem.id so single-step row swaps don't wipe unrelated values", async () => {
+      const { result } = renderHook(
+        () =>
+          useDataGrid({
+            resource: "posts",
+            filters: { mode: "off" },
+          }),
+        { wrapper: TestWrapper({}) },
+      );
+
+      await waitFor(() => {
+        expect(!result.current.tableQuery?.isLoading).toBeTruthy();
+      });
+
+      // Seed: two filters with stable ids.
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange(
+          {
+            items: [
+              { id: 1, field: "title", operator: "contains", value: "X" },
+              { id: 2, field: "status", operator: "contains", value: "draft" },
+            ],
+          },
+          {} as any,
+        );
+      });
+
+      // Single-step change: row id=1 is removed and id=3 is added at the same
+      // time, so length is preserved. A naive index diff would compare
+      // previous id=1 (title) against new id=2 (status) at position 0 and
+      // wipe the untouched "draft" value.
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange(
+          {
+            items: [
+              { id: 2, field: "status", operator: "contains", value: "draft" },
+              {
+                id: 3,
+                field: "created_at",
+                operator: "contains",
+                value: "2024",
+              },
+            ],
+          },
+          {} as any,
+        );
+      });
+
+      expect(result.current.filters).toEqual([
+        { field: "status", operator: "contains", value: "draft" },
+        { field: "created_at", operator: "contains", value: "2024" },
+      ]);
+    });
+
+    it("does not misidentify a value-only edit as a field swap after search() rewrites filters", async () => {
+      const { result } = renderHook(
+        () =>
+          useDataGrid<any, any, { title: string }>({
+            resource: "posts",
+            filters: { mode: "off" },
+            onSearch: (values) => [
+              {
+                field: "status",
+                operator: "contains" as const,
+                value: values.title,
+              },
+            ],
+          }),
+        { wrapper: TestWrapper({}) },
+      );
+
+      await waitFor(() => {
+        expect(!result.current.tableQuery?.isLoading).toBeTruthy();
+      });
+
+      // User edits the grid: field "title" with value "X".
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange(
+          {
+            items: [
+              { id: 1, field: "title", operator: "contains", value: "X" },
+            ],
+          },
+          {} as any,
+        );
+      });
+
+      // External: search() rewrites filters to a different field. The grid's
+      // controlled filterModel now reflects {field: "status"} but the cached
+      // previous model still says {field: "title"}.
+      await act(async () => {
+        await result.current.search({ title: "draft" });
+      });
+
+      // User edits only the value of the (now status) row. Without the ref
+      // being reset in search(), the position-0 diff would see
+      // "title" !== "status" and wipe the new value.
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange(
+          {
+            items: [
+              {
+                id: 1,
+                field: "status",
+                operator: "contains",
+                value: "published",
+              },
+            ],
+          },
+          {} as any,
+        );
+      });
+
+      expect(result.current.filters).toEqual([
+        { field: "status", operator: "contains", value: "published" },
+      ]);
+    });
+
+    it("clears the carried-over value in server filter mode (debounced)", async () => {
+      const { result } = renderHook(
+        () =>
+          useDataGrid({
+            resource: "posts",
+            // default mode is "server" — debounced applyFilters via setTimeout.
+          }),
+        { wrapper: TestWrapper({}) },
+      );
+
+      await waitFor(() => {
+        expect(!result.current.tableQuery?.isLoading).toBeTruthy();
+      });
+
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          result.current.dataGridProps.onFilterModelChange(
+            {
+              items: [
+                { id: 1, field: "title", operator: "contains", value: "X" },
+              ],
+            },
+            {} as any,
+          );
+        });
+
+        // Flush the first debounce so the title="X" filter actually lands in
+        // `result.current.filters` before we trigger the field swap.
+        await act(async () => {
+          vi.advanceTimersByTime(301);
+        });
+
+        expect(result.current.filters).toEqual([
+          { field: "title", operator: "contains", value: "X" },
+        ]);
+
+        // User swaps the field to "status" while MUI carries over value "X".
+        await act(async () => {
+          result.current.dataGridProps.onFilterModelChange(
+            {
+              items: [
+                { id: 1, field: "status", operator: "contains", value: "X" },
+              ],
+            },
+            {} as any,
+          );
+        });
+
+        // Before the debounce fires, the data provider should not see the new
+        // model yet — filters still reflect the previous state.
+        expect(result.current.filters).toEqual([
+          { field: "title", operator: "contains", value: "X" },
+        ]);
+
+        // After debounce, the cleared value must not have leaked.
+        await act(async () => {
+          vi.advanceTimersByTime(301);
+        });
+
+        expect(result.current.filters).toEqual([]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   it("should not change sortModel when page changes", async () => {
     const { result } = renderHook(
       () =>

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -18,6 +18,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import type {
   DataGridProps,
+  GridFilterItem,
   GridFilterModel,
   GridSortModel,
 } from "@mui/x-data-grid";
@@ -161,6 +162,9 @@ export function useDataGrid<
   const columnsTypes = useRef<Record<string, string>>({});
   // Debounce server-side filter fetches so UI input stays responsive.
   const filterDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Tracks the last filter model seen by `onFilterModelChange` so we can detect
+  // when the user swapped a row's `field` and clear the now-stale `value`.
+  const previousFilterModelRef = useRef<GridFilterModel | null>(null);
 
   const { identifier } = useResourceParams({ resource: resourceFromProp });
 
@@ -260,7 +264,44 @@ export function useDataGrid<
   };
 
   const handleFilterModelChange = (filterModel: GridFilterModel) => {
-    const crudFilters = transformFilterModelToCrudFilters(filterModel);
+    // When the user changes a row's `field` in the filter panel, MUI keeps the
+    // previous `value` — which is meaningless under the new field (enums,
+    // foreign-key refs, booleans, etc). Clear it before translating to a
+    // CrudFilter so we don't ship an invalid query to the data provider.
+    const previousModel = previousFilterModelRef.current;
+    let normalizedModel = filterModel;
+    if (
+      previousModel &&
+      previousModel.items.length === filterModel.items.length
+    ) {
+      // Prefer matching by `GridFilterItem.id` so reorders and single-step
+      // swap operations (delete + add in one model update) aren't misread as
+      // field changes. Fall back to position when the id is absent.
+      const previousById = new Map<GridFilterItem["id"], GridFilterItem>();
+      previousModel.items.forEach((item) => {
+        if (item.id !== undefined) {
+          previousById.set(item.id, item);
+        }
+      });
+      let mutated = false;
+      const items = filterModel.items.map((newItem, i) => {
+        const oldItem =
+          newItem.id !== undefined
+            ? previousById.get(newItem.id)
+            : previousModel.items[i];
+        if (oldItem && oldItem.field !== newItem.field) {
+          mutated = true;
+          return { ...newItem, value: null };
+        }
+        return newItem;
+      });
+      if (mutated) {
+        normalizedModel = { ...filterModel, items };
+      }
+    }
+    previousFilterModelRef.current = normalizedModel;
+
+    const crudFilters = transformFilterModelToCrudFilters(normalizedModel);
     setMuiCrudFilters(crudFilters);
     if (isServerSideFilteringEnabled) {
       // Let the input update immediately; debounce only the server query.
@@ -278,6 +319,10 @@ export function useDataGrid<
       const searchFilters = await onSearchProp(value);
       clearFilterDebounce();
       setMuiCrudFilters(searchFilters);
+      // Drop the cached grid model: `search()` replaces filters out-of-band
+      // and the next `onFilterModelChange` should not diff against a model
+      // that no longer reflects the grid's current state.
+      previousFilterModelRef.current = null;
       applyFilters(searchFilters);
     }
   };


### PR DESCRIPTION
When a user changed the column on an existing filter row in the MUI X DataGrid filter panel, MUI carried over the previous value to the new field. `useDataGrid` forwarded that value to the data provider as a CrudFilter, producing nonsensical queries for fields whose value space differs (enums, foreign-key references, booleans, etc.).

`onFilterModelChange` now keeps a ref to the previous filter model and, when the item count is unchanged, clears `value` on any row whose `field` changed. Items are matched by `GridFilterItem.id` (falling back to position when an id is absent) so reorders and single-step swap operations — e.g. delete + add in one model update — aren't misread as field changes. The cached previous model is also reset in `search()`, which replaces filters out-of-band and would otherwise leave a stale baseline that wipes the next user value edit. The caller's model is not mutated.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

The value for the old filter is preserved when switching fields, causing issues, particularly when switching fields that have different types (i.e. text input to date input).

## What is the new behavior?

Value is cleared.

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
