### PR TITLE
chore(cli): replace temp with native mkdtemp

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,7 +68,6 @@
     "prettier": "^2.7.1",
     "semver": "7.5.2",
     "semver-diff": "^3.1.1",
-    "temp": "^0.9.4",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -90,7 +89,6 @@
     "@types/pluralize": "^0.0.29",
     "@types/prettier": "^2.7.3",
     "@types/semver": "^7.5.8",
-    "@types/temp": "^0.9.1",
     "@vitest/ui": "^2.1.8",
     "tsup": "^6.7.0",
     "typescript": "^5.8.3",

--- a/packages/cli/src/commands/add/sub-commands/resource/create-resources.ts
+++ b/packages/cli/src/commands/add/sub-commands/resource/create-resources.ts
@@ -6,17 +6,19 @@ import { getResourcePath } from "@utils/resource";
 import spinner from "@utils/spinner";
 import { uppercaseFirstChar } from "@utils/text";
 import execa from "execa";
+import { mkdtempSync } from "fs";
 import {
   copySync,
   mkdirSync,
   moveSync,
   pathExistsSync,
+  removeSync,
   unlinkSync,
 } from "fs-extra";
 import inquirer from "inquirer";
+import { tmpdir } from "os";
 import { join } from "path";
 import { plural } from "pluralize";
-import temp from "temp";
 import { getCommandRootDir } from "./get-command-root-dir";
 
 export const defaultActions = ["list", "create", "edit", "show"];
@@ -97,9 +99,6 @@ export const createResources = async (
     // create temp dir
     const tempDir = generateTempDir();
 
-    // copy template files
-    copySync(sourceDir, tempDir);
-
     const compileParams = {
       resourceName,
       resource,
@@ -108,34 +107,39 @@ export const createResources = async (
       isNextJs,
     };
 
-    // compile dir
-    compileDir(tempDir, compileParams);
-
-    // delete ignored actions
-    if (customActions) {
-      defaultActions.forEach((action) => {
-        if (!customActions.includes(action)) {
-          unlinkSync(`${tempDir}/${action}.tsx`);
-        }
-      });
-    }
-
-    // create desctination dir
-    mkdirSync(destinationPath, { recursive: true });
-
-    // copy to destination
     const destinationResourcePath = `${destinationPath}/${resourceFolderName}`;
 
-    let moveSyncOptions = {};
+    try {
+      // copy template files
+      copySync(sourceDir, tempDir);
 
-    // empty dir override
-    if (pathExistsSync(destinationResourcePath)) {
-      moveSyncOptions = { overwrite: true };
+      // compile dir
+      compileDir(tempDir, compileParams);
+
+      // delete ignored actions
+      if (customActions) {
+        defaultActions.forEach((action) => {
+          if (!customActions.includes(action)) {
+            unlinkSync(`${tempDir}/${action}.tsx`);
+          }
+        });
+      }
+
+      // create desctination dir
+      mkdirSync(destinationPath, { recursive: true });
+
+      let moveSyncOptions = {};
+
+      // empty dir override
+      if (pathExistsSync(destinationResourcePath)) {
+        moveSyncOptions = { overwrite: true };
+      }
+      moveSync(tempDir, destinationResourcePath, moveSyncOptions);
+    } finally {
+      if (pathExistsSync(tempDir)) {
+        removeSync(tempDir);
+      }
     }
-    moveSync(tempDir, destinationResourcePath, moveSyncOptions);
-
-    // clear temp dir
-    temp.cleanupSync();
 
     // if use Next.js, generate page files. This makes easier to use the resource
     if (isNextJs) {
@@ -182,8 +186,7 @@ export const createResources = async (
 };
 
 const generateTempDir = (): string => {
-  temp.track();
-  return temp.mkdirSync("resource");
+  return mkdtempSync(join(tmpdir(), "refine-resource-"));
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11521,9 +11521,6 @@ importers:
       semver-diff:
         specifier: ^3.1.1
         version: 3.1.1
-      temp:
-        specifier: ^0.9.4
-        version: 0.9.4
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -11582,9 +11579,6 @@ importers:
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
-      '@types/temp':
-        specifier: ^0.9.1
-        version: 0.9.4
       '@vitest/ui':
         specifier: ^2.1.8
         version: 2.1.9(vitest@2.1.9)
@@ -20721,9 +20715,6 @@ packages:
 
   '@types/tar@6.1.13':
     resolution: {integrity: sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==}
-
-  '@types/temp@0.9.4':
-    resolution: {integrity: sha512-+VfWIwrlept2VBTj7Y2wQnI/Xfscy1u8Pyj/puYwss6V1IblXn1x7S0S9eFh6KyBolgLCm+rUFzhFAbdkR691g==}
 
   '@types/through@0.0.33':
     resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
@@ -43194,10 +43185,6 @@ snapshots:
     dependencies:
       '@types/node': 20.5.1
       minipass: 4.2.8
-
-  '@types/temp@0.9.4':
-    dependencies:
-      '@types/node': 20.5.1
 
   '@types/through@0.0.33':
     dependencies:


### PR DESCRIPTION
## Summary

- replace the CLI `temp` package usage in resource generation with native `fs.mkdtempSync`
- clean up the temporary resource directory with the existing `fs-extra` utilities
- remove the direct `temp` and `@types/temp` dependencies from `@refinedev/cli`

Closes #7375.

## Verification

- `pnpm --filter @refinedev/cli test -- src/commands/add/sub-commands/resource/index.test.ts`
- `pnpm biome check packages/cli/src/commands/add/sub-commands/resource/create-resources.ts packages/cli/package.json`
- `git diff --check`

## Notes

- `pnpm --filter @refinedev/cli build` completed the `tsup` CJS/ESM bundle step, then failed during declaration generation because this filtered install did not have prebuilt `@refinedev/devtools-server` workspace declarations available.
