### PR TITLE
feat: add scroll-to-top button for better navigation

### DIFF
--- a/.changeset/7390-feat-scroll-to-top.md
+++ b/.changeset/7390-feat-scroll-to-top.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/mantine": patch
+---
+
+fix: add scroll-to-top button for better navigation. #7390
+
+We had an edge case where navigation became inconvenient on long pages due to the lack of a quick return-to-top action. A scroll-to-top button has now been added to improve usability and navigation flow.
+
+Fixes #7390

--- a/.changeset/scroll-to-top-button.md
+++ b/.changeset/scroll-to-top-button.md
@@ -1,0 +1,5 @@
+---
+"documentation": patch
+---
+
+Add a scroll-to-top button to the docs layout.

--- a/.changeset/scroll-to-top-button.md
+++ b/.changeset/scroll-to-top-button.md
@@ -1,5 +1,0 @@
----
-"documentation": patch
----
-
-Add a scroll-to-top button to the docs layout.

--- a/documentation/src/refine-theme/common-layout.tsx
+++ b/documentation/src/refine-theme/common-layout.tsx
@@ -8,6 +8,7 @@ import SkipToContent from "@theme/SkipToContent";
 import { LivePreviewProvider } from "../components/live-preview-context";
 import useRouteFavicon from "../hooks/use-route-favicon";
 import clsx from "clsx";
+import { ScrollToTop } from "./scroll-to-top";
 
 type Props = {
   className?: string;
@@ -35,6 +36,7 @@ export const CommonLayout = (props: Props) => {
         <ErrorBoundary fallback={(params) => <ErrorPageContent {...params} />}>
           <LivePreviewProvider>{children}</LivePreviewProvider>
         </ErrorBoundary>
+        <ScrollToTop />
       </div>
     </LayoutProvider>
   );

--- a/documentation/src/refine-theme/scroll-to-top.tsx
+++ b/documentation/src/refine-theme/scroll-to-top.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import clsx from "clsx";
+import { ArrowUpIcon } from "./icons/arrow-up";
+
+const SCROLL_THRESHOLD_PX = 360;
+
+export const ScrollToTop = () => {
+  const [isVisible, setIsVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > SCROLL_THRESHOLD_PX);
+    };
+
+    handleScroll();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  const handleClick = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label="Scroll to top"
+      onClick={handleClick}
+      className={clsx(
+        "fixed bottom-6 right-6 z-40",
+        "flex h-11 w-11 items-center justify-center",
+        "rounded-full border border-zinc-200/80",
+        "bg-gradient-to-br from-zinc-50 via-white to-zinc-100",
+        "text-zinc-900 shadow-[0_10px_24px_rgba(0,0,0,0.18)]",
+        "backdrop-blur",
+        "transition-all duration-200",
+        "hover:-translate-y-0.5 hover:shadow-[0_14px_28px_rgba(0,0,0,0.22)]",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/40",
+        "dark:border-zinc-700",
+        "dark:bg-gradient-to-br dark:from-zinc-900 dark:via-zinc-900 dark:to-zinc-800",
+        "dark:text-zinc-100 dark:focus-visible:ring-zinc-100/40",
+        isVisible
+          ? "pointer-events-auto opacity-100"
+          : "pointer-events-none opacity-0",
+      )}
+    >
+      <ArrowUpIcon className="h-4 w-4" />
+    </button>
+  );
+};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

Users navigating long pages do not have a quick way to return to the top of the page, which can negatively affect usability and navigation experience.

## What is the new behavior?

A scroll-to-top button has been added to improve navigation and provide a smoother user experience on long pages.

Fixes #7390

## Notes for reviewers

- Added scroll-to-top functionality for better page navigation.
- No breaking changes introduced.
