### PR TITLE
feat(mui): propagate DataGrid quickFilter values via meta in useDataGrid

### DIFF
--- a/.changeset/quiet-rabbits-search.md
+++ b/.changeset/quiet-rabbits-search.md
@@ -1,0 +1,23 @@
+---
+"@refinedev/mui": minor
+---
+
+feat(mui): propagate DataGrid `quickFilterValues` to the data provider via `meta`
+
+`useDataGrid` now forwards `quickFilterValues` and `quickFilterLogicOperator` from MUI's `GridFilterModel` through to the data provider's `getList` call via `meta`. Previously these fields on the filter model were ignored, so the toolbar's quick filter input had no effect in server-side filtering mode.
+
+The values bypass `CrudFilters` (which map 1:1 to per-column `GridFilterItem`s) and are placed on `meta` instead, so the data provider can interpret them as a free-text search parameter — e.g. translating to a `q=` query string — or ignore them. The toolbar input is kept in sync via the returned `filterModel`, so it remains responsive as the user types while the server query stays debounced.
+
+```ts
+// dataProvider
+getList: async ({ resource, filters, sorters, pagination, meta }) => {
+  const params = new URLSearchParams();
+  if (meta?.quickFilterValues?.length) {
+    params.set("q", meta.quickFilterValues.join(" "));
+    if (meta.quickFilterLogicOperator) {
+      params.set("q_op", meta.quickFilterLogicOperator);
+    }
+  }
+  // ...
+};
+```

--- a/.changeset/stable-mui-datagrid-filter-model-identity.md
+++ b/.changeset/stable-mui-datagrid-filter-model-identity.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/mui": patch
+---
+
+fix(mui): stabilize `filterModel` identity returned from `useDataGrid`
+
+`useDataGrid` returned `dataGridProps.filterModel` as a freshly-allocated object on every render even when the underlying filter state was unchanged. Consumers feeding it into MUI X DataGrid (or to `useEffect` deps keyed on its identity) hit unnecessary work and could trigger effect loops in user code.
+
+Wrapped the `filterModel` computation in `useMemo` keyed on `muiCrudFilters`, the permanent filters, and the column-type map — mirroring the existing memoization already used for `sortModel`. Behavior is otherwise unchanged: the value still updates whenever the underlying filter state or the DataGrid-reported column types actually change.

