### PR TITLE
docs: reference MIT License in README

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -234,4 +234,4 @@ Refine CORE is a community-driven project, and your contributions continually im
 
 ## License
 
-Licensed under the MIT License, Copyright © 2021-present Refinedev
+Licensed under the [MIT License](LICENSE), Copyright © 2021-present Refinedev


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://refine.dev/docs/guides-concepts/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://refine.dev/docs/guides-concepts/contributing/#creating-a-changeset

## What is the current behavior?
The README does not mention the project's MIT license

## What is the new behavior?
Added a reference to the MIT License in the README.

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
