### PR TITLE
fix: notification type not correctly rendered in antd and mantine providers

### DIFF
--- a/packages/antd/src/providers/notificationProvider/index.tsx
+++ b/packages/antd/src/providers/notificationProvider/index.tsx
@@ -38,12 +38,35 @@ export const useNotificationProvider = (): NotificationProvider => {
           duration: 0,
           closeIcon: <></>,
         });
+      } else if (type === "success") {
+        notification.success({
+          key,
+          description: message,
+          message: description ?? null,
+        });
+      } else if (type === "error") {
+        notification.error({
+          key,
+          description: message,
+          message: description ?? null,
+        });
+      } else if (type === "info") {
+        notification.info({
+          key,
+          description: message,
+          message: description ?? null,
+        });
+      } else if (type === "warning") {
+        notification.warning({
+          key,
+          description: message,
+          message: description ?? null,
+        });
       } else {
         notification.open({
           key,
           description: message,
           message: description ?? null,
-          type,
         });
       }
     },

--- a/packages/core/src/contexts/notification/types.ts
+++ b/packages/core/src/contexts/notification/types.ts
@@ -33,7 +33,7 @@ export type SuccessErrorNotification<
 export type OpenNotificationParams = {
   key?: string;
   message: string;
-  type: "success" | "error" | "progress";
+  type?: "success" | "error" | "progress" | "info" | "warning";
   description?: string;
   cancelMutation?: () => void;
   undoableTimeout?: number;

--- a/packages/mantine/src/providers/notificationProvider.tsx
+++ b/packages/mantine/src/providers/notificationProvider.tsx
@@ -6,9 +6,27 @@ import {
   hideNotification,
 } from "@mantine/notifications";
 import { ActionIcon, Box, Group, Text } from "@mantine/core";
-import { IconCheck, IconRotate2, IconX } from "@tabler/icons-react";
+import {
+  IconCheck,
+  IconRotate2,
+  IconX,
+  IconInfoCircle,
+  IconAlertCircle,
+} from "@tabler/icons-react";
 
 import { RingCountdown } from "@components";
+
+const notificationStyleByType: Record<
+  string,
+  { color: string; icon: React.ReactNode }
+> = {
+  success: { color: "primary", icon: <IconCheck size={18} /> },
+  error: { color: "red", icon: <IconX size={18} /> },
+  info: { color: "blue", icon: <IconInfoCircle size={18} /> },
+  warning: { color: "orange", icon: <IconAlertCircle size={18} /> },
+};
+
+const defaultStyle = { color: "gray", icon: null };
 
 export const useNotificationProvider = (): NotificationProvider => {
   const activeNotifications: string[] = [];
@@ -33,6 +51,10 @@ export const useNotificationProvider = (): NotificationProvider => {
         activeNotifications.splice(index, 1);
       }
     }
+  };
+
+  const getStyle = (type?: string) => {
+    return notificationStyleByType[type ?? ""] ?? defaultStyle;
   };
 
   const notificationProvider: NotificationProvider = {
@@ -123,16 +145,12 @@ export const useNotificationProvider = (): NotificationProvider => {
           });
         }
       } else {
+        const style = getStyle(type);
         if (isNotificationActive(key)) {
           updateNotification({
             id: key!,
-            color: type === "success" ? "primary" : "red",
-            icon:
-              type === "success" ? (
-                <IconCheck size={18} />
-              ) : (
-                <IconX size={18} />
-              ),
+            color: style.color,
+            icon: style.icon ?? undefined,
             message,
             title: description,
             autoClose: 5000,
@@ -141,13 +159,8 @@ export const useNotificationProvider = (): NotificationProvider => {
           addNotification(key);
           showNotification({
             id: key!,
-            color: type === "success" ? "primary" : "red",
-            icon:
-              type === "success" ? (
-                <IconCheck size={18} />
-              ) : (
-                <IconX size={18} />
-              ),
+            color: style.color,
+            icon: style.icon ?? undefined,
             message,
             title: description,
             onClose: () => {


### PR DESCRIPTION
﻿## Summary

- `@refinedev/antd`: `notificationProvider` now calls the `notification.success` / `notification.error` / `notification.info` / `notification.warning` shortcut methods instead of passing an unsupported `type` option to `notification.open()`. antd's `open()` has no `type` option, so it was silently dropped and every non-progress notification rendered with no icon/color.
- `@refinedev/mantine`: `notificationProvider` now maps each notification `type` to its own color and icon (via a `notificationStyleByType` map) instead of collapsing every non-success type into the same red/error styling.
- `@refinedev/core`: widened `OpenNotificationParams.type` to `"success" | "error" | "progress" | "info" | "warning"` and made it optional.

Fixes #7477
Resolves #6326