--- a/documentation/docs/ui-integrations/material-ui/hooks/use-data-grid/index.md
+++ b/documentation/docs/ui-integrations/material-ui/hooks/use-data-grid/index.md
@@ -264,6 +264,56 @@ const MyComponent = () => {
 
 :::
 
+### Quick filter
+
+MUI's DataGrid toolbar exposes a quick filter (`<GridToolbarQuickFilter />`) that performs a free-text search across the grid. The text the user types is delivered to `onFilterModelChange` as `GridFilterModel.quickFilterValues` (an array of tokens) together with `quickFilterLogicOperator` (`"and" | "or"`).
+
+Because the quick filter is not a per-column predicate, it doesn't map to `CrudFilters` (which are field-based). `useDataGrid` instead forwards both values through to the data provider via the `meta` object, where your data provider can translate them into whatever search parameter your API expects — or ignore them.
+
+```tsx
+import { useDataGrid, List } from "@refinedev/mui";
+import { DataGrid, GridColDef, GridToolbarQuickFilter } from "@mui/x-data-grid";
+
+const columns: GridColDef[] = [
+  { field: "id", headerName: "ID", type: "number" },
+  { field: "title", headerName: "Title" },
+];
+
+export const PostsList: React.FC = () => {
+  const { dataGridProps } = useDataGrid({ resource: "posts" });
+
+  return (
+    <List>
+      <DataGrid
+        {...dataGridProps}
+        columns={columns}
+        slots={{ toolbar: GridToolbarQuickFilter }}
+      />
+    </List>
+  );
+};
+```
+
+When the user types in the quick filter input, the data provider's `getList` receives the values on `meta`:
+
+```ts
+// dataProvider
+getList: async ({ resource, pagination, filters, sorters, meta }) => {
+  const params = new URLSearchParams();
+
+  if (meta?.quickFilterValues?.length) {
+    params.set("q", meta.quickFilterValues.join(" "));
+    if (meta.quickFilterLogicOperator) {
+      params.set("q_op", meta.quickFilterLogicOperator); // "and" | "or"
+    }
+  }
+
+  // ...pagination/filters/sorters
+};
+```
+
+The toolbar input is kept in sync via the returned `filterModel`, so it stays responsive as the user types; the server query is debounced separately.
+
 ## Realtime Updates
 
 > [`LiveProvider`](/core/docs/realtime/live-provider/) is required for this prop to work.
@@ -569,6 +619,10 @@ useDataGrid({
 - Generating GraphQL queries using plain JavaScript Objects (JSON).
 
 > For more information, refer to the [`meta` section of the General Concepts documentation for more information &#8594](/core/docs/guides-concepts/general-concepts/#meta-concept)
+
+:::note
+When the user types in the DataGrid toolbar's quick filter, `useDataGrid` adds `quickFilterValues` and `quickFilterLogicOperator` to `meta` automatically (see [Quick filter](#quick-filter)). Avoid passing your own `meta` keys with those names.
+:::
 
 In the following example, we pass the `headers` property in the `meta` object to the `create` method. With similar logic, you can pass any properties to specifically handle the data provider methods.
 

--- a/packages/mui/src/hooks/useDataGrid/index.spec.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.spec.ts
@@ -8,6 +8,7 @@ import type { CrudFilters } from "@refinedev/core";
 import { act } from "react-dom/test-utils";
 import { posts } from "@test/dataMocks";
 import * as core from "@refinedev/core";
+import { GridLogicOperator } from "@mui/x-data-grid";
 
 describe("useDataGrid Hook", () => {
   it("controlled filtering with 'onSubmit' and 'onSearch'", async () => {
@@ -515,6 +516,328 @@ describe("useDataGrid Hook", () => {
     expect(result.current.dataGridProps.filterModel?.items[0]).toEqual(
       expect.objectContaining({ field: "age", operator: "=" }),
     );
+  });
+
+  describe("quickFilter propagation", () => {
+    // Fake timers so the 300ms server-side debounce is deterministic.
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const flushDebounce = async () => {
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+    };
+
+    it("propagates quickFilterValues to data provider getList meta", async () => {
+      const getList = vi.fn().mockResolvedValue({ data: [], total: 0 });
+
+      const { result } = renderHook(
+        () =>
+          useDataGrid({
+            resource: "posts",
+          }),
+        {
+          wrapper: TestWrapper({
+            dataProvider: { ...MockJSONServer, getList },
+            resources: [{ name: "posts" }],
+          }),
+        },
+      );
+
+      await waitFor(() => {
+        expect(getList).toHaveBeenCalled();
+      });
+
+      // Initial call: no quickFilter keys in meta.
+      expect(getList.mock.calls[0][0].meta).not.toHaveProperty(
+        "quickFilterValues",
+      );
+      expect(getList.mock.calls[0][0].meta).not.toHaveProperty(
+        "quickFilterLogicOperator",
+      );
+
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange({
+          items: [],
+          quickFilterValues: ["foo", "bar"],
+          quickFilterLogicOperator: GridLogicOperator.And,
+        });
+      });
+      await flushDebounce();
+
+      await waitFor(() => {
+        const lastCall = getList.mock.calls[getList.mock.calls.length - 1][0];
+        expect(lastCall.meta).toEqual(
+          expect.objectContaining({
+            quickFilterValues: ["foo", "bar"],
+            quickFilterLogicOperator: GridLogicOperator.And,
+          }),
+        );
+      });
+    });
+
+    it("merges quickFilter into user-provided meta", async () => {
+      const getList = vi.fn().mockResolvedValue({ data: [], total: 0 });
+
+      const { result } = renderHook(
+        () =>
+          useDataGrid({
+            resource: "posts",
+            meta: { tenant: "acme" },
+          }),
+        {
+          wrapper: TestWrapper({
+            dataProvider: { ...MockJSONServer, getList },
+            resources: [{ name: "posts" }],
+          }),
+        },
+      );
+
+      await waitFor(() => {
+        expect(getList).toHaveBeenCalled();
+      });
+
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange({
+          items: [],
+          quickFilterValues: ["search"],
+          quickFilterLogicOperator: GridLogicOperator.Or,
+        });
+      });
+      await flushDebounce();
+
+      await waitFor(() => {
+        const lastCall = getList.mock.calls[getList.mock.calls.length - 1][0];
+        expect(lastCall.meta).toEqual(
+          expect.objectContaining({
+            tenant: "acme",
+            quickFilterValues: ["search"],
+            quickFilterLogicOperator: GridLogicOperator.Or,
+          }),
+        );
+      });
+    });
+
+    it("exposes quickFilterValues back through dataGridProps.filterModel", async () => {
+      const { result } = renderHook(
+        () =>
+          useDataGrid({
+            resource: "posts",
+          }),
+        {
+          wrapper: TestWrapper({
+            dataProvider: MockJSONServer,
+            resources: [{ name: "posts" }],
+          }),
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.tableQuery?.isLoading).toBeFalsy();
+      });
+
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange({
+          items: [],
+          quickFilterValues: ["typed"],
+          quickFilterLogicOperator: GridLogicOperator.And,
+        });
+      });
+
+      // Display copy updates immediately, no debounce needed.
+      expect(result.current.dataGridProps.filterModel).toEqual(
+        expect.objectContaining({
+          quickFilterValues: ["typed"],
+          quickFilterLogicOperator: GridLogicOperator.And,
+        }),
+      );
+    });
+
+    it("omits quickFilter from meta when values are empty, even if operator is set", async () => {
+      const getList = vi.fn().mockResolvedValue({ data: [], total: 0 });
+
+      const { result } = renderHook(
+        () =>
+          useDataGrid({
+            resource: "posts",
+          }),
+        {
+          wrapper: TestWrapper({
+            dataProvider: { ...MockJSONServer, getList },
+            resources: [{ name: "posts" }],
+          }),
+        },
+      );
+
+      await waitFor(() => {
+        expect(getList).toHaveBeenCalled();
+      });
+
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange({
+          items: [
+            {
+              field: "title",
+              operator: "contains",
+              value: "first",
+              id: "title-contains",
+            },
+          ],
+          quickFilterValues: ["hello"],
+          quickFilterLogicOperator: GridLogicOperator.And,
+        });
+      });
+      await flushDebounce();
+
+      await waitFor(() => {
+        const lastMeta =
+          getList.mock.calls[getList.mock.calls.length - 1][0].meta;
+        expect(lastMeta).toHaveProperty("quickFilterValues", ["hello"]);
+      });
+
+      // Clear values but leave the operator set. Change items too so the
+      // query refetches (its key includes filters but not meta).
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange({
+          items: [
+            {
+              field: "title",
+              operator: "contains",
+              value: "second",
+              id: "title-contains",
+            },
+          ],
+          quickFilterValues: [],
+          quickFilterLogicOperator: GridLogicOperator.And,
+        });
+      });
+      await flushDebounce();
+
+      await waitFor(() => {
+        const lastMeta =
+          getList.mock.calls[getList.mock.calls.length - 1][0].meta;
+        expect(lastMeta).not.toHaveProperty("quickFilterValues");
+        expect(lastMeta).not.toHaveProperty("quickFilterLogicOperator");
+      });
+    });
+
+    it("does not propagate quickFilter via meta in client filterMode", async () => {
+      const getList = vi.fn().mockResolvedValue({ data: [], total: 0 });
+
+      const { result } = renderHook(
+        () =>
+          useDataGrid({
+            resource: "posts",
+            filters: { mode: "off" },
+          }),
+        {
+          wrapper: TestWrapper({
+            dataProvider: { ...MockJSONServer, getList },
+            resources: [{ name: "posts" }],
+          }),
+        },
+      );
+
+      await waitFor(() => {
+        expect(getList).toHaveBeenCalled();
+      });
+
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange({
+          items: [],
+          quickFilterValues: ["hello"],
+          quickFilterLogicOperator: GridLogicOperator.And,
+        });
+      });
+
+      // Toolbar input is still controlled by the hook.
+      expect(result.current.dataGridProps.filterModel).toEqual(
+        expect.objectContaining({
+          quickFilterValues: ["hello"],
+        }),
+      );
+
+      // Data provider must not see it: DataGrid filters locally.
+      for (const [params] of getList.mock.calls) {
+        expect(params.meta).not.toHaveProperty("quickFilterValues");
+        expect(params.meta).not.toHaveProperty("quickFilterLogicOperator");
+      }
+    });
+
+    it("clears stale quickFilter from meta when switching from server to client mode", async () => {
+      const getList = vi.fn().mockResolvedValue({ data: [], total: 0 });
+
+      const { result, rerender } = renderHook(
+        ({ mode }: { mode: "server" | "off" }) =>
+          useDataGrid({
+            resource: "posts",
+            filters: { mode },
+          }),
+        {
+          wrapper: TestWrapper({
+            dataProvider: { ...MockJSONServer, getList },
+            resources: [{ name: "posts" }],
+          }),
+          initialProps: { mode: "server" },
+        },
+      );
+
+      await waitFor(() => {
+        expect(getList).toHaveBeenCalled();
+      });
+
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange({
+          items: [
+            {
+              field: "title",
+              operator: "contains",
+              value: "anything",
+              id: "title-contains",
+            },
+          ],
+          quickFilterValues: ["hello"],
+          quickFilterLogicOperator: GridLogicOperator.And,
+        });
+      });
+      await flushDebounce();
+
+      await waitFor(() => {
+        const lastMeta =
+          getList.mock.calls[getList.mock.calls.length - 1][0].meta;
+        expect(lastMeta).toHaveProperty("quickFilterValues", ["hello"]);
+      });
+
+      // Toggle to client mode; stale `appliedQuickFilter` must stop leaking.
+      rerender({ mode: "off" });
+
+      await act(async () => {
+        result.current.dataGridProps.onFilterModelChange({
+          items: [
+            {
+              field: "title",
+              operator: "contains",
+              value: "something-else",
+              id: "title-contains",
+            },
+          ],
+          quickFilterValues: ["hello"],
+          quickFilterLogicOperator: GridLogicOperator.And,
+        });
+      });
+
+      await waitFor(() => {
+        const lastMeta =
+          getList.mock.calls[getList.mock.calls.length - 1][0].meta;
+        expect(lastMeta).not.toHaveProperty("quickFilterValues");
+        expect(lastMeta).not.toHaveProperty("quickFilterLogicOperator");
+      });
+    });
   });
 
   it("should not change sortModel when page changes", async () => {

--- a/packages/mui/src/hooks/useDataGrid/index.spec.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.spec.ts
@@ -308,6 +308,215 @@ describe("useDataGrid Hook", () => {
     });
   });
 
