### PR TITLE
feat(core): add namespace option to useTranslation/useTranslate hooks

### DIFF
--- a/.changeset/fix-create-modal-cached-data.md
+++ b/.changeset/fix-create-modal-cached-data.md
@@ -1,0 +1,11 @@
+---
+"@refinedev/refine-core": patch
+"@refinedev/refine-react-hook-form": patch
+---
+
+fix(core, react-hook-form): prevent cached show-page data from overwriting create modal defaultValues
+
+When opening a create modal on a show page for the same resource, the form's `defaultValues` were overwritten by cached data from the show page's `useOne` query. This happened because `useForm` passed the URL-derived `id` to `useOne` even for create actions, causing a query key collision with the cached entry.
+
+- **core:** Don't pass `id` to `useOne` for create actions, preventing the cache key collision at the source.
+- **react-hook-form:** Guard the `useModalForm` visibility reset effect against create actions.

--- a/.changeset/safe-route-id-decoding.md
+++ b/.changeset/safe-route-id-decoding.md
@@ -1,0 +1,7 @@
+---
+"@refinedev/core": patch
+"@refinedev/react-router": patch
+"@refinedev/remix-router": patch
+---
+
+Safely handle malformed URI-encoded route params when parsing route ids and query targets.

--- a/packages/core/src/definitions/helpers/handleUseParams/index.tsx
+++ b/packages/core/src/definitions/helpers/handleUseParams/index.tsx
@@ -1,8 +1,16 @@
+const safeDecodeURIComponent = (value: string) => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
 export const handleUseParams = (params: any = {}): any => {
   if (params?.id) {
     return {
       ...params,
-      id: decodeURIComponent(params.id),
+      id: safeDecodeURIComponent(params.id),
     };
   }
   return params;

--- a/packages/core/src/hooks/form/index.ts
+++ b/packages/core/src/hooks/form/index.ts
@@ -156,7 +156,7 @@ export const useForm = <
 
   const queryResult = useOne<TQueryFnData, TError, TData>({
     resource: identifier,
-    id,
+    id: isCreate ? undefined : id,
     queryOptions: {
       // Only enable the query if it's not a create action and the `id` is defined
       ...props.queryOptions,

--- a/packages/core/src/hooks/i18n/useTranslate.ts
+++ b/packages/core/src/hooks/i18n/useTranslate.ts
@@ -1,6 +1,7 @@
 import { useContext, useMemo } from "react";
 
 import { I18nContext } from "@contexts/i18n";
+import type { UseTranslationProps } from "./useTranslation";
 
 /**
  * If you need to translate the texts in your own components, refine provides the `useTranslate` hook.
@@ -8,7 +9,7 @@ import { I18nContext } from "@contexts/i18n";
  *
  * @see {@link https://refine.dev/docs/api-reference/core/hooks/translate/useTranslate} for more details.
  */
-export const useTranslate = () => {
+export const useTranslate = ({ ns }: UseTranslationProps = {}) => {
   const { i18nProvider } = useContext(I18nContext);
 
   const fn = useMemo(() => {
@@ -21,20 +22,37 @@ export const useTranslate = () => {
 
     function translate(
       key: string,
-      options?: string | any,
-      defaultMessage?: string,
+      _options?: string | any,
+      _defaultMessage?: string,
     ) {
+      let options = _options;
+      let defaultMessage = _defaultMessage;
+
+      if (typeof options === "string" && defaultMessage === undefined) {
+        defaultMessage = options;
+
+        if (ns) {
+          options = { ns };
+        } else {
+          options = undefined;
+        }
+      }
+
+      if (ns && options && typeof options !== "string") {
+        options = { ns, ...options };
+      }
+
       return (
         i18nProvider?.translate(key, options, defaultMessage) ??
         defaultMessage ??
-        (typeof options === "string" && typeof defaultMessage === "undefined"
-          ? options
+        (typeof _options === "string" && typeof _defaultMessage === "undefined"
+          ? _options
           : key)
       );
     }
 
     return translate;
-  }, [i18nProvider]);
+  }, [i18nProvider, ns]);
 
   return fn;
 };

--- a/packages/core/src/hooks/i18n/useTranslation.tsx
+++ b/packages/core/src/hooks/i18n/useTranslation.tsx
@@ -2,6 +2,10 @@ import { useGetLocale } from "./useGetLocale";
 import { useSetLocale } from "./useSetLocale";
 import { useTranslate } from "./useTranslate";
 
+export interface UseTranslationProps {
+  ns?: string | string[];
+}
+
 /**
  * It combines `useTranslate`, `useSetLocale` and `useGetLocale` hooks for a better developer experience.
  * It returns `i18nProvider` methods under the hood.
@@ -11,8 +15,8 @@ import { useTranslate } from "./useTranslate";
  *
  * @see {@link https://refine.dev/docs/i18n/i18n-provider/} for more details.
  */
-export const useTranslation = () => {
-  const translate = useTranslate();
+export const useTranslation = ({ ns }: UseTranslationProps = {}) => {
+  const translate = useTranslate({ ns });
   const changeLocale = useSetLocale();
   const getLocale = useGetLocale();
 

--- a/packages/react-hook-form/src/useModalForm/index.ts
+++ b/packages/react-hook-form/src/useModalForm/index.ts
@@ -187,7 +187,7 @@ export const useModalForm = <
 
   // compensate for setting of initial form values in useForm since it doesnt track modal visibility
   React.useEffect(() => {
-    if (!visible || !query?.data?.data) return;
+    if (!visible || !query?.data?.data || action === "create") return;
 
     const formData = query.data.data;
     if (!formData) return;
@@ -197,7 +197,7 @@ export const useModalForm = <
         keepDirtyValues: true,
       }),
     });
-  }, [visible, query?.data?.data, autoResetFormWhenClose]);
+  }, [visible, query?.data?.data, autoResetFormWhenClose, action]);
 
   React.useEffect(() => {
     if (initiallySynced === false && syncWithLocationKey) {

--- a/packages/react-hook-form/test/index.tsx
+++ b/packages/react-hook-form/test/index.tsx
@@ -6,6 +6,7 @@ import {
   type IResourceItem,
   type I18nProvider,
   type IRefineOptions,
+  type RouterProvider,
 } from "@refinedev/core";
 
 import { MockJSONServer, mockRouterProvider } from "./dataMocks";
@@ -15,6 +16,7 @@ interface ITestWrapperProps {
   dataProvider?: DataProvider;
   resources?: IResourceItem[];
   routerInitialEntries?: string[];
+  routerProvider?: RouterProvider;
   i18nProvider?: I18nProvider;
   options?: IRefineOptions;
 }
@@ -25,6 +27,7 @@ export const TestWrapper: (
   dataProvider,
   resources,
   routerInitialEntries,
+  routerProvider,
   i18nProvider,
   options,
 }) => {
@@ -34,12 +37,12 @@ export const TestWrapper: (
         <Refine
           i18nProvider={i18nProvider}
           dataProvider={dataProvider ?? MockJSONServer}
-          routerProvider={mockRouterProvider()}
+          routerProvider={routerProvider ?? mockRouterProvider()}
           resources={resources ?? [{ name: "posts" }]}
           options={{
             ...options,
             reactQuery: {
-              clientConfig: {
+              clientConfig: options?.reactQuery?.clientConfig ?? {
                 defaultOptions: {
                   queries: {
                     retry: false,

--- a/packages/react-router/src/bindings.tsx
+++ b/packages/react-router/src/bindings.tsx
@@ -17,6 +17,7 @@ import {
   useParams,
 } from "react-router";
 import { convertToNumberIfPossible } from "./convert-to-number-if-possible";
+import { safeDecodeURIComponent } from "./safe-decode-uri-component";
 
 export const stringifyConfig = {
   addQueryPrefix: true,
@@ -124,7 +125,7 @@ export const routerProvider: RouterProvider = {
       const response: ParseResponse = {
         ...(resource && { resource }),
         ...(action && { action }),
-        ...(params?.id && { id: decodeURIComponent(params.id) }),
+        ...(params?.id && { id: safeDecodeURIComponent(params.id) }),
         // ...(params?.action && { action: params.action }), // lets see if there is a need for this
         pathname,
         params: {
@@ -136,7 +137,7 @@ export const routerProvider: RouterProvider = {
             combinedParams.pageSize as string,
           ) as number | undefined,
           to: combinedParams.to
-            ? decodeURIComponent(combinedParams.to as string)
+            ? safeDecodeURIComponent(combinedParams.to as string)
             : undefined,
         },
       };

--- a/packages/react-router/src/safe-decode-uri-component.ts
+++ b/packages/react-router/src/safe-decode-uri-component.ts
@@ -1,0 +1,7 @@
+export const safeDecodeURIComponent = (value: string) => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};

--- a/packages/react-router/src/use-document-title.ts
+++ b/packages/react-router/src/use-document-title.ts
@@ -1,26 +1,36 @@
-import { useTranslate } from "@refinedev/core";
-import { useEffect } from "react";
+import { useTranslate, type UseTranslationProps } from "@refinedev/core";
+import { useCallback, useEffect } from "react";
 
 type Title = string | { i18nKey: string };
 
-export const useDocumentTitle = (title?: Title) => {
-  const translate = useTranslate();
+interface useDocumentTitleOptions {
+  ns?: UseTranslationProps["ns"];
+
+  defaultTitle?: string;
+}
+
+export const useDocumentTitle = (
+  title?: Title,
+  options?: useDocumentTitleOptions,
+) => {
+  const translate = useTranslate({ ns: options?.ns });
+
+  const getTitle = useCallback(
+    (title: Title) => {
+      const key = typeof title === "string" ? title : title.i18nKey;
+
+      return translate(key, options?.defaultTitle);
+    },
+    [translate, options?.defaultTitle],
+  );
 
   useEffect(() => {
     if (!title) return;
 
-    if (typeof title === "string") {
-      document.title = translate(title);
-    } else {
-      document.title = translate(title.i18nKey);
-    }
-  }, [title]);
+    document.title = getTitle(title);
+  }, [title, getTitle]);
 
   return (title: Title) => {
-    if (typeof title === "string") {
-      document.title = translate(title);
-    } else {
-      document.title = translate(title.i18nKey);
-    }
+    document.title = getTitle(title);
   };
 };

--- a/packages/remix-router/src/bindings.tsx
+++ b/packages/remix-router/src/bindings.tsx
@@ -11,6 +11,7 @@ import qs from "qs";
 import React, { type ComponentProps, useCallback, useContext } from "react";
 import { paramsFromCurrentPath } from "./params-from-current-path";
 import { convertToNumberIfPossible } from "./convert-to-number-if-possible";
+import { safeDecodeURIComponent } from "./safe-decode-uri-component";
 
 export const stringifyConfig = {
   addQueryPrefix: true,
@@ -116,8 +117,8 @@ export const routerProvider: RouterProvider = {
       const response: ParseResponse = {
         ...(resource && { resource }),
         ...(action && { action }),
-        ...(inferredId && { id: decodeURIComponent(inferredId) }),
-        ...(params?.id && { id: decodeURIComponent(params.id) }),
+        ...(inferredId && { id: safeDecodeURIComponent(inferredId) }),
+        ...(params?.id && { id: safeDecodeURIComponent(params.id) }),
         // ...(params?.action && { action: params.action }), // lets see if there is a need for this
         pathname,
         params: {
@@ -129,7 +130,7 @@ export const routerProvider: RouterProvider = {
             combinedParams.pageSize as string,
           ) as number | undefined,
           to: combinedParams.to
-            ? decodeURIComponent(combinedParams.to as string)
+            ? safeDecodeURIComponent(combinedParams.to as string)
             : undefined,
         },
       };

--- a/packages/remix-router/src/safe-decode-uri-component.ts
+++ b/packages/remix-router/src/safe-decode-uri-component.ts
@@ -1,0 +1,7 @@
+export const safeDecodeURIComponent = (value: string) => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};


### PR DESCRIPTION
Adds \
s\ (namespace) option to \useTranslation\ and \useTranslate\ hooks so users can set a default namespace for all translations in a component. Also updates \useDocumentTitle\ to support \
s\ and \defaultTitle\ options.

Closes #7386