### PR TITLE
fix(inferencer): correct typos in user-facing error messages

### DIFF
--- a/.changeset/wild-buttons-fix.md
+++ b/.changeset/wild-buttons-fix.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/inferencer": patch
+---
+
+fix(inferencer): correct typos in user-facing error messages
+
+Fixed the misspelled word "occured" to "occurred" in the error messages shown when fetching resource data fails and when the generated component fails to render. Also added the missing space after the period in the component render error message ("component.You" -> "component. You").

--- a/packages/inferencer/src/components/live/index.tsx
+++ b/packages/inferencer/src/components/live/index.tsx
@@ -69,7 +69,7 @@ export const LiveComponent: React.FC<LiveComponentProps> = ({
           <ErrorComponent
             error={
               error
-                ? `<p>An error occured while rendering the generated component.You can check the generated code from the below "Show Code" button and fix the error manually.</p>
+                ? `<p>An error occurred while rendering the generated component. You can check the generated code from the below "Show Code" button and fix the error manually.</p>
                                     <p>If you think this is a bug, please report the issue at <a target="_blank" rel="noopener noreferrer" href="https://github.com/refinedev/refine/issues">https://github.com/refinedev/refine/issues</a></p>
                                     <p>Exception:</p>
                                     <code>${error}</code>`

--- a/packages/inferencer/src/use-infer-fetch/index.tsx
+++ b/packages/inferencer/src/use-infer-fetch/index.tsx
@@ -101,7 +101,7 @@ export const useInferFetch = (
         }
       } catch (error) {
         console.warn(
-          "An error occured while fetching the resource data. Please check the error message below:",
+          "An error occurred while fetching the resource data. Please check the error message below:",
           error,
         );
         setError(


### PR DESCRIPTION
## Summary

Two user-facing error strings in `@refinedev/inferencer` misspelled "occured" (correct: "occurred"), and one ran a sentence together with no space ("component.You"). This corrects the spelling in both places and adds the missing space.

## Changes

- Fix "occured" → "occurred" in `use-infer-fetch/index.tsx` (console warning) and `components/live/index.tsx` (render-error HTML)
- Add the missing space in the render-error string ("component. You")
- Add a changeset

No behavior change — text-only edits inside existing string literals.