### PR TITLE
chore: use maintained @11ty/gray-matter fork

### DIFF
--- a/.changeset/gray-matter-fork.md
+++ b/.changeset/gray-matter-fork.md
@@ -1,0 +1,8 @@
+---
+"@refinedev/cli": patch
+"@refinedev/devtools-server": patch
+---
+
+chore: use maintained `@11ty/gray-matter` fork
+
+Replaces the unmaintained `gray-matter` dependency with the `@11ty/gray-matter` fork, which keeps dependencies (including `js-yaml`) up to date for security.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
     "figlet": "^1.5.2",
     "fs-extra": "^10.1.0",
     "globby": "^11.1.0",
-    "gray-matter": "^4.0.3",
+    "@11ty/gray-matter": "^3.0.0",
     "handlebars": "^4.7.7",
     "inquirer": "^8.2.5",
     "inquirer-autocomplete-prompt": "^2.0.0",

--- a/packages/cli/src/utils/announcement/index.tsx
+++ b/packages/cli/src/utils/announcement/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import matter from "gray-matter";
+import matter from "@11ty/gray-matter";
 import boxen from "boxen";
 
 import type { Announcement } from "../../definitions/announcement";

--- a/packages/devtools-server/package.json
+++ b/packages/devtools-server/package.json
@@ -57,7 +57,7 @@
     "express": "^4.21.0",
     "fs-extra": "^10.1.0",
     "globby": "^11.1.0",
-    "gray-matter": "^4.0.3",
+    "@11ty/gray-matter": "^3.0.0",
     "http-proxy-middleware": "^3.0.0",
     "jscodeshift": "^17.3.0",
     "lodash": "^4.17.21",

--- a/packages/devtools-server/src/feed/get-feed.ts
+++ b/packages/devtools-server/src/feed/get-feed.ts
@@ -1,5 +1,5 @@
 import fetch from "node-fetch";
-import matter from "gray-matter";
+import matter from "@11ty/gray-matter";
 import { marked } from "marked";
 import sanitizeHtml from "sanitize-html";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11419,6 +11419,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@11ty/gray-matter':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@npmcli/package-json':
         specifier: ^5.2.0
         version: 5.2.0
@@ -11473,9 +11476,6 @@ importers:
       globby:
         specifier: ^11.1.0
         version: 11.1.0
-      gray-matter:
-        specifier: ^4.0.3
-        version: 4.0.3
       handlebars:
         specifier: ^4.7.7
         version: 4.7.8
@@ -11956,6 +11956,9 @@ importers:
 
   packages/devtools-server:
     dependencies:
+      '@11ty/gray-matter':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@refinedev/devtools-shared':
         specifier: 2.0.2
         version: link:../devtools-shared
@@ -11995,9 +11998,6 @@ importers:
       globby:
         specifier: ^11.1.0
         version: 11.1.0
-      gray-matter:
-        specifier: ^4.0.3
-        version: 4.0.3
       http-proxy-middleware:
         specifier: ^3.0.0
         version: 3.0.0
@@ -14065,6 +14065,10 @@ packages:
     peerDependenciesMeta:
       graphql:
         optional: true
+
+  '@11ty/gray-matter@3.0.0':
+    resolution: {integrity: sha512-mi6KB36DZCpCfCb9XP3NtDDNXe1N0jKtuFj9mTCZNy5H7vTabODyMgFmmOiGIGJKt+i8mJqEb/REtK+JTEzlpQ==}
+    engines: {node: '>=11'}
 
   '@aashutoshrathi/word-wrap@1.2.6':
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
@@ -24859,10 +24863,6 @@ packages:
     resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
-  gray-matter@4.0.3:
-    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
-    engines: {node: '>=6.0'}
-
   groqd@0.15.11:
     resolution: {integrity: sha512-i1JBi6CnRAVbsld9pThccvEg0jEq+xDiZE1OAkbTTt6bakpic5nv3QASvdgA+nWAoaX754q1ACvntgB7Pf83VQ==}
     engines: {node: '>= 14'}
@@ -26163,6 +26163,10 @@ packages:
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  js-yaml@5.2.3:
+    resolution: {integrity: sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==}
     hasBin: true
 
   jsbn@0.1.1:
@@ -31259,10 +31263,6 @@ packages:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
 
-  strip-bom-string@1.0.0:
-    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
-    engines: {node: '>=0.10.0'}
-
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
@@ -33176,6 +33176,11 @@ snapshots:
   '@0no-co/graphql.web@1.0.8(graphql@16.9.0)':
     optionalDependencies:
       graphql: 16.9.0
+
+  '@11ty/gray-matter@3.0.0':
+    dependencies:
+      js-yaml: 5.2.3
+      section-matter: 1.0.0
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
@@ -48676,13 +48681,6 @@ snapshots:
 
   graphql@16.9.0: {}
 
-  gray-matter@4.0.3:
-    dependencies:
-      js-yaml: 3.14.1
-      kind-of: 6.0.3
-      section-matter: 1.0.0
-      strip-bom-string: 1.0.0
-
   groqd@0.15.11:
     dependencies:
       zod: 3.22.4
@@ -50368,6 +50366,10 @@ snapshots:
       esprima: 4.0.1
 
   js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@5.2.3:
     dependencies:
       argparse: 2.0.1
 
@@ -57023,8 +57025,6 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.0.1
-
-  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 


### PR DESCRIPTION
Replaces the unmaintained `gray-matter` dependency (last release Jan 2019) with the maintained `@11ty/gray-matter` fork, which keeps `js-yaml` and other dependencies up to date — addressing the `js-yaml` CVE alert.

- `packages/cli` and `packages/devtools-server`: `gray-matter@^4.0.3` → `@11ty/gray-matter@^3.0.0`
- Updated both import sites and the lockfile
- Changeset added

Closes #7510