### PR TITLE
fix(mui): apply MUI styling props to Breadcrumb links

### DIFF
--- a/.changeset/fix-mui-breadcrumb-links.md
+++ b/.changeset/fix-mui-breadcrumb-links.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mui": patch
+---
+
+fix(mui): apply MUI styling props to Breadcrumb links

--- a/packages/mui/src/components/breadcrumb/index.tsx
+++ b/packages/mui/src/components/breadcrumb/index.tsx
@@ -39,7 +39,9 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
     const { to, children, ...restProps } = props;
     return (
       <Link to={to || ""}>
-        <span {...restProps}>{children}</span>
+        <MuiLink component="span" {...restProps}>
+          {children}
+        </MuiLink>
       </Link>
     );
   };


### PR DESCRIPTION
## Description
   Fixes a regression in the Breadcrumb component where MUI styling props 
   (`sx`, `underline`, `color`, `variant`) were being rendered as invalid 
   HTML attributes on a bare `<span>` instead of being applied to an actual 
   MUI Link component.

   ## Changes
   - Modified `LinkRouter` to wrap content in `<MuiLink component="span">` 
     instead of a plain `<span>`
   - This ensures MUI styling props are properly applied
   - Fixes flex alignment, hover underline, color inheritance, and typography

   ## Impact
   - ✅ Breadcrumb links now styled with flex alignment
   - ✅ Hover underline effect works
   - ✅ Color inheritance applied correctly
   - ✅ Typography variant sizing correct

   ## Testing
   - All 425 MUI tests pass ✅
   - Package builds successfully ✅
   
   Closes #7462