### PR TITLE
fix: typo 'recieved' -> 'received' in doc-survey-widget

### DIFF
--- a/documentation/src/refine-theme/doc-survey-widget.tsx
+++ b/documentation/src/refine-theme/doc-survey-widget.tsx
@@ -287,7 +287,7 @@ const SurveyFinished = (props: {
         animate={{ opacity: 1, transition: { delay: 0.2 } }}
         exit={{ opacity: 0 }}
       >
-        <div className={clsx("mt-1")}>Your feedback has been recieved.</div>
+        <div className={clsx("mt-1")}>Your feedback has been received.</div>
       </motion.div>
     </div>
   );


### PR DESCRIPTION
This is an independent contribution made in a personal capacity. Not associated with any organization or event.

## Summary
Fix a spelling error in the user-facing survey widget text.

## Root Cause
The word "recieved" is misspelled in the thank-you message displayed after submitting feedback in the documentation survey widget.

## Fix
Corrected "recieved" to "received" on line 290 of `documentation/src/refine-theme/doc-survey-widget.tsx`.

## Testing
- Visual inspection confirmed the change only affects the one misspelled word
- No functional changes or behavior modifications