### PR TITLE
fix(react-hook-form): reset form state on query data change to fix useFieldArray on revisit

### DIFF
--- a/.changeset/fix-use-field-array-empty-on-revisit.md
+++ b/.changeset/fix-use-field-array-empty-on-revisit.md
@@ -1,0 +1,16 @@
+---
+"@refinedev/react-hook-form": patch
+---
+
+Fix useFieldArray fields being empty on second visit to an edit form.
+
+When navigating away from an edit form and returning to it within a SPA, useFieldArray.fields
+was empty on every visit after the first. The root cause was the field-by-field setValue approach
+in the query data sync effect: syncedFieldsRef accumulated field paths across navigations,
+preventing fields registered by useFieldArray from being populated on re-mount.
+
+The fix replaces applyValuesToFields with reset(data, { keepDirtyValues: true }), which
+re-initialises the entire form state including field arrays on each new query result, while
+preserving any in-progress user edits via the keepDirtyValues option.
+
+Fixes #7401.

--- a/packages/react-hook-form/src/useForm/index.ts
+++ b/packages/react-hook-form/src/useForm/index.ts
@@ -129,6 +129,7 @@ export const useForm = <
     watch,
     setValue,
     getValues,
+    reset,
     handleSubmit: handleSubmitReactHookForm,
     setError,
     formState: { dirtyFields },
@@ -268,7 +269,7 @@ export const useForm = <
     const applyQueryValues = () => {
       if (!isActive) return;
 
-      applyValuesToFields(getRegisteredFields(), data, false);
+      reset(data as unknown as TVariables, { keepDirtyValues: true });
     };
 
     queryDataRef.current = data;


### PR DESCRIPTION
## Problem

When navigating away from an edit form and returning to it within a SPA, `useFieldArray.fields` is empty on every visit after the first. The issue is in `packages/react-hook-form/src/useForm/index.ts`.

The existing approach calls `applyValuesToFields(getRegisteredFields(), data, false)` which uses `setValue` on individual field paths and tracks synced paths in `syncedFieldsRef`. On re-visit:

- `syncedFieldsRef` accumulates paths across mount/unmount cycles
- Fields registered by `useFieldArray` are not present in the set when the effect runs again on the second visit
- The guard incorrectly skips them, so `useFieldArray.fields` stays empty

Minimal reproduction is in the issue: https://codesandbox.io/p/sandbox/t6pxft

## Fix

Replace `applyValuesToFields(getRegisteredFields(), data, false)` with `reset(data, { keepDirtyValues: true })`.

The `reset` API from react-hook-form re-initialises the entire form state, including all field arrays, on each new query result. The `keepDirtyValues` option ensures that any in-progress user edits are not discarded.

Changes:
- Added `reset` to the destructured result from `useHookForm`
- Replaced `applyValuesToFields` call inside `applyQueryValues` with `reset(data, { keepDirtyValues: true })`

Closes #7401