### PR TITLE
fix malformed route id decoding

### DIFF
--- a/.changeset/safe-route-id-decoding.md
+++ b/.changeset/safe-route-id-decoding.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+"@refinedev/react-router": patch
+"@refinedev/remix-router": patch
+---
+
+Safely handle malformed URI-encoded route params when parsing route ids and query targets.

--- a/packages/core/src/definitions/helpers/handleUseParams/index.spec.tsx
+++ b/packages/core/src/definitions/helpers/handleUseParams/index.spec.tsx
@@ -47,13 +47,24 @@ describe("handleUseParams", () => {
     ).toEqual(paramsWithUniqueId);
   });
 
-  it("should return params true with nique Id", () => {
+  it("should return params true with base64 encoded Id", () => {
     expect(
       handleUseParams({
         ...paramsWithBase64EncodedId,
         id: encodeURIComponent(paramsWithBase64EncodedId.id),
       }),
     ).toEqual(paramsWithBase64EncodedId);
+  });
+
+  it("should keep original id when encoded id is malformed", () => {
+    const paramsWithMalformedId = {
+      resource: "posts",
+      id: "%E0%A4%A",
+    };
+
+    expect(handleUseParams(paramsWithMalformedId)).toEqual(
+      paramsWithMalformedId,
+    );
   });
 
   it("should return params without id", () => {

--- a/packages/core/src/definitions/helpers/handleUseParams/index.tsx
+++ b/packages/core/src/definitions/helpers/handleUseParams/index.tsx
@@ -1,8 +1,16 @@
+const safeDecodeURIComponent = (value: string) => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
 export const handleUseParams = (params: any = {}): any => {
   if (params?.id) {
     return {
       ...params,
-      id: decodeURIComponent(params.id),
+      id: safeDecodeURIComponent(params.id),
     };
   }
   return params;

--- a/packages/react-router/src/bindings.tsx
+++ b/packages/react-router/src/bindings.tsx
@@ -17,6 +17,7 @@ import {
   useParams,
 } from "react-router";
 import { convertToNumberIfPossible } from "./convert-to-number-if-possible";
+import { safeDecodeURIComponent } from "./safe-decode-uri-component";
 
 export const stringifyConfig = {
   addQueryPrefix: true,
@@ -124,7 +125,7 @@ export const routerProvider: RouterProvider = {
       const response: ParseResponse = {
         ...(resource && { resource }),
         ...(action && { action }),
-        ...(params?.id && { id: decodeURIComponent(params.id) }),
+        ...(params?.id && { id: safeDecodeURIComponent(params.id) }),
         // ...(params?.action && { action: params.action }), // lets see if there is a need for this
         pathname,
         params: {
@@ -136,7 +137,7 @@ export const routerProvider: RouterProvider = {
             combinedParams.pageSize as string,
           ) as number | undefined,
           to: combinedParams.to
-            ? decodeURIComponent(combinedParams.to as string)
+            ? safeDecodeURIComponent(combinedParams.to as string)
             : undefined,
         },
       };

--- a/packages/react-router/src/safe-decode-uri-component.test.ts
+++ b/packages/react-router/src/safe-decode-uri-component.test.ts
@@ -1,0 +1,11 @@
+import { safeDecodeURIComponent } from "./safe-decode-uri-component";
+
+describe("safeDecodeURIComponent", () => {
+  it("decodes valid encoded values", () => {
+    expect(safeDecodeURIComponent("posts%2F123")).toBe("posts/123");
+  });
+
+  it("returns the original value when encoded value is malformed", () => {
+    expect(safeDecodeURIComponent("%E0%A4%A")).toBe("%E0%A4%A");
+  });
+});

--- a/packages/react-router/src/safe-decode-uri-component.ts
+++ b/packages/react-router/src/safe-decode-uri-component.ts
@@ -1,0 +1,7 @@
+export const safeDecodeURIComponent = (value: string) => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};

--- a/packages/remix-router/src/bindings.tsx
+++ b/packages/remix-router/src/bindings.tsx
@@ -11,6 +11,7 @@ import qs from "qs";
 import React, { type ComponentProps, useCallback, useContext } from "react";
 import { paramsFromCurrentPath } from "./params-from-current-path";
 import { convertToNumberIfPossible } from "./convert-to-number-if-possible";
+import { safeDecodeURIComponent } from "./safe-decode-uri-component";
 
 export const stringifyConfig = {
   addQueryPrefix: true,
@@ -116,8 +117,8 @@ export const routerProvider: RouterProvider = {
       const response: ParseResponse = {
         ...(resource && { resource }),
         ...(action && { action }),
-        ...(inferredId && { id: decodeURIComponent(inferredId) }),
-        ...(params?.id && { id: decodeURIComponent(params.id) }),
+        ...(inferredId && { id: safeDecodeURIComponent(inferredId) }),
+        ...(params?.id && { id: safeDecodeURIComponent(params.id) }),
         // ...(params?.action && { action: params.action }), // lets see if there is a need for this
         pathname,
         params: {
@@ -129,7 +130,7 @@ export const routerProvider: RouterProvider = {
             combinedParams.pageSize as string,
           ) as number | undefined,
           to: combinedParams.to
-            ? decodeURIComponent(combinedParams.to as string)
+            ? safeDecodeURIComponent(combinedParams.to as string)
             : undefined,
         },
       };

--- a/packages/remix-router/src/safe-decode-uri-component.test.ts
+++ b/packages/remix-router/src/safe-decode-uri-component.test.ts
@@ -1,0 +1,11 @@
+import { safeDecodeURIComponent } from "./safe-decode-uri-component";
+
+describe("safeDecodeURIComponent", () => {
+  it("decodes valid encoded values", () => {
+    expect(safeDecodeURIComponent("posts%2F123")).toBe("posts/123");
+  });
+
+  it("returns the original value when encoded value is malformed", () => {
+    expect(safeDecodeURIComponent("%E0%A4%A")).toBe("%E0%A4%A");
+  });
+});

--- a/packages/remix-router/src/safe-decode-uri-component.ts
+++ b/packages/remix-router/src/safe-decode-uri-component.ts
@@ -1,0 +1,7 @@
+export const safeDecodeURIComponent = (value: string) => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

Malformed percent-encoded route params can throw a `URIError` while route ids or the `to` query target are decoded.

## What is the new behavior?

Route id and `to` decoding now preserves valid decoding behavior while falling back to the original string for malformed encoded values. This prevents malformed route params from crashing parsing in `@refinedev/core`, `@refinedev/react-router`, and `@refinedev/remix-router`.

## Notes for reviewers

Validation run locally:

- `vitest run src/definitions/helpers/handleUseParams/index.spec.tsx` in `packages/core`
- `vitest run` in `packages/react-router`
- `vitest run` in `packages/remix-router`
- `biome check` on touched source/test files
- `tsup` and declaration generation for `core`, `react-router`, and `remix-router`
