### PR TITLE
fix(mui): render breadcrumb LinkRouter props on MuiLink

### DIFF
--- a/packages/mui/src/components/breadcrumb/index.tsx
+++ b/packages/mui/src/components/breadcrumb/index.tsx
@@ -39,7 +39,12 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
     const { to, children, ...restProps } = props;
     return (
       <Link to={to || ""}>
-        <span {...restProps}>{children}</span>
+        <MuiLink
+          {...restProps}
+          sx={{ textDecoration: "none", ...restProps.sx }}
+        >
+          {children}
+        </MuiLink>
       </Link>
     );
   };


### PR DESCRIPTION
Fixes #7462

`LinkRouter` in `@refinedev/mui`'s Breadcrumb typed itself to accept MUI `LinkProps` (`sx`, `underline`, `color`, `variant`) but spread them onto a bare native `<span>`, so none of the styling applied and the props leaked into the DOM as invalid attributes. This regressed in the v5 migration (#6945).

The component now renders the already-imported `MuiLink` with those props (with `textDecoration: "none"` default so the router `Link` styling stays intact), restoring flex alignment, hover underline, color inheritance, and typography.
