### PR TITLE
fix(cli): replace temp with native fs.mkdtempSync

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,7 +68,6 @@
     "prettier": "^2.7.1",
     "semver": "7.5.2",
     "semver-diff": "^3.1.1",
-    "temp": "^0.9.4",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
@@ -90,7 +89,6 @@
     "@types/pluralize": "^0.0.29",
     "@types/prettier": "^2.7.3",
     "@types/semver": "^7.5.8",
-    "@types/temp": "^0.9.1",
     "@vitest/ui": "^2.1.8",
     "tsup": "^6.7.0",
     "typescript": "^5.8.3",

--- a/packages/cli/src/commands/add/sub-commands/resource/create-resources.ts
+++ b/packages/cli/src/commands/add/sub-commands/resource/create-resources.ts
@@ -16,8 +16,9 @@ import {
 import inquirer from "inquirer";
 import { join } from "path";
 import { plural } from "pluralize";
-import temp from "temp";
 import { getCommandRootDir } from "./get-command-root-dir";
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
 
 export const defaultActions = ["list", "create", "edit", "show"];
 
@@ -134,9 +135,6 @@ export const createResources = async (
     }
     moveSync(tempDir, destinationResourcePath, moveSyncOptions);
 
-    // clear temp dir
-    temp.cleanupSync();
-
     // if use Next.js, generate page files. This makes easier to use the resource
     if (isNextJs) {
       generateNextJsPages(
@@ -182,8 +180,7 @@ export const createResources = async (
 };
 
 const generateTempDir = (): string => {
-  temp.track();
-  return temp.mkdirSync("resource");
+  return mkdtempSync(join(tmpdir(), "resource-"));
 };
 
 /**


### PR DESCRIPTION
Replaces the \	emp\ package with native \s.mkdtempSync\ for temporary directory generation in CLI resource creation.

Closes #7388