### PR TITLE
fix(mui): restore MUI Link styling in Breadcrumb links

### DIFF
--- a/.changeset/fixed-breadcrumb-mui-link.md
+++ b/.changeset/fixed-breadcrumb-mui-link.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/mui": patch
+---
+
+Fix `Breadcrumb` links losing MUI styling. `LinkRouter` now renders the MUI `Link` component (via `component` prop) instead of spreading `sx`, `color`, `variant`, and `underline` props onto a plain `<span>`, restoring the pre-v5-migration styling behavior.

--- a/packages/mui/src/components/breadcrumb/index.tsx
+++ b/packages/mui/src/components/breadcrumb/index.tsx
@@ -35,14 +35,9 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
 
   if (breadcrumbs.length < minItems) return null;
 
-  const LinkRouter = (props: LinkProps & { to?: string }) => {
-    const { to, children, ...restProps } = props;
-    return (
-      <Link to={to || ""}>
-        <span {...restProps}>{children}</span>
-      </Link>
-    );
-  };
+  const LinkRouter = (props: LinkProps & { to?: string }) => (
+    <MuiLink {...props} component={Link as any} />
+  );
 
   return (
     <Breadcrumbs


### PR DESCRIPTION
### The bug

`LinkRouter` in `@refinedev/mui`'s Breadcrumb spreads MUI styling props (`sx`, `underline`, `color`, `variant`) onto a plain `<span>`, so they land in the DOM as invalid HTML attributes and all styling is lost. This is a regression from the v5 migration (#6945, commit `5d63adac08`), which changed `LinkRouter` from rendering MUI's `Link` to wrapping a raw `<span>`.

### The fix

Render MUI's `Link` component and set `component={Link}` (the refine router link from `useLink()`), matching the pre-regression behavior. The breadcrumb links once again get their hover underline, inherited color, flex alignment, and typography size.

Fixes #7462

### Screenshots

![Output from the reported repro before the fix](https://github.com/user-attachments/assets/8d3b48f5-9cd6-48e3-9c9a-34b57a6b2f45)

_Invalid props dumped onto the `<span>` in the buggy version._
