### PR TITLE
docs: fix double spaces in blog 2022-09-01

### DIFF
--- a/documentation/blog/2022-09-01-framer-text-animations.md
+++ b/documentation/blog/2022-09-01-framer-text-animations.md
@@ -124,7 +124,7 @@ function App() {
 <br/>
 <div>
 <a href="https://github.com/refinedev/refine">
-  <img  src="https://refine.ams3.cdn.digitaloceanspaces.com/website/static/img/github-support-banner.png" alt="Support Refine on GitHub banner" />
+  <img src="https://refine.ams3.cdn.digitaloceanspaces.com/website/static/img/github-support-banner.png" alt="Support Refine on GitHub banner" />
 </a>
 </div>
 
@@ -310,7 +310,7 @@ You can access the app [here](https://framer-motion-animation-snowy.vercel.app/)
 <br/>
 <div>
 <a href="https://discord.gg/refine">
-  <img  src="https://refine.ams3.cdn.digitaloceanspaces.com/website/static/img/discord-banner.png" alt="Join Refine on Discord banner" />
+  <img src="https://refine.ams3.cdn.digitaloceanspaces.com/website/static/img/discord-banner.png" alt="Join Refine on Discord banner" />
 </a>
 </div>
 


### PR DESCRIPTION
Fix double spaces in img tags in 2022-09-01 blog post.