### PR TITLE
ci: pin calibreapp/image-actions to a full commit SHA

### DIFF
--- a/.github/workflows/calibreapp-image-actions-dispatch.yml
+++ b/.github/workflows/calibreapp-image-actions-dispatch.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Compress Images
         id: calibre
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@e9858fbe00fd2463e64f4501a7fc8fa521bb0c53 # v1.0.0
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           compressOnly: true

--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Compress Images
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@e9858fbe00fd2463e64f4501a7fc8fa521bb0c53 # v1.0.0
         with:
           githubToken: ${{ secrets.PANKOD_BOT_TOKEN }}
           commit-message: "doc(compress): compressed images"


### PR DESCRIPTION
﻿### What
Pin `calibreapp/image-actions@main` -> `e9858fbe00fd2463e64f4501a7fc8fa521bb0c53` in `calibreapp-image-actions.yml` and `calibreapp-image-actions-dispatch.yml`.

### Why
`calibreapp-image-actions.yml` passes `githubToken: ${{ secrets.PANKOD_BOT_TOKEN }}` (a bot PAT with repo write scope) directly to this third-party action, referenced by the moving `@main` ref. If that action's `main` were moved (compromise or an accidental change), the new code would run in refine CI with the bot PAT. Pinning to a SHA removes that risk.

### Scope / safety
Behaviour unchanged (SHA = current tip of main). Per GitHub's pin-to-SHA guidance.
