### PR TITLE
fix(mui): avoid nested anchors in themed title

### DIFF
--- a/.changeset/calm-mui-title-link.md
+++ b/.changeset/calm-mui-title-link.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mui": patch
+---
+
+Fix ThemedTitle to avoid rendering nested anchor elements.

--- a/packages/mui/src/components/themedLayout/title/index.spec.tsx
+++ b/packages/mui/src/components/themedLayout/title/index.spec.tsx
@@ -1,6 +1,19 @@
+import React from "react";
 import { layoutTitleTests } from "@refinedev/ui-tests";
+import { render, TestWrapper } from "@test";
 import { ThemedTitle } from "./index";
 
 describe("ThemedTitle", () => {
   layoutTitleTests.bind(this)(ThemedTitle);
+
+  it("should not render nested anchor elements", () => {
+    const { container } = render(<ThemedTitle collapsed={false} />, {
+      wrapper: TestWrapper({}),
+    });
+
+    const anchors = container.querySelectorAll("a");
+
+    expect(anchors).toHaveLength(1);
+    expect(anchors[0]?.querySelector("a")).toBeNull();
+  });
 });

--- a/packages/mui/src/components/themedLayout/title/index.tsx
+++ b/packages/mui/src/components/themedLayout/title/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useLink, useRefineOptions } from "@refinedev/core";
 
-import MuiLink from "@mui/material/Link";
+import Box from "@mui/material/Box";
 import SvgIcon from "@mui/material/SvgIcon";
 import Typography from "@mui/material/Typography";
 
@@ -24,8 +24,7 @@ export const ThemedTitle: React.FC<RefineLayoutThemedTitleProps> = ({
 
   return (
     <Link to="/" style={{ textDecoration: "none" }}>
-      <MuiLink
-        underline="none"
+      <Box
         sx={{
           display: "flex",
           alignItems: "center",
@@ -48,7 +47,7 @@ export const ThemedTitle: React.FC<RefineLayoutThemedTitleProps> = ({
             {text}
           </Typography>
         )}
-      </MuiLink>
+      </Box>
     </Link>
   );
 };


### PR DESCRIPTION
Fixes #7418.

## Summary
- Replace the inner MUI Link in ThemedTitle with Box to avoid rendering nested anchors
- Add a regression test that asserts ThemedTitle renders a single anchor
- Add a patch changeset for @refinedev/mui

## Tests
- pnpm --filter @refinedev/mui test -- themedLayout/title
- pnpm --filter @refinedev/mui test
- pnpm --filter @refinedev/mui build