### PR TITLE
feat(antd): add onParse support to useTable and useSimpleList

### DIFF
--- a/.changeset/add-onparse-to-antd.md
+++ b/.changeset/add-onparse-to-antd.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/antd": minor
+---
+
+Added `onParse` callback to `useTable` and `useSimpleList` hooks to support custom transformation/mapping of URL-synced filters back into search form fields.

--- a/packages/antd/src/hooks/table/useTable/useTable.spec.tsx
+++ b/packages/antd/src/hooks/table/useTable/useTable.spec.tsx
@@ -355,4 +355,58 @@ describe("useTable Hook", () => {
 
     expect(result.current.tableQuery).toEqual(result.current.tableQuery);
   });
+
+  it("should pass form values parsed by onParse to search form from params (syncWithLocation)", async () => {
+    const Component = () => {
+      const { searchFormProps } = useTable({
+        resource: "categories",
+        syncWithLocation: true,
+        onParse: (filters) => {
+          const nameFilter = filters.find((f) => "field" in f && f.field === "name");
+          return {
+            name: nameFilter?.value ? `Parsed: ${nameFilter.value}` : "",
+          };
+        },
+      });
+
+      return (
+        <Form {...searchFormProps}>
+          <Form.Item name="name" noStyle>
+            <Input
+              data-test-id="search-name"
+              size="large"
+              placeholder="Search by name"
+            />
+          </Form.Item>
+        </Form>
+      );
+    };
+
+    const { getByDisplayValue } = render(<Component />, {
+      wrapper: TestWrapper({
+        routerProvider: {
+          parse: () => {
+            return () => ({
+              resource: {
+                name: "posts",
+              },
+              params: {
+                filters: [
+                  {
+                    field: "name",
+                    operator: "contains",
+                    value: "Some Name To Look For",
+                  },
+                ],
+              },
+            });
+          },
+        },
+      }),
+    });
+
+    await waitFor(() => {
+      expect(getByDisplayValue("Parsed: Some Name To Look For")).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/antd/src/hooks/table/useTable/useTable.spec.tsx
+++ b/packages/antd/src/hooks/table/useTable/useTable.spec.tsx
@@ -362,7 +362,9 @@ describe("useTable Hook", () => {
         resource: "categories",
         syncWithLocation: true,
         onParse: (filters) => {
-          const nameFilter = filters.find((f) => "field" in f && f.field === "name");
+          const nameFilter = filters.find(
+            (f) => "field" in f && f.field === "name",
+          );
           return {
             name: nameFilter?.value ? `Parsed: ${nameFilter.value}` : "",
           };
@@ -406,7 +408,9 @@ describe("useTable Hook", () => {
     });
 
     await waitFor(() => {
-      expect(getByDisplayValue("Parsed: Some Name To Look For")).toBeInTheDocument();
+      expect(
+        getByDisplayValue("Parsed: Some Name To Look For"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/packages/antd/src/hooks/table/useTable/useTable.ts
+++ b/packages/antd/src/hooks/table/useTable/useTable.ts
@@ -29,6 +29,7 @@ import type { FilterValue, SorterResult } from "../../../definitions/table";
 export type useTableProps<TQueryFnData, TError, TSearchVariables, TData> =
   useTablePropsCore<TQueryFnData, TError, TData> & {
     onSearch?: (data: TSearchVariables) => CrudFilters | Promise<CrudFilters>;
+    onParse?: (filters: CrudFilters) => TSearchVariables;
   };
 
 export type useTableReturnType<
@@ -61,6 +62,7 @@ export const useTable = <
   TData extends BaseRecord = TQueryFnData,
 >({
   onSearch,
+  onParse,
   pagination: paginationFromProp,
   filters: filtersFromProp,
   sorters: sortersFromProp,
@@ -126,28 +128,33 @@ export const useTable = <
 
   React.useEffect(() => {
     if (shouldSyncWithLocation) {
-      // get registered fields of form
-      const registeredFields = formSF.form.getFieldsValue() as Record<
-        string,
-        any
-      >;
-      // map `filters` for registered fields
-      const filterFilterMap = Object.keys(registeredFields).reduce(
-        (acc, curr) => {
-          // find filter for current field
-          const filter = filters.find(
-            (filter) => "field" in filter && filter.field === curr,
-          );
-          // if filter exists, set value to filter value
-          if (filter) {
-            acc[curr] = filter?.value;
-          }
-          return acc;
-        },
-        {} as Record<string, any>,
-      );
-      // set values to form
-      formSF.form.setFieldsValue(filterFilterMap as any);
+      if (onParse) {
+        const parsedValues = onParse(filters);
+        formSF.form.setFieldsValue(parsedValues as any);
+      } else {
+        // get registered fields of form
+        const registeredFields = formSF.form.getFieldsValue() as Record<
+          string,
+          any
+        >;
+        // map `filters` for registered fields
+        const filterFilterMap = Object.keys(registeredFields).reduce(
+          (acc, curr) => {
+            // find filter for current field
+            const filter = filters.find(
+              (filter) => "field" in filter && filter.field === curr,
+            );
+            // if filter exists, set value to filter value
+            if (filter) {
+              acc[curr] = filter?.value;
+            }
+            return acc;
+          },
+          {} as Record<string, any>,
+        );
+        // set values to form
+        formSF.form.setFieldsValue(filterFilterMap as any);
+      }
     }
   }, [shouldSyncWithLocation]);
 

--- a/packages/antd/src/hooks/useSimpleList/useSimpleList.spec.ts
+++ b/packages/antd/src/hooks/useSimpleList/useSimpleList.spec.ts
@@ -201,7 +201,11 @@ describe("useSimpleList Hook", () => {
       return createElement(
         Form,
         searchFormProps,
-        createElement(Form.Item, { name: "name", noStyle: true }, createElement(Input)),
+        createElement(
+          Form.Item,
+          { name: "name", noStyle: true },
+          createElement(Input),
+        ),
       );
     };
 
@@ -252,7 +256,11 @@ describe("useSimpleList Hook", () => {
       return createElement(
         Form,
         searchFormProps,
-        createElement(Form.Item, { name: "name", noStyle: true }, createElement(Input)),
+        createElement(
+          Form.Item,
+          { name: "name", noStyle: true },
+          createElement(Input),
+        ),
       );
     };
 
@@ -281,7 +289,9 @@ describe("useSimpleList Hook", () => {
     });
 
     await waitFor(() => {
-      expect(getByDisplayValue("Parsed: Some Name To Look For")).toBeInTheDocument();
+      expect(
+        getByDisplayValue("Parsed: Some Name To Look For"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/packages/antd/src/hooks/useSimpleList/useSimpleList.spec.ts
+++ b/packages/antd/src/hooks/useSimpleList/useSimpleList.spec.ts
@@ -1,6 +1,8 @@
+import { createElement } from "react";
 import { renderHook, waitFor } from "@testing-library/react";
+import { Form, Input } from "antd";
 
-import { MockJSONServer, TestWrapper } from "@test";
+import { MockJSONServer, TestWrapper, render } from "@test";
 
 import { useSimpleList } from "./useSimpleList";
 
@@ -187,5 +189,99 @@ describe("useSimpleList Hook", () => {
     });
 
     expect(result.current.query).toEqual(result.current.query);
+  });
+
+  it("should pass form values to search form from params (syncWithLocation)", async () => {
+    const Component = () => {
+      const { searchFormProps } = useSimpleList({
+        resource: "categories",
+        syncWithLocation: true,
+      });
+
+      return createElement(
+        Form,
+        searchFormProps,
+        createElement(Form.Item, { name: "name", noStyle: true }, createElement(Input)),
+      );
+    };
+
+    const { getByDisplayValue } = render(createElement(Component), {
+      wrapper: TestWrapper({
+        dataProvider: MockJSONServer,
+        routerProvider: {
+          parse: () => {
+            return () => ({
+              resource: {
+                name: "posts",
+              },
+              params: {
+                filters: [
+                  {
+                    field: "name",
+                    operator: "contains",
+                    value: "Some Name To Look For",
+                  },
+                ],
+              },
+            });
+          },
+        },
+      }),
+    });
+
+    await waitFor(() => {
+      expect(getByDisplayValue("Some Name To Look For")).toBeInTheDocument();
+    });
+  });
+
+  it("should pass form values parsed by onParse to search form from params (syncWithLocation)", async () => {
+    const Component = () => {
+      const { searchFormProps } = useSimpleList({
+        resource: "categories",
+        syncWithLocation: true,
+        onParse: (filters) => {
+          const nameFilter = filters.find(
+            (f) => "field" in f && f.field === "name",
+          );
+          return {
+            name: nameFilter?.value ? `Parsed: ${nameFilter.value}` : "",
+          };
+        },
+      });
+
+      return createElement(
+        Form,
+        searchFormProps,
+        createElement(Form.Item, { name: "name", noStyle: true }, createElement(Input)),
+      );
+    };
+
+    const { getByDisplayValue } = render(createElement(Component), {
+      wrapper: TestWrapper({
+        dataProvider: MockJSONServer,
+        routerProvider: {
+          parse: () => {
+            return () => ({
+              resource: {
+                name: "posts",
+              },
+              params: {
+                filters: [
+                  {
+                    field: "name",
+                    operator: "contains",
+                    value: "Some Name To Look For",
+                  },
+                ],
+              },
+            });
+          },
+        },
+      }),
+    });
+
+    await waitFor(() => {
+      expect(getByDisplayValue("Parsed: Some Name To Look For")).toBeInTheDocument();
+    });
   });
 });

--- a/packages/antd/src/hooks/useSimpleList/useSimpleList.ts
+++ b/packages/antd/src/hooks/useSimpleList/useSimpleList.ts
@@ -119,10 +119,7 @@ export const useSimpleList = <
         form.setFieldsValue(parsedValues as any);
       } else {
         // get registered fields of form
-        const registeredFields = form.getFieldsValue() as Record<
-          string,
-          any
-        >;
+        const registeredFields = form.getFieldsValue() as Record<string, any>;
         // map `filters` for registered fields
         const filterFilterMap = Object.keys(registeredFields).reduce(
           (acc, curr) => {

--- a/packages/antd/src/hooks/useSimpleList/useSimpleList.ts
+++ b/packages/antd/src/hooks/useSimpleList/useSimpleList.ts
@@ -1,4 +1,4 @@
-import { Children, createElement, Fragment } from "react";
+import { Children, createElement, Fragment, useEffect } from "react";
 import { type ListProps, type FormProps, Form, Grid } from "antd";
 
 import {
@@ -8,6 +8,7 @@ import {
   useTable as useTableCore,
   type useTableProps as useTablePropsCore,
   type useTableReturnType,
+  useSyncWithLocation,
 } from "@refinedev/core";
 import { useLiveMode } from "@refinedev/core";
 import { PaginationLink } from "@hooks/table/useTable/paginationLink";
@@ -16,6 +17,7 @@ import type { PaginationConfig } from "antd/lib/pagination";
 export type useSimpleListProps<TQueryFnData, TError, TSearchVariables, TData> =
   useTablePropsCore<TQueryFnData, TError, TData> & {
     onSearch?: (data: TSearchVariables) => CrudFilters | Promise<CrudFilters>;
+    onParse?: (filters: CrudFilters) => TSearchVariables;
   };
 
 export type useSimpleListReturnType<
@@ -53,6 +55,7 @@ export const useSimpleList = <
   filters: filtersFromProp,
   sorters: sortersFromProp,
   onSearch,
+  onParse,
   queryOptions,
   syncWithLocation,
   successNotification,
@@ -105,6 +108,41 @@ export const useSimpleList = <
   const liveMode = useLiveMode(liveModeFromProp);
 
   const [form] = Form.useForm<TSearchVariables>();
+
+  const { syncWithLocation: defaultSyncWithLocation } = useSyncWithLocation();
+  const shouldSyncWithLocation = syncWithLocation ?? defaultSyncWithLocation;
+
+  useEffect(() => {
+    if (shouldSyncWithLocation) {
+      if (onParse) {
+        const parsedValues = onParse(filters);
+        form.setFieldsValue(parsedValues as any);
+      } else {
+        // get registered fields of form
+        const registeredFields = form.getFieldsValue() as Record<
+          string,
+          any
+        >;
+        // map `filters` for registered fields
+        const filterFilterMap = Object.keys(registeredFields).reduce(
+          (acc, curr) => {
+            // find filter for current field
+            const filter = filters.find(
+              (filter) => "field" in filter && filter.field === curr,
+            );
+            // if filter exists, set value to filter value
+            if (filter) {
+              acc[curr] = filter?.value;
+            }
+            return acc;
+          },
+          {} as Record<string, any>,
+        );
+        // set values to form
+        form.setFieldsValue(filterFilterMap as any);
+      }
+    }
+  }, [shouldSyncWithLocation]);
 
   const { data, isFetched, isLoading } = tableQuery;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

When using `useTable` or `useSimpleList` from `@refinedev/antd` with `syncLocation: true` and an search form via `onSearch`, the reverse mapping (URL / Table Filters -> Form Fields) uses a simple field-matching logic. This causes two main limitations:
1. All values restored from the URL filters are strings (e.g., number category IDs become strings), causing issues in components like Antd `Select`.
2. Complex objects (e.g. Ant Design `RangePicker` arrays constructed from splitting a filter into `gte` and `lte` constraints) cannot be reconstructed.
3. In addition, `useSimpleList` search forms had no automated synchronization with URL filters at all.

## What is the new behavior?

We introduced an optional `onParse` parameter to `useTableProps` and `useSimpleListProps`:
- `onParse?: (filters: CrudFilters) => TSearchVariables;`

If `onParse` is provided, the hook calls it during location synchronization and sets the return value directly on the Ant Design form instance, allowing developers to customize how filters are transformed back into form values (e.g., type casting or merging filters). 

Also, search form location syncing was implemented for `useSimpleList` using the same logic as `useTable`.

## Notes for reviewers

The feature has been fully covered by unit tests in both `useTable.spec.tsx` and `useSimpleList.spec.ts`. A changeset file (`.changeset/add-onparse-to-antd.md`) has been created for versioning.
