### PR TITLE
fix(mui): render Breadcrumb links as MUI Link so styling applies

### DIFF
--- a/.changeset/mui-breadcrumb-link-styling.md
+++ b/.changeset/mui-breadcrumb-link-styling.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/mui": patch
+---
+
+fix(mui): render `Breadcrumb` links as a MUI `Link` so styling is applied
+
+The internal `LinkRouter` helper in `@refinedev/mui`'s `Breadcrumb` spread MUI `Link` props (`sx`, `underline`, `color`, `variant`) onto a bare native `<span>`, so none of them had any effect. As a result breadcrumb links weren't flex-aligned with their icons, got no hover underline, didn't inherit color, and lost their typography size.
+
+`LinkRouter` now renders a real MUI `Link` (`component={LinkFromRouter}`), so the styling props are consumed by MUI while client-side routing via `to` is preserved. This also removes the previously-unused `Link as MuiLink` import that had been dead since the v5 migration.

--- a/packages/mui/src/components/breadcrumb/index.spec.tsx
+++ b/packages/mui/src/components/breadcrumb/index.spec.tsx
@@ -1,5 +1,8 @@
+import React from "react";
 import { vi } from "vitest";
 import { breadcrumbTests } from "@refinedev/ui-tests";
+
+import { render, TestWrapper, MockRouterProvider } from "@test";
 
 import { Breadcrumb } from "./";
 
@@ -9,4 +12,31 @@ describe("Breadcrumb", () => {
   });
 
   breadcrumbTests.bind(this)(Breadcrumb);
+
+  it("should render breadcrumb links as a MUI Link so styling props are applied", async () => {
+    const { container } = render(<Breadcrumb />, {
+      wrapper: TestWrapper({
+        routerProvider: MockRouterProvider({
+          pathname: "/posts/create",
+          resource: { name: "posts", list: "/posts", create: "/posts/create" },
+          action: "create",
+        }),
+        resources: [{ name: "posts", list: "/posts", create: "/posts/create" }],
+        routerInitialEntries: ["/posts/create"],
+      }),
+    });
+
+    const link = container.querySelector("a");
+
+    expect(link).toHaveAttribute("href", "/posts");
+    // The link must be a real MUI Link (component={LinkFromRouter}) so that
+    // `sx`, `underline`, `color` and `variant` are consumed by MUI instead of
+    // being dumped onto a plain <span> as invalid DOM attributes.
+    expect(link?.className).toContain("MuiLink-root");
+    // Guard against the regression: styling props must not leak into the DOM,
+    // and there must be no bare <span> wrapper carrying them.
+    expect(link).not.toHaveAttribute("underline");
+    expect(link).not.toHaveAttribute("sx");
+    expect(container.querySelector("span[underline]")).toBeNull();
+  });
 });

--- a/packages/mui/src/components/breadcrumb/index.tsx
+++ b/packages/mui/src/components/breadcrumb/index.tsx
@@ -38,9 +38,9 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
   const LinkRouter = (props: LinkProps & { to?: string }) => {
     const { to, children, ...restProps } = props;
     return (
-      <Link to={to || ""}>
-        <span {...restProps}>{children}</span>
-      </Link>
+      <MuiLink component={Link} to={to || ""} {...restProps}>
+        {children}
+      </MuiLink>
     );
   };
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated (not needed, no public API change)
- [x] Changesets have been added

## What is the current behavior?

In `@refinedev/mui`'s `Breadcrumb`, the internal `LinkRouter` helper is typed to accept MUI `LinkProps` (`sx`, `underline`, `color`, `variant`) but renders them onto a bare native `<span>`:

```tsx
const LinkRouter = (props: LinkProps & { to?: string }) => {
  const { to, children, ...restProps } = props;
  return (
    <Link to={to || ""}>
      <span {...restProps}>{children}</span>
    </Link>
  );
};
```

Because `<span>` is a plain DOM element, none of the MUI styling props do anything, they just get dumped onto the node as invalid HTML attributes. Visible impact: breadcrumb links aren't flex-aligned with their icons, get no hover underline, don't inherit color, and don't get the intended typography size.

This is a regression from the v5 migration (#6945), commit `5d63adac08`. Before that, `LinkRouter` rendered MUI's actual `Link`. When the legacy-router plumbing was removed in favor of `useLink()`, the component was rewritten to wrap a `<span>` but the props were never re-wired to a MUI component. The file still carried an unused `import { Link as MuiLink } from "@mui/material"` from that incomplete change.

fixes #7462

## What is the new behavior?

`LinkRouter` now renders a real MUI `Link`, using the router's link component as the underlying element:

```tsx
<MuiLink component={Link} to={to || ""} {...restProps}>
  {children}
</MuiLink>
```

This matches the existing pattern used by refine's MUI buttons (`component={LinkComponent}`), so the styling props (`sx`, `underline`, `color`, `variant`) are consumed by MUI while client-side routing through `to` is preserved. The previously-dead `MuiLink` import is now used.

## Notes for reviewers

The shared `breadcrumbTests` suite (`packages/ui-tests`) only checks structure (text, href, icon), so this slipped through untested. I added a MUI-specific test in `packages/mui/src/components/breadcrumb/index.spec.tsx` asserting the rendered link carries the `MuiLink-root` class and that no styling props leak into the DOM. Verified the test fails on the old `<span>` implementation and passes with the fix.
