### PR TITLE
docs: fix hyphenation open-source

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -21,8 +21,7 @@
 
 <div align="center"><strong>The sweet spot between the low/no code and “starting from scratch” for CRUD-heavy applications.</strong><br>
 
-Refine Core is an open source, React meta-framework for enterprise. It provides a headless solution for everything from admin panels to
-dashboards and internal tools.
+Refine Core is an open-source, React meta-framework for enterprise. It provides a headless solution for everything from admin panels to dashboards and internal tools.
 <br />
 
 <strong>Refine CORE also powers <a href="https://refine.dev/">Refine's purpose built AI agent.</a></strong>


### PR DESCRIPTION
Fix hyphenation: open source → open-source.