### PR TITLE
fix(antd,mantine): respect notification type in providers

### DIFF
--- a/packages/antd/src/providers/notificationProvider/index.tsx
+++ b/packages/antd/src/providers/notificationProvider/index.tsx
@@ -34,17 +34,21 @@ export const useNotificationProvider = (): NotificationProvider => {
               undoableTimeout={undoableTimeout}
             />
           ),
-          message: null,
+          title: null,
           duration: 0,
           closeIcon: <></>,
         });
       } else {
-        notification.open({
+        const notificationParams = {
           key,
-          description: message,
-          message: description ?? null,
-          type,
-        });
+          title: message,
+          description: description ?? null,
+        };
+        if (type === "error") {
+          notification.error(notificationParams);
+        } else {
+          notification.success(notificationParams);
+        }
       }
     },
     close: (key) => notification.destroy(key),

--- a/packages/mantine/src/providers/notificationProvider.tsx
+++ b/packages/mantine/src/providers/notificationProvider.tsx
@@ -126,13 +126,14 @@ export const useNotificationProvider = (): NotificationProvider => {
         if (isNotificationActive(key)) {
           updateNotification({
             id: key!,
-            color: type === "success" ? "primary" : "red",
+            color:
+              type === "error" ? "red" : type === "success" ? "green" : "blue",
             icon:
-              type === "success" ? (
-                <IconCheck size={18} />
-              ) : (
+              type === "error" ? (
                 <IconX size={18} />
-              ),
+              ) : type === "success" ? (
+                <IconCheck size={18} />
+              ) : null,
             message,
             title: description,
             autoClose: 5000,
@@ -141,13 +142,14 @@ export const useNotificationProvider = (): NotificationProvider => {
           addNotification(key);
           showNotification({
             id: key!,
-            color: type === "success" ? "primary" : "red",
+            color:
+              type === "error" ? "red" : type === "success" ? "green" : "blue",
             icon:
-              type === "success" ? (
-                <IconCheck size={18} />
-              ) : (
+              type === "error" ? (
                 <IconX size={18} />
-              ),
+              ) : type === "success" ? (
+                <IconCheck size={18} />
+              ) : null,
             message,
             title: description,
             onClose: () => {


### PR DESCRIPTION
Fixes #7477

**@refinedev/antd**: `notification.open()` has no `type` option, so the value was silently dropped and every non-progress notification rendered with no icon/color. Now uses the `notification.success()` / `notification.error()` shortcut methods.

**@refinedev/mantine**: replaced `color: type === "success" ? "primary" : "red"` with a proper per-type map — error → red + X icon, success → green + check icon, anything else → neutral blue with no icon.
