### PR TITLE
feat(core): add generic type support to useDataProvider

### DIFF
--- a/.changeset/tricky-eggs-destroy.md
+++ b/.changeset/tricky-eggs-destroy.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": minor
+---
+
+Add generic type support to `useDataProvider` so custom data providers keep their assigned types when accessed through the hook.
+
+This is a type-only improvement. Existing runtime behavior is unchanged, and consumers can opt into the stronger type by passing a generic argument when calling `useDataProvider`.

--- a/packages/core/src/hooks/data/useDataProvider.spec.tsx
+++ b/packages/core/src/hooks/data/useDataProvider.spec.tsx
@@ -1,8 +1,17 @@
 import { renderHook } from "@testing-library/react";
 
 import { MockJSONServer, TestWrapper } from "@test";
+import type { BaseKey, DataProvider, GetOneParams } from "@refinedev/core";
 
 import { useDataProvider } from ".";
+
+type CustomDataProvider = Omit<DataProvider, "getOne"> & {
+  getOne: (params: {
+    resource: string;
+    id: BaseKey;
+    meta?: { test?: string } & GetOneParams["meta"];
+  }) => ReturnType<DataProvider["getOne"]>;
+};
 
 describe("useDataProvider Hook", () => {
   const { result } = renderHook(() => useDataProvider(), {
@@ -23,6 +32,16 @@ describe("useDataProvider Hook", () => {
     const dataProvider = result.current("second");
 
     expect(dataProvider.getList).toBeDefined();
+  });
+
+  it("preserves custom provider types when generic is provided", async () => {
+    const dataProvider = result.current<CustomDataProvider>();
+
+    await dataProvider.getOne({
+      resource: "posts",
+      id: 1,
+      meta: { test: "typed" },
+    });
   });
 
   it("get list with from second data provider", async () => {

--- a/packages/core/src/hooks/data/useDataProvider.tsx
+++ b/packages/core/src/hooks/data/useDataProvider.tsx
@@ -1,13 +1,16 @@
 import { useCallback, useContext } from "react";
 
 import { DataContext } from "@contexts/data";
-import { type DataProvider, IDataContext } from "../../contexts/data/types";
-export const useDataProvider = (): ((
+import type { DataProvider } from "../../contexts/data/types";
+
+export const useDataProvider = <
+  TDataProvider extends DataProvider = DataProvider,
+>(): ((
   /**
    * The name of the `data provider` you want to access
    */
   dataProviderName?: string,
-) => DataProvider) => {
+) => TDataProvider) => {
   const context = useContext(DataContext);
 
   const handleDataProvider = useCallback(
@@ -36,7 +39,7 @@ export const useDataProvider = (): ((
       );
     },
     [context],
-  );
+  ) as (dataProviderName?: string) => TDataProvider;
 
   return handleDataProvider;
 };


### PR DESCRIPTION
## Summary

Adds generic type support to `useDataProvider`, allowing custom data providers to be used with their own types without manual casting.

## Changes

- Added a generic type parameter to `useDataProvider`
- Preserved the existing default `DataProvider` behavior
- Enables usage like `useDataProvider<CustomDataProvider>()` for typed custom providers

## Testing

- Commit hook/lint-staged passed successfully
- Verified the updated core typing behavior locally

Closes #7445 