### PR TITLE
fix(mui): preserve breadcrumb link styling props

### DIFF
--- a/.changeset/bright-breadcrumbs-serve.md
+++ b/.changeset/bright-breadcrumbs-serve.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mui": patch
+---
+
+Preserve MUI Breadcrumb link styling props when rendering router links.

--- a/packages/mui/src/components/breadcrumb/index.tsx
+++ b/packages/mui/src/components/breadcrumb/index.tsx
@@ -37,9 +37,12 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
 
   const LinkRouter = (props: LinkProps & { to?: string }) => {
     const { to, children, ...restProps } = props;
+
     return (
       <Link to={to || ""}>
-        <span {...restProps}>{children}</span>
+        <MuiLink component="span" {...restProps}>
+          {children}
+        </MuiLink>
       </Link>
     );
   };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

The MUI Breadcrumb router link renders its content as a plain `span`, so MUI Link props like `underline`, `color`, `variant`, and `sx` are not preserved.

## What is the new behavior?

The Breadcrumb router link now renders a `MuiLink` with `component="span"` inside the router link, preserving MUI link styling props while keeping navigation behavior.

Fixes: N/A

## Notes for reviewers

Focused fix for `@refinedev/mui` Breadcrumb link styling.