### PR TITLE
fix(core): extend BaseKey to support array types for UUID compatibility

### DIFF
--- a/packages/core/src/contexts/data/types.ts
+++ b/packages/core/src/contexts/data/types.ts
@@ -5,7 +5,7 @@ export type Prettify<T> = {
   [K in keyof T]: T[K];
 } & {};
 
-export type BaseKey = string | number;
+export type BaseKey = string | number | string[] | number[];
 export type BaseRecord = {
   id?: BaseKey;
   [key: string]: any;


### PR DESCRIPTION
## Description

The `BaseKey` type currently only accepts `string | number`, which forces users with OpenAPI-generated types (where UUIDs are typed as `number[]`) to use forced type casting.

This PR extends `BaseKey` to include `string[]` and `number[]`:

```typescript
// Before
export type BaseKey = string | number;

// After
export type BaseKey = string | number | string[] | number[];
```

This is a type-only change with no runtime impact. TypeScript compilation passes with no errors.

Closes #7403

## General Checklist

- [x] I have read the [Contributing Guide](https://refine.dev/docs/guides-concepts/contributing/) and the [Code of Conduct](https://github.com/refinedev/refine/blob/main/CODE_OF_CONDUCT.md)
- [x] I have verified the changes locally with `tsc --noEmit`