### PR TITLE
fix: hydrate field array values after form remount

### DIFF
--- a/.changeset/fix-use-field-array-navigation.md
+++ b/.changeset/fix-use-field-array-navigation.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/react-hook-form": patch
+---
+
+Fixed query data hydration for forms using `useFieldArray` after SPA navigation.

--- a/packages/react-hook-form/src/useForm/index.spec.tsx
+++ b/packages/react-hook-form/src/useForm/index.spec.tsx
@@ -4,8 +4,8 @@ import { useForm } from ".";
 import type { IRefineOptions, HttpError } from "@refinedev/core";
 import * as Core from "@refinedev/core";
 import { MockJSONServer, TestWrapper, act, render, waitFor } from "../../test";
-import { Route, Routes } from "react-router";
-import { Controller } from "react-hook-form";
+import { Link, Route, Routes } from "react-router";
+import { Controller, type Control, useFieldArray } from "react-hook-form";
 
 interface IPost {
   title: string;
@@ -328,5 +328,120 @@ describe("useForm hook", () => {
     } finally {
       useFormCoreSpy.mockRestore();
     }
+  });
+
+  it("should populate useFieldArray fields after navigating back to an edit form", async () => {
+    interface PostWithSkills {
+      id: string;
+      title: string;
+      skills: Array<{ name: string }>;
+    }
+
+    const dataProvider = {
+      ...MockJSONServer,
+      getOne: vi.fn().mockResolvedValue({
+        data: {
+          id: "1",
+          title: "Post 1",
+          skills: [{ name: "TypeScript" }, { name: "React" }],
+        },
+      }),
+    };
+
+    const EditFields = ({
+      control,
+    }: {
+      control: Control<PostWithSkills>;
+    }) => {
+      const { fields } = useFieldArray({
+        control,
+        name: "skills",
+      });
+
+      return (
+        <div>
+          <span data-testid="field-count">{fields.length}</span>
+          {fields.map((field, index) => (
+            <Controller
+              key={field.id}
+              control={control}
+              name={`skills.${index}.name`}
+              render={({ field }) => (
+                <input
+                  data-testid={`skill-${index}`}
+                  value={field.value ?? ""}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+          ))}
+        </div>
+      );
+    };
+
+    const EditPage = () => {
+      const {
+        control,
+        refineCore: { formLoading },
+      } = useForm<PostWithSkills, HttpError, PostWithSkills>({
+        refineCoreProps: {
+          resource: "posts",
+          action: "edit",
+          id: "1",
+        },
+      });
+
+      return (
+        <div>
+          <Link to="/" data-testid="back-link">
+            Back
+          </Link>
+          {!formLoading && <EditFields control={control} />}
+        </div>
+      );
+    };
+
+    const ListPage = () => (
+      <Link to="/posts/edit/1" data-testid="edit-link">
+        Edit
+      </Link>
+    );
+
+    const { findByTestId, getByTestId } = render(
+      <Routes>
+        <Route path="/" element={<ListPage />} />
+        <Route path="/posts/edit/:id" element={<EditPage />} />
+      </Routes>,
+      {
+        wrapper: TestWrapper({
+          dataProvider,
+          routerInitialEntries: ["/posts/edit/1"],
+        }),
+      },
+    );
+
+    expect(
+      await findByTestId("field-count", {}, { timeout: 1000 }),
+    ).toHaveTextContent("2");
+    expect(await findByTestId("skill-0")).toHaveValue("TypeScript");
+    expect(await findByTestId("skill-1")).toHaveValue("React");
+
+    act(() => {
+      getByTestId("back-link").click();
+    });
+
+    expect(
+      await findByTestId("edit-link", {}, { timeout: 1000 }),
+    ).toBeInTheDocument();
+
+    act(() => {
+      getByTestId("edit-link").click();
+    });
+
+    expect(
+      await findByTestId("field-count", {}, { timeout: 1000 }),
+    ).toHaveTextContent("2");
+    expect(await findByTestId("skill-0")).toHaveValue("TypeScript");
+    expect(await findByTestId("skill-1")).toHaveValue("React");
   });
 });

--- a/packages/react-hook-form/src/useForm/index.ts
+++ b/packages/react-hook-form/src/useForm/index.ts
@@ -127,6 +127,7 @@ export const useForm = <
   const {
     control,
     watch,
+    reset,
     setValue,
     getValues,
     handleSubmit: handleSubmitReactHookForm,
@@ -268,7 +269,15 @@ export const useForm = <
     const applyQueryValues = () => {
       if (!isActive) return;
 
-      applyValuesToFields(getRegisteredFields(), data, false);
+      reset(
+        {
+          ...getValues(),
+          ...data,
+        } as unknown as TVariables,
+        {
+          keepDirtyValues: true,
+        },
+      );
     };
 
     queryDataRef.current = data;
@@ -285,7 +294,7 @@ export const useForm = <
     return () => {
       isActive = false;
     };
-  }, [query?.data, setValue, getValues]);
+  }, [query?.data, reset, getValues]);
 
   // Re-sync when new fields register; do not override user edits.
   useEffect(() => {


### PR DESCRIPTION
## Description

Fixes #7401.

This PR fixes an issue where `useFieldArray.fields` could be empty after navigating away from an edit form and then returning to it in an SPA.

The problem occurs when components using `useFieldArray` are rendered only after `useForm`'s `formLoading` becomes `false`. In that flow, the form receives the query data, but the field array may not be registered at the time values are applied. Hydrating fields with individual `setValue` calls does not reliably initialize React Hook Form's field array internals, so `fields` can remain empty even though the query response contains array data.

This updates query data hydration to use React Hook Form's `reset` API with `keepDirtyValues: true`. That allows field arrays to be initialized from the fetched record while preserving dirty user edits. The reset payload also merges the current form values with the query data so registered fields that are not present in the API response keep their existing/default values.

## Changes

- Replaced initial query-data hydration via registered-field `setValue` calls with `reset`.
- Preserved dirty values during hydration with `keepDirtyValues: true`.
- Added a regression test for navigating from an edit form to a list route and back to the edit form.
- Added a patch changeset for `@refinedev/react-hook-form`.

## Tests

```bash
pnpm.cmd --filter @refinedev/react-hook-form test
pnpm.cmd --filter @refinedev/react-hook-form build