### PR TITLE
docs: fix hyphenation open-source in ui-types README

### DIFF
--- a/packages/ui-types/README.md
+++ b/packages/ui-types/README.md
@@ -18,7 +18,7 @@
 
 <br />
 
-<div align="center"><strong>Build your <a href="https://reactjs.org/">React</a>-based CRUD applications, without constraints.</strong><br>An open source, headless web application framework developed with flexibility in mind.
+<div align="center"><strong>Build your <a href="https://reactjs.org/">React</a>-based CRUD applications, without constraints.</strong><br>An open-source, headless web application framework developed with flexibility in mind.
 
 <br />
 <br />


### PR DESCRIPTION
docs(ui-types): open source, headless -> open-source, headless when used as adjective.