### PR TITLE
fix(mui): preserve breadcrumb link styling

### DIFF
--- a/packages/mui/src/components/breadcrumb/index.tsx
+++ b/packages/mui/src/components/breadcrumb/index.tsx
@@ -37,9 +37,12 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
 
   const LinkRouter = (props: LinkProps & { to?: string }) => {
     const { to, children, ...restProps } = props;
+
     return (
       <Link to={to || ""}>
-        <span {...restProps}>{children}</span>
+        <MuiLink component="span" {...restProps}>
+          {children}
+        </MuiLink>
       </Link>
     );
   };
@@ -72,6 +75,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
           )}
         </LinkRouter>
       )}
+
       {breadcrumbs.map(({ label, icon, href }) => {
         return (
           <Grid
@@ -85,6 +89,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
             }}
           >
             {!hideIcons && icon}
+
             {href ? (
               <LinkRouter
                 underline="hover"


### PR DESCRIPTION

## Summary

This PR fixes a regression in the `@refinedev/mui` Breadcrumb component where MUI `LinkProps` (`sx`, `underline`, `color`, and `variant`) were forwarded to a native `<span>` instead of a MUI component.

As a result, these props were rendered as invalid HTML attributes and the intended MUI styling was not applied.

## Changes

- Replace the inner `<span>` in `LinkRouter` with `<MuiLink component="span">`
- Preserve the existing router navigation behavior
- Ensure MUI styling props are correctly handled by `MuiLink`

## Result

- ✅ `sx` styles are applied correctly
- ✅ Hover underline works
- ✅ Color inheritance works
- ✅ Typography variant styling is restored
- ✅ Prevents invalid HTML attributes from being rendered

## Validation

- Built `@refinedev/mui` successfully
- Package declarations generated successfully

Fixes #7462