### PR TITLE
fix(examples): handle OAuth access_denied in auth-headless example

### DIFF
--- a/examples/auth-headless/src/App.tsx
+++ b/examples/auth-headless/src/App.tsx
@@ -119,6 +119,20 @@ const App: React.FC = () => {
       return { error };
     },
     check: async () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      const error = urlParams.get("error");
+
+      if (error === "access_denied") {
+        return {
+          authenticated: false,
+          redirectTo: "/login",
+          error: {
+            message: "Login cancelled by user",
+            name: "Authorization denied",
+          },
+        };
+      }
+
       return localStorage.getItem("email")
         ? { authenticated: true }
         : {


### PR DESCRIPTION
fix(examples): handle OAuth access_denied in auth-headless example

## Description

When a user cancels GitHub OAuth login by clicking "Cancel" on the GitHub authorization screen, the callback URL contains `error=access_denied`. Previously, the authProvider did not handle this case, resulting in a generic "No user information from OAuth provider" 401 Unauthorized error.

This PR adds handling for the `access_denied` error in the auth-headless example's authProvider check method. Now when a user cancels OAuth, they see a friendly error message: "Login cancelled by user" / "Authorization denied".

## Changes

- Updated `examples/auth-headless/src/App.tsx`
- Added OAuth cancellation detection in `authProvider.check()`
- Returns user-friendly error message when `error=access_denied` is detected in URL

## Testing

1. Navigate to login page
2. Click "Sign in with GitHub"
3. On GitHub authorization screen, click "Cancel"
4. Verify that a user-friendly error message is displayed instead of 401

## Related Issue

Closes #7407
