### PR TITLE
fix

### DIFF
--- a/packages/antd/src/providers/notificationProvider/index.spec.tsx
+++ b/packages/antd/src/providers/notificationProvider/index.spec.tsx
@@ -22,6 +22,8 @@ describe("Antd useNotificationProvider", () => {
     });
 
     const notificationOpenSpy = vi.spyOn(notification, "open");
+    const notificationSuccessSpy = vi.spyOn(notification, "success");
+    const notificationErrorSpy = vi.spyOn(notification, "error");
     const notificationCloseSpy = vi.spyOn(notification, "destroy");
 
     it("should render notification type succes notification", async () => {
@@ -29,9 +31,9 @@ describe("Antd useNotificationProvider", () => {
 
       result.current.open?.(mockNotification);
 
-      expect(notificationOpenSpy).toHaveBeenCalledTimes(1);
-      expect(notificationOpenSpy).toHaveBeenCalledWith({
-        ...mockNotification,
+      expect(notificationSuccessSpy).toHaveBeenCalledTimes(1);
+      expect(notificationSuccessSpy).toHaveBeenCalledWith({
+        key: mockNotification.key,
         message: null,
         description: mockNotification.message,
       });
@@ -45,12 +47,11 @@ describe("Antd useNotificationProvider", () => {
         type: "error",
       });
 
-      expect(notificationOpenSpy).toHaveBeenCalledTimes(1);
-      expect(notificationOpenSpy).toHaveBeenCalledWith({
-        ...mockNotification,
+      expect(notificationErrorSpy).toHaveBeenCalledTimes(1);
+      expect(notificationErrorSpy).toHaveBeenCalledWith({
+        key: mockNotification.key,
         message: null,
         description: mockNotification.message,
-        type: "error",
       });
     });
 
@@ -62,9 +63,9 @@ describe("Antd useNotificationProvider", () => {
         description: "Notification Description",
       });
 
-      expect(notificationOpenSpy).toHaveBeenCalledTimes(1);
-      expect(notificationOpenSpy).toHaveBeenCalledWith({
-        ...mockNotification,
+      expect(notificationSuccessSpy).toHaveBeenCalledTimes(1);
+      expect(notificationSuccessSpy).toHaveBeenCalledWith({
+        key: mockNotification.key,
         message: "Notification Description",
         description: "Test Notification Message",
       });
@@ -109,12 +110,16 @@ describe("Antd useNotificationProvider", () => {
 
   describe("using with Ant design's App component", () => {
     const openFn = vi.fn();
+    const successFn = vi.fn();
+    const errorFn = vi.fn();
     const destroyFn = vi.fn();
 
     beforeAll(() => {
       vi.spyOn(App, "useApp").mockReturnValue({
         notification: {
           open: openFn,
+          success: successFn,
+          error: errorFn,
           destroy: destroyFn,
         },
       } as unknown as ReturnType<typeof App.useApp>);
@@ -132,9 +137,9 @@ describe("Antd useNotificationProvider", () => {
       });
 
       await waitFor(() => {
-        expect(openFn).toHaveBeenCalledTimes(1);
-        expect(openFn).toHaveBeenCalledWith({
-          ...mockNotification,
+        expect(successFn).toHaveBeenCalledTimes(1);
+        expect(successFn).toHaveBeenCalledWith({
+          key: mockNotification.key,
           message: null,
           description: mockNotification.message,
         });
@@ -152,12 +157,11 @@ describe("Antd useNotificationProvider", () => {
       });
 
       await waitFor(() => {
-        expect(openFn).toHaveBeenCalledTimes(1);
-        expect(openFn).toHaveBeenCalledWith({
-          ...mockNotification,
+        expect(errorFn).toHaveBeenCalledTimes(1);
+        expect(errorFn).toHaveBeenCalledWith({
+          key: mockNotification.key,
           message: null,
           description: mockNotification.message,
-          type: "error",
         });
       });
     });
@@ -173,9 +177,9 @@ describe("Antd useNotificationProvider", () => {
       });
 
       await waitFor(() => {
-        expect(openFn).toHaveBeenCalledTimes(1);
-        expect(openFn).toHaveBeenCalledWith({
-          ...mockNotification,
+        expect(successFn).toHaveBeenCalledTimes(1);
+        expect(successFn).toHaveBeenCalledWith({
+          key: mockNotification.key,
           message: "Notification Description",
           description: "Test Notification Message",
         });

--- a/packages/antd/src/providers/notificationProvider/index.tsx
+++ b/packages/antd/src/providers/notificationProvider/index.tsx
@@ -39,12 +39,25 @@ export const useNotificationProvider = (): NotificationProvider => {
           closeIcon: <></>,
         });
       } else {
-        notification.open({
-          key,
-          description: message,
-          message: description ?? null,
-          type,
-        });
+        if (
+          type === "success" ||
+          type === "error" ||
+          type === "info" ||
+          type === "warning"
+        ) {
+          notification[type]({
+            key,
+            description: message,
+            message: description ?? null,
+          });
+        } else {
+          notification.open({
+            key,
+            description: message,
+            message: description ?? null,
+            type,
+          });
+        }
       }
     },
     close: (key) => notification.destroy(key),

--- a/packages/core/src/contexts/notification/types.ts
+++ b/packages/core/src/contexts/notification/types.ts
@@ -33,7 +33,7 @@ export type SuccessErrorNotification<
 export type OpenNotificationParams = {
   key?: string;
   message: string;
-  type: "success" | "error" | "progress";
+  type?: "success" | "error" | "progress" | "info" | "warning";
   description?: string;
   cancelMutation?: () => void;
   undoableTimeout?: number;

--- a/packages/mantine/src/providers/notificationProvider.tsx
+++ b/packages/mantine/src/providers/notificationProvider.tsx
@@ -6,8 +6,13 @@ import {
   hideNotification,
 } from "@mantine/notifications";
 import { ActionIcon, Box, Group, Text } from "@mantine/core";
-import { IconCheck, IconRotate2, IconX } from "@tabler/icons-react";
-
+import {
+  IconCheck,
+  IconRotate2,
+  IconX,
+  IconInfoCircle,
+  IconAlertCircle,
+} from "@tabler/icons-react";
 import { RingCountdown } from "@components";
 
 export const useNotificationProvider = (): NotificationProvider => {
@@ -123,16 +128,41 @@ export const useNotificationProvider = (): NotificationProvider => {
           });
         }
       } else {
+        const getIcon = (type?: "success" | "error" | "progress" | "info" | "warning") => {
+          switch (type) {
+            case "success":
+              return <IconCheck size={18} />;
+            case "error":
+              return <IconX size={18} />;
+            case "info":
+              return <IconInfoCircle size={18} />;
+            case "warning":
+              return <IconAlertCircle size={18} />;
+            default:
+              return undefined;
+          }
+        };
+
+        const getColor = (type?: "success" | "error" | "progress" | "info" | "warning") => {
+          switch (type) {
+            case "success":
+              return "primary";
+            case "error":
+              return "red";
+            case "info":
+              return "blue";
+            case "warning":
+              return "orange";
+            default:
+              return undefined;
+          }
+        };
+
         if (isNotificationActive(key)) {
           updateNotification({
             id: key!,
-            color: type === "success" ? "primary" : "red",
-            icon:
-              type === "success" ? (
-                <IconCheck size={18} />
-              ) : (
-                <IconX size={18} />
-              ),
+            color: getColor(type),
+            icon: getIcon(type),
             message,
             title: description,
             autoClose: 5000,
@@ -141,13 +171,8 @@ export const useNotificationProvider = (): NotificationProvider => {
           addNotification(key);
           showNotification({
             id: key!,
-            color: type === "success" ? "primary" : "red",
-            icon:
-              type === "success" ? (
-                <IconCheck size={18} />
-              ) : (
-                <IconX size={18} />
-              ),
+            color: getColor(type),
+            icon: getIcon(type),
             message,
             title: description,
             onClose: () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

- **`@refinedev/core`**: `OpenNotificationParams.type` is strictly required and restricted to `"success" | "error" | "progress"`. This prevents developers from showing a plain/neutral notification without resorting to `@ts-expect-error` hacks.
- **`@refinedev/antd`**: The notification provider passes `type` into `notification.open()`. Ant Design's `open()` API has no `type` option, so it is silently dropped. As a result, non-progress notifications render without any icon or color, regardless of their actual type.
- **`@refinedev/mantine`**: The notification provider strictly checks `type === "success"`. All other non-success types (including `"error"`, or any custom usages) incorrectly collapse into a unified red aesthetic with an error icon.

## What is the new behavior?

- **`@refinedev/core`**: Widened `OpenNotificationParams.type` to be optional and to include `"info"` and `"warning"`, unlocking native support for more statuses and plain notifications.
- **`@refinedev/antd`**: Updated the notification provider to use Ant Design's native shortcut methods (`notification.success`, `notification.error`, `notification.info`, `notification.warning`) for styled notifications, while gracefully falling back to `notification.open()` if the `type` is undefined (providing a plain notification). Updated relevant unit tests.
- **`@refinedev/mantine`**: Introduced a comprehensive mapping for icons (`IconCheck`, `IconX`, `IconInfoCircle`, `IconAlertCircle`) and colors (`primary`, `red`, `blue`, `orange`) depending on the `type`. It now properly supports all defined statuses and correctly renders a neutral aesthetic if the `type` is undefined.

fixes #(issue-number-here)

## Notes for reviewers

The widening of `OpenNotificationParams.type` is backwards-compatible and naturally integrates well with downstream implementations like `@refinedev/mui` and `@refinedev/chakra-ui` since their underlying libraries already safely accept `undefined`, `"info"`, and `"warning"` statuses.
