### PR TITLE
feat(core): make MetaQuery and GraphQLQueryOptions interfaces to support declaration merging

### DIFF
--- a/.changeset/metaquery-interface.md
+++ b/.changeset/metaquery-interface.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": minor
+---
+
+feat: convert `MetaQuery` and `GraphQLQueryOptions` to interfaces to support TypeScript declaration merging. Consumers can now augment `MetaQuery` via `declare module "@refinedev/core"` to get typed `meta` properties across all data hooks.

--- a/packages/core/src/contexts/data/types.ts
+++ b/packages/core/src/contexts/data/types.ts
@@ -39,7 +39,7 @@ export interface QueryBuilderOptions {
   variables?: VariableOptions;
 }
 
-export type GraphQLQueryOptions = {
+export interface GraphQLQueryOptions {
   /**
    * @description GraphQL query to be used by data providers.
    * @optional
@@ -161,13 +161,12 @@ export type GraphQLQueryOptions = {
   gqlVariables?: {
     [key: string]: any;
   };
-};
+}
 
-export type MetaQuery = {
+export interface MetaQuery extends QueryBuilderOptions, GraphQLQueryOptions {
   [k: string]: any;
   queryContext?: Omit<QueryFunctionContext, "meta">;
-} & QueryBuilderOptions &
-  GraphQLQueryOptions;
+}
 
 export interface Pagination {
   /**


### PR DESCRIPTION
## Description

Converts `MetaQuery` and `GraphQLQueryOptions` from type aliases to interfaces so TypeScript **declaration merging** works. This lets consumers augment `MetaQuery` via `declare module "@refinedev/core"` to get full autocomplete and type-checking for custom `meta` properties (e.g. `meta.queryParams`) across every data hook (`useTable`, `useShow`, `useList`, ...).

Closes #7527.

### Before

```ts
export type GraphQLQueryOptions = { ... };

export type MetaQuery = {
  [k: string]: any;
  queryContext?: Omit<QueryFunctionContext, "meta">;
} & QueryBuilderOptions & GraphQLQueryOptions;
```

### After

```ts
export interface GraphQLQueryOptions { ... }

export interface MetaQuery extends QueryBuilderOptions, GraphQLQueryOptions {
  [k: string]: any;
  queryContext?: Omit<QueryFunctionContext, "meta">;
}
```

Structurally identical — fully backward compatible — but unlocks module augmentation:

```ts
declare module "@refinedev/core" {
  interface MetaQuery {
    queryParams?: { _pull?: string; _perPage?: number; [key: string]: unknown; };
  }
}
```

## Changes
- `packages/core/src/contexts/data/types.ts`: type → interface conversion
- `.changeset/metaquery-interface.md`: changeset (`minor`)
