### PR TITLE
fix(router): reject non-finite values in convertToNumberIfPossible

### DIFF
--- a/.changeset/router-convert-number-non-finite.md
+++ b/.changeset/router-convert-number-non-finite.md
@@ -1,0 +1,11 @@
+---
+"@refinedev/react-router": patch
+"@refinedev/remix-router": patch
+"@refinedev/nextjs-router": patch
+---
+
+fix(router): do not convert non-finite values in `convertToNumberIfPossible`
+
+`convertToNumberIfPossible` guarded conversions with `` `${num}` === value ``, which is meant to only convert strings that round-trip cleanly through `Number()`. The guard had a hole: `Number("NaN")`, `Number("Infinity")` and `Number("-Infinity")` produce non-finite numbers whose string form (`"NaN"`, `"Infinity"`, `"-Infinity"`) matches the input, so those strings were returned as the JS values `NaN`/`Infinity`/`-Infinity`.
+
+This function feeds the `currentPage` and `pageSize` pagination params parsed from the URL and the result is typed as `number | undefined`. A URL such as `?currentPage=NaN` therefore yielded `currentPage: NaN` instead of leaving it as a string, producing a non-finite "page number" that is neither a valid index nor `undefined` (and serializes to `null`). Added a `Number.isFinite(num)` check so only finite numeric strings are converted; all other inputs (including `"007"`, `"1e3"`, `"NaN"`, `"Infinity"`) are left untouched.

--- a/packages/nextjs-router/src/common/convert-to-number-if-possible/index.test.ts
+++ b/packages/nextjs-router/src/common/convert-to-number-if-possible/index.test.ts
@@ -1,0 +1,25 @@
+import { convertToNumberIfPossible } from ".";
+
+describe("convertToNumberIfPossible", () => {
+  it("returns the value as is when it is undefined", () => {
+    expect(convertToNumberIfPossible(undefined)).toBeUndefined();
+  });
+
+  it("converts numeric strings to numbers", () => {
+    expect(convertToNumberIfPossible("42")).toBe(42);
+    expect(convertToNumberIfPossible("0")).toBe(0);
+  });
+
+  it("keeps strings that do not round-trip cleanly as strings", () => {
+    expect(convertToNumberIfPossible("007")).toBe("007");
+    expect(convertToNumberIfPossible("1e3")).toBe("1e3");
+    expect(convertToNumberIfPossible(" 5")).toBe(" 5");
+    expect(convertToNumberIfPossible("abc")).toBe("abc");
+  });
+
+  it("does not convert non-finite values to numbers", () => {
+    expect(convertToNumberIfPossible("NaN")).toBe("NaN");
+    expect(convertToNumberIfPossible("Infinity")).toBe("Infinity");
+    expect(convertToNumberIfPossible("-Infinity")).toBe("-Infinity");
+  });
+});

--- a/packages/nextjs-router/src/common/convert-to-number-if-possible/index.ts
+++ b/packages/nextjs-router/src/common/convert-to-number-if-possible/index.ts
@@ -3,7 +3,7 @@ export const convertToNumberIfPossible = (value: string | undefined) => {
     return value;
   }
   const num = Number(value);
