### PR TITLE
Refactor notification.open to use config object

### DIFF
--- a/packages/antd/src/providers/notificationProvider/index.tsx
+++ b/packages/antd/src/providers/notificationProvider/index.tsx
@@ -39,12 +39,21 @@ export const useNotificationProvider = (): NotificationProvider => {
           closeIcon: <></>,
         });
       } else {
-        notification.open({
+        const config = {
           key,
           description: message,
           message: description ?? null,
-          type,
-        });
+        };
+        const method =
+          type && type !== "progress"
+            ? notification[type as "success" | "error" | "warning" | "info"]
+            : notification.open;
+        
+        if (typeof method === "function") {
+          method(config);
+        } else {
+          notification.open(config);
+        }
       }
     },
     close: (key) => notification.destroy(key),


### PR DESCRIPTION
Refactor notification opening logic to use a config object.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
