### PR TITLE
feat(core): support generic parameter for custom data provider types …

### DIFF
--- a/.changeset/feat-use-dataprovider-generic-types.md
+++ b/.changeset/feat-use-dataprovider-generic-types.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": patch
+---
+
+Add generic parameter `TDataProvider` to `useDataProvider` hook to return the data provider with its assigned types.

--- a/packages/core/src/hooks/data/useDataProvider.spec.tsx
+++ b/packages/core/src/hooks/data/useDataProvider.spec.tsx
@@ -32,6 +32,29 @@ describe("useDataProvider Hook", () => {
       expect(error).toEqual(new Error(`"not-exist" Data provider not found`));
     }
   });
+
+  it("should return custom typed data provider when generic is provided", async () => {
+    interface CustomDataProvider extends DataProvider {
+      customMethod: () => void;
+    }
+
+    const { result: customResult } = renderHook(
+      () => useDataProvider<CustomDataProvider>(),
+      {
+        wrapper: TestWrapper({
+          dataProvider: {
+            default: {
+              ...MockJSONServer.default,
+              customMethod: () => {},
+            } as CustomDataProvider,
+          },
+        }),
+      },
+    );
+
+    const dataProvider = customResult.current();
+    expect(dataProvider.customMethod).toBeDefined();
+  });
 });
 describe("useDataProvider Hook without default data provider property", () => {
   const { result } = renderHook(() => useDataProvider(), {

--- a/packages/core/src/hooks/data/useDataProvider.tsx
+++ b/packages/core/src/hooks/data/useDataProvider.tsx
@@ -2,12 +2,14 @@ import { useCallback, useContext } from "react";
 
 import { DataContext } from "@contexts/data";
 import { type DataProvider, IDataContext } from "../../contexts/data/types";
-export const useDataProvider = (): ((
+export const useDataProvider = <
+  TDataProvider extends DataProvider = DataProvider,
+>(): ((
   /**
    * The name of the `data provider` you want to access
    */
   dataProviderName?: string,
-) => DataProvider) => {
+) => TDataProvider) => {
   const context = useContext(DataContext);
 
   const handleDataProvider = useCallback(
@@ -24,11 +26,11 @@ export const useDataProvider = (): ((
           );
         }
 
-        return context[dataProviderName];
+        return context[dataProviderName] as TDataProvider;
       }
 
       if (context.default) {
-        return context.default;
+        return context.default as TDataProvider;
       }
 
       throw new Error(
@@ -40,3 +42,4 @@ export const useDataProvider = (): ((
 
   return handleDataProvider;
 };
+


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
The `useDataProvider` hook returns data providers typed as the generic `DataProvider` type. There is no way to provide or use custom data provider types, forcing developers to manually cast types in their components to access custom methods or properties.

## What is the new behavior?
Added support for a generic type parameter `TDataProvider` on the `useDataProvider` hook, which defaults to the standard `DataProvider`:
`export const useDataProvider = <TDataProvider extends DataProvider = DataProvider>(): ...`
This allows developers to specify their custom provider type (e.g. `useDataProvider<CustomDataProvider>()`), ensuring that the returned provider is fully typed without any type casting.

fixes #7445
