### PR TITLE
Allow BaseKey to be an array of numbers

### DIFF
--- a/.changeset/support-number-array-basekey.md
+++ b/.changeset/support-number-array-basekey.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/core": patch
+---
+
+fix: support number array identifiers in `BaseKey` #7403
+
+`BaseKey` now supports `number[]` identifiers for compatibility with generated API models that represent identifiers as arrays of numbers.
+
+Fixes #7403

--- a/packages/core/src/contexts/data/types.ts
+++ b/packages/core/src/contexts/data/types.ts
@@ -5,7 +5,7 @@ export type Prettify<T> = {
   [K in keyof T]: T[K];
 } & {};
 
-export type BaseKey = string | number;
+export type BaseKey = string | number | number[];
 export type BaseRecord = {
   id?: BaseKey;
   [key: string]: any;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

`BaseKey` only supports `string` and `number` identifiers. Generated API models that represent identifiers as `number[]` are not compatible with the `BaseKey` type without explicit type casting.

## What is the new behavior?

`BaseKey` now supports `number[]` identifiers in addition to `string` and `number`.

This improves compatibility with generated API models that represent identifiers as arrays of numbers.

Fixes #7403

## Notes for reviewers

This change extends the existing `BaseKey` union type to support `number[]` identifiers as requested in #7403.