### PR TITLE
feat(docs): enable scroll-to-top button

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -251,6 +251,7 @@ License: MIT`,
     ],
   ],
   themeConfig: {
+    scrollToTop: true,
     prism: {
       theme: require("prism-react-renderer/themes/github"),
       darkTheme: require("prism-react-renderer/themes/vsDark"),


### PR DESCRIPTION
## Summary\n\nEnables Docusaurus built-in scroll-to-top button so users can quickly return to the top of long documentation pages.\n\n## Changes\n\n- Added scrollToTop: true to 	hemeConfig in docusaurus.config.js\n\nCloses #7390