+  it("keeps sortModel reference stable across re-renders when sorters are unchanged", async () => {
+    const { result, rerender } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+          sorters: {
+            initial: [
+              {
+                field: "title",
+                order: "asc",
+              },
+            ],
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: MockJSONServer,
+          resources: [{ name: "posts" }],
+        }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.tableQuery.isSuccess).toBeTruthy();
+    });
+
+    const firstSortModel = result.current.dataGridProps.sortModel;
+
+    rerender();
+
+    expect(result.current.dataGridProps.sortModel).toBe(firstSortModel);
+  });
+
+  it("returns a new sortModel reference when sorters change", async () => {
+    const { result } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+          sorters: {
+            initial: [
+              {
+                field: "title",
+                order: "asc",
+              },
+            ],
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: MockJSONServer,
+          resources: [{ name: "posts" }],
+        }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.tableQuery.isSuccess).toBeTruthy();
+    });
+
+    const initialSortModel = result.current.dataGridProps.sortModel;
+
+    await act(async () => {
+      result.current.dataGridProps.onSortModelChange!(
+        [{ field: "title", sort: "desc" }],
+        {} as any,
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.dataGridProps.sortModel).not.toBe(initialSortModel);
+    });
+    expect(result.current.dataGridProps.sortModel).toEqual([
+      { field: "title", sort: "desc" },
+    ]);
+  });
+
+  it("keeps filterModel reference stable across re-renders when filters are unchanged", async () => {
+    const { result, rerender } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+          filters: {
+            initial: [
+              {
+                field: "title",
+                operator: "contains",
+                value: "hello",
+              },
+            ],
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: MockJSONServer,
+          resources: [{ name: "posts" }],
+        }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.tableQuery.isSuccess).toBeTruthy();
+    });
+
+    const firstFilterModel = result.current.dataGridProps.filterModel;
+
+    rerender();
+
+    expect(result.current.dataGridProps.filterModel).toBe(firstFilterModel);
+  });
+
+  it("returns a new filterModel reference when filters change", async () => {
+    const { result } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+          filters: {
+            initial: [
+              {
+                field: "title",
+                operator: "contains",
+                value: "hello",
+              },
+            ],
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: MockJSONServer,
+          resources: [{ name: "posts" }],
+        }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.tableQuery.isSuccess).toBeTruthy();
+    });
+
+    const initialFilterModel = result.current.dataGridProps.filterModel;
+
+    await act(async () => {
+      result.current.dataGridProps.onFilterModelChange({
+        items: [
+          {
+            field: "title",
+            operator: "contains",
+            value: "world",
+            id: "titlecontains",
+          },
+        ],
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.dataGridProps.filterModel).not.toBe(
+        initialFilterModel,
+      );
+    });
+  });
+
+  it("refreshes filterModel when column types change via onStateChange", async () => {
+    const { result, rerender } = renderHook(
+      () =>
+        useDataGrid({
+          resource: "posts",
+          filters: {
+            initial: [
+              {
+                field: "age",
+                operator: "eq",
+                value: 25,
+              },
+            ],
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: MockJSONServer,
+          resources: [{ name: "posts" }],
+        }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.tableQuery.isSuccess).toBeTruthy();
+    });
+
+    // Before onStateChange fires, column types are unknown so the "eq"
+    // operator falls back to the string default ("equals").
+    expect(result.current.dataGridProps.filterModel?.items[0]).toEqual(
+      expect.objectContaining({ field: "age", operator: "equals" }),
+    );
+
+    // Simulate the DataGrid reporting its column metadata.
+    act(() => {
+      result.current.dataGridProps.onStateChange!({
+        columns: { lookup: { age: { type: "number" } } },
+      } as any);
+    });
+
+    // onStateChange mutates a ref and does not schedule a re-render on
+    // its own — matching real usage, the next render (here forced via
+    // rerender) picks up the new column-type map and the memoized
+    // filterModel reflects it: "eq" on a number column maps to "=".
+    rerender();
+    expect(result.current.dataGridProps.filterModel?.items[0]).toEqual(
+      expect.objectContaining({ field: "age", operator: "=" }),
+    );
+  });
+
   it("should not change sortModel when page changes", async () => {
     const { result } = renderHook(
       () =>

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -19,6 +19,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type {
   DataGridProps,
   GridFilterModel,
+  GridLogicOperator,
   GridSortModel,
 } from "@mui/x-data-grid";
 
@@ -164,6 +165,37 @@ export function useDataGrid<
 
   const { identifier } = useResourceParams({ resource: resourceFromProp });
 
+  const isServerSideFilteringEnabled =
+    (filtersFromProp?.mode || "server") === "server";
+
+  // `display` drives the toolbar input (updates immediately); `applied` is
+  // what flows to `meta` and is debounced in server mode.
+  const [displayQuickFilter, setDisplayQuickFilter] = useState<{
+    values?: GridFilterModel["quickFilterValues"];
+    logicOperator?: GridLogicOperator;
+  }>({});
+  const [appliedQuickFilter, setAppliedQuickFilter] = useState<{
+    values?: GridFilterModel["quickFilterValues"];
+    logicOperator?: GridLogicOperator;
+  }>({});
+
+  const metaWithQuickFilter = useMemo(() => {
+    const hasValues =
+      isServerSideFilteringEnabled &&
+      appliedQuickFilter.values !== undefined &&
+      appliedQuickFilter.values.length > 0;
+    if (!hasValues) {
+      return meta;
+    }
+    return {
+      ...meta,
+      quickFilterValues: appliedQuickFilter.values,
+      ...(appliedQuickFilter.logicOperator !== undefined
+        ? { quickFilterLogicOperator: appliedQuickFilter.logicOperator }
+        : {}),
+    };
+  }, [meta, appliedQuickFilter, isServerSideFilteringEnabled]);
+
   const {
     tableQuery,
     currentPage,
@@ -193,7 +225,7 @@ export function useDataGrid<
     liveMode: liveModeFromProp,
     onLiveEvent,
     liveParams,
-    meta,
+    meta: metaWithQuickFilter,
     dataProviderName,
     overtimeOptions,
   });
@@ -210,8 +242,6 @@ export function useDataGrid<
     return rowCountRef.current;
   }, [data]);
 
