### PR TITLE
fix(core): extend BaseKey type to support number[] for UUID compatibility

### DIFF
--- a/packages/core/src/contexts/data/types.ts
+++ b/packages/core/src/contexts/data/types.ts
@@ -5,7 +5,7 @@ export type Prettify<T> = {
   [K in keyof T]: T[K];
 } & {};
 
-export type BaseKey = string | number;
+export type BaseKey = string | number | number[];
 export type BaseRecord = {
   id?: BaseKey;
   [key: string]: any;


### PR DESCRIPTION
## Description

UUID types from some OpenAPI generators use `number[]` (byte arrays) as their representation. Previously `BaseKey` only accepted `string | number`, forcing users to use type assertions when working with such UUID representations.

This change widens the `BaseKey` type to also accept `number[]`.

## Related Issue

Closes #7403

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

This is a pure type-level change — widening a union type — so no runtime behavior is affected. TypeScript compilation succeeds with the widened type.