### PR TITLE
fix(mui): remove nested anchor in ThemedTitle to prevent hydration error

### DIFF
--- a/packages/mui/src/components/themedLayout/title/index.tsx
+++ b/packages/mui/src/components/themedLayout/title/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useLink, useRefineOptions } from "@refinedev/core";
 
-import MuiLink from "@mui/material/Link";
+import Box from "@mui/material/Box";
 import SvgIcon from "@mui/material/SvgIcon";
 import Typography from "@mui/material/Typography";
 
@@ -24,8 +24,7 @@ export const ThemedTitle: React.FC<RefineLayoutThemedTitleProps> = ({
 
   return (
     <Link to="/" style={{ textDecoration: "none" }}>
-      <MuiLink
-        underline="none"
+      <Box
         sx={{
           display: "flex",
           alignItems: "center",
@@ -48,7 +47,7 @@ export const ThemedTitle: React.FC<RefineLayoutThemedTitleProps> = ({
             {text}
           </Typography>
         )}
-      </MuiLink>
+      </Box>
     </Link>
   );
 };


### PR DESCRIPTION
## Summary

Replaces `MuiLink` with `Box` inside `ThemedTitle` so the component no longer renders nested `<a>` tags, which is invalid HTML and causes a hydration error in React 19.

## Changes

- Replaced `MuiLink` import with `Box` from @mui/material
- Replaced `<MuiLink underline="none" ...>` with `<Box sx={{ display: "flex", ... }}>`

## Why

`Link` from `@refinedev/core` already renders as an `<a>` tag. Wrapping `MuiLink` (which also renders as `<a>` by default) inside it produces nested anchors, triggering React 19 hydration warnings.

Closes #7418