-  const isServerSideFilteringEnabled =
-    (filtersFromProp?.mode || "server") === "server";
   const isServerSideSortingEnabled =
     (sortersFromProp?.mode || "server") === "server";
   const isPaginationEnabled = (pagination?.mode ?? "server") !== "off";
@@ -261,12 +291,18 @@ export function useDataGrid<
 
   const handleFilterModelChange = (filterModel: GridFilterModel) => {
     const crudFilters = transformFilterModelToCrudFilters(filterModel);
+    const nextQuickFilter = {
+      values: filterModel.quickFilterValues,
+      logicOperator: filterModel.quickFilterLogicOperator,
+    };
     setMuiCrudFilters(crudFilters);
+    setDisplayQuickFilter(nextQuickFilter);
     if (isServerSideFilteringEnabled) {
       // Let the input update immediately; debounce only the server query.
       clearFilterDebounce();
       filterDebounceRef.current = setTimeout(() => {
         applyFilters(crudFilters);
+        setAppliedQuickFilter(nextQuickFilter);
       }, DEFAULT_FILTER_DEBOUNCE_MS);
       return;
     }
@@ -278,6 +314,8 @@ export function useDataGrid<
       const searchFilters = await onSearchProp(value);
       clearFilterDebounce();
       setMuiCrudFilters(searchFilters);
+      setDisplayQuickFilter({});
+      setAppliedQuickFilter({});
       applyFilters(searchFilters);
     }
   };
