### PR TITLE
fix(core): prevent React Query double fetching by lazy signal access

### DIFF
--- a/packages/core/src/hooks/data/useCustom.ts
+++ b/packages/core/src/hooks/data/useCustom.ts
@@ -6,7 +6,7 @@ import {
   useQuery,
 } from "@tanstack/react-query";
 
-import { prepareQueryContext } from "@definitions/helpers";
+
 import {
   useDataProvider,
   useHandleNotification,
@@ -168,16 +168,24 @@ export const useCustom = <
           ...(preferredMeta || {}),
         })
         .get(),
-      queryFn: (context) =>
-        custom<TQueryFnData>({
+      queryFn: (context) => {
+        const meta = {
+          ...combinedMeta,
+          queryKey: context.queryKey,
+        };
+        Object.defineProperty(meta, "signal", {
+          enumerable: true,
+          get() {
+            return context.signal;
+          },
+        });
+        return custom<TQueryFnData>({
           url,
           method,
           ...config,
-          meta: {
-            ...combinedMeta,
-            ...prepareQueryContext(context as any),
-          },
-        }),
+          meta,
+        });
+      },
       ...queryOptions,
       meta: {
         ...queryOptions?.meta,

--- a/packages/core/src/hooks/data/useInfiniteList.ts
+++ b/packages/core/src/hooks/data/useInfiniteList.ts
@@ -12,7 +12,6 @@ import {
   getPreviousPageParam,
   handlePaginationParams,
   pickDataProvider,
-  prepareQueryContext,
 } from "@definitions/helpers";
 import {
   useDataProvider,
@@ -256,8 +255,14 @@ export const useInfiniteList = <
 
       const meta = {
         ...combinedMeta,
-        ...prepareQueryContext(context),
+        queryKey: context.queryKey,
       };
+      Object.defineProperty(meta, "signal", {
+        enumerable: true,
+        get() {
+          return context.signal;
+        },
+      });
 
       return getList<TQueryFnData>({
         resource: resource?.name || "",

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -11,7 +11,6 @@ import {
 import {
   handlePaginationParams,
   pickDataProvider,
-  prepareQueryContext,
 } from "@definitions/helpers";
 import {
   useDataProvider,
@@ -257,8 +256,14 @@ export const useList = <
     queryFn: (context) => {
       const meta = {
         ...combinedMeta,
-        ...prepareQueryContext(context),
+        queryKey: context.queryKey,
       };
+      Object.defineProperty(meta, "signal", {
+        enumerable: true,
+        get() {
+          return context.signal;
+        },
+      });
       return getList<TQueryFnData>({
         resource: resource?.name ?? "",
         pagination: prefferedPagination,

--- a/packages/core/src/hooks/data/useMany.ts
+++ b/packages/core/src/hooks/data/useMany.ts
@@ -9,7 +9,6 @@ import {
 import {
   handleMultiple,
   pickDataProvider,
-  prepareQueryContext,
 } from "@definitions/helpers";
 import {
   useDataProvider,
@@ -190,8 +189,14 @@ export const useMany = <
     queryFn: (context) => {
       const meta = {
         ...combinedMeta,
-        ...prepareQueryContext(context as any),
+        queryKey: context.queryKey,
       };
+      Object.defineProperty(meta, "signal", {
+        enumerable: true,
+        get() {
+          return context.signal;
+        },
+      });
 
       if (getMany) {
         return getMany({

--- a/packages/core/src/hooks/data/useOne.ts
+++ b/packages/core/src/hooks/data/useOne.ts
@@ -6,7 +6,7 @@ import {
   useQuery,
 } from "@tanstack/react-query";
 
-import { pickDataProvider, prepareQueryContext } from "@definitions";
+import { pickDataProvider } from "@definitions";
 import {
   useDataProvider,
   useHandleNotification,
@@ -181,15 +181,23 @@ export const useOne = <
         ...(preferredMeta || {}),
       })
       .get(),
-    queryFn: (context) =>
-      getOne<TQueryFnData>({
+    queryFn: (context) => {
+      const meta = {
+        ...combinedMeta,
+        queryKey: context.queryKey,
+      };
+      Object.defineProperty(meta, "signal", {
+        enumerable: true,
+        get() {
+          return context.signal;
+        },
+      });
+      return getOne<TQueryFnData>({
         resource: resource?.name ?? "",
         id: id!,
-        meta: {
-          ...combinedMeta,
-          ...prepareQueryContext(context as any),
-        },
-      }),
+        meta,
+      });
+    },
     ...queryOptions,
     enabled: isEnabled,
     meta: {


### PR DESCRIPTION
fix(core): prevent React Query double fetching by lazy signal access

## Description

Refine v5's `useList` and other data hooks perform **two HTTP requests** in React 18 + Strict Mode in development, while refine v4 performed only one.

## Root Cause

Spreading `prepareQueryContext(context)` inside `queryFn` invokes the `signal` getter, causing React Query to detect that `signal` is used. When `signal` is used, React Query treats the query as abortable, and in dev + Strict Mode it cancels the first run and issues a second fetch.

## Fix

Avoid spreading the object with the `signal` getter and instead define the lazy getter directly on the `meta` object, matching v4 behavior.

### Changed
- `packages/core/src/hooks/data/useList.ts`
- `packages/core/src/hooks/data/useOne.ts`
- `packages/core/src/hooks/data/useMany.ts`
- `packages/core/src/hooks/data/useCustom.ts`
- `packages/core/src/hooks/data/useInfiniteList.ts`

## Verification

Before fix: 2 network requests in Strict Mode dev
After fix: 1 network request in Strict Mode dev

## Related Issue

Closes #7132
