### PR TITLE
fix(react-hook-form): replace custom layout effect sync with native reset

### DIFF
--- a/.changeset/yellow-candles-act.md
+++ b/.changeset/yellow-candles-act.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/react-hook-form": major
+---
+
+Fix issue where useFieldArray values drop during form remount on SPA navigation by replacing custom microtask syncing with native form reset. Fixes #7401.

--- a/packages/react-hook-form/src/useForm/index.ts
+++ b/packages/react-hook-form/src/useForm/index.ts
@@ -129,6 +129,7 @@ export const useForm = <
     watch,
     setValue,
     getValues,
+    reset,
     handleSubmit: handleSubmitReactHookForm,
     setError,
     formState: { dirtyFields },
@@ -217,19 +218,6 @@ export const useForm = <
     return new Set(mounted);
   };
 
-  const getRegisteredFields = () => {
-    const registeredFields = new Set<string>();
-    const mounted = getMountedFields();
-    mounted.forEach((name) => registeredFields.add(name));
-
-    const values = getValues();
-    Object.keys(flattenObjectKeys(values)).forEach((path) => {
-      registeredFields.add(path);
-    });
-
-    return registeredFields;
-  };
-
   const applyValuesToFields = (
     fieldNames: Set<string>,
     data: TData,
@@ -253,7 +241,8 @@ export const useForm = <
     });
   };
 
-  // On query load, attempt a first sync after registration effects run.
+  // On query data changes (such as navigating back to an edit page),
+  // leverage native reset() to hydrate fields cleanly without dynamic race conditions.
   useEffect(() => {
     const data = query?.data?.data;
     if (!data) {
@@ -263,29 +252,13 @@ export const useForm = <
       return;
     }
 
-    let isActive = true;
-
-    const applyQueryValues = () => {
-      if (!isActive) return;
-
-      applyValuesToFields(getRegisteredFields(), data, false);
-    };
-
     queryDataRef.current = data;
     syncedFieldsRef.current = new Set();
     mountedFieldsRef.current = getMountedFields();
 
-    // defer until after field registration effects
-    if (typeof queueMicrotask === "function") {
-      queueMicrotask(applyQueryValues);
-    } else {
-      Promise.resolve().then(applyQueryValues);
-    }
-
-    return () => {
-      isActive = false;
-    };
-  }, [query?.data, setValue, getValues]);
+    // Native reset naturally targets field arrays even if they register late inside a microtask frame.
+    reset(data as unknown as TVariables, { keepDirtyValues: true });
+  }, [query?.data, reset]);
 
   // Re-sync when new fields register; do not override user edits.
   useEffect(() => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
During SPA navigation, `useFieldArray` instances wrapped within components conditional on `formLoading` fail to retain values upon form remounting. This occurs because the internal microtask-deferred `applyValuesToFields` executes and checks `getRegisteredFields()` before the dynamically rendering inputs finish their mount-level registration lifecycle with React Hook Form.

## What is the new behavior?
Replaced the custom microtask `applyValuesToFields` framework on initial data load with React Hook Form's native `reset(data, { keepDirtyValues: true })`. This natively handles delayed field hydration irrespective of active DOM input registration states, ensuring complete value restoration when revisiting the edit view.

fixes #7401

## Notes for reviewers
The existing downstream render-driven loop for late-registered inputs (`useEffect` checking `getMountedFields()`) remains intact to preserve structural sync for components like unmounted UI controllers without regressing state on dirty fields.