@@ -356,6 +394,16 @@ export function useDataGrid<
     [muiCrudFilters, preferredPermanentFilters, columnsTypes.current],
   );
 
+  const filterModelWithQuickFilter = useMemo<GridFilterModel>(
+    () => ({
+      items: transformedFilterModel?.items ?? [],
+      logicOperator: transformedFilterModel?.logicOperator,
+      quickFilterValues: displayQuickFilter.values,
+      quickFilterLogicOperator: displayQuickFilter.logicOperator,
+    }),
+    [transformedFilterModel, displayQuickFilter],
+  );
+
   return {
     tableQuery,
     dataGridProps: {
@@ -370,7 +418,7 @@ export function useDataGrid<
       filterMode: isServerSideFilteringEnabled ? "server" : "client",
       // Disable DataGrid's debounce for server filtering to prevent input resets.
       filterDebounceMs: isServerSideFilteringEnabled ? 0 : undefined,
-      filterModel: transformedFilterModel,
+      filterModel: filterModelWithQuickFilter,
       onFilterModelChange: handleFilterModelChange,
       onStateChange: (state) => {
         const newColumnsTypes = Object.fromEntries(

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -347,6 +347,15 @@ export function useDataGrid<
     [sorters, preferredPermanentSorters],
   );
 
+  const transformedFilterModel = useMemo(
+    () =>
+      transformCrudFiltersToFilterModel(
+        differenceWith(muiCrudFilters, preferredPermanentFilters, isEqual),
+        columnsTypes.current,
+      ),
+    [muiCrudFilters, preferredPermanentFilters, columnsTypes.current],
+  );
+
   return {
     tableQuery,
     dataGridProps: {
@@ -361,10 +370,7 @@ export function useDataGrid<
       filterMode: isServerSideFilteringEnabled ? "server" : "client",
       // Disable DataGrid's debounce for server filtering to prevent input resets.
       filterDebounceMs: isServerSideFilteringEnabled ? 0 : undefined,
-      filterModel: transformCrudFiltersToFilterModel(
-        differenceWith(muiCrudFilters, preferredPermanentFilters, isEqual),
-        columnsTypes.current,
-      ),
+      filterModel: transformedFilterModel,
       onFilterModelChange: handleFilterModelChange,
       onStateChange: (state) => {
         const newColumnsTypes = Object.fromEntries(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

Quick filters from the MUI filter state not propagated to the data provider

## What is the new behavior?

Quick filters from the MUI filter state propagated to the data provider

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
