### PR TITLE
fix(react-table): only reset the current page when filters or sorters actually change

### DIFF
--- a/.changeset/guard-page-reset-on-sync.md
+++ b/.changeset/guard-page-reset-on-sync.md
@@ -1,0 +1,9 @@
+---
+"@refinedev/react-table": patch
+---
+
+fix(react-table): only reset the current page when filters or sorters actually change
+
+The `columnFilters`/`sorting` sync effects in `useTable` reset `currentPage` to 1 on **every** effect re-run while a filter or sort was active — the `isEqual` guard covered `setFilters`/`setSorters` but not the page reset. Since the filters effect is keyed on `[columnFilters, columns]`, any change of the `columns` array identity re-fired it: with `syncWithLocation`, `useNavigation()`'s callbacks are recreated on every URL change (the router bindings' `go` depends on `useLocation()`), so columns memoized over them get a fresh identity right after the pagination click itself — the next page was fetched and immediately snapped back to page 1.
+
+Both resets now live inside their `isEqual` guards: the page still resets when filters or sorters actually change, and deep links keep working (the existing `isFirstRender` guard already suppressed the mount pass).

--- a/packages/react-table/src/useTable/index.spec.ts
+++ b/packages/react-table/src/useTable/index.spec.ts
@@ -184,6 +184,120 @@ describe("useTable Hook", () => {
     ]);
   });
 
+  it("should keep the current page when the columns identity changes without a filter change", async () => {
+    const { result, rerender } = renderHook(
+      ({ tableColumns }: { tableColumns: ColumnDef<Post>[] }) =>
+        useTable({
+          columns: tableColumns,
+          refineCoreProps: {
+            resource: "posts",
+            pagination: {
+              pageSize: 1,
+            },
+            filters: {
+              initial: [
+                {
+                  field: "active",
+                  operator: "eq",
+                  value: true,
+                },
+              ],
+            },
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          routerInitialEntries: ["/posts"],
+        }),
+        initialProps: { tableColumns: columns },
+      },
+    );
+
+    await waitFor(() => {
+      expect(!result.current.refineCore.tableQuery.isLoading).toBeTruthy();
+    });
+
+    act(() => {
+      result.current.refineCore.setCurrentPage(2);
+    });
+
+    await waitFor(() => {
+      expect(result.current.refineCore.currentPage).toBe(2);
+    });
+
+    // A columns array with fresh identity but identical content — cell
+    // renderers are commonly memoized over location-sensitive values
+    // (e.g. useNavigation callbacks depend on useLocation), so with
+    // syncWithLocation this happens right after every pagination click.
+    // The filters did not change, so the page must survive.
+    rerender({
+      tableColumns: columns.map((column) => ({ ...column })),
+    });
+
+    await waitFor(() => {
+      expect(!result.current.refineCore.tableQuery.isFetching).toBeTruthy();
+    });
+
+    expect(result.current.refineCore.currentPage).toBe(2);
+  });
+
+  it("should reset to the first page when a filter actually changes", async () => {
+    const { result } = renderHook(
+      () =>
+        useTable({
+          columns,
+          refineCoreProps: {
+            resource: "posts",
+            pagination: {
+              pageSize: 1,
+            },
+            filters: {
+              initial: [
+                {
+                  field: "active",
+                  operator: "eq",
+                  value: true,
+                },
+              ],
+            },
+          },
+        }),
+      {
+        wrapper: TestWrapper({
+          routerInitialEntries: ["/posts"],
+        }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(!result.current.refineCore.tableQuery.isLoading).toBeTruthy();
+    });
+
+    act(() => {
+      result.current.refineCore.setCurrentPage(2);
+    });
+
+    await waitFor(() => {
+      expect(result.current.refineCore.currentPage).toBe(2);
+    });
+
+    act(() => {
+      const titleColumn = result.current.reactTable.getColumn("title");
+      titleColumn?.setFilterValue("Hello");
+    });
+
+    await waitFor(() => {
+      expect(!result.current.refineCore.tableQuery.isFetching).toBeTruthy();
+    });
+
+    expect(result.current.refineCore.filters).toEqual(
+      expect.arrayContaining([
+        { field: "title", value: "Hello", operator: "contains" },
+      ]),
+    );
+    expect(result.current.refineCore.currentPage).toBe(1);
+  });
+
   it("It should work successfully with initialSorter", async () => {
     const { result } = renderHook(
       () =>

--- a/packages/react-table/src/useTable/index.ts
+++ b/packages/react-table/src/useTable/index.ts
@@ -141,10 +141,10 @@ export function useTable<
 
       if (!isEqual(sorters, newSorters)) {
         setSorters(newSorters);
-      }
 
-      if (sorting.length > 0 && isPaginationEnabled && !isFirstRender) {
-        setCurrentPage(1);
+        if (sorting.length > 0 && isPaginationEnabled && !isFirstRender) {
+          setCurrentPage(1);
+        }
       }
     }
   }, [sorting]);
@@ -168,10 +168,10 @@ export function useTable<
 
     if (!isEqual(crudFilters, filtersCore)) {
       setFilters(crudFilters);
-    }
 
-    if (crudFilters.length > 0 && isPaginationEnabled && !isFirstRender) {
-      setCurrentPage(1);
+      if (crudFilters.length > 0 && isPaginationEnabled && !isFirstRender) {
+        setCurrentPage(1);
+      }
     }
   }, [columnFilters, columns]);
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated (not needed — bug fix, no API change)
- [x] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?

`useTable`'s `columnFilters`/`sorting` sync effects reset `currentPage` to 1 on **every** effect re-run while a filter or sort is active — the `isEqual` guard covers `setFilters`/`setSorters` but not the page reset:

```ts
if (!isEqual(crudFilters, filtersCore)) {
  setFilters(crudFilters);
}

if (crudFilters.length > 0 && isPaginationEnabled && !isFirstRender) {
  setCurrentPage(1); // fires on every re-run, not only on real changes
}