### PR TITLE
feat(core): add truncateMiddle helper to definitions/helpers

### DIFF
--- a/packages/core/src/definitions/helpers/index.ts
+++ b/packages/core/src/definitions/helpers/index.ts
@@ -28,3 +28,4 @@ export { downloadInBrowser } from "./downloadInBrowser";
 export { deferExecution } from "./defer-execution";
 export { asyncDebounce } from "./async-debounce";
 export { prepareQueryContext } from "./prepare-query-context";
+export { truncateMiddle } from "./truncateMiddle";

--- a/packages/core/src/definitions/helpers/truncateMiddle/index.ts
+++ b/packages/core/src/definitions/helpers/truncateMiddle/index.ts
@@ -1,0 +1,9 @@
+export const truncateMiddle = (text: string, maxLength: number): string => {
+  if (text.length <= maxLength || maxLength <= 3) {
+    return text;
+  }
+  const charsToShow = maxLength - 3;
+  const frontChars = Math.ceil(charsToShow / 2);
+  const backChars = Math.floor(charsToShow / 2);
+  return `${text.slice(0, frontChars)}...${text.slice(text.length - backChars)}`;
+};


### PR DESCRIPTION
## Description
Adds a type-safe \	runcateMiddle(text, maxLength)\ string formatting helper function to \packages/core/src/definitions/helpers/truncateMiddle/index.ts\ for cleanly rendering resource names and table column headers in Refine UI components.

## Features
- Middle truncation helper \	runcateMiddle(text, maxLength)\.
- Exported from \@refinedev/core\ definitions.