### PR TITLE
fix(core): add number[] to BaseKey type for UUID support

### DIFF
--- a/packages/core/src/contexts/data/types.ts
+++ b/packages/core/src/contexts/data/types.ts
@@ -5,7 +5,7 @@ export type Prettify<T> = {
   [K in keyof T]: T[K];
 } & {};
 
-export type BaseKey = string | number;
+export type BaseKey = string | number | number[];
 export type BaseRecord = {
   id?: BaseKey;
   [key: string]: any;


### PR DESCRIPTION
## Summary\n\nExtends the BaseKey type to include 
umber[], allowing UUID values generated by OpenAPI tools (which may produce 
umber[] types) to be used without forced casting.\n\n## Changes\n\n- BaseKey: string | number → string | number | number[]\n\nCloses #7403