### PR TITLE
fix(core): extend BaseKey to support number[] for UUID ids

### DIFF
--- a/.changeset/basekey-number-array.md
+++ b/.changeset/basekey-number-array.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": patch
+---
+
+fix(core): support number[] keys in BaseKey for UUID types

--- a/packages/core/src/contexts/data/types.ts
+++ b/packages/core/src/contexts/data/types.ts
@@ -5,7 +5,7 @@ export type Prettify<T> = {
   [K in keyof T]: T[K];
 } & {};
 
-export type BaseKey = string | number;
+export type BaseKey = string | number | number[];
 export type BaseRecord = {
   id?: BaseKey;
   [key: string]: any;


### PR DESCRIPTION
﻿Extends `BaseKey` to support `number[]` so `useShow`/`useDelete` work with numeric UUID ids.

Fixes #7403.
