### PR TITLE
docs: improve quickstart intro grammar and clarity

### DIFF
--- a/documentation/docs/getting-started/quickstart.md
+++ b/documentation/docs/getting-started/quickstart.md
@@ -10,9 +10,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import { Playground } from "@site/src/components/playground";
 
-**Refine** works on any environment that can run **React** (incl. _Vite, Next.js, Remix, and CRA(Legacy)_ etc.)
+**Refine** works in any environment that can run **React** (incl. _Vite, Next.js, Remix, and CRA (Legacy)_ etc.).
 
-Although you could take the time to manually set up your environment and install the **Refine** packages afterwards, the optimal way to get started with **Refine** is using the [Browser-based Scaffolder](https://refine.dev/?playground=true) and **CLI-based Scaffolder**.
+Although you could manually set up your environment and install the **Refine** packages afterwards, the fastest way to get started with **Refine** is using the [Browser-based Scaffolder](https://refine.dev/?playground=true) or the **CLI-based Scaffolder**.
 
 ## Using CLI
 


### PR DESCRIPTION
Improve quickstart intro: works in any environment, fix CRA (Legacy) spacing, optimal -> fastest, and/or.