### PR TITLE
ci: pin calibreapp/image-actions to a full commit SHA

### DIFF
--- a/.github/workflows/calibreapp-image-actions-dispatch.yml
+++ b/.github/workflows/calibreapp-image-actions-dispatch.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Compress Images
         id: calibre
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@e9858fbe00fd2463e64f4501a7fc8fa521bb0c53 # main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           compressOnly: true

--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Compress Images
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@e9858fbe00fd2463e64f4501a7fc8fa521bb0c53 # main
         with:
           githubToken: ${{ secrets.PANKOD_BOT_TOKEN }}
           commit-message: "doc(compress): compressed images"


### PR DESCRIPTION
### What
Pin `calibreapp/image-actions@main` → `e9858fb…` in `calibreapp-image-actions.yml` and
`calibreapp-image-actions-dispatch.yml` (tag kept in a comment).

### Why
`calibreapp-image-actions.yml` passes `githubToken: ${{ secrets.PANKOD_BOT_TOKEN }}` (a bot PAT with
repo write scope) directly to this third-party action, referenced by the moving `@main` ref. If that
action's `main` were moved (compromise or an accidental change), the new code would run in refine's CI
with the bot PAT — the class of issue behind the 2025 `tj-actions/changed-files` incident. Pinning to
a SHA removes that. (The dispatch variant passes the scoped `GITHUB_TOKEN`; pinned for consistency.)

### Scope / safety
Behaviour unchanged (SHA = current tip of main). Signed-off. Per GitHub's [pin-to-SHA guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflows, the token exposure, and the pinned SHA myself.</sub>
