### PR TITLE
fix(core): extend BaseKey to include number[] for UUID support

### DIFF
--- a/.changeset/fix-base-key-uuid-support.md
+++ b/.changeset/fix-base-key-uuid-support.md
@@ -1,0 +1,14 @@
+---
+"@refinedev/core": patch
+---
+
+Extend BaseKey to include number[] to support UUID representations.
+
+Some OpenAPI code generators represent UUID fields as number[] (byte arrays)
+in TypeScript. Previously, users working with such types had to cast their ID
+values to satisfy the BaseKey constraint, which reduces type safety.
+
+Adding number[] to the union allows these use cases without any type casts.
+Existing code using string or number IDs is unaffected.
+
+Fixes #7403.

--- a/packages/core/src/contexts/data/types.ts
+++ b/packages/core/src/contexts/data/types.ts
@@ -5,7 +5,7 @@ export type Prettify<T> = {
   [K in keyof T]: T[K];
 } & {};
 
-export type BaseKey = string | number;
+export type BaseKey = string | number | number[];
 export type BaseRecord = {
   id?: BaseKey;
   [key: string]: any;

--- a/packages/core/src/hooks/navigation/index.ts
+++ b/packages/core/src/hooks/navigation/index.ts
@@ -58,7 +58,7 @@ export const useNavigation = () => {
     id: BaseKey,
     meta: MetaQuery = {},
   ) => {
-    const encodedId = encodeURIComponent(id);
+    const encodedId = encodeURIComponent(Array.isArray(id) ? id.join(",") : id);
     const resourceItem =
       typeof resource === "string"
         ? pickResource(resource, resources) ?? { name: resource }
@@ -88,7 +88,7 @@ export const useNavigation = () => {
     id: BaseKey,
     meta: MetaQuery = {},
   ) => {
-    const encodedId = encodeURIComponent(id);
+    const encodedId = encodeURIComponent(Array.isArray(id) ? id.join(",") : id);
     const resourceItem =
       typeof resource === "string"
         ? pickResource(resource, resources) ?? { name: resource }
@@ -118,7 +118,7 @@ export const useNavigation = () => {
     id: BaseKey,
     meta: MetaQuery = {},
   ) => {
-    const encodedId = encodeURIComponent(id);
+    const encodedId = encodeURIComponent(Array.isArray(id) ? id.join(",") : id);
     const resourceItem =
       typeof resource === "string"
         ? pickResource(resource, resources) ?? { name: resource }


### PR DESCRIPTION
## Problem

`BaseKey` is currently typed as `string | number`. Some OpenAPI code generators represent UUID fields as `number[]` (byte arrays) in TypeScript. Users working with such types must cast their ID values to satisfy the `BaseKey` constraint:

```ts
useOne({ resource: "orders", id: uuidBytes as unknown as string })
```

This defeats TypeScript safety and produces confusing code.

See: #7403

## Fix

Extend `BaseKey` from `string | number` to `string | number | number[]`.

The change is additive. All existing usage of `string` and `number` IDs is unaffected.

```ts
// Before: required an explicit cast
useOne({ resource: "orders", id: uuidBytes as unknown as string })

// After: works without a cast
useOne({ resource: "orders", id: uuidBytes })
```

## Files changed

- `packages/core/src/contexts/data/types.ts` — extends `BaseKey` union type
- `packages/core/src/hooks/navigation/index.ts` — fixes three `encodeURIComponent(id)` call sites that TypeScript correctly flags after the type extension; `number[]` is converted to a comma-separated string before encoding

## TypeScript verification

Ran `tsc --noEmit` on `packages/core` before and after the change. The only remaining error is a pre-existing test file path issue present on `main` as well.

Closes #7403