### PR TITLE
fix(mui): apply Link styling props to MuiLink instead of span in Breadcrumb

### DIFF
--- a/.changeset/fix-mui-breadcrumb-link-styling.md
+++ b/.changeset/fix-mui-breadcrumb-link-styling.md
@@ -1,0 +1,9 @@
+\---
+
+"@refinedev/mui": patch
+
+\---
+
+fix(mui): apply `Link` styling props (`sx`, `underline`, `color`, `variant`) to `MuiLink` instead of a plain `<span>` in `Breadcrumb`'s `LinkRouter`, and add a regression test
+
+Resolves \[#7462](https://github.com/refinedev/refine/issues/7462)

--- a/packages/mui/src/components/breadcrumb/index.spec.tsx
+++ b/packages/mui/src/components/breadcrumb/index.spec.tsx
@@ -1,5 +1,8 @@
+import React from "react";
+import { Route, Routes } from "react-router";
 import { vi } from "vitest";
 import { breadcrumbTests } from "@refinedev/ui-tests";
+import { render, TestWrapper, MockRouterProvider } from "@test";
 
 import { Breadcrumb } from "./";
 
@@ -9,4 +12,39 @@ describe("Breadcrumb", () => {
   });
 
   breadcrumbTests.bind(this)(Breadcrumb);
+
+  it("should style breadcrumb links via MuiLink instead of leaking sx/underline/color/variant as raw DOM attributes", async () => {
+    const { container } = render(
+      <Routes>
+        <Route path="/:resource/:action" element={<Breadcrumb />} />
+      </Routes>,
+      {
+        wrapper: TestWrapper({
+          resources: [
+            { name: "posts", list: "/posts", create: "/posts/create" },
+          ],
+          routerProvider: MockRouterProvider({
+            pathname: "/posts",
+            resource: {
+              name: "posts",
+              list: "/posts",
+              create: "/posts/create",
+            },
+            action: "create",
+          }),
+        }),
+      },
+    );
+
+    const link = container.querySelector("a");
+    expect(link).not.toBeNull();
+
+    const styledChild = link?.firstElementChild;
+    expect(styledChild).not.toBeUndefined();
+    expect(styledChild).not.toHaveAttribute("sx");
+    expect(styledChild).not.toHaveAttribute("underline");
+    expect(styledChild).not.toHaveAttribute("color");
+    expect(styledChild).not.toHaveAttribute("variant");
+    expect(styledChild?.className).toContain("MuiLink-root");
+  });
 });

--- a/packages/mui/src/components/breadcrumb/index.tsx
+++ b/packages/mui/src/components/breadcrumb/index.tsx
@@ -39,7 +39,9 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
     const { to, children, ...restProps } = props;
     return (
       <Link to={to || ""}>
-        <span {...restProps}>{children}</span>
+        <MuiLink component="span" {...restProps}>
+          {children}
+        </MuiLink>
       </Link>
     );
   };


### PR DESCRIPTION
Resolves #7462

#7463 already proposes the same one-line fix, but adds no test coverage. The issue itself calls out that the existing `breadcrumbTests` suite only checks structure (text/href/icon), never styling — which is exactly why this regression shipped unnoticed. This PR includes the fix **and** closes that gap with a regression test that fails against the buggy `<span>` implementation and passes against the fix.

### What's the problem?

`@refinedev/mui`'s `Breadcrumb` renders links through an internal `LinkRouter` helper, typed to accept MUI `LinkProps` (`sx`, `underline`, `color`, `variant`) but spreading them onto a bare `<span>` instead of an MUI component — so the props do nothing and leak as invalid DOM attributes (e.g. `sx="[object Object]"`).

Regression from the v5 migration (#6945, commit 5d63adac08), which rewrote `LinkRouter` for the new `useLink()` API but never re-wired the styling props to an actual MUI component.

### Fix

Wrap the content in MUI's real `Link` (`component="span"` to avoid nesting two `<a>` tags, same precaution as #7428):

```tsx
const LinkRouter = (props: LinkProps & { to?: string }) => {
  const { to, children, ...restProps } = props;
  return (
    <Link to={to || ""}>
      <MuiLink component="span" {...restProps}>
        {children}
      </MuiLink>
    </Link>
  );
};
```

### Test added

`packages/mui/src/components/breadcrumb/index.spec.tsx` asserts the rendered link's inner element carries the `MuiLink-root` class and that none of `sx`/`underline`/`color`/`variant` leak through as literal DOM attributes.

### Checklist

- [x] Reproduced the bug
- [x] Verified the fix resolves it
- [x] Added a changeset
- [x] Added a regression test
- [x] Existing tests pass (`pnpm test` in `packages/mui` — 420 passed, 4 pre-existing/unrelated failures: timezone-dependent `DateField` tests and a flaky `useDataGrid` timeout, neither touched by this change)