### PR TITLE
docs: fix double space in create-refine-app README

### DIFF
--- a/packages/create-refine-app/README.md
+++ b/packages/create-refine-app/README.md
@@ -27,5 +27,5 @@ refine has connectors for 15+ backend services, including REST API, [GraphQL](ht
 ## Install
 
 ```
-npm create refine-app@latest  my-app
+npm create refine-app@latest my-app
 ```


### PR DESCRIPTION
Fix double space between package and app name.
