### PR TITLE
fix(core): preserve falsy values in getDefaultFilter

### DIFF
--- a/.changeset/get-default-filter-falsy.md
+++ b/.changeset/get-default-filter-falsy.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+---
+
+fix(core): preserve falsy values in `getDefaultFilter`
+
+`getDefaultFilter` used `filter.value || []`, which replaced valid falsy filter values (`0`, `false`, `""`) with an empty array. As a result, default values for numeric/boolean/empty-string filters were lost when populating form controls. Switched to `filter.value ?? []` so only `undefined`/`null` fall back to `[]`.

--- a/packages/core/src/definitions/table/index.spec.ts
+++ b/packages/core/src/definitions/table/index.spec.ts
@@ -76,6 +76,22 @@ describe("definitions/table", () => {
     expect(getDefaultFilter("title", filters)).toEqual("test");
   });
 
+  it("getDefaultFilter preserves falsy values", () => {
+    expect(
+      getDefaultFilter("status", [
+        { field: "status", operator: "eq", value: 0 },
+      ]),
+    ).toEqual(0);
+    expect(
+      getDefaultFilter("active", [
+        { field: "active", operator: "eq", value: false },
+      ]),
+    ).toEqual(false);
+    expect(
+      getDefaultFilter("name", [{ field: "name", operator: "eq", value: "" }]),
+    ).toEqual("");
+  });
+
   it("stringify table params correctly", async () => {
     const pagination = {
       currentPage: 1,

--- a/packages/core/src/definitions/table/index.ts
+++ b/packages/core/src/definitions/table/index.ts
@@ -200,7 +200,7 @@ export const getDefaultFilter = (
   });
 
   if (filter) {
-    return filter.value || [];
+    return filter.value ?? [];
   }
 
   return undefined;


### PR DESCRIPTION
## What's broken

`getDefaultFilter` returns `filter.value || []`, so a valid filter value of `0`, `false`, or `""` is silently replaced with `[]`. It's used to seed form controls from active filters, so filtering on e.g. `status = 0` or a boolean loses the real default and the control comes up empty.

```
getDefaultFilter("status", [{ field: "status", operator: "eq", value: 0 }])  // returns [] instead of 0
```

## Why it happens

`|| []` treats every falsy value as "missing". The `[]` fallback is only meant for an absent value (the existing empty-array test uses `value: undefined`).

## Fix

Use nullish coalescing (`?? []`) so only `undefined`/`null` fall back to `[]`.

## Test

Added a case asserting `0`, `false`, and `""` round-trip through `getDefaultFilter`; the existing `undefined → []` behaviour is unchanged.
