### PR TITLE
feat(core): convert MetaQuery and GraphQLQueryOptions to interfaces

### DIFF
--- a/.changeset/tame-lions-smile.md
+++ b/.changeset/tame-lions-smile.md
@@ -1,0 +1,20 @@
+---
+"@refinedev/core": minor
+---
+
+Converted `MetaQuery` and `GraphQLQueryOptions` from type aliases to interfaces.
+
+This is structurally identical and fully backward compatible, but it unlocks TypeScript's [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) for `MetaQuery`. Consumers can now extend it in their own apps to get autocompletion and type-checking for custom `meta` fields (e.g. `meta.queryParams` used by custom data providers) across every hook that accepts `meta`:
+
+```ts
+declare module "@refinedev/core" {
+  interface MetaQuery {
+    queryParams?: {
+      _pull?: string;
+      [key: string]: unknown;
+    };
+  }
+}
+```
+
+Previously this was not possible because declaration merging only applies to interfaces, not type aliases.

--- a/documentation/docs/core/interface-references/index.md
+++ b/documentation/docs/core/interface-references/index.md
@@ -203,11 +203,23 @@ type OpenNotificationParams = {
 ### MetaQuery
 
 ```tsx
-type MetaQuery = {
+interface MetaQuery extends QueryBuilderOptions, GraphQLQueryOptions {
   queryContext?: Omit<QueryFunctionContext, "meta">;
   [key: string]: any;
-} & QueryBuilderOptions &
-  GraphQLQueryOptions;
+}
+```
+
+Since `MetaQuery` is an interface, you can use [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) to add typed fields to it (e.g. the `queryParams` your data provider reads) and get autocompletion/type-checking across every hook that accepts `meta`:
+
+```tsx
+declare module "@refinedev/core" {
+  interface MetaQuery {
+    queryParams?: {
+      _pull?: string;
+      [key: string]: unknown;
+    };
+  }
+}
 ```
 
 ### GraphQLQueryOptions
@@ -215,13 +227,13 @@ type MetaQuery = {
 ```tsx
 import type { DocumentNode } from "graphql";
 
-type GraphQLQueryOptions = {
+interface GraphQLQueryOptions {
   gqlQuery?: DocumentNode;
   gqlMutation?: DocumentNode;
   gqlVariables?: {
     [key: string]: any;
   };
-};
+}
 ```
 
 ### QueryFunctionContext

--- a/packages/core/src/contexts/data/types.ts
+++ b/packages/core/src/contexts/data/types.ts
@@ -39,7 +39,7 @@ export interface QueryBuilderOptions {
   variables?: VariableOptions;
 }
 
-export type GraphQLQueryOptions = {
+export interface GraphQLQueryOptions {
   /**
    * @description GraphQL query to be used by data providers.
    * @optional
@@ -161,13 +161,12 @@ export type GraphQLQueryOptions = {
   gqlVariables?: {
     [key: string]: any;
   };
-};
+}
 
-export type MetaQuery = {
+export interface MetaQuery extends QueryBuilderOptions, GraphQLQueryOptions {
   [k: string]: any;
   queryContext?: Omit<QueryFunctionContext, "meta">;
-} & QueryBuilderOptions &
-  GraphQLQueryOptions;
+}
 
 export interface Pagination {
   /**


### PR DESCRIPTION
Both types were plain type aliases, which prevented consumers from using TypeScript's declaration merging to extend MetaQuery with app-specific fields (e.g. meta.queryParams read by custom data providers). Converting them to interfaces is structurally identical and fully backward compatible, but unlocks:

```ts
declare module "@refinedev/core" {
  interface MetaQuery {
    queryParams?: { _pull?: string };
  }
}
```

Fixes #7527

## PR Checklist

- [x] The commit message follows our guidelines

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added

## What is the current behavior?

`MetaQuery` and `GraphQLQueryOptions` are plain type aliases. Because type aliases can't be extended via TypeScript's declaration merging, consumers have no way to add typed fields to `meta` (e.g. `meta.queryParams`, read by most custom data providers to build query strings). Every key on `meta` is typed as `any`, so typos and shape mismatches go uncaught.

## What is the new behavior?

Converted both to interfaces (`MetaQuery extends QueryBuilderOptions, GraphQLQueryOptions`). This is structurally identical and fully backward compatible, but it unlocks declaration merging:

```ts
declare module "@refinedev/core" {
  interface MetaQuery {
    queryParams?: { _pull?: string; [key: string]: unknown };
  }
}
```

...giving autocompletion/type-checking for custom `meta` fields across every hook (`useTable`, `useShow`, `useList`, etc.) without wrapper hooks or per-call-site casting.

fixes #7527

## Notes for reviewers

This is a type-only change with no behavioral difference, so I didn't add a new runtime test (the package has no type-level test infrastructure like `tsd`/`expectTypeOf`). Verified instead by:
- `pnpm build` (incl. `.d.ts` generation) passing with zero errors for `core`, `hasura`, `strapi-v4`, and `ui-types` (all packages that reference `MetaQuery`/`GraphQLQueryOptions`)
- Full `core` test suite: 122 files / 1213 tests passing
- A manual smoke test confirming declaration merging works end-to-end (extended field gets autocompletion, wrong-typed value is rejected by `tsc`)
