### PR TITLE
chore: switch to maintained @11ty/gray-matter fork

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
     "figlet": "^1.5.2",
     "fs-extra": "^10.1.0",
     "globby": "^11.1.0",
-    "gray-matter": "^4.0.3",
+    "@11ty/gray-matter": "^3.0.0",
     "handlebars": "^4.7.7",
     "inquirer": "^8.2.5",
     "inquirer-autocomplete-prompt": "^2.0.0",

--- a/packages/cli/src/utils/announcement/index.tsx
+++ b/packages/cli/src/utils/announcement/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import matter from "gray-matter";
+import matter from "@11ty/gray-matter";
 import boxen from "boxen";
 
 import type { Announcement } from "../../definitions/announcement";

--- a/packages/devtools-server/package.json
+++ b/packages/devtools-server/package.json
@@ -57,7 +57,7 @@
     "express": "^4.21.0",
     "fs-extra": "^10.1.0",
     "globby": "^11.1.0",
-    "gray-matter": "^4.0.3",
+    "@11ty/gray-matter": "^3.0.0",
     "http-proxy-middleware": "^3.0.0",
     "jscodeshift": "^17.3.0",
     "lodash": "^4.17.21",

--- a/packages/devtools-server/src/feed/get-feed.ts
+++ b/packages/devtools-server/src/feed/get-feed.ts
@@ -1,5 +1,5 @@
 import fetch from "node-fetch";
-import matter from "gray-matter";
+import matter from "@11ty/gray-matter";
 import { marked } from "marked";
 import sanitizeHtml from "sanitize-html";
 


### PR DESCRIPTION
Fixes #7510

`gray-matter` is unmaintained (last release January 2019) and its `js-yaml` dependency has open CVEs (SNYK-JS-JSYAML-18313070). Switches `packages/cli` and `packages/devtools-server` to the maintained `@11ty/gray-matter` fork (v3.0.0, CJS, same default-export API), updating the two import sites.
