### PR TITLE
docs: fix NumberField Intl description

### DIFF
--- a/documentation/docs/ui-integrations/ant-design/components/fields/number-field/index.md
+++ b/documentation/docs/ui-integrations/ant-design/components/fields/number-field/index.md
@@ -6,7 +6,7 @@ description: "Learn to integrate Number Field in Refine v5. Learn integrate ente
 swizzle: true
 ---
 
-This field is used to display a number formatted according to the browser locale, right aligned. and uses [`Intl`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) to display date format.
+This field is used to display a number formatted according to the browser locale, right-aligned, and uses [`Intl`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) to format numbers.
 
 :::simple Good to know
 

--- a/documentation/docs/ui-integrations/chakra-ui/components/fields/number-field/index.md
+++ b/documentation/docs/ui-integrations/chakra-ui/components/fields/number-field/index.md
@@ -6,7 +6,7 @@ description: "Implement Number Field in Refine v5. Learn the key steps. Learn in
 swizzle: true
 ---
 
-This field is used to display a number formatted according to the browser locale, right aligned. and uses [`Intl`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) to display date format.
+This field is used to display a number formatted according to the browser locale, right-aligned, and uses [`Intl`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) to format numbers.
 
 :::simple Good to know
 

--- a/documentation/docs/ui-integrations/mantine/components/fields/number-field/index.md
+++ b/documentation/docs/ui-integrations/mantine/components/fields/number-field/index.md
@@ -6,7 +6,7 @@ description: "Explore how to integrate Number Field in Refine v5. Explore custom
 swizzle: true
 ---
 
-This field is used to display a number formatted according to the browser locale, right aligned. and uses [`Intl`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) to display date format.
+This field is used to display a number formatted according to the browser locale, right-aligned, and uses [`Intl`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) to format numbers.
 
 :::simple Good to know
 

--- a/documentation/docs/ui-integrations/material-ui/components/fields/number-field/index.md
+++ b/documentation/docs/ui-integrations/material-ui/components/fields/number-field/index.md
@@ -6,7 +6,7 @@ description: "Learn to integrate Number Field in Refine v5. Learn integrate opti
 swizzle: true
 ---
 
-This field is used to display a number formatted according to the browser locale, right aligned. and uses [`Intl`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) to display date format.
+This field is used to display a number formatted according to the browser locale, right-aligned, and uses [`Intl`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) to format numbers.
 
 :::simple Good to know
 

--- a/packages/antd/src/components/fields/number/index.tsx
+++ b/packages/antd/src/components/fields/number/index.tsx
@@ -12,7 +12,7 @@ function toLocaleStringSupportsOptions() {
 import type { NumberFieldProps } from "../types";
 
 /**
- * This field is used to display a number formatted according to the browser locale, right aligned. and uses {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl `Intl`} to display date format.
+ * This field is used to display a number formatted according to the browser locale, right-aligned, and uses {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl `Intl`} to format numbers.
  *
  * @see {@link https://refine.dev/docs/api-reference/antd/components/fields/number} for more details.
  */

--- a/packages/chakra-ui/src/components/fields/number/index.tsx
+++ b/packages/chakra-ui/src/components/fields/number/index.tsx
@@ -11,7 +11,7 @@ function toLocaleStringSupportsOptions() {
   );
 }
 /**
- * This field is used to display a number formatted according to the browser locale, right aligned. and uses {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl `Intl`} to display date format
+ * This field is used to display a number formatted according to the browser locale, right-aligned, and uses {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl `Intl`} to format numbers
  * and Chakra UI {@link https://chakra-ui.com/docs/components/text  `<Text>`} component.
  * @see {@link https://refine.dev/docs/api-reference/chakra-ui/components/fields/number} for more details.
  */

--- a/packages/mantine/src/components/fields/number/index.tsx
+++ b/packages/mantine/src/components/fields/number/index.tsx
@@ -11,7 +11,7 @@ function toLocaleStringSupportsOptions() {
   );
 }
 /**
- * This field is used to display a number formatted according to the browser locale, right aligned. and uses {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl `Intl`} to display date format
+ * This field is used to display a number formatted according to the browser locale, right-aligned, and uses {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl `Intl`} to format numbers
  * and Mantine {@link https://mantine.dev/core/text `<Text>`} component.
  * @see {@link https://refine.dev/docs/api-reference/mantine/components/fields/number/} for more details.
  */

--- a/packages/mui/src/components/fields/number/index.tsx
+++ b/packages/mui/src/components/fields/number/index.tsx
@@ -12,7 +12,7 @@ function toLocaleStringSupportsOptions() {
 }
 
 /**
- * This field is used to display a number formatted according to the browser locale, right aligned. and uses {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl `Intl`} to display date format
+ * This field is used to display a number formatted according to the browser locale, right-aligned, and uses {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl `Intl`} to format numbers
  * and Material UI {@link https://mui.com/material-ui/react-typography/#main-content `<Typography>`} component.
  * @see {@link https://refine.dev/docs/api-reference/mui/components/fields/number} for more details.
  */


### PR DESCRIPTION
## Summary
- Fixes incorrect NumberField intro/JSDoc that said `Intl` was used "to display date format" (copy-paste from DateField)
- Updates all four UI integrations (antd, MUI, Mantine, Chakra) docs and matching package JSDoc comments
- Closes #7551

## Test plan
- [ ] Confirm NumberField docs no longer mention "date format" on antd/MUI/Mantine/Chakra pages
- [ ] Confirm Usage sections still correctly reference `Intl.NumberFormat()`
- [ ] Spot-check JSDoc on `packages/*/src/components/fields/number/index.tsx`


Made with [Cursor](https://cursor.com)