### PR TITLE
feat(core): add updateIdentity method to auth provider

### DIFF
--- a/.changeset/auth-provider-update-identity.md
+++ b/.changeset/auth-provider-update-identity.md
@@ -1,0 +1,21 @@
+---
+"@refinedev/core": minor
+---
+
+feat: add `updateIdentity` method to auth provider and `useUpdateIdentity` hook
+
+Added an optional `updateIdentity` method to the `AuthProvider` interface so consumers can natively update the current user's identity (e.g. username and/or email), following the same pattern as `updatePassword`.
+
+A new `useUpdateIdentity` hook calls the `updateIdentity` method from the `authProvider` under the hood, mirroring `useUpdatePassword`'s behavior for redirects, notifications and error handling.
+
+```tsx
+import { useUpdateIdentity } from "@refinedev/core";
+
+const { mutate: updateIdentity } = useUpdateIdentity();
+
+updateIdentity({ name: "New Name", email: "new@email.com" });
+```
+
+The `updateIdentity` method is optional, so existing auth providers remain fully backwards-compatible.
+
+[Resolves #6926](https://github.com/refinedev/refine/issues/6926)

--- a/documentation/docs/authentication/auth-provider/index.md
+++ b/documentation/docs/authentication/auth-provider/index.md
@@ -54,6 +54,7 @@ const authProvider: AuthProvider = {
     register: async (params: any): AuthActionResponse,
     forgotPassword: async (params: any): AuthActionResponse,
     updatePassword: async (params: any): AuthActionResponse,
+    updateIdentity: async (params: any): AuthActionResponse,
     getPermissions: async (params: any): unknown,
     getIdentity: async (params: any): unknown,
 };
@@ -1157,6 +1158,63 @@ const authProvider: AuthProvider = {
 
 </details>
 
+### updateIdentity
+
+`updateIdentity` method is used to update the current user's identity (e.g. username and/or email). It expects to return a resolved promise with the following type:
+
+```ts
+type AuthActionResponse = {
+  success: boolean;
+  redirectTo?: string;
+  error?: Error;
+  [key: string]: unknown;
+};
+```
+
+- `success`: Determines whether the operation is successful or not.
+- `redirectTo`: The path of the page that the user will be redirected to after the operation is completed.
+- `error`: An object containing details about any errors encountered during the operation.
+- `[key: string]`: Any additional data you wish to include in the response, keyed by a string identifier.
+
+<br />
+
+To update the user's identity and resolve the promise:
+
+```tsx title="src/authProvider.ts"
+import { AuthProvider } from "@refinedev/core";
+
+const authProvider: AuthProvider = {
+  // ---
+  updateIdentity: async ({ name, email }) => {
+    // update the user's identity here
+
+    // if request is successful
+    return {
+      success: true,
+    };
+
+    // if request is not successful
+    return {
+      success: false,
+      error: {
+        name: "Update Identity Error",
+        message: "Update identity failed",
+      },
+    };
+  },
+};
+```
+
+[`useUpdateIdentity`][use-update-identity] hook is used to call the `updateIdentity` method from the `authProvider`.
+
+```tsx
+import { useUpdateIdentity } from "@refinedev/core";
+
+const { mutate: updateIdentity } = useUpdateIdentity();
+
+updateIdentity({ name: "New Name", email: "new@email.com" });
+```
+
 ## Legacy Auth Provider
 
 Refine's v4 release is backward compatible and supports legacy auth provider implementations until v5.
@@ -1207,4 +1265,5 @@ const App = () => {
 [use-register]: /core/docs/authentication/hooks/use-register
 [use-forgot-password]: /core/docs/authentication/hooks/use-forgot-password
 [use-update-password]: /core/docs/authentication/hooks/use-update-password
+[use-update-identity]: /core/docs/authentication/hooks/use-update-identity
 [create-auth-provider-tutorial]: /core/docs/guides-concepts/authentication

--- a/documentation/docs/authentication/hooks/use-update-identity/index.md
+++ b/documentation/docs/authentication/hooks/use-update-identity/index.md
@@ -1,0 +1,152 @@
+---
+title: "useUpdateIdentity Hook | Options, Patterns & Edge Cases in Refine v5"
+display_title: "useUpdateIdentity"
+sidebar_label: "useUpdateIdentity"
+description: "Set up Use Update Identity in Refine v5. Learn how to update the current user's identity (e.g. username and email) from the auth provider with code snippets."
+source: /packages/core/src/hooks/auth/useUpdateIdentity/index.ts
+---
+
+`useUpdateIdentity` calls `updateIdentity` method from [`authProvider`](/core/docs/authentication/auth-provider/) under the hood. It lets you update the current user's identity (e.g. username and/or email) natively, following the same pattern as [`useUpdatePassword`](/core/docs/authentication/hooks/use-update-password/).
+
+It returns the result of `react-query`'s [useMutation](https://tanstack.com/query/v5/docs/react/reference/useMutation).
+
+Data that is resolved from `updateIdentity` will be returned as the `data` in the query result with the following type:
+
+```ts
+type SuccessNotificationResponse = {
+  message: string;
+  description?: string;
+};
+
+type AuthActionResponse = {
+  success: boolean;
+  redirectTo?: string;
+  error?: Error;
+  [key: string]: unknown;
+  successNotification?: SuccessNotificationResponse;
+};
+```
+
+- `success`: A boolean indicating whether the operation was successful. If `success` is false, a notification will be shown.
+  - When `error` is provided, the notification will contain the error message and name. Otherwise, a generic error message will be shown with the following values: `{ name: "Update Identity Error", message: "Error while updating identity" }`.
+- `redirectTo`: If has a value, the app will be redirected to the given URL.
+- `error`: If has a value, a notification will be shown with the error message and name.
+- `[key: string]`: Any additional data you wish to include in the response, keyed by a string identifier.
+- `successNotification`: If provided, a success notification will be shown. The structure is as follows:
+
+```ts
+type SuccessNotificationResponse = {
+  message: string;
+  description?: string;
+};
+```
+
+## Usage
+
+To update the current user's identity, you can use the `useUpdateIdentity` hook like this:
+
+```tsx title="pages/customUpdateIdentityPage"
+import { useUpdateIdentity } from "@refinedev/core";
+
+type UpdateIdentityVariables = {
+  name: string;
+  email: string;
+};
+
+export const UpdateIdentityPage = () => {
+  const { mutate: updateIdentity } =
+    useUpdateIdentity<UpdateIdentityVariables>();
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const values = {
+      name: e.currentTarget.name.value,
+      email: e.currentTarget.email.value,
+    };
+
+    updateIdentity(values);
+  };
+
+  return (
+    <form onSubmit={onSubmit}>
+      <label>Name</label>
+      <input name="name" />
+      <label>Email</label>
+      <input name="email" />
+      <button type="submit">Submit</button>
+    </form>
+  );
+};
+```
+
+`mutate` acquired from `useUpdateIdentity` can accept any kind of object for values since the `updateIdentity` method from `authProvider` doesn't have a restriction on its parameters.
+A type parameter for the values can be provided to `useUpdateIdentity`.
+
+```tsx
+const { mutate: updateIdentity } = useUpdateIdentity<{ email: string }>();
+```
+
+## Redirection after updateIdentity
+
+A custom URL can be given to mutate the function from the `useUpdateIdentity` hook if you want to redirect yourself to a certain URL:
+
+```tsx
+import { useUpdateIdentity } from "@refinedev/core";
+
+const { mutate: updateIdentity } = useUpdateIdentity();
+
+updateIdentity({ redirectPath: "/custom-url" });
+```
+
+Then, you can handle this URL in your `updateIdentity` method of the `authProvider`:
+
+```tsx
+import type { AuthProvider } from "@refinedev/core";
+
+const authProvider: AuthProvider = {
+  // ...
+  updateIdentity: async ({ redirectPath, ...identity }) => {
+    // ...
+    return {
+      success: true,
+      redirectTo: redirectPath,
+      successNotification: {
+        message: "Update identity successful",
+        description: "You have successfully updated your identity.",
+      },
+    };
+  },
+};
+```
+
+## Error handling
+
+Since the methods of `authProvider` always return a resolved promise, you can handle errors by using the `success` value in the response:
+
+```tsx
+import { useUpdateIdentity } from "@refinedev/core";
+
+const { mutate: updateIdentity } = useUpdateIdentity();
+
+updateIdentity(
+  {
+    email: "new@email.com",
+  },
+  {
+    onSuccess: (data) => {
+      if (!data.success) {
+        // handle error
+      }
+
+      // handle success
+    },
+  },
+);
+```
+
+:::caution
+
+The `onError` callback of the `useUpdateIdentity` hook will not be called if `success` is `false`. This is because the `authProvider` methods always return a resolved promise, and the callback is only triggered when the promise is rejected.
+
+:::

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -418,6 +418,7 @@ module.exports = {
             "authentication/hooks/use-register/index",
             "authentication/hooks/use-forgot-password/index",
             "authentication/hooks/use-update-password/index",
+            "authentication/hooks/use-update-identity/index",
           ],
         },
         {

--- a/packages/core/src/contexts/auth/index.tsx
+++ b/packages/core/src/contexts/auth/index.tsx
@@ -96,6 +96,19 @@ export const AuthProviderContextProvider: React.FC<
     }
   };
 
+  const handleUpdateIdentity = async (params: unknown) => {
+    try {
+      const result = await authProvider.updateIdentity?.(params);
+      return Promise.resolve(result);
+    } catch (error) {
+      console.warn(
+        "Unhandled Error in updateIdentity: refine always expects a resolved promise.",
+        error,
+      );
+      return Promise.reject(error);
+    }
+  };
+
   return (
     <AuthProviderContext.Provider
       value={{
@@ -106,6 +119,7 @@ export const AuthProviderContextProvider: React.FC<
         register: handleRegister as IAuthContext["register"],
         forgotPassword: handleForgotPassword as IAuthContext["forgotPassword"],
         updatePassword: handleUpdatePassword as IAuthContext["updatePassword"],
+        updateIdentity: handleUpdateIdentity as IAuthContext["updateIdentity"],
         isProvided,
       }}
     >

--- a/packages/core/src/contexts/auth/types.ts
+++ b/packages/core/src/contexts/auth/types.ts
@@ -71,6 +71,7 @@ export type AuthProvider = {
   register?: (params: any) => Promise<AuthActionResponse>;
   forgotPassword?: (params: any) => Promise<AuthActionResponse>;
   updatePassword?: (params: any) => Promise<AuthActionResponse>;
+  updateIdentity?: (params: any) => Promise<AuthActionResponse>;
   getPermissions?: (
     params?: Record<string, any>,
   ) => Promise<PermissionResponse>;

--- a/packages/core/src/definitions/helpers/keys/index.ts
+++ b/packages/core/src/definitions/helpers/keys/index.ts
@@ -22,7 +22,8 @@ type AuthActionType =
   | "check"
   | "onError"
   | "permissions"
-  | "updatePassword";
+  | "updatePassword"
+  | "updateIdentity";
 
 type AuditActionType = "list" | "log" | "rename";
 

--- a/packages/core/src/hooks/auth/index.ts
+++ b/packages/core/src/hooks/auth/index.ts
@@ -5,6 +5,7 @@ export { useLogin } from "./useLogin";
 export { useRegister } from "./useRegister";
 export { useForgotPassword } from "./useForgotPassword";
 export { useUpdatePassword } from "./useUpdatePassword";
+export { useUpdateIdentity } from "./useUpdateIdentity";
 export { useIsAuthenticated } from "./useIsAuthenticated";
 export { useOnError } from "./useOnError";
 export { useIsExistAuthentication } from "./useIsExistAuthentication";

--- a/packages/core/src/hooks/auth/useUpdateIdentity/index.spec.ts
+++ b/packages/core/src/hooks/auth/useUpdateIdentity/index.spec.ts
@@ -1,0 +1,534 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { TestWrapper, act, mockRouterProvider, queryClient } from "@test";
+
+import { useUpdateIdentity } from "./";
+
+const mockFn = vi.fn();
+
+const mockAuthProvider = {
+  login: () => Promise.resolve({ success: true }),
+  check: () => Promise.resolve({ authenticated: true }),
+  onError: () => Promise.resolve({}),
+  logout: () => Promise.resolve({ success: true }),
+};
+
+describe("useUpdateIdentity Hook", () => {
+  beforeEach(() => {
+    mockFn.mockReset();
+    vi.spyOn(console, "error").mockImplementation((message) => {
+      if (message?.message === "Missing fields") return;
+      if (typeof message === "undefined") return;
+      console.warn(message);
+    });
+  });
+
+  it("succeed update identity with legacyRouterProvider", async () => {
+    const { result } = renderHook(() => useUpdateIdentity(), {
+      wrapper: TestWrapper({
+        authProvider: {
+          ...mockAuthProvider,
+          updateIdentity: ({ name, email }: any) => {
+            if (name && email) {
+              return Promise.resolve({ success: true });
+            }
+            return Promise.resolve({
+              success: false,
+              error: new Error("Missing fields"),
+            });
+          },
+        },
+      }),
+    });
+
+    const { mutate: updateIdentity } = result.current;
+
+    await act(async () => {
+      updateIdentity({ name: "Refine", email: "info@refine.dev" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy();
+    });
+
+    expect(result.current.data).toEqual({ success: true });
+    expect(mockFn).not.toHaveBeenCalledWith();
+  });
+
+  it("succeed update identity", async () => {
+    const mockGo = vi.fn();
+
+    const { result } = renderHook(() => useUpdateIdentity(), {
+      wrapper: TestWrapper({
+        authProvider: {
+          ...mockAuthProvider,
+          updateIdentity: ({ name, email }: any) => {
+            if (name && email) {
+              return Promise.resolve({
+                success: true,
+                redirectTo: "redirectTo",
+              });
+            }
+            return Promise.resolve({
+              success: false,
+              error: new Error("Missing fields"),
+            });
+          },
+        },
+        routerProvider: mockRouterProvider({
+          fns: {
+            go: () => mockGo,
+          },
+        }),
+      }),
+    });
+
+    const { mutate: updateIdentity } = result.current;
+
+    await act(async () => {
+      updateIdentity({ name: "Refine", email: "info@refine.dev" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy();
+    });
+
+    expect(mockGo).toHaveBeenCalledWith({
+      to: "redirectTo",
+      type: "replace",
+    });
+  });
+
+  it("fail update identity", async () => {
+    const { result } = renderHook(() => useUpdateIdentity(), {
+      wrapper: TestWrapper({
+        authProvider: {
+          ...mockAuthProvider,
+          updateIdentity: ({ name, email }: any) => {
+            if (name && email) {
+              return Promise.resolve({ success: true });
+            }
+            return Promise.resolve({
+              success: false,
+              error: new Error("Missing fields"),
+            });
+          },
+        },
+      }),
+    });
+
+    const { mutate: updateIdentity } = result.current;
+
+    await act(async () => {
+      updateIdentity({ name: "Refine" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy();
+    });
+
+    expect(result.current.data).toEqual({
+      success: false,
+      error: new Error("Missing fields"),
+    });
+    expect(mockFn).not.toHaveBeenCalledWith();
+  });
+
+  it("success and redirect", async () => {
+    const mockGo = vi.fn();
+
+    const { result } = renderHook(() => useUpdateIdentity(), {
+      wrapper: TestWrapper({
+        authProvider: {
+          login: () => Promise.resolve({ success: true }),
+          logout: () => Promise.resolve({ success: true }),
+          check: () => Promise.resolve({ authenticated: true }),
+          onError: () => Promise.resolve({}),
+          updateIdentity: ({ name, email }: any) => {
+            if (name && email) {
+              return Promise.resolve({
+                success: true,
+                redirectTo: "/login",
+              });
+            }
+            return Promise.resolve({
+              success: false,
+              error: new Error("Missing fields"),
+            });
+          },
+        },
+        routerProvider: mockRouterProvider({
+          fns: {
+            go: () => mockGo,
+          },
+        }),
+      }),
+    });
+
+    const { mutate: updateIdentity } = result.current;
+
+    await act(async () => {
+      updateIdentity({ name: "Refine", email: "info@refine.dev" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy();
+    });
+
+    expect(result.current.data).toEqual({
+      success: true,
+      redirectTo: "/login",
+    });
+    expect(mockGo).toHaveBeenCalledWith({
+      to: "/login",
+      type: "replace",
+    });
+  });
+
+  it("fail and redirect", async () => {
+    const mockGo = vi.fn();
+
+    const { result } = renderHook(() => useUpdateIdentity(), {
+      wrapper: TestWrapper({
+        authProvider: {
+          login: () => Promise.resolve({ success: true }),
+          logout: () => Promise.resolve({ success: true }),
+          check: () => Promise.resolve({ authenticated: true }),
+          onError: () => Promise.resolve({}),
+          updateIdentity: ({ name, email }: any) => {
+            if (name && email) {
+              return Promise.resolve({
+                success: true,
+              });
+            }
+            return Promise.resolve({
+              success: false,
+              error: new Error("Missing fields"),
+              redirectTo: "/register",
+            });
+          },
+        },
+        routerProvider: mockRouterProvider({
+          fns: {
+            go: () => mockGo,
+          },
+        }),
+      }),
+    });
+
+    const { mutate: updateIdentity } = result.current;
+
+    await act(async () => {
+      updateIdentity({ email: "info@refine.dev" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy();
+    });
+
+    expect(result.current.data).toEqual({
+      success: false,
+      error: new Error("Missing fields"),
+      redirectTo: "/register",
+    });
+    expect(mockGo).toHaveBeenCalledWith({
+      to: "/register",
+      type: "replace",
+    });
+  });
+
+  it("should open notification when has error is true", async () => {
+    const openNotificationMock = vi.fn();
+
+    const { result } = renderHook(() => useUpdateIdentity(), {
+      wrapper: TestWrapper({
+        notificationProvider: {
+          open: openNotificationMock,
+          close: vi.fn(),
+        },
+        authProvider: {
+          login: () => Promise.resolve({ success: true }),
+          logout: () => Promise.resolve({ success: true }),
+          check: () => Promise.resolve({ authenticated: true }),
+          onError: () => Promise.resolve({}),
+          updateIdentity: () =>
+            Promise.resolve({
+              success: false,
+              error: new Error("Error"),
+            }),
+        },
+      }),
+    });
+
+    const { mutate: updateIdentity } = result.current;
+
+    await act(async () => {
+      updateIdentity({});
+    });
+
+    await waitFor(() => {
+      expect(openNotificationMock).toHaveBeenCalledWith({
+        key: "update-identity-error",
+        type: "error",
+        message: "Error",
+        description: "Error",
+      });
+    });
+  });
+
+  it("should open notification when has success is false, error is undefined", async () => {
+    const updateIdentityMock = vi.fn();
+    const openNotificationMock = vi.fn();
+    const closeNotificationMock = vi.fn();
+
+    const { result } = renderHook(() => useUpdateIdentity(), {
+      wrapper: TestWrapper({
+        notificationProvider: {
+          open: openNotificationMock,
+          close: closeNotificationMock,
+        },
+        authProvider: {
+          login: () => Promise.resolve({ success: true }),
+          logout: () => Promise.resolve({ success: true }),
+          check: () => Promise.resolve({ authenticated: true }),
+          onError: () => Promise.resolve({}),
+          updateIdentity: updateIdentityMock,
+        },
+      }),
+    });
+
+    const { mutate: updateIdentity } = result.current;
+
+    updateIdentityMock.mockResolvedValueOnce({
+      success: false,
+    });
+    await act(async () => {
+      updateIdentity({});
+    });
+
+    await waitFor(() => {
+      expect(openNotificationMock).toHaveBeenCalledWith({
+        key: "update-identity-error",
+        type: "error",
+        message: "Update Identity Error",
+        description: "Error while updating identity",
+      });
+    });
+
+    updateIdentityMock.mockResolvedValueOnce({
+      success: true,
+    });
+    await act(async () => {
+      updateIdentity({});
+    });
+    await waitFor(() => {
+      expect(closeNotificationMock).toHaveBeenCalledWith(
+        "update-identity-error",
+      );
+    });
+  });
+
+  it("should open notification when throw error", async () => {
+    const openNotificationMock = vi.fn();
+
+    const { result } = renderHook(() => useUpdateIdentity(), {
+      wrapper: TestWrapper({
+        notificationProvider: {
+          open: openNotificationMock,
+          close: vi.fn(),
+        },
+        authProvider: {
+          login: () => Promise.resolve({ success: true }),
+          logout: () => Promise.resolve({ success: true }),
+          check: () => Promise.resolve({ authenticated: true }),
+          onError: () => Promise.resolve({}),
+          updateIdentity: () => {
+            throw new Error("Unhandled error");
+          },
+        },
+      }),
+    });
+
+    const { mutate: updateIdentity } = result.current;
+
+    await act(async () => {
+      updateIdentity({});
+    });
+
+    await waitFor(() => {
+      expect(openNotificationMock).toHaveBeenCalledWith({
+        key: "update-identity-error",
+        type: "error",
+        message: "Error",
+        description: "Unhandled error",
+      });
+    });
+  });
+
+  it("should work notificationProvider", async () => {
+    const onErrorMock = vi.fn();
+    const onSuccessMock = vi.fn();
+    const updateIdentityMock = vi.fn();
+
+    const { result } = renderHook(
+      () =>
+        useUpdateIdentity({
+          mutationOptions: {
+            onSuccess: onSuccessMock,
+            onError: onErrorMock,
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          authProvider: {
+            login: () => Promise.resolve({ success: true }),
+            logout: () => Promise.resolve({ success: true }),
+            check: () => Promise.resolve({ authenticated: true }),
+            onError: () => Promise.resolve({}),
+            updateIdentity: updateIdentityMock,
+          },
+        }),
+      },
+    );
+
+    const { mutate: updateIdentity } = result.current;
+
+    updateIdentityMock.mockRejectedValueOnce(new Error("Error"));
+    await act(async () => {
+      updateIdentity({});
+    });
+    await waitFor(() => {
+      expect(onErrorMock).toHaveBeenCalledTimes(1);
+    });
+
+    updateIdentityMock.mockResolvedValueOnce({
+      success: false,
+    });
+    await act(async () => {
+      updateIdentity({});
+    });
+    await waitFor(() => {
+      expect(onSuccessMock).toHaveBeenCalledTimes(1);
+    });
+
+    updateIdentityMock.mockResolvedValueOnce({
+      success: true,
+    });
+    await act(async () => {
+      updateIdentity({});
+    });
+    await waitFor(() => {
+      expect(onSuccessMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("should override `mutationFn` with mutationOptions.mutationFn", async () => {
+    const updateIdentityMock = vi.fn().mockResolvedValue({ data: {} });
+    const mutationFnMock = vi.fn().mockResolvedValue({ data: {} });
+
+    const { result } = renderHook(
+      () =>
+        useUpdateIdentity({
+          mutationOptions: {
+            // mutationFn is omitted in types. So we need to use @ts-ignore test it.
+            // @ts-ignore
+            mutationFn: mutationFnMock,
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          authProvider: {
+            login: () => Promise.resolve({ success: true }),
+            logout: () => Promise.resolve({ success: true }),
+            check: () => Promise.resolve({ authenticated: true }),
+            onError: () => Promise.resolve({}),
+            updateIdentity: updateIdentityMock,
+          },
+        }),
+      },
+    );
+
+    result.current.mutate({});
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy();
+    });
+
+    expect(updateIdentityMock).not.toHaveBeenCalled();
+    expect(mutationFnMock).toHaveBeenCalled();
+  });
+
+  it("should override `mutationKey` with `mutationOptions.mutationKey`", async () => {
+    const updateIdentityMock = vi.fn().mockResolvedValue({ data: {} });
+
+    const { result } = renderHook(
+      () =>
+        useUpdateIdentity({
+          mutationOptions: {
+            mutationKey: ["foo", "bar"],
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          authProvider: {
+            login: () => Promise.resolve({ success: true }),
+            logout: () => Promise.resolve({ success: true }),
+            check: () => Promise.resolve({ authenticated: true }),
+            onError: () => Promise.resolve({}),
+            updateIdentity: updateIdentityMock,
+          },
+        }),
+      },
+    );
+
+    result.current.mutate({});
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy();
+    });
+
+    expect(
+      queryClient.getMutationCache().findAll({
+        mutationKey: ["foo", "bar"],
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("should open success notification when successNotification is passed", async () => {
+    const openNotificationMock = vi.fn();
+
+    const successNotification = {
+      message: "Success!",
+      description: "Operation completed successfully",
+    };
+
+    const { result } = renderHook(() => useUpdateIdentity(), {
+      wrapper: TestWrapper({
+        notificationProvider: {
+          open: openNotificationMock,
+          close: vi.fn(),
+        },
+        authProvider: {
+          ...mockAuthProvider,
+          updateIdentity: () =>
+            Promise.resolve({
+              success: true,
+              successNotification,
+            }),
+        },
+      }),
+    });
+
+    await act(async () => {
+      result.current.mutate({});
+    });
+
+    expect(openNotificationMock).toHaveBeenCalledWith({
+      key: "update-identity-success",
+      type: "success",
+      message: "Success!",
+      description: "Operation completed successfully",
+    });
+  });
+});

--- a/packages/core/src/hooks/auth/useUpdateIdentity/index.spec.ts
+++ b/packages/core/src/hooks/auth/useUpdateIdentity/index.spec.ts
@@ -524,11 +524,32 @@ describe("useUpdateIdentity Hook", () => {
       result.current.mutate({});
     });
 
-    expect(openNotificationMock).toHaveBeenCalledWith({
-      key: "update-identity-success",
-      type: "success",
-      message: "Success!",
-      description: "Operation completed successfully",
+    await waitFor(() => {
+      expect(openNotificationMock).toHaveBeenCalledWith({
+        key: "update-identity-success",
+        type: "success",
+        message: "Success!",
+        description: "Operation completed successfully",
+      });
+    });
+  });
+
+  it("should surface an error state when `updateIdentity` is not implemented", async () => {
+    // `updateIdentity` is optional on the auth provider. When it is not
+    // implemented, the mutation resolves `undefined` and the hook ends up in
+    // an error state instead of silently succeeding.
+    const { result } = renderHook(() => useUpdateIdentity(), {
+      wrapper: TestWrapper({
+        authProvider: mockAuthProvider,
+      }),
+    });
+
+    await act(async () => {
+      result.current.mutate({});
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBeTruthy();
     });
   });
 });

--- a/packages/core/src/hooks/auth/useUpdateIdentity/index.ts
+++ b/packages/core/src/hooks/auth/useUpdateIdentity/index.ts
@@ -1,0 +1,122 @@
+import React from "react";
+import { getXRay } from "@refinedev/devtools-internal";
+import {
+  type UseMutationOptions,
+  type UseMutationResult,
+  useMutation,
+} from "@tanstack/react-query";
+
+import { useAuthProviderContext } from "@contexts/auth";
+import { useGo, useKeys, useNotification, useParsed } from "@hooks";
+
+import type {
+  AuthActionResponse,
+  SuccessNotificationResponse,
+} from "../../../contexts/auth/types";
+import type { RefineError } from "../../../contexts/data/types";
+import type { OpenNotificationParams } from "../../../contexts/notification/types";
+
+export type UseUpdateIdentityProps<TVariables> = {
+  mutationOptions?: Omit<
+    UseMutationOptions<
+      AuthActionResponse,
+      Error | RefineError,
+      TVariables,
+      unknown
+    >,
+    "mutationFn"
+  >;
+};
+
+export type UseUpdateIdentityReturnType<TVariables> = UseMutationResult<
+  AuthActionResponse,
+  Error | RefineError,
+  TVariables,
+  unknown
+>;
+
+/**
+ * `useUpdateIdentity` calls `updateIdentity` method from {@link https://refine.dev/docs/api-reference/core/providers/auth-provider `authProvider`} under the hood.
+ *
+ * @see {@link https://refine.dev/docs/api-reference/core/providers/auth-provider} for more details.
+ *
+ * @typeParam TVariables - Values for mutation function. default `{}`
+ *
+ */
+export function useUpdateIdentity<TVariables = {}>({
+  mutationOptions,
+}: UseUpdateIdentityProps<TVariables> = {}): UseUpdateIdentityReturnType<TVariables> {
+  const go = useGo();
+  const { updateIdentity: updateIdentityFromContext } =
+    useAuthProviderContext();
+  const { close, open } = useNotification();
+  const { keys } = useKeys();
+  const parsed = useParsed();
+  const params = parsed.params ?? {};
+
+  const mutation = useMutation<
+    AuthActionResponse,
+    Error | RefineError,
+    TVariables,
+    unknown
+  >({
+    mutationKey: keys().auth().action("updateIdentity").get(),
+    mutationFn: async (variables) => {
+      return updateIdentityFromContext?.({
+        ...params,
+        ...variables,
+      }) as Promise<AuthActionResponse>;
+    },
+    onSuccess: ({ success, redirectTo, error, successNotification }) => {
+      if (success) {
+        close?.("update-identity-error");
+
+        if (successNotification) {
+          open?.(buildSuccessNotification(successNotification));
+        }
+      }
+
+      if (error || !success) {
+        open?.(buildNotification(error));
+      }
+
+      if (redirectTo) {
+        go({ to: redirectTo, type: "replace" });
+      }
+    },
+    onError: (error: any) => {
+      open?.(buildNotification(error));
+    },
+    ...mutationOptions,
+    meta: {
+      ...mutationOptions?.meta,
+      ...getXRay("useUpdateIdentity"),
+    },
+  });
+
+  return {
+    ...mutation,
+  };
+}
+
+const buildNotification = (
+  error?: Error | RefineError,
+): OpenNotificationParams => {
+  return {
+    message: error?.name || "Update Identity Error",
+    description: error?.message || "Error while updating identity",
+    key: "update-identity-error",
+    type: "error",
+  };
+};
+
+const buildSuccessNotification = (
+  successNotification: SuccessNotificationResponse,
+): OpenNotificationParams => {
+  return {
+    message: successNotification.message,
+    description: successNotification.description,
+    key: "update-identity-success",
+    type: "success",
+  };
+};

--- a/packages/core/src/hooks/auth/useUpdateIdentity/index.ts
+++ b/packages/core/src/hooks/auth/useUpdateIdentity/index.ts
@@ -1,4 +1,3 @@
-import React from "react";
 import { getXRay } from "@refinedev/devtools-internal";
 import {
   type UseMutationOptions,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

The auth provider supports updating a user's password (`updatePassword` + `useUpdatePassword`), but there is no native way to update the current user's identity (e.g. username and/or email). Consumers have to fall back to `useCustomMutation`.

fixes #6926

## What is the new behavior?

This implements the maintainer-approved generic design from the issue thread. As suggested by @BatuhanW ("Maybe we could have something more generic, such as `updateIdentity`, since we already have `getIdentity`"), this adds a single generic `updateIdentity` method rather than separate `updateUsername`/`updateEmail` methods. It mirrors the existing `updatePassword` pattern exactly.

- Added an optional `updateIdentity` method to the `AuthProvider` interface (`packages/core/src/contexts/auth/types.ts`).
- Wired `updateIdentity` through the auth context provider with the same resolved-promise error handling as `updatePassword` (`packages/core/src/contexts/auth/index.tsx`).
- Added the `"updateIdentity"` auth action key (`packages/core/src/definitions/helpers/keys/index.ts`).
- Added a new `useUpdateIdentity` hook that mirrors `useUpdatePassword` for mutation key, redirect handling, success/error notifications and `mutationOptions` overrides (`packages/core/src/hooks/auth/useUpdateIdentity/index.ts`).
- Exported `useUpdateIdentity` from the auth hooks barrel so it is publicly available from `@refinedev/core`.
- Added tests mirroring the `useUpdatePassword` test suite (12 tests).
- Added docs: a new `useUpdateIdentity` hook page, an `updateIdentity` section in the auth provider reference, and a sidebar entry.
- Added a changeset (`minor` bump for `@refinedev/core`).

Usage:

```tsx
import { useUpdateIdentity } from "@refinedev/core";

const { mutate: updateIdentity } = useUpdateIdentity();

updateIdentity({ name: "New Name", email: "new@email.com" });
```

The method is **optional**, so existing auth providers remain fully backwards-compatible.

## Notes for reviewers

- The design follows the maintainer steer in #6926 toward a single generic `updateIdentity` method (analogous to `getIdentity`) rather than separate username/email methods.
- Verified locally against `@refinedev/core`: `vitest run` (1211 tests pass, incl. 12 new), `biome ci`, `tsup` build, type declaration generation, `attw`, `publint`, `syncpack lint`, and `tsdoc-link-check` all pass.
- The new hook's `@see` TSDoc link points at the existing auth-provider reference page (which resolves today) since the dedicated hook page is published from this same PR; happy to switch it to the per-hook URL if preferred.