### PR TITLE
docs: fix hyphenation open-source in core README

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -21,7 +21,7 @@
 
 <div align="center"><strong>The sweet spot between the low/no code and “starting from scratch” for CRUD-heavy applications.</strong><br>
 
-Refine Core is an open source, React meta-framework for enterprise. It provides a headless solution for everything from admin panels to
+Refine Core is an open-source, React meta-framework for enterprise. It provides a headless solution for everything from admin panels to
 dashboards and internal tools.
 <br />
 


### PR DESCRIPTION
Fixes hyphenation: 'open source, React' -> 'open-source, React'.