### PR TITLE
fix(core): prevent cached show page data in create forms

### DIFF
--- a/.changeset/fix-create-modal-cached-data.md
+++ b/.changeset/fix-create-modal-cached-data.md
@@ -1,0 +1,11 @@
+---
+"@refinedev/refine-core": patch
+"@refinedev/refine-react-hook-form": patch
+---
+
+fix(core, react-hook-form): prevent cached show-page data from overwriting create modal defaultValues
+
+When opening a create modal on a show page for the same resource, the form's `defaultValues` were overwritten by cached data from the show page's `useOne` query. This happened because `useForm` passed the URL-derived `id` to `useOne` even for create actions, causing a query key collision with the cached entry.
+
+- **core:** Don't pass `id` to `useOne` for create actions, preventing the cache key collision at the source.
+- **react-hook-form:** Guard the `useModalForm` visibility reset effect against create actions.

--- a/packages/core/src/hooks/form/index.ts
+++ b/packages/core/src/hooks/form/index.ts
@@ -156,7 +156,7 @@ export const useForm = <
 
   const queryResult = useOne<TQueryFnData, TError, TData>({
     resource: identifier,
-    id,
+    id: isCreate ? undefined : id,
     queryOptions: {
       // Only enable the query if it's not a create action and the `id` is defined
       ...props.queryOptions,

--- a/packages/react-hook-form/src/useModalForm/index.spec.ts
+++ b/packages/react-hook-form/src/useModalForm/index.spec.ts
@@ -1,6 +1,8 @@
 import { renderHook, waitFor } from "@testing-library/react";
+import { useOne } from "@refinedev/core";
 
 import { act, MockJSONServer, TestWrapper } from "../../test";
+import { mockRouterProvider } from "../../test/dataMocks";
 
 import { useModalForm } from "./";
 
@@ -440,5 +442,79 @@ describe("useModalForm Hook", () => {
     });
 
     expect(result.current.modal.visible).toBe(true);
+  });
+
+  it("should not overwrite defaultValues with cached show-page data when action is 'create'", async () => {
+    const showPageData = {
+      id: 1,
+      title: "Show page title",
+      parent: "existing-parent-from-show-page",
+    };
+
+    const mockGetOne = vi.fn().mockResolvedValue({ data: showPageData });
+
+    const { result } = renderHook(
+      () => ({
+        // Simulates the show page fetching data (populates the shared cache)
+        showQuery: useOne({ resource: "posts", id: "1" }),
+        // The create modal form on the same page
+        modalForm: useModalForm({
+          refineCoreProps: {
+            resource: "posts",
+            action: "create",
+          },
+          defaultValues: {
+            title: "defaultValue title",
+            newField: "defaultValue newField",
+          },
+        }),
+      }),
+      {
+        wrapper: TestWrapper({
+          dataProvider: { ...MockJSONServer, getOne: mockGetOne },
+          routerProvider: mockRouterProvider({
+            resource: { name: "posts" },
+            action: "show",
+            id: "1",
+          }),
+          resources: [{ name: "posts" }],
+        }),
+      },
+    );
+
+    // Wait for the show page query to resolve (populating the cache)
+    await waitFor(() =>
+      expect(result.current.showQuery.query.isSuccess).toBe(true),
+    );
+    expect(mockGetOne).toHaveBeenCalledTimes(1);
+
+    // Verify defaultValues are intact before showing modal
+    expect(result.current.modalForm.getValues("title")).toBe(
+      "defaultValue title",
+    );
+
+    // Open the create modal
+    await act(async () => {
+      result.current.modalForm.modal.show();
+    });
+
+    expect(result.current.modalForm.modal.visible).toBe(true);
+
+    // Allow effects to settle
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    // getOne should only have been called once (by the show page query)
+    expect(mockGetOne).toHaveBeenCalledTimes(1);
+
+    // The create form's core query should not have received cached data
+    expect(result.current.modalForm.refineCore.query?.data).toBeUndefined();
+
+    // The form values should still be the defaultValues
+    const finalValues = result.current.modalForm.getValues();
+    expect(finalValues.title).toBe("defaultValue title");
+    expect(finalValues.newField).toBe("defaultValue newField");
+    expect(finalValues.id).toBeUndefined();
   });
 });

--- a/packages/react-hook-form/src/useModalForm/index.ts
+++ b/packages/react-hook-form/src/useModalForm/index.ts
@@ -187,7 +187,7 @@ export const useModalForm = <
 
   // compensate for setting of initial form values in useForm since it doesnt track modal visibility
   React.useEffect(() => {
-    if (!visible || !query?.data?.data) return;
+    if (!visible || !query?.data?.data || action === "create") return;
 
     const formData = query.data.data;
     if (!formData) return;
@@ -197,7 +197,7 @@ export const useModalForm = <
         keepDirtyValues: true,
       }),
     });
-  }, [visible, query?.data?.data, autoResetFormWhenClose]);
+  }, [visible, query?.data?.data, autoResetFormWhenClose, action]);
 
   React.useEffect(() => {
     if (initiallySynced === false && syncWithLocationKey) {

--- a/packages/react-hook-form/test/index.tsx
+++ b/packages/react-hook-form/test/index.tsx
@@ -6,6 +6,7 @@ import {
   type IResourceItem,
   type I18nProvider,
   type IRefineOptions,
+  type RouterProvider,
 } from "@refinedev/core";
 
 import { MockJSONServer, mockRouterProvider } from "./dataMocks";
@@ -15,6 +16,7 @@ interface ITestWrapperProps {
   dataProvider?: DataProvider;
   resources?: IResourceItem[];
   routerInitialEntries?: string[];
+  routerProvider?: RouterProvider;
   i18nProvider?: I18nProvider;
   options?: IRefineOptions;
 }
@@ -25,6 +27,7 @@ export const TestWrapper: (
   dataProvider,
   resources,
   routerInitialEntries,
+  routerProvider,
   i18nProvider,
   options,
 }) => {
@@ -34,7 +37,7 @@ export const TestWrapper: (
         <Refine
           i18nProvider={i18nProvider}
           dataProvider={dataProvider ?? MockJSONServer}
-          routerProvider={mockRouterProvider()}
+          routerProvider={routerProvider ?? mockRouterProvider()}
           resources={resources ?? [{ name: "posts" }]}
           options={{
             ...options,

--- a/packages/react-hook-form/test/index.tsx
+++ b/packages/react-hook-form/test/index.tsx
@@ -42,7 +42,7 @@ export const TestWrapper: (
           options={{
             ...options,
             reactQuery: {
-              clientConfig: {
+              clientConfig: options?.reactQuery?.clientConfig ?? {
                 defaultOptions: {
                   queries: {
                     retry: false,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

When opening a create modal (`useModalForm` with `action: "create"`) on a show page for the same resource, the form's `defaultValues` are overwritten by cached data from the show page's `useOne` query. This happens because `useForm` passes the URL-derived `id` to `useOne` even for create actions, causing a query key collision with the cached entry. The `useModalForm` visibility reset effect then calls `reset()` with the cached show-page data, replacing the user-provided `defaultValues`.

## What is the new behavior?

- core (`useForm`): `id` is no longer passed to `useOne` when the action is `"create"`, preventing the cache key collision at the source.
- react-hook-form (`useModalForm`): The visibility reset effect is guarded against `"create"` actions, so it never calls `reset()` with query data for create forms.

Create modal forms now correctly retain their `defaultValues` regardless of cached data from the same resource.