-  if (`${num}` === value) {
+  if (Number.isFinite(num) && `${num}` === value) {
     return num;
   }
   return value;

--- a/packages/react-router/src/convert-to-number-if-possible.test.ts
+++ b/packages/react-router/src/convert-to-number-if-possible.test.ts
@@ -1,0 +1,25 @@
+import { convertToNumberIfPossible } from "./convert-to-number-if-possible";
+
+describe("convertToNumberIfPossible", () => {
+  it("returns the value as is when it is undefined", () => {
+    expect(convertToNumberIfPossible(undefined)).toBeUndefined();
+  });
+
+  it("converts numeric strings to numbers", () => {
+    expect(convertToNumberIfPossible("42")).toBe(42);
+    expect(convertToNumberIfPossible("0")).toBe(0);
+  });
+
+  it("keeps strings that do not round-trip cleanly as strings", () => {
+    expect(convertToNumberIfPossible("007")).toBe("007");
+    expect(convertToNumberIfPossible("1e3")).toBe("1e3");
+    expect(convertToNumberIfPossible(" 5")).toBe(" 5");
+    expect(convertToNumberIfPossible("abc")).toBe("abc");
+  });
+
+  it("does not convert non-finite values to numbers", () => {
+    expect(convertToNumberIfPossible("NaN")).toBe("NaN");
+    expect(convertToNumberIfPossible("Infinity")).toBe("Infinity");
+    expect(convertToNumberIfPossible("-Infinity")).toBe("-Infinity");
+  });
+});

--- a/packages/react-router/src/convert-to-number-if-possible.ts
+++ b/packages/react-router/src/convert-to-number-if-possible.ts
@@ -3,7 +3,7 @@ export const convertToNumberIfPossible = (value: string | undefined) => {
     return value;
   }
   const num = Number(value);
-  if (`${num}` === value) {
+  if (Number.isFinite(num) && `${num}` === value) {
     return num;
   }
   return value;

--- a/packages/remix-router/src/convert-to-number-if-possible.test.ts
+++ b/packages/remix-router/src/convert-to-number-if-possible.test.ts
@@ -1,0 +1,25 @@
+import { convertToNumberIfPossible } from "./convert-to-number-if-possible";
+
+describe("convertToNumberIfPossible", () => {
+  it("returns the value as is when it is undefined", () => {
+    expect(convertToNumberIfPossible(undefined)).toBeUndefined();
+  });
+
+  it("converts numeric strings to numbers", () => {
+    expect(convertToNumberIfPossible("42")).toBe(42);
+    expect(convertToNumberIfPossible("0")).toBe(0);
+  });
+
+  it("keeps strings that do not round-trip cleanly as strings", () => {
+    expect(convertToNumberIfPossible("007")).toBe("007");
+    expect(convertToNumberIfPossible("1e3")).toBe("1e3");
+    expect(convertToNumberIfPossible(" 5")).toBe(" 5");
+    expect(convertToNumberIfPossible("abc")).toBe("abc");
+  });
+
+  it("does not convert non-finite values to numbers", () => {
+    expect(convertToNumberIfPossible("NaN")).toBe("NaN");
+    expect(convertToNumberIfPossible("Infinity")).toBe("Infinity");
+    expect(convertToNumberIfPossible("-Infinity")).toBe("-Infinity");
+  });
+});

--- a/packages/remix-router/src/convert-to-number-if-possible.ts
+++ b/packages/remix-router/src/convert-to-number-if-possible.ts
@@ -3,7 +3,7 @@ export const convertToNumberIfPossible = (value: string | undefined) => {
     return value;
   }
   const num = Number(value);
-  if (`${num}` === value) {
+  if (Number.isFinite(num) && `${num}` === value) {
     return num;
   }
   return value;


### PR DESCRIPTION
`convertToNumberIfPossible` parses URL pagination params (`currentPage`/`pageSize`, typed `number | undefined`) with a round-trip guard `` `${num}` === value ``. Because `String(NaN) === "NaN"`, `String(Infinity) === "Infinity"`, etc., the inputs `"NaN"`, `"Infinity"`, `"-Infinity"` pass the guard and are returned as the non-finite JS numbers instead of strings — so `?currentPage=NaN` yields a non-finite "page number".

This adds `Number.isFinite(num)` to the guard. The helper is duplicated verbatim in three packages (`react-router`, `remix-router`, `nextjs-router`), all fixed. Adds the first vitest coverage for the helper in each package and a `patch` changeset.

Red-green proven; a 500k-input fuzz confirms behavior is identical to the old code for every finite value (zero regression). `biome` + per-package `tsc --noEmit` clean.