### PR TITLE
fix(mui): render Breadcrumb LinkRouter inner element as MUI Link

### DIFF
--- a/packages/mui/src/components/breadcrumb/index.tsx
+++ b/packages/mui/src/components/breadcrumb/index.tsx
@@ -39,7 +39,9 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
     const { to, children, ...restProps } = props;
     return (
       <Link to={to || ""}>
-        <span {...restProps}>{children}</span>
+        <MuiLink component="span" {...restProps}>
+          {children}
+        </MuiLink>
       </Link>
     );
   };


### PR DESCRIPTION
﻿Renders the Breadcrumb `LinkRouter` inner element as an MUI `Link` so breadcrumb navigation uses the correct anchor styling and behavior.

Fixes #7462.
