### PR TITLE
docs: fix typos in blog posts

### DIFF
--- a/documentation/blog/2022-02-21-react-antd-admin.md
+++ b/documentation/blog/2022-02-21-react-antd-admin.md
@@ -528,7 +528,7 @@ Let's create two Roles, Admin and Editor. Admin have full CRUD authority on the 
 
 Let's start by creating two buttons for the `Admin` and `Editor` roles in our created Header Component.
 
-```tsx title="/src/componets/header.tsx"
+```tsx title="/src/components/header.tsx"
 import { useGetLocale, useSetLocale } from "@refinedev/core";
 import {
   AntdLayout,

--- a/documentation/blog/2023-07-26-refine-primereact-dashboard.md
+++ b/documentation/blog/2023-07-26-refine-primereact-dashboard.md
@@ -141,7 +141,7 @@ Previously, we mentioned that the scaffolded project includes auto-generated CRU
 
     body {
       margin: 0px;
-      // Build-in PrimeReact themes use this variable
+      // Built-in PrimeReact themes use this variable
       font-family: var(--font-family);
     }
     ```

--- a/documentation/blog/2023-09-20-next-ui-panel.md
+++ b/documentation/blog/2023-09-20-next-ui-panel.md
@@ -2289,7 +2289,7 @@ export { ProductEdit } from "./edit";
 export { ProductShow } from "./show";
 ```
 
-Finally, add the following highligthed changes to the `src/App.tsx` file.
+Finally, add the following highlighted changes to the `src/App.tsx` file.
 
 <details>
 

--- a/documentation/blog/2024-03-19-ts-shadcn.md
+++ b/documentation/blog/2024-03-19-ts-shadcn.md
@@ -1715,7 +1715,7 @@ In this post, we demonstrated with a blog posts list page example how Shadcn can
 
 We learned how Refin'es headless architecture offers easy integration of Shadcn within a Refine app. We covered Shadcn relies on TailwindCSS and its dependencies and elaborated how Shadcn is configured to operate with TypeScript within a Vite based React app like Refine.
 
-Later on, we generated necessary Shadcn components we needed to rebuild a data grid for a list page in our Refine app. While rebuiling the data table and pagination with Shadcn components, we saw how Shadcn components complement and play well with the sophisticated data fetching, state management and React Table integrations typical of Refine apps. We also examined how Shadcn utilizes Class Variance Authority to produce style maps for component variants that are difficult to implement with plain TailwindCSS.
+Later on, we generated necessary Shadcn components we needed to rebuild a data grid for a list page in our Refine app. While rebuilding the data table and pagination with Shadcn components, we saw how Shadcn components complement and play well with the sophisticated data fetching, state management and React Table integrations typical of Refine apps. We also examined how Shadcn utilizes Class Variance Authority to produce style maps for component variants that are difficult to implement with plain TailwindCSS.
 
 Towards the end, we refactored the Shadcn based paginated data table into a reusable component that we can use to present any data we want.
 

--- a/documentation/blog/2024-04-01-ts-keyof.md
+++ b/documentation/blog/2024-04-01-ts-keyof.md
@@ -102,7 +102,7 @@ It is common to use the `typeof` operator with `keyof` in order to derive an obj
 ```ts
 const account = {
   username: "donald_duck",
-  email: "donald.duck@exmaple.com",
+  email: "donald.duck@example.com",
   password: "goawaygoaway",
   role: "admin",
 };
@@ -144,7 +144,7 @@ We can use the `keyof` operator in generic functions. Let's say we have an `acco
 ```ts
 const account = {
   username: "donald_duck",
-  email: "donald.duck@exmaple.com",
+  email: "donald.duck@example.com",
   password: "goawaygoaway",
   role: "admin",
 };
@@ -152,7 +152,7 @@ const account = {
 function getProp<T, K extends keyof T> (obj: T, prop: K) { return obj[prop] };
 function setProp<T, K extends keyof T> (obj: T, prop: K, value: T[K]) { obj[prop] = value };
 
-console.log(getProp(account, "email")); // "donald.duck@exmaple.com"
+console.log(getProp(account, "email")); // "donald.duck@example.com"
 console.log(getProp<{"name": string}, "name">(account, "email")); // 2345 Error: "name" not compatible to `account` keys
 
 setProp(account, "role", "project manager");

--- a/documentation/blog/2024-05-21-zod.md
+++ b/documentation/blog/2024-05-21-zod.md
@@ -688,7 +688,7 @@ export function EditProfile() {
             <input
               type="text"
               className="w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500"
-              placeholder="email@exmaple.kr"
+              placeholder="email@example.kr"
               {...formInstance?.register("email")}
             ></input>
             {formInstance?.formState.errors?.email && (

--- a/documentation/blog/2024-06-21-auth-with-nextauth.md
+++ b/documentation/blog/2024-06-21-auth-with-nextauth.md
@@ -318,7 +318,7 @@ export default function Home() {
               height={200}
             />
             <div className={styles.blogCardContent}>
-              <h2>Nexjs for Beginers</h2>
+              <h2>Nexjs for Beginners</h2>
               <p>
                 Lorem ipsum dolor sit amet consectetur adipisicing elit.
                 Quisquam, quidem.
@@ -450,7 +450,7 @@ export default function Home() {
                 height={200}
               />
               <div className={styles.blogCardContent}>
-                <h2>Nexjs for Beginers</h2>
+                <h2>Nexjs for Beginners</h2>
                 <p>
                   Lorem ipsum dolor sit amet consectetur adipisicing elit.
                   Quisquam, quidem.

--- a/documentation/blog/2024-08-12-bun-vs-node.md
+++ b/documentation/blog/2024-08-12-bun-vs-node.md
@@ -20,7 +20,7 @@ Do you want to try out a new runtime environment? [Bun](https://bun.sh/) is the 
 
 While there is no prerequisite to follow in this tutorial, you should at least know the fundamentals of Javascript and building basic web applications.
 
-You need the followings:
+You need the following:
 
 - [Node 14](https://nodejs.org/en) or higher
 - [Bun runtime](https://bun.sh/) installed

--- a/documentation/blog/2024-09-16-stylex-post.md
+++ b/documentation/blog/2024-09-16-stylex-post.md
@@ -298,7 +298,7 @@ const style = stylex.create({
 
 </details>
 
-It takes a styles object with property indentifiers that represent a CSS class and values that compose the actual CSS rules. Under the hood, Stylex creates a CSS class with an identifier starting with `x` for each of the Stylex style object property. When the style is applied to a JSX element with `stylex.props`, this generated CSS class is added to the element's `className` property.
+It takes a styles object with property identifiers that represent a CSS class and values that compose the actual CSS rules. Under the hood, Stylex creates a CSS class with an identifier starting with `x` for each of the Stylex style object property. When the style is applied to a JSX element with `stylex.props`, this generated CSS class is added to the element's `className` property.
 
 <br />
 


### PR DESCRIPTION
## Summary

Fixes 12 spelling typos across several blog articles. Blog-content only, no code or behavior changes.

## Details

- 2022-02-21-react-antd-admin.md: `componets` to `components`
- 2023-07-26-refine-primereact-dashboard.md: `Build-in` to `Built-in`
- 2023-09-20-next-ui-panel.md: `highligthed` to `highlighted`
- 2024-03-19-ts-shadcn.md: `rebuiling` to `rebuilding`
- 2024-04-01-ts-keyof.md, 2024-05-21-zod.md: `exmaple` to `example` (sample data)
- 2024-06-21-auth-with-nextauth.md: `Beginers` to `Beginners`
- 2024-08-12-bun-vs-node.md: `followings` to `following`
- 2024-09-16-stylex-post.md: `indentifiers` to `identifiers`
