### PR TITLE
fix(rest): type update.buildHeaders params with UpdateParams<any>

### DIFF
--- a/.changeset/rest-update-buildheaders-variables-type.md
+++ b/.changeset/rest-update-buildheaders-variables-type.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/rest": patch
+---
+
+fix(rest): type `update.buildHeaders` params with `UpdateParams<any>`
+
+The `update.buildHeaders` option in `createDataProvider` was typed as `BuildHeaders<UpdateParams>`, which resolves `variables` to the default `{}` instead of `any`. This was inconsistent with every other `update` option (`getEndpoint`, `buildQueryParams`, `buildBodyParams`, `mapResponse`, `transformError`) and with the default implementation, all of which use `UpdateParams<any>`. As a result, a custom `update.buildHeaders` callback could not read fields off `params.variables` without a type error. Aligned the type with the rest of the `update` options.

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -85,7 +85,7 @@ export type CreateDataProviderOptions = {
   update?: {
     getEndpoint?: GetEndpoint<UpdateParams<any>>;
     getRequestMethod?: (params: UpdateParams<any>) => "put" | "patch";
-    buildHeaders?: BuildHeaders<UpdateParams>;
+    buildHeaders?: BuildHeaders<UpdateParams<any>>;
 
     buildQueryParams?: BuildQueryParams<UpdateParams<any>>;
 

--- a/packages/rest/test/methods/update.spec.ts
+++ b/packages/rest/test/methods/update.spec.ts
@@ -85,6 +85,31 @@ describe("update", () => {
     });
   });
 
+  describe("custom buildHeaders", () => {
+    it("should derive a header from params.variables", async () => {
+      nock(API_URL)
+        .matchHeader("x-from-variables", "bar")
+        .patch("/update/1", variables)
+        .reply(200, response);
+
+      const { dataProvider } = createDataProvider(API_URL, {
+        update: {
+          buildHeaders: async (params) => ({
+            "x-from-variables": params.variables.foo,
+          }),
+        },
+      });
+
+      const result = await dataProvider.update({
+        id: 1,
+        resource: "update",
+        variables,
+      });
+
+      expect(result).toEqual({ data: response });
+    });
+  });
+
   describe("failure", () => {
     it("should throw HttpError with message and statusCode", async () => {
       nock(API_URL).patch("/update/1", variables).reply(400, {


### PR DESCRIPTION
## Summary

In `@refinedev/rest`, `UpdateParams<TVariables = {}>` defaults to `{}`. The `update.buildHeaders` option was typed `BuildHeaders<UpdateParams>` (no type arg), so a consumer's custom `update.buildHeaders` saw `params.variables` as `{}` and couldn't read any field off it without a TypeScript error.

This was the single outlier: all 9 other `buildHeaders` declarations, every other `update` option, and the default implementation use `<any>`. Sibling `update.buildBodyParams` / `transformError` already worked; only `update.buildHeaders` was affected.

## Changes

- `packages/rest/src/types.ts`: `BuildHeaders<UpdateParams>` → `BuildHeaders<UpdateParams<any>>`
- Add a `custom buildHeaders` test in `update.spec.ts` (reads `params.variables.foo`, asserts the derived header) + a `patch` changeset

## Testing

- Red-green proven against the real `@refinedev/core` types: reverting the line makes `update.spec.ts` fail with `TS2339: Property 'foo' does not exist on type '{}'`
- `biome ci` clean; full `@refinedev/rest` vitest suite 90 tests pass