### PR TITLE
fix(mui): preserve styling props in breadcrumb links

### DIFF
--- a/packages/mui/src/components/breadcrumb/index.tsx
+++ b/packages/mui/src/components/breadcrumb/index.tsx
@@ -38,9 +38,9 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
   const LinkRouter = (props: LinkProps & { to?: string }) => {
     const { to, children, ...restProps } = props;
     return (
-      <Link to={to || ""}>
-        <span {...restProps}>{children}</span>
-      </Link>
+      <MuiLink component={Link as any} to={to || ""} {...restProps}>
+        {children}
+      </MuiLink>
     );
   };
 


### PR DESCRIPTION
The LinkRouter component inside Breadcrumb was wrapping children in a plain HTML <span> inside router Link component.

This caused MUI-specific styling props (sx, color, variant, underline) to be lost.

Fix this by wrapping the children with MuiLink and setting its component prop to the router Link component.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
