### PR TITLE
fix(core): recompute defaultOpenKeys when resource changes

### DIFF
--- a/.changeset/use-menu-default-open-keys.md
+++ b/.changeset/use-menu-default-open-keys.md
@@ -1,0 +1,5 @@
+---
+"@refinedev/core": patch
+---
+
+Fix `useMenu` to recompute `defaultOpenKeys` when the resource changes, so the sider updates correctly when navigating between nested resources.

--- a/packages/core/src/hooks/menu/useMenu.spec.tsx
+++ b/packages/core/src/hooks/menu/useMenu.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { renderHook } from "@testing-library/react";
+import { act, fireEvent, renderHook, screen } from "@testing-library/react";
 
 import { TestWrapper, mockRouterProvider } from "@test";
 
@@ -328,6 +328,59 @@ describe("useMenu Hook", () => {
           name: "categories",
         }),
       ]),
+    );
+  });
+
+  it("should recompute defaultOpenKeys when the resource changes", async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => {
+      const [hasResource, setHasResource] = React.useState(false);
+
+      return (
+        <div>
+          <button onClick={() => setHasResource(true)}>switch</button>
+          <TestWrapper
+            routerProvider={mockRouterProvider(
+              hasResource
+                ? {
+                    pathname: "/CMS/posts",
+                    resource: {
+                      name: "posts",
+                      meta: {
+                        parent: "CMS",
+                      },
+                    },
+                  }
+                : { pathname: "/" },
+            )}
+            resources={[
+              {
+                name: "CMS",
+              },
+              {
+                name: "posts",
+                list: "/posts",
+                meta: {
+                  parent: "CMS",
+                },
+              },
+            ]}
+          >
+            {children}
+          </TestWrapper>
+        </div>
+      );
+    };
+
+    const { result } = renderHook(() => useMenu(), { wrapper });
+
+    expect(result.current.defaultOpenKeys).toEqual([]);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("switch"));
+    });
+
+    expect(result.current.defaultOpenKeys).toEqual(
+      expect.arrayContaining(["/CMS", "/CMS/posts"]),
     );
   });
 

--- a/packages/core/src/hooks/menu/useMenu.tsx
+++ b/packages/core/src/hooks/menu/useMenu.tsx
@@ -76,7 +76,7 @@ export const useMenu = (
       parent = getParentResource(parent, resources);
     }
     return keys;
-  }, []);
+  }, [resource, resources]);
 
   const prepareItem = React.useCallback(
     (item: FlatTreeItem): TreeMenuItem | undefined => {


### PR DESCRIPTION
Fixes #5432

The \defaultOpenKeys\ memo in \useMenu\ had an empty dependency array, so it was computed once on mount and never updated when the resource changed. This caused the sider to fail to highlight/expand the correct menu item when navigating between nested resources.

Adds \esource\ and \esources\ to the memo dependencies and a regression